### PR TITLE
Add ABTB1 knowledge gaps

### DIFF
--- a/genes/human/ABTB1/ABTB1-ai-review.html
+++ b/genes/human/ABTB1/ABTB1-ai-review.html
@@ -2387,6 +2387,20 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ABTB1/ABTB1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis of ABTB1 function</div>
+
+
+            </div>
+
         </div>
     </div>
 
@@ -2546,6 +2560,104 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> ABTB1-specific CRL3 substrate-adaptor activity remains inferential because no physiological ABTB1 substrate or direct substrate-bridging assay has been established in the reviewed evidence.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts cullin family protein binding and Cul3-RING ubiquitin ligase complex membership. It does not yet assert ubiquitin-like ligase-substrate adaptor activity as a confirmed ABTB1 molecular function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether ABTB1 should receive a specific substrate-adaptor molecular-function annotation and which biological processes, if any, should be assigned based on the substrates it recruits.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous ABTB1-CUL3 complex isolation, substrate-trapping mutants, quantitative ubiquitin-remnant proteomics, and in vitro ternary-complex and ubiquitination assays should identify direct substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"I did not find ABTB1-specific substrate identification or a direct assay showing that ABTB1 bridges CUL3 to a substrate"</em> — file:human/ABTB1/ABTB1-notes.md</li>
+
+                <li><em>"While ABTB1 is plausibly a CUL3 adaptor by domain logic and foundational BTB/POZ literature, **ABTB1-specific** reconstitution of a CUL3 complex and identification of ubiquitination substrates were not present in the retrieved full-text evidence."</em> — file:human/ABTB1/ABTB1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The compartment where ABTB1 performs its putative CRL3/scaffold function is not well resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt and the review support cytoplasmic/cytosolic context, and interaction resources support CUL3 and EEF1A/EEF1D binding. The gap is whether ABTB1 has a regulated, substrate-specific localization or subcellular pool that explains those interactions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Better localization evidence would refine cellular-component annotations and distinguish a generic cytoplasmic scaffold from a specific CRL3, translation factor, or signaling compartment.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous tagging or validated antibodies should map ABTB1 localization under basal, PTEN/miRNA, cell-cycle, and proteasome/neddylation-perturbation conditions with CUL3 and candidate substrate colocalization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"No definitive cellular compartment localization for human ABTB1 was established from the currently retrieved excerpts; localization should be treated as **unknown/insufficiently supported** here."</em> — file:human/ABTB1/ABTB1-deep-research-falcon.md</li>
+
+                <li><em>"SUBCELLULAR LOCATION: Cytoplasm"</em> — file:human/ABTB1/ABTB1-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> ABTB1&#39;s anti-proliferative/PTEN-linked role and prostate-cancer expression association remain mechanistically and contextually unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts that ABTB1 has been linked to PTEN growth-suppressive signaling and is directly regulated by miR-125b in myeloid models, but it does not annotate ABTB1 to a specific cell-cycle, cancer, or signaling biological process from correlative or context-dependent evidence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether any proliferation, PTEN-pathway, miRNA-regulated, or cancer-relevant GO process is a direct ABTB1 function, or whether these findings remain disease-model context downstream of an unknown substrate/scaffold mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Isoform-resolved ABTB1 perturbation and rescue across myeloid and prostate models, combined with substrate identification and PTEN/AR/miRNA pathway epistasis, should define which phenotypes are direct.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"BPOZ were able to suppress growth of cancer cells"</em> — PMID:11494141</li>
+
+                <li><em>"In prostate cancer, the authors emphasize that ABTB1 produces multiple protein forms and that it is not known which form(s) mediate growth inhibition, which is important when reconciling apparently conflicting associations across cancers."</em> — file:human/ABTB1/ABTB1-deep-research-falcon.md</li>
+
+                <li><em>"Association is correlative and context-specific; contrasts with anti-proliferative narrative in other systems, implying context dependence or isoform complexity."</em> — file:human/ABTB1/ABTB1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -3430,6 +3542,8 @@ references:
     supporting_text: &gt;-
       I did not find ABTB1-specific substrate identification or a direct assay showing
       that ABTB1 bridges CUL3 to a substrate
+- id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+  title: Falcon deep research synthesis of ABTB1 function
 core_functions:
 - description: &gt;-
     ABTB1 is best treated as a probable CUL3-associated BTB/ankyrin component of a
@@ -3461,6 +3575,88 @@ core_functions:
       ubiquitin ligase complex membership
   - reference_id: file:human/ABTB1/ABTB1-uniprot.txt
     supporting_text: &#34;Q969K4; Q05639: EEF1A2; NbExp=12&#34;
