### PR TITLE
Add BCCIP knowledge gaps

### DIFF
--- a/genes/human/BCCIP/BCCIP-ai-review.html
+++ b/genes/human/BCCIP/BCCIP-ai-review.html
@@ -4821,6 +4821,20 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/BCCIP/BCCIP-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research on BCCIP isoform-resolved function</div>
+
+
+            </div>
+
         </div>
     </div>
 
@@ -4911,6 +4925,104 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The GO representation and physiological scope of BCCIPalpha-mediated FAM46/TENT5 inhibition remain unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already captures BCCIPbeta RAD51 regulation, ribosome biogenesis, spindle assembly, and p21/CDK2 regulation as core functions. BCCIPalpha inhibition of FAM46/TENT5 poly(A) polymerases is a strong isoform-specific mechanism, but it has not yet been integrated into the core-function block or mapped to a specific GO molecular function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether BCCIPalpha should be annotated as a negative regulator/adaptor of noncanonical poly(A) polymerase activity, and whether the current broad RNA-binding representation should be refined for this isoform-specific activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Isoform-specific curation should connect the structural FAM46/TENT5 inhibition evidence to direct cellular substrates and decide whether the activity warrants a new molecular-function annotation, a process annotation, or both.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"BCCIP itself has no demonstrated catalytic activity; rather, BCCIPα directly inhibits the enzymatic activity of FAM46/TENT5 noncanonical poly(A) polymerases by binding their active site, while BCCIPβ stimulates the recombinase activity of RAD51 by promoting ADP release from RAD51 filaments"</em> — file:human/BCCIP/BCCIP-deep-research-falcon.md</li>
+
+                <li><em>"FAM46/TENT5: BCCIPα binds into the active site of FAM46A/C/D to inhibit PAP activity; BCCIPβ does not bind/inhibit"</em> — file:human/BCCIP/BCCIP-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How BCCIP&#39;s isoform-specific activities are coordinated across DNA repair, RNA metabolism, ribosome biogenesis, spindle assembly, and CDK regulation remains incompletely understood.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Individual activities are supported well enough to retain as core or non-core functions. The unresolved issue is whether these are separable pathway-specific functions, manifestations of a common scaffold/adaptor role, or context-dependent functions of distinct isoforms.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would clarify which biological-process annotations are primary for BCCIP, which are isoform-specific, and which are downstream consequences of perturbing an essential multifunctional factor.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Isoform-specific rescue, separation-of-function mutants, time-resolved localization, and pathway-specific substrate/partner assays should distinguish shared from independent mechanisms.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"BCCIP is a non‑enzymatic regulator/adaptor in several pathways: homologous recombination (HR) DNA repair with BRCA2/RAD51; transcriptional regulation of p21 via p53 and YY1/INO80; large subunit (60S) ribosome biogenesis via nucleolar recruitment of eIF6 and 12S pre‑rRNA production; and mitotic spindle/centrosome organization"</em> — file:human/BCCIP/BCCIP-deep-research-falcon.md</li>
+
+                <li><em>"The discovery that BCCIPα and BCCIPβ assume distinct folds provides a structural logic for their divergent functions—RNA metabolism (via FAM46 inhibition) versus DNA repair (via RAD51 stimulation), and highlights the limits of purely sequence‑based function prediction"</em> — file:human/BCCIP/BCCIP-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> BCCIP&#39;s cancer biology remains context-dependent: partial loss can promote genome instability and tumor initiation, while retained or elevated BCCIP activity may support proliferation in some established cancers.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review treats genome-maintenance and ribosome-biogenesis functions as molecular/cellular activities. It does not infer a single tumor-suppressor or oncogenic GO process annotation from disease-context observations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether cancer-context annotations are appropriate for BCCIP, and would prevent over-annotation from mixing tumor initiation, tumor maintenance, essentiality, and proliferation-support effects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Dose- and isoform-resolved perturbation across tumor-initiation and established-tumor models should separate genome-instability effects from dependencies on DNA repair, ribosome biogenesis, and spindle function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"BCCIP has since emerged as a multifunctional protein whose partial loss promotes tumorigenesis while complete loss is lethal."</em> — file:human/BCCIP/BCCIP-deep-research-cyberian.md</li>
+
+                <li><em>"The relationship between BCCIP and cancer is unexpectedly complex."</em> — file:human/BCCIP/BCCIP-deep-research-cyberian.md</li>
+
+                <li><em>"This indicates that transient BCCIP downregulation, rather than permanent mutation, is sufficient to initiate tumorigenesis; however, once malignant transformation is established, BCCIP expression becomes necessary for tumor progression."</em> — file:human/BCCIP/BCCIP-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -6677,6 +6789,9 @@ references:
   - id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
     title: Cyberian deep research on BCCIP function
     findings: []
+  - id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+    title: Falcon deep research on BCCIP isoform-resolved function
+    findings: []
 
 core_functions:
   - description: &gt;-
@@ -6760,6 +6875,108 @@ core_functions:
         supporting_text: &gt;-
           TOK-1alpha enhanced the inhibitory activity of p21 toward histone H1 kinase
           activity of CDK2
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The GO representation and physiological scope of BCCIPalpha-mediated
+      FAM46/TENT5 inhibition remain unresolved.
+    boundary: &gt;-
+      The review already captures BCCIPbeta RAD51 regulation, ribosome
+      biogenesis, spindle assembly, and p21/CDK2 regulation as core functions.
+      BCCIPalpha inhibition of FAM46/TENT5 poly(A) polymerases is a strong
+      isoform-specific mechanism, but it has not yet been integrated into the
+      core-function block or mapped to a specific GO molecular function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: &gt;-
+      Resolving this gap would determine whether BCCIPalpha should be annotated
+      as a negative regulator/adaptor of noncanonical poly(A) polymerase activity,
+      and whether the current broad RNA-binding representation should be refined
+      for this isoform-specific activity.
+    resolution: &gt;-
+      Isoform-specific curation should connect the structural FAM46/TENT5
+      inhibition evidence to direct cellular substrates and decide whether the
+      activity warrants a new molecular-function annotation, a process annotation,
+      or both.
+    provenance:
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: &gt;-
+          BCCIP itself has no demonstrated catalytic activity; rather, BCCIPα
+          directly inhibits the enzymatic activity of FAM46/TENT5 noncanonical
+          poly(A) polymerases by binding their active site, while BCCIPβ
+          stimulates the recombinase activity of RAD51 by promoting ADP release
+          from RAD51 filaments
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: &gt;-
+          FAM46/TENT5: BCCIPα binds into the active site of FAM46A/C/D to inhibit
+          PAP activity; BCCIPβ does not bind/inhibit
+  - gap_statement: &gt;-
+      How BCCIP&#39;s isoform-specific activities are coordinated across DNA repair,
+      RNA metabolism, ribosome biogenesis, spindle assembly, and CDK regulation
+      remains incompletely understood.
+    boundary: &gt;-
+      Individual activities are supported well enough to retain as core or
+      non-core functions. The unresolved issue is whether these are separable
+      pathway-specific functions, manifestations of a common scaffold/adaptor
+      role, or context-dependent functions of distinct isoforms.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would clarify which biological-process annotations are
+      primary for BCCIP, which are isoform-specific, and which are downstream
+      consequences of perturbing an essential multifunctional factor.
+    resolution: &gt;-
+      Isoform-specific rescue, separation-of-function mutants, time-resolved
+      localization, and pathway-specific substrate/partner assays should
+      distinguish shared from independent mechanisms.
+    provenance:
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: &gt;-
+          BCCIP is a non‑enzymatic regulator/adaptor in several pathways:
+          homologous recombination (HR) DNA repair with BRCA2/RAD51;
+          transcriptional regulation of p21 via p53 and YY1/INO80; large subunit
+          (60S) ribosome biogenesis via nucleolar recruitment of eIF6 and 12S
+          pre‑rRNA production; and mitotic spindle/centrosome organization
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: &gt;-
+          The discovery that BCCIPα and BCCIPβ assume distinct folds provides a
+          structural logic for their divergent functions—RNA metabolism (via
+          FAM46 inhibition) versus DNA repair (via RAD51 stimulation), and
+          highlights the limits of purely sequence‑based function prediction
+  - gap_statement: &gt;-
+      BCCIP&#39;s cancer biology remains context-dependent: partial loss can promote
+      genome instability and tumor initiation, while retained or elevated BCCIP
+      activity may support proliferation in some established cancers.
+    boundary: &gt;-
+      The review treats genome-maintenance and ribosome-biogenesis functions as
+      molecular/cellular activities. It does not infer a single tumor-suppressor
+      or oncogenic GO process annotation from disease-context observations.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine whether cancer-context annotations are
+      appropriate for BCCIP, and would prevent over-annotation from mixing tumor
+      initiation, tumor maintenance, essentiality, and proliferation-support
+      effects.
+    resolution: &gt;-
+      Dose- and isoform-resolved perturbation across tumor-initiation and
+      established-tumor models should separate genome-instability effects from
+      dependencies on DNA repair, ribosome biogenesis, and spindle function.
+    provenance:
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
+        supporting_text: BCCIP has since emerged as a multifunctional protein whose partial loss promotes tumorigenesis while complete loss is lethal.
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
+        supporting_text: The relationship between BCCIP and cancer is unexpectedly complex.
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
+        supporting_text: This indicates that transient BCCIP downregulation, rather than permanent mutation, is sufficient to initiate tumorigenesis; however, once malignant transformation is established, BCCIP expression becomes necessary for tumor progression.
 
 proposed_new_terms: []
 

--- a/genes/human/BCCIP/BCCIP-ai-review.yaml
+++ b/genes/human/BCCIP/BCCIP-ai-review.yaml
@@ -987,6 +987,9 @@ references:
   - id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
     title: Cyberian deep research on BCCIP function
     findings: []
+  - id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+    title: Falcon deep research on BCCIP isoform-resolved function
+    findings: []
 
 core_functions:
   - description: >-
@@ -1070,6 +1073,108 @@ core_functions:
         supporting_text: >-
           TOK-1alpha enhanced the inhibitory activity of p21 toward histone H1 kinase
           activity of CDK2
+knowledge_gaps:
+  - gap_statement: >-
+      The GO representation and physiological scope of BCCIPalpha-mediated
+      FAM46/TENT5 inhibition remain unresolved.
+    boundary: >-
+      The review already captures BCCIPbeta RAD51 regulation, ribosome
+      biogenesis, spindle assembly, and p21/CDK2 regulation as core functions.
+      BCCIPalpha inhibition of FAM46/TENT5 poly(A) polymerases is a strong
+      isoform-specific mechanism, but it has not yet been integrated into the
+      core-function block or mapped to a specific GO molecular function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: >-
+      Resolving this gap would determine whether BCCIPalpha should be annotated
+      as a negative regulator/adaptor of noncanonical poly(A) polymerase activity,
+      and whether the current broad RNA-binding representation should be refined
+      for this isoform-specific activity.
+    resolution: >-
+      Isoform-specific curation should connect the structural FAM46/TENT5
+      inhibition evidence to direct cellular substrates and decide whether the
+      activity warrants a new molecular-function annotation, a process annotation,
+      or both.
+    provenance:
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: >-
+          BCCIP itself has no demonstrated catalytic activity; rather, BCCIPα
+          directly inhibits the enzymatic activity of FAM46/TENT5 noncanonical
+          poly(A) polymerases by binding their active site, while BCCIPβ
+          stimulates the recombinase activity of RAD51 by promoting ADP release
+          from RAD51 filaments
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: >-
+          FAM46/TENT5: BCCIPα binds into the active site of FAM46A/C/D to inhibit
+          PAP activity; BCCIPβ does not bind/inhibit
+  - gap_statement: >-
+      How BCCIP's isoform-specific activities are coordinated across DNA repair,
+      RNA metabolism, ribosome biogenesis, spindle assembly, and CDK regulation
+      remains incompletely understood.
+    boundary: >-
+      Individual activities are supported well enough to retain as core or
+      non-core functions. The unresolved issue is whether these are separable
+      pathway-specific functions, manifestations of a common scaffold/adaptor
+      role, or context-dependent functions of distinct isoforms.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would clarify which biological-process annotations are
+      primary for BCCIP, which are isoform-specific, and which are downstream
+      consequences of perturbing an essential multifunctional factor.
+    resolution: >-
+      Isoform-specific rescue, separation-of-function mutants, time-resolved
+      localization, and pathway-specific substrate/partner assays should
+      distinguish shared from independent mechanisms.
+    provenance:
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: >-
+          BCCIP is a non‑enzymatic regulator/adaptor in several pathways:
+          homologous recombination (HR) DNA repair with BRCA2/RAD51;
+          transcriptional regulation of p21 via p53 and YY1/INO80; large subunit
+          (60S) ribosome biogenesis via nucleolar recruitment of eIF6 and 12S
+          pre‑rRNA production; and mitotic spindle/centrosome organization
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-falcon.md
+        supporting_text: >-
+          The discovery that BCCIPα and BCCIPβ assume distinct folds provides a
+          structural logic for their divergent functions—RNA metabolism (via
+          FAM46 inhibition) versus DNA repair (via RAD51 stimulation), and
+          highlights the limits of purely sequence‑based function prediction
+  - gap_statement: >-
+      BCCIP's cancer biology remains context-dependent: partial loss can promote
+      genome instability and tumor initiation, while retained or elevated BCCIP
+      activity may support proliferation in some established cancers.
+    boundary: >-
+      The review treats genome-maintenance and ribosome-biogenesis functions as
+      molecular/cellular activities. It does not infer a single tumor-suppressor
+      or oncogenic GO process annotation from disease-context observations.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine whether cancer-context annotations are
+      appropriate for BCCIP, and would prevent over-annotation from mixing tumor
+      initiation, tumor maintenance, essentiality, and proliferation-support
+      effects.
+    resolution: >-
+      Dose- and isoform-resolved perturbation across tumor-initiation and
+      established-tumor models should separate genome-instability effects from
+      dependencies on DNA repair, ribosome biogenesis, and spindle function.
+    provenance:
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
+        supporting_text: BCCIP has since emerged as a multifunctional protein whose partial loss promotes tumorigenesis while complete loss is lethal.
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
+        supporting_text: The relationship between BCCIP and cancer is unexpectedly complex.
+      - reference_id: file:human/BCCIP/BCCIP-deep-research-cyberian.md
+        supporting_text: This indicates that transient BCCIP downregulation, rather than permanent mutation, is sufficient to initiate tumorigenesis; however, once malignant transformation is established, BCCIP expression becomes necessary for tumor progression.
 
 proposed_new_terms: []
 


### PR DESCRIPTION
## Summary
- add structured BCCIP knowledge gaps for FAM46/TENT5 representation, coordination of isoform-specific functions, and context-dependent cancer biology
- add the Falcon deep-research file to review references for the new provenance
- render the updated BCCIP review HTML

## Validation
- `just validate human BCCIP`
- `just render human BCCIP`
- `git diff --check`