### PR TITLE
Add ATP13A1 knowledge gaps

### DIFF
--- a/genes/human/ATP13A1/ATP13A1-ai-review.html
+++ b/genes/human/ATP13A1/ATP13A1-ai-review.html
@@ -3764,6 +3764,102 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether ATP13A1 is exclusively a membrane-protein dislocase or can also directly promote insertion, secretion, or topogenesis for selected clients remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts ATP13A1&#39;s core molecular function as ATP-dependent extraction of misinserted terminal hydrophobic helices from the ER membrane. The open question is whether the GET3/SEC61-linked models represent a separable productive routing activity or a downstream consequence of the accepted dislocase reaction.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether ATP13A1 should remain annotated only to membrane protein dislocase activity and extraction of mislocalized proteins from the ER, or whether additional topogenesis/translocation proofreading processes are warranted.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstituted assays and cell-rescue experiments with client-specific reporters should test whether ATP13A1 directly enables productive insertion or SEC61 handoff, independently of extracting mislocalized helices.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Whether ATP13A1 acts only as a dislocase or can also directly support insertion, secretion, or topogenesis for selected substrates remains unresolved."</em> — file:human/ATP13A1/ATP13A1-deep-research-falcon.md</li>
+
+                <li><em>"A key open question raised by structural work is whether ATP13A1 is strictly a dislocase or can also facilitate insertion/secretion/topogenesis for selected clients under some contexts"</em> — file:human/ATP13A1/ATP13A1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The human ATP13A1 client spectrum and selection rules are still incompletely defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts mistargeted mitochondrial tail-anchored proteins and misinserted terminal hydrophobic helices as supported substrates/classes. It does not infer that all atypical signal sequences, ERAD substrates, EMC clients, or mitochondrial-targeting errors are ATP13A1 clients.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A resolved substrate code would refine the molecular-function annotation, distinguish ATP13A1 from general ER quality-control factors, and identify which biological-process annotations should be client-specific.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Proteome-scale client trapping, topology-sensitive reporters, ATPase-dead and pocket-mutant rescue, and GET3/SEC61/EMC/ERAD epistasis should define the sequence, topology, and pathway features that make a human substrate ATP13A1-dependent.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The full human substrate spectrum, selection rules, and integration with GET3, SEC61, EMC, ERAD, and mitochondrial targeting pathways are still being defined."</em> — file:human/ATP13A1/ATP13A1-deep-research-falcon.md</li>
+
+                <li><em>"The best-supported primary function of ATP13A1 is **ATP-dependent dislocation/extraction of transmembrane helices (polypeptide segments)** from the ER membrane."</em> — file:human/ATP13A1/ATP13A1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The connection between ATP13A1 membrane-protein quality control and reported immune or developmental phenotypes remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review treats antiviral signaling, MR1/MAIT antigen-presentation, and developmental phenotypes as downstream or context-dependent unless direct ATP13A1 client-specific mechanisms are shown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether ATP13A1 should be annotated to specific immune or developmental processes, or whether those phenotypes are secondary consequences of ER membrane-protein quality-control failure.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Client-resolved perturbation and rescue experiments should separate direct ATP13A1-dependent handling of immune/developmental substrates from broad ER stress, mistargeting, and homeostasis effects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"It remains unclear which immune and developmental phenotypes are direct client-specific effects versus secondary consequences of ER homeostasis failure."</em> — file:human/ATP13A1/ATP13A1-deep-research-falcon.md</li>
+
+                <li><em>"ATP13A1 knockout/rescue systems and in vitro extraction assays are now used as a testbed for understanding how cells correct mislocalization/topology errors for α-helical membrane proteins"</em> — file:human/ATP13A1/ATP13A1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -4897,6 +4993,88 @@ core_functions:
   - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
     supporting_text: The best-supported primary function of ATP13A1 is **ATP-dependent dislocation/extraction
       of transmembrane helices (polypeptide segments)** from the ER membrane.
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether ATP13A1 is exclusively a membrane-protein dislocase or can also
+    directly promote insertion, secretion, or topogenesis for selected clients
+    remains unresolved.
+  boundary: &gt;-
+    The review accepts ATP13A1&#39;s core molecular function as ATP-dependent
+    extraction of misinserted terminal hydrophobic helices from the ER membrane.
+    The open question is whether the GET3/SEC61-linked models represent a
+    separable productive routing activity or a downstream consequence of the
+    accepted dislocase reaction.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether ATP13A1 should remain annotated
+    only to membrane protein dislocase activity and extraction of mislocalized
+    proteins from the ER, or whether additional topogenesis/translocation
+    proofreading processes are warranted.
+  resolution: &gt;-
+    Reconstituted assays and cell-rescue experiments with client-specific
+    reporters should test whether ATP13A1 directly enables productive insertion
+    or SEC61 handoff, independently of extracting mislocalized helices.
+  provenance:
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: Whether ATP13A1 acts only as a dislocase or can also directly support insertion, secretion, or topogenesis for selected substrates remains unresolved.
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: A key open question raised by structural work is whether ATP13A1 is strictly a dislocase or can also facilitate insertion/secretion/topogenesis for selected clients under some contexts
+- gap_statement: &gt;-
+    The human ATP13A1 client spectrum and selection rules are still incompletely
+    defined.
+  boundary: &gt;-
+    The review accepts mistargeted mitochondrial tail-anchored proteins and
+    misinserted terminal hydrophobic helices as supported substrates/classes.
+    It does not infer that all atypical signal sequences, ERAD substrates, EMC
+    clients, or mitochondrial-targeting errors are ATP13A1 clients.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    A resolved substrate code would refine the molecular-function annotation,
+    distinguish ATP13A1 from general ER quality-control factors, and identify
+    which biological-process annotations should be client-specific.
+  resolution: &gt;-
+    Proteome-scale client trapping, topology-sensitive reporters, ATPase-dead
+    and pocket-mutant rescue, and GET3/SEC61/EMC/ERAD epistasis should define
+    the sequence, topology, and pathway features that make a human substrate
+    ATP13A1-dependent.
+  provenance:
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: The full human substrate spectrum, selection rules, and integration with GET3, SEC61, EMC, ERAD, and mitochondrial targeting pathways are still being defined.
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: The best-supported primary function of ATP13A1 is **ATP-dependent dislocation/extraction of transmembrane helices (polypeptide segments)** from the ER membrane.
+- gap_statement: &gt;-
+    The connection between ATP13A1 membrane-protein quality control and reported
+    immune or developmental phenotypes remains unresolved.
+  boundary: &gt;-
+    The review treats antiviral signaling, MR1/MAIT antigen-presentation, and
+    developmental phenotypes as downstream or context-dependent unless direct
+    ATP13A1 client-specific mechanisms are shown.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether ATP13A1 should be annotated to
+    specific immune or developmental processes, or whether those phenotypes are
+    secondary consequences of ER membrane-protein quality-control failure.
+  resolution: &gt;-
+    Client-resolved perturbation and rescue experiments should separate direct
+    ATP13A1-dependent handling of immune/developmental substrates from broad ER
+    stress, mistargeting, and homeostasis effects.
+  provenance:
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: It remains unclear which immune and developmental phenotypes are direct client-specific effects versus secondary consequences of ER homeostasis failure.
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: ATP13A1 knockout/rescue systems and in vitro extraction assays are now used as a testbed for understanding how cells correct mislocalization/topology errors for α-helical membrane proteins
 proposed_new_terms: []
 suggested_questions:
 - question: Do any ATP13A1-dependent manganese or lipid/glycosylation phenotypes remain after

--- a/genes/human/ATP13A1/ATP13A1-ai-review.yaml
+++ b/genes/human/ATP13A1/ATP13A1-ai-review.yaml
@@ -691,6 +691,88 @@ core_functions:
   - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
     supporting_text: The best-supported primary function of ATP13A1 is **ATP-dependent dislocation/extraction
       of transmembrane helices (polypeptide segments)** from the ER membrane.
+knowledge_gaps:
+- gap_statement: >-
+    Whether ATP13A1 is exclusively a membrane-protein dislocase or can also
+    directly promote insertion, secretion, or topogenesis for selected clients
+    remains unresolved.
+  boundary: >-
+    The review accepts ATP13A1's core molecular function as ATP-dependent
+    extraction of misinserted terminal hydrophobic helices from the ER membrane.
+    The open question is whether the GET3/SEC61-linked models represent a
+    separable productive routing activity or a downstream consequence of the
+    accepted dislocase reaction.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether ATP13A1 should remain annotated
+    only to membrane protein dislocase activity and extraction of mislocalized
+    proteins from the ER, or whether additional topogenesis/translocation
+    proofreading processes are warranted.
+  resolution: >-
+    Reconstituted assays and cell-rescue experiments with client-specific
+    reporters should test whether ATP13A1 directly enables productive insertion
+    or SEC61 handoff, independently of extracting mislocalized helices.
+  provenance:
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: Whether ATP13A1 acts only as a dislocase or can also directly support insertion, secretion, or topogenesis for selected substrates remains unresolved.
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: A key open question raised by structural work is whether ATP13A1 is strictly a dislocase or can also facilitate insertion/secretion/topogenesis for selected clients under some contexts
+- gap_statement: >-
+    The human ATP13A1 client spectrum and selection rules are still incompletely
+    defined.
+  boundary: >-
+    The review accepts mistargeted mitochondrial tail-anchored proteins and
+    misinserted terminal hydrophobic helices as supported substrates/classes.
+    It does not infer that all atypical signal sequences, ERAD substrates, EMC
+    clients, or mitochondrial-targeting errors are ATP13A1 clients.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    A resolved substrate code would refine the molecular-function annotation,
+    distinguish ATP13A1 from general ER quality-control factors, and identify
+    which biological-process annotations should be client-specific.
+  resolution: >-
+    Proteome-scale client trapping, topology-sensitive reporters, ATPase-dead
+    and pocket-mutant rescue, and GET3/SEC61/EMC/ERAD epistasis should define
+    the sequence, topology, and pathway features that make a human substrate
+    ATP13A1-dependent.
+  provenance:
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: The full human substrate spectrum, selection rules, and integration with GET3, SEC61, EMC, ERAD, and mitochondrial targeting pathways are still being defined.
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: The best-supported primary function of ATP13A1 is **ATP-dependent dislocation/extraction of transmembrane helices (polypeptide segments)** from the ER membrane.
+- gap_statement: >-
+    The connection between ATP13A1 membrane-protein quality control and reported
+    immune or developmental phenotypes remains unresolved.
+  boundary: >-
+    The review treats antiviral signaling, MR1/MAIT antigen-presentation, and
+    developmental phenotypes as downstream or context-dependent unless direct
+    ATP13A1 client-specific mechanisms are shown.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether ATP13A1 should be annotated to
+    specific immune or developmental processes, or whether those phenotypes are
+    secondary consequences of ER membrane-protein quality-control failure.
+  resolution: >-
+    Client-resolved perturbation and rescue experiments should separate direct
+    ATP13A1-dependent handling of immune/developmental substrates from broad ER
+    stress, mistargeting, and homeostasis effects.
+  provenance:
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: It remains unclear which immune and developmental phenotypes are direct client-specific effects versus secondary consequences of ER homeostasis failure.
+  - reference_id: file:human/ATP13A1/ATP13A1-deep-research-falcon.md
+    supporting_text: ATP13A1 knockout/rescue systems and in vitro extraction assays are now used as a testbed for understanding how cells correct mislocalization/topology errors for α-helical membrane proteins
 proposed_new_terms: []
 suggested_questions:
 - question: Do any ATP13A1-dependent manganese or lipid/glycosylation phenotypes remain after


### PR DESCRIPTION
## Summary
- add structured ATP13A1 knowledge gaps for dislocase-versus-topogenesis activity, substrate selection rules, and immune/developmental phenotype interpretation
- render the updated ATP13A1 review HTML

## Validation
- `just validate human ATP13A1` (passes with 4 pre-existing IBA propagation metadata warnings)
- `just render human ATP13A1`
- `git diff --check`