+knowledge_gaps:
+- gap_statement: &gt;-
+    ABTB1-specific CRL3 substrate-adaptor activity remains inferential because
+    no physiological ABTB1 substrate or direct substrate-bridging assay has been
+    established in the reviewed evidence.
+  boundary: &gt;-
+    The review accepts cullin family protein binding and Cul3-RING ubiquitin
+    ligase complex membership. It does not yet assert ubiquitin-like
+    ligase-substrate adaptor activity as a confirmed ABTB1 molecular function.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether ABTB1 should receive a specific
+    substrate-adaptor molecular-function annotation and which biological
+    processes, if any, should be assigned based on the substrates it recruits.
+  resolution: &gt;-
+    Endogenous ABTB1-CUL3 complex isolation, substrate-trapping mutants,
+    quantitative ubiquitin-remnant proteomics, and in vitro ternary-complex and
+    ubiquitination assays should identify direct substrates.
+  provenance:
+  - reference_id: file:human/ABTB1/ABTB1-notes.md
+    supporting_text: I did not find ABTB1-specific substrate identification or a direct assay showing that ABTB1 bridges CUL3 to a substrate
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: While ABTB1 is plausibly a CUL3 adaptor by domain logic and foundational BTB/POZ literature, **ABTB1-specific** reconstitution of a CUL3 complex and identification of ubiquitination substrates were not present in the retrieved full-text evidence.
+- gap_statement: &gt;-
+    The compartment where ABTB1 performs its putative CRL3/scaffold function is
+    not well resolved.
+  boundary: &gt;-
+    UniProt and the review support cytoplasmic/cytosolic context, and interaction
+    resources support CUL3 and EEF1A/EEF1D binding. The gap is whether ABTB1 has a
+    regulated, substrate-specific localization or subcellular pool that explains
+    those interactions.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Better localization evidence would refine cellular-component annotations and
+    distinguish a generic cytoplasmic scaffold from a specific CRL3, translation
+    factor, or signaling compartment.
+  resolution: &gt;-
+    Endogenous tagging or validated antibodies should map ABTB1 localization
+    under basal, PTEN/miRNA, cell-cycle, and proteasome/neddylation-perturbation
+    conditions with CUL3 and candidate substrate colocalization.
+  provenance:
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: No definitive cellular compartment localization for human ABTB1 was established from the currently retrieved excerpts; localization should be treated as **unknown/insufficiently supported** here.
+  - reference_id: file:human/ABTB1/ABTB1-uniprot.txt
+    supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm&#34;
+- gap_statement: &gt;-
+    ABTB1&#39;s anti-proliferative/PTEN-linked role and prostate-cancer expression
+    association remain mechanistically and contextually unresolved.
+  boundary: &gt;-
+    The review accepts that ABTB1 has been linked to PTEN growth-suppressive
+    signaling and is directly regulated by miR-125b in myeloid models, but it
+    does not annotate ABTB1 to a specific cell-cycle, cancer, or signaling
+    biological process from correlative or context-dependent evidence.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would determine whether any proliferation, PTEN-pathway,
+    miRNA-regulated, or cancer-relevant GO process is a direct ABTB1 function, or
+    whether these findings remain disease-model context downstream of an unknown
+    substrate/scaffold mechanism.
+  resolution: &gt;-
+    Isoform-resolved ABTB1 perturbation and rescue across myeloid and prostate
+    models, combined with substrate identification and PTEN/AR/miRNA pathway
+    epistasis, should define which phenotypes are direct.
+  provenance:
+  - reference_id: PMID:11494141
+    supporting_text: BPOZ were able to suppress growth of cancer cells
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: In prostate cancer, the authors emphasize that ABTB1 produces multiple protein forms and that it is not known which form(s) mediate growth inhibition, which is important when reconciling apparently conflicting associations across cancers.
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: Association is correlative and context-specific; contrasts with anti-proliferative narrative in other systems, implying context dependence or isoform complexity.
 proposed_new_terms: []
 suggested_questions:
 - question: &gt;-

--- a/genes/human/ABTB1/ABTB1-ai-review.yaml
+++ b/genes/human/ABTB1/ABTB1-ai-review.yaml
@@ -409,6 +409,8 @@ references:
     supporting_text: >-
       I did not find ABTB1-specific substrate identification or a direct assay showing
       that ABTB1 bridges CUL3 to a substrate
+- id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+  title: Falcon deep research synthesis of ABTB1 function
 core_functions:
 - description: >-
     ABTB1 is best treated as a probable CUL3-associated BTB/ankyrin component of a
@@ -440,6 +442,88 @@ core_functions:
       ubiquitin ligase complex membership
   - reference_id: file:human/ABTB1/ABTB1-uniprot.txt
     supporting_text: "Q969K4; Q05639: EEF1A2; NbExp=12"
+knowledge_gaps:
+- gap_statement: >-
+    ABTB1-specific CRL3 substrate-adaptor activity remains inferential because
+    no physiological ABTB1 substrate or direct substrate-bridging assay has been
+    established in the reviewed evidence.
+  boundary: >-
+    The review accepts cullin family protein binding and Cul3-RING ubiquitin
+    ligase complex membership. It does not yet assert ubiquitin-like
+    ligase-substrate adaptor activity as a confirmed ABTB1 molecular function.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether ABTB1 should receive a specific
+    substrate-adaptor molecular-function annotation and which biological
+    processes, if any, should be assigned based on the substrates it recruits.
+  resolution: >-
+    Endogenous ABTB1-CUL3 complex isolation, substrate-trapping mutants,
+    quantitative ubiquitin-remnant proteomics, and in vitro ternary-complex and
+    ubiquitination assays should identify direct substrates.
+  provenance:
+  - reference_id: file:human/ABTB1/ABTB1-notes.md
+    supporting_text: I did not find ABTB1-specific substrate identification or a direct assay showing that ABTB1 bridges CUL3 to a substrate
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: While ABTB1 is plausibly a CUL3 adaptor by domain logic and foundational BTB/POZ literature, **ABTB1-specific** reconstitution of a CUL3 complex and identification of ubiquitination substrates were not present in the retrieved full-text evidence.
+- gap_statement: >-
+    The compartment where ABTB1 performs its putative CRL3/scaffold function is
+    not well resolved.
+  boundary: >-
+    UniProt and the review support cytoplasmic/cytosolic context, and interaction
+    resources support CUL3 and EEF1A/EEF1D binding. The gap is whether ABTB1 has a
+    regulated, substrate-specific localization or subcellular pool that explains
+    those interactions.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    Better localization evidence would refine cellular-component annotations and
+    distinguish a generic cytoplasmic scaffold from a specific CRL3, translation
+    factor, or signaling compartment.
+  resolution: >-
+    Endogenous tagging or validated antibodies should map ABTB1 localization
+    under basal, PTEN/miRNA, cell-cycle, and proteasome/neddylation-perturbation
+    conditions with CUL3 and candidate substrate colocalization.
+  provenance:
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: No definitive cellular compartment localization for human ABTB1 was established from the currently retrieved excerpts; localization should be treated as **unknown/insufficiently supported** here.
+  - reference_id: file:human/ABTB1/ABTB1-uniprot.txt
+    supporting_text: "SUBCELLULAR LOCATION: Cytoplasm"
+- gap_statement: >-
+    ABTB1's anti-proliferative/PTEN-linked role and prostate-cancer expression
+    association remain mechanistically and contextually unresolved.
+  boundary: >-
+    The review accepts that ABTB1 has been linked to PTEN growth-suppressive
+    signaling and is directly regulated by miR-125b in myeloid models, but it
+    does not annotate ABTB1 to a specific cell-cycle, cancer, or signaling
+    biological process from correlative or context-dependent evidence.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would determine whether any proliferation, PTEN-pathway,
+    miRNA-regulated, or cancer-relevant GO process is a direct ABTB1 function, or
+    whether these findings remain disease-model context downstream of an unknown
+    substrate/scaffold mechanism.
+  resolution: >-
+    Isoform-resolved ABTB1 perturbation and rescue across myeloid and prostate
+    models, combined with substrate identification and PTEN/AR/miRNA pathway
+    epistasis, should define which phenotypes are direct.
+  provenance:
+  - reference_id: PMID:11494141
+    supporting_text: BPOZ were able to suppress growth of cancer cells
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: In prostate cancer, the authors emphasize that ABTB1 produces multiple protein forms and that it is not known which form(s) mediate growth inhibition, which is important when reconciling apparently conflicting associations across cancers.
+  - reference_id: file:human/ABTB1/ABTB1-deep-research-falcon.md
+    supporting_text: Association is correlative and context-specific; contrasts with anti-proliferative narrative in other systems, implying context dependence or isoform complexity.
 proposed_new_terms: []
 suggested_questions:
 - question: >-


### PR DESCRIPTION
## Summary
- add structured ABTB1 knowledge gaps for CRL3 substrate-adaptor evidence, localization specificity, and context-dependent proliferation/cancer biology
- add the Falcon deep-research file to review references for the new provenance
- render the updated ABTB1 review HTML

## Validation
- `just validate human ABTB1` (passes with 2 warnings: pre-existing IBA propagation metadata warning; Falcon deep-research file is used for knowledge-gap provenance rather than annotation-review evidence)
- `just render human ABTB1`
- `git diff --check`