### PR TITLE
Add C18orf21 knowledge gaps

### DIFF
--- a/genes/human/C18orf21/C18orf21-ai-review.html
+++ b/genes/human/C18orf21/C18orf21-ai-review.html
@@ -1285,6 +1285,20 @@
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        file:human/C18orf21/C18orf21-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis of C18orf21 RNase MRP evidence</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         file:human/C18orf21/C18orf21-bioinformatics/RESULTS.md
 
                     </span>
@@ -1430,6 +1444,102 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The strongest current functional lead identifies C18orf21 as an RNase MRP-specific subunit, but this assignment still needs peer-reviewed consolidation before the review should replace the historical unknown-function framing with definitive GO molecular-function and complex annotations.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review records C18orf21 as an intracellular UPF0711/DUF4674 protein with unknown molecular function, while noting a strong RNase MRP/RMP24 lead. It does not yet assert RNase MRP complex membership as the settled core function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether C18orf21 should be annotated to RNase MRP complex membership and pre-rRNA processing/ribosome biogenesis, replacing broad root-function annotations with specific curated terms.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Peer-reviewed publication or independently reproduced evidence should be checked against the primary data, followed by a focused update to molecular-function, complex, and biological-process annotations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Multiple independent studies now identify C18orf21 as a specific, constitutive protein subunit of the metazoan RNase MRP ribonucleoprotein complex, not RNase P."</em> — file:human/C18orf21/C18orf21-deep-research-falcon.md</li>
+
+                <li><em>"Caveat: As of now, the most detailed sources are 2025 preprints. Peer‑reviewed confirmations will further solidify these assignments; nonetheless, the breadth of orthogonal evidence is notable."</em> — file:human/C18orf21/C18orf21-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The precise biochemical contribution of C18orf21 within RNase MRP remains incompletely resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Current evidence supports a non-catalytic, MRP-specific RNP subunit model. The unresolved part is how C18orf21 contacts RMRP RNA and other protein subunits to control RNA stability, assembly, cleavage specificity, and pre-rRNA processing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Mechanistic resolution would determine whether the most informative GO representation is complex membership alone, an RNA-binding/RNP-stabilizing molecular function, or a more specific contribution to RNase MRP-mediated pre-rRNA cleavage.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structural studies of the metazoan RNase MRP complex, mutational rescue of predicted C18orf21-RMRP and C18orf21-RPP29 contacts, and direct cleavage assays should distinguish assembly, RNA-stabilization, and catalytic-site positioning roles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Non‑catalytic, MRP‑specific RNP subunit stabilizing RMRP RNA and enabling RNase MRP–mediated pre‑rRNA cleavage for 40S ribosome biogenesis."</em> — file:human/C18orf21/C18orf21-deep-research-falcon.md</li>
+
+                <li><em>"Comparative structural analyses indicate similarity between human C18orf21 and yeast RNase MRP subunits (e.g., Snm1), and modeling places C18orf21 in proximity to RPP29 and RPP38 with predicted contacts to the RMRP catalytic RNA."</em> — file:human/C18orf21/C18orf21-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The cellular and disease contexts in which C18orf21/RNase MRP activity is limiting remain unclear.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review can support intracellular/nuclear localization and a strong nucleolar RNase MRP lead, but it does not yet connect C18orf21 directly to HBV response, human disease, or broader cell-fitness phenotypes beyond ribosome-biogenesis hypotheses.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would prevent disease, viral-response, or generic essentiality annotations from being inferred from aliases, screens, or expression data, while preserving a route to specific process annotations if direct mechanisms are demonstrated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous localization, cell-type-specific depletion/rescue, viral perturbation assays, and disease-genetics follow-up should test whether C18orf21 has contexts beyond core RNase MRP-dependent ribosome biogenesis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This suggests a potential role in viral response or cell signaling under HBV infection, but the exact molecular mechanism remains unknown."</em> — file:human/C18orf21/C18orf21-deep-research.md</li>
+
+                <li><em>"Direct clinical associations for C18orf21 were not detailed in the retrieved excerpts."</em> — file:human/C18orf21/C18orf21-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -2345,6 +2455,8 @@ references:
     title: A quantitative atlas of mitotic phosphorylation
   - id: file:human/C18orf21/C18orf21-deep-research.md
     title: Deep research synthesis of C18orf21 literature and databases
+  - id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+    title: Falcon deep research synthesis of C18orf21 RNase MRP evidence
   - id: file:human/C18orf21/C18orf21-bioinformatics/RESULTS.md
     title: Bioinformatics analysis of C18orf21 structural and functional features
 existing_annotations:
@@ -2438,6 +2550,91 @@ core_functions:
       - reference_id: file:human/C18orf21/C18orf21-bioinformatics/RESULTS.md
         supporting_text: &#39;Isoelectric Point (pI): 10.27 ... Predicted Disordered Regions:
           Residues 22-199 (disorder-promoting residue enriched)&#39;
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The strongest current functional lead identifies C18orf21 as an RNase
+      MRP-specific subunit, but this assignment still needs peer-reviewed
+      consolidation before the review should replace the historical
+      unknown-function framing with definitive GO molecular-function and complex
+      annotations.
+    boundary: &gt;-
+      The review records C18orf21 as an intracellular UPF0711/DUF4674 protein
+      with unknown molecular function, while noting a strong RNase MRP/RMP24
+      lead. It does not yet assert RNase MRP complex membership as the settled
+      core function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: &gt;-
+      Resolving this gap would determine whether C18orf21 should be annotated to
+      RNase MRP complex membership and pre-rRNA processing/ribosome biogenesis,
+      replacing broad root-function annotations with specific curated terms.
+    resolution: &gt;-
+      Peer-reviewed publication or independently reproduced evidence should be
+      checked against the primary data, followed by a focused update to
+      molecular-function, complex, and biological-process annotations.
+    provenance:
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Multiple independent studies now identify C18orf21 as a specific, constitutive protein subunit of the metazoan RNase MRP ribonucleoprotein complex, not RNase P.
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: &#34;Caveat: As of now, the most detailed sources are 2025 preprints. Peer‑reviewed confirmations will further solidify these assignments; nonetheless, the breadth of orthogonal evidence is notable.&#34;
+  - gap_statement: &gt;-
+      The precise biochemical contribution of C18orf21 within RNase MRP remains
+      incompletely resolved.
+    boundary: &gt;-
+      Current evidence supports a non-catalytic, MRP-specific RNP subunit model.
+      The unresolved part is how C18orf21 contacts RMRP RNA and other protein
+      subunits to control RNA stability, assembly, cleavage specificity, and
+      pre-rRNA processing.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Mechanistic resolution would determine whether the most informative GO
+      representation is complex membership alone, an RNA-binding/RNP-stabilizing
+      molecular function, or a more specific contribution to RNase MRP-mediated
+      pre-rRNA cleavage.
+    resolution: &gt;-
+      Structural studies of the metazoan RNase MRP complex, mutational rescue of
+      predicted C18orf21-RMRP and C18orf21-RPP29 contacts, and direct cleavage
+      assays should distinguish assembly, RNA-stabilization, and catalytic-site
+      positioning roles.
+    provenance:
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Non‑catalytic, MRP‑specific RNP subunit stabilizing RMRP RNA and enabling RNase MRP–mediated pre‑rRNA cleavage for 40S ribosome biogenesis.
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Comparative structural analyses indicate similarity between human C18orf21 and yeast RNase MRP subunits (e.g., Snm1), and modeling places C18orf21 in proximity to RPP29 and RPP38 with predicted contacts to the RMRP catalytic RNA.
+  - gap_statement: &gt;-
+      The cellular and disease contexts in which C18orf21/RNase MRP activity is
+      limiting remain unclear.
+    boundary: &gt;-
+      The review can support intracellular/nuclear localization and a strong
+      nucleolar RNase MRP lead, but it does not yet connect C18orf21 directly to
+      HBV response, human disease, or broader cell-fitness phenotypes beyond
+      ribosome-biogenesis hypotheses.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would prevent disease, viral-response, or generic
+      essentiality annotations from being inferred from aliases, screens, or
+      expression data, while preserving a route to specific process annotations
+      if direct mechanisms are demonstrated.
+    resolution: &gt;-
+      Endogenous localization, cell-type-specific depletion/rescue, viral
+      perturbation assays, and disease-genetics follow-up should test whether
+      C18orf21 has contexts beyond core RNase MRP-dependent ribosome biogenesis.
+    provenance:
+      - reference_id: file:human/C18orf21/C18orf21-deep-research.md
+        supporting_text: This suggests a potential role in viral response or cell signaling under HBV infection, but the exact molecular mechanism remains unknown.
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Direct clinical associations for C18orf21 were not detailed in the retrieved excerpts.
 suggested_questions:
   - question: What is the molecular function of C18orf21 and how does it contribute
       to cellular processes?

--- a/genes/human/C18orf21/C18orf21-ai-review.yaml
+++ b/genes/human/C18orf21/C18orf21-ai-review.yaml
@@ -36,6 +36,8 @@ references:
     title: A quantitative atlas of mitotic phosphorylation
   - id: file:human/C18orf21/C18orf21-deep-research.md
     title: Deep research synthesis of C18orf21 literature and databases
+  - id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+    title: Falcon deep research synthesis of C18orf21 RNase MRP evidence
   - id: file:human/C18orf21/C18orf21-bioinformatics/RESULTS.md
     title: Bioinformatics analysis of C18orf21 structural and functional features
 existing_annotations:
@@ -129,6 +131,91 @@ core_functions:
       - reference_id: file:human/C18orf21/C18orf21-bioinformatics/RESULTS.md
         supporting_text: 'Isoelectric Point (pI): 10.27 ... Predicted Disordered Regions:
           Residues 22-199 (disorder-promoting residue enriched)'
+knowledge_gaps:
+  - gap_statement: >-
+      The strongest current functional lead identifies C18orf21 as an RNase
+      MRP-specific subunit, but this assignment still needs peer-reviewed
+      consolidation before the review should replace the historical
+      unknown-function framing with definitive GO molecular-function and complex
+      annotations.
+    boundary: >-
+      The review records C18orf21 as an intracellular UPF0711/DUF4674 protein
+      with unknown molecular function, while noting a strong RNase MRP/RMP24
+      lead. It does not yet assert RNase MRP complex membership as the settled
+      core function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: >-
+      Resolving this gap would determine whether C18orf21 should be annotated to
+      RNase MRP complex membership and pre-rRNA processing/ribosome biogenesis,
+      replacing broad root-function annotations with specific curated terms.
+    resolution: >-
+      Peer-reviewed publication or independently reproduced evidence should be
+      checked against the primary data, followed by a focused update to
+      molecular-function, complex, and biological-process annotations.
+    provenance:
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Multiple independent studies now identify C18orf21 as a specific, constitutive protein subunit of the metazoan RNase MRP ribonucleoprotein complex, not RNase P.
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: "Caveat: As of now, the most detailed sources are 2025 preprints. Peer‑reviewed confirmations will further solidify these assignments; nonetheless, the breadth of orthogonal evidence is notable."
+  - gap_statement: >-
+      The precise biochemical contribution of C18orf21 within RNase MRP remains
+      incompletely resolved.
+    boundary: >-
+      Current evidence supports a non-catalytic, MRP-specific RNP subunit model.
+      The unresolved part is how C18orf21 contacts RMRP RNA and other protein
+      subunits to control RNA stability, assembly, cleavage specificity, and
+      pre-rRNA processing.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Mechanistic resolution would determine whether the most informative GO
+      representation is complex membership alone, an RNA-binding/RNP-stabilizing
+      molecular function, or a more specific contribution to RNase MRP-mediated
+      pre-rRNA cleavage.
+    resolution: >-
+      Structural studies of the metazoan RNase MRP complex, mutational rescue of
+      predicted C18orf21-RMRP and C18orf21-RPP29 contacts, and direct cleavage
+      assays should distinguish assembly, RNA-stabilization, and catalytic-site
+      positioning roles.
+    provenance:
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Non‑catalytic, MRP‑specific RNP subunit stabilizing RMRP RNA and enabling RNase MRP–mediated pre‑rRNA cleavage for 40S ribosome biogenesis.
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Comparative structural analyses indicate similarity between human C18orf21 and yeast RNase MRP subunits (e.g., Snm1), and modeling places C18orf21 in proximity to RPP29 and RPP38 with predicted contacts to the RMRP catalytic RNA.
+  - gap_statement: >-
+      The cellular and disease contexts in which C18orf21/RNase MRP activity is
+      limiting remain unclear.
+    boundary: >-
+      The review can support intracellular/nuclear localization and a strong
+      nucleolar RNase MRP lead, but it does not yet connect C18orf21 directly to
+      HBV response, human disease, or broader cell-fitness phenotypes beyond
+      ribosome-biogenesis hypotheses.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would prevent disease, viral-response, or generic
+      essentiality annotations from being inferred from aliases, screens, or
+      expression data, while preserving a route to specific process annotations
+      if direct mechanisms are demonstrated.
+    resolution: >-
+      Endogenous localization, cell-type-specific depletion/rescue, viral
+      perturbation assays, and disease-genetics follow-up should test whether
+      C18orf21 has contexts beyond core RNase MRP-dependent ribosome biogenesis.
+    provenance:
+      - reference_id: file:human/C18orf21/C18orf21-deep-research.md
+        supporting_text: This suggests a potential role in viral response or cell signaling under HBV infection, but the exact molecular mechanism remains unknown.
+      - reference_id: file:human/C18orf21/C18orf21-deep-research-falcon.md
+        supporting_text: Direct clinical associations for C18orf21 were not detailed in the retrieved excerpts.
 suggested_questions:
   - question: What is the molecular function of C18orf21 and how does it contribute
       to cellular processes?


### PR DESCRIPTION
## Summary
- add structured C18orf21 knowledge gaps for RNase MRP assignment confirmation, biochemical contribution, and disease/viral-context interpretation
- add the Falcon deep-research file to review references for the new provenance
- render the updated C18orf21 review HTML

## Validation
- `just validate human C18orf21`
- `just render human C18orf21`
- `git diff --check`