### PR TITLE
Add WDR6 knowledge gaps

### DIFF
--- a/genes/human/WDR6/WDR6-ai-review.html
+++ b/genes/human/WDR6/WDR6-ai-review.html
@@ -3007,6 +3007,104 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The structural basis by which human WDR6 selects and positions position-34 tRNA substrates for FTSJ1 remains incompletely resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already accepts WDR6 as the FTSJ1 regulatory/adaptor subunit for wobble-position ribose methylation. The unresolved gap is the human structure-function mechanism: which WDR6 surfaces, FTSJ1 interfaces, and tRNA features determine Nm34 substrate selectivity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would strengthen the molecular-function representation of WDR6 beyond generic adaptor and tRNA-binding terms, and would clarify how human substrate specificity differs from yeast Trm7-Trm734.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> High-resolution human FTSJ1-WDR6-tRNA structures, paired with separation-of-function WDR6 mutants and tRNA substrate panels, should define the substrate-recognition determinants that support precise curation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"While the yeast structure has been solved, high-resolution structures of the human FTSJ1-WDR6 complex with tRNA substrate would provide crucial insights into the mechanism of position 34-specific methylation and potential therapeutic targeting."</em> — file:human/WDR6/WDR6-deep-research-cyberian.md</li>
+
+                <li><em>"Human substrates and differences to yeast: The human FTSJ1–WDR6 complex generates Gm34 on specific cytosolic tRNAs including tRNAPhe(GAA) and tRNALeu(CAA), and displays substrate selectivity distinct from yeast Trm7–Trm734 (e.g., some yeast targets such as tRNATrp(CCA) are not modified by the human complex) (EMBO Reports, Jun 2020; https://doi.org/10.15252/embr.202050095). (li2020intellectualdisability‐associatedgene pages 9-11)"</em> — file:human/WDR6/WDR6-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The relationship between WDR6&#39;s core tRNA-modification role and its reported LKB1, insulin signaling, lipogenesis, viral restriction, autophagy, and ubiquitin-ligase-associated phenotypes remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The core function is WDR6-dependent FTSJ1 Nm34 tRNA modification. Existing cell-cycle and autophagy annotations are kept as non-core or undecided because current evidence does not distinguish direct WDR6 moonlighting functions from downstream consequences of altered translation or context-specific scaffolding.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would prevent broad process over-annotation while identifying any bona fide WDR6-specific signaling or proteostasis functions that should be curated separately from the FTSJ1-WDR6 tRNA pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Separation-of-function alleles that retain FTSJ1 binding or tRNA modification while disrupting candidate signaling or ubiquitin-ligase interfaces should be tested across the reported cellular contexts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"How WDR6&#39;s tRNA modification function relates to its roles in LKB1 signaling, insulin signaling, lipogenesis, and viral restriction remains unclear. Are these independent functions, or does tRNA modification status influence these pathways?"</em> — file:human/WDR6/WDR6-deep-research-cyberian.md</li>
+
+                <li><em>"Evidence for alternative functions (LKB1 interaction, insulin signaling, lipogenesis, viral restriction) comes from independent yeast two-hybrid screens, co-immunoprecipitation, and genetic manipulation studies, though these functions may be secondary to or independent from the tRNA modification role."</em> — file:human/WDR6/WDR6-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> WDR6&#39;s tissue-specific and disease-relevant functions remain poorly defined, especially for brain, liver, cancer, and variant-associated phenotypes.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> WDR6 is mechanistically linked to FTSJ1-dependent tRNA modification and has disease-context evidence from FTSJ1 intellectual-disability biology, metabolic studies, HCC studies, and GWAS signals. The gap is whether WDR6 variants or tissue-specific regulation cause distinct human phenotypes and which of those phenotypes are annotation-worthy biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would clarify whether WDR6 should receive disease- or tissue-context biological-process annotations, or whether those observations should remain contextual evidence around a conserved tRNA-modification module.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Patient-variant functional assays, tissue-specific WDR6 perturbation, and rescue with tRNA-modification-competent versus separation-of-function WDR6 alleles should connect genotype, tissue context, and molecular mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"WDR6 is ubiquitously expressed, but its specific functions may vary by tissue. The mechanisms controlling tissue-specific WDR6 activity, particularly in brain versus liver, need further investigation."</em> — file:human/WDR6/WDR6-deep-research-cyberian.md</li>
+
+                <li><em>"While WDR6 has been identified in GWAS for OCD and other conditions, the functional consequences of specific variants and their contribution to disease pathogenesis remain to be determined."</em> — file:human/WDR6/WDR6-deep-research-cyberian.md</li>
+
+                <li><em>"While FTSJ1 variants are clearly implicated in NSXLID, the specific contribution of WDR6 variants to human disease via loss of Nm34 has yet to be systematically defined; separation-of-function alleles informed by ortholog studies can address this (ACS Omega, Jun 2024; https://doi.org/10.1021/acsomega.4c02313). (funk2024identificationofamino pages 7-7)"</em> — file:human/WDR6/WDR6-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -4165,6 +4263,123 @@ references:
   - id: file:human/WDR6/WDR6-deep-research-cyberian.md
     title: Cyberian deep research on WDR6 function
     findings: []
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The structural basis by which human WDR6 selects and positions position-34
+      tRNA substrates for FTSJ1 remains incompletely resolved.
+    boundary: &gt;-
+      The review already accepts WDR6 as the FTSJ1 regulatory/adaptor subunit for
+      wobble-position ribose methylation. The unresolved gap is the human
+      structure-function mechanism: which WDR6 surfaces, FTSJ1 interfaces, and
+      tRNA features determine Nm34 substrate selectivity.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: &gt;-
+      Resolving this gap would strengthen the molecular-function representation
+      of WDR6 beyond generic adaptor and tRNA-binding terms, and would clarify
+      how human substrate specificity differs from yeast Trm7-Trm734.
+    resolution: &gt;-
+      High-resolution human FTSJ1-WDR6-tRNA structures, paired with
+      separation-of-function WDR6 mutants and tRNA substrate panels, should define
+      the substrate-recognition determinants that support precise curation.
+    provenance:
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: &gt;-
+          While the yeast structure has been solved, high-resolution structures of
+          the human FTSJ1-WDR6 complex with tRNA substrate would provide crucial
+          insights into the mechanism of position 34-specific methylation and
+          potential therapeutic targeting.
+      - reference_id: file:human/WDR6/WDR6-deep-research-falcon.md
+        supporting_text: &gt;-
+          Human substrates and differences to yeast: The human FTSJ1–WDR6 complex
+          generates Gm34 on specific cytosolic tRNAs including tRNAPhe(GAA) and
+          tRNALeu(CAA), and displays substrate selectivity distinct from yeast
+          Trm7–Trm734 (e.g., some yeast targets such as tRNATrp(CCA) are not
+          modified by the human complex) (EMBO Reports, Jun 2020;
+          https://doi.org/10.15252/embr.202050095).
+          (li2020intellectualdisability‐associatedgene pages 9-11)
+  - gap_statement: &gt;-
+      The relationship between WDR6&#39;s core tRNA-modification role and its reported
+      LKB1, insulin signaling, lipogenesis, viral restriction, autophagy, and
+      ubiquitin-ligase-associated phenotypes remains unresolved.
+    boundary: &gt;-
+      The core function is WDR6-dependent FTSJ1 Nm34 tRNA modification. Existing
+      cell-cycle and autophagy annotations are kept as non-core or undecided
+      because current evidence does not distinguish direct WDR6 moonlighting
+      functions from downstream consequences of altered translation or
+      context-specific scaffolding.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would prevent broad process over-annotation while
+      identifying any bona fide WDR6-specific signaling or proteostasis functions
+      that should be curated separately from the FTSJ1-WDR6 tRNA pathway.
+    resolution: &gt;-
+      Separation-of-function alleles that retain FTSJ1 binding or tRNA
+      modification while disrupting candidate signaling or ubiquitin-ligase
+      interfaces should be tested across the reported cellular contexts.
+    provenance:
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: &gt;-
+          How WDR6&#39;s tRNA modification function relates to its roles in LKB1
+          signaling, insulin signaling, lipogenesis, and viral restriction remains
+          unclear. Are these independent functions, or does tRNA modification
+          status influence these pathways?
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Evidence for alternative functions (LKB1 interaction, insulin signaling,
+          lipogenesis, viral restriction) comes from independent yeast two-hybrid
+          screens, co-immunoprecipitation, and genetic manipulation studies, though
+          these functions may be secondary to or independent from the tRNA
+          modification role.
+  - gap_statement: &gt;-
+      WDR6&#39;s tissue-specific and disease-relevant functions remain poorly defined,
+      especially for brain, liver, cancer, and variant-associated phenotypes.
+    boundary: &gt;-
+      WDR6 is mechanistically linked to FTSJ1-dependent tRNA modification and has
+      disease-context evidence from FTSJ1 intellectual-disability biology,
+      metabolic studies, HCC studies, and GWAS signals. The gap is whether WDR6
+      variants or tissue-specific regulation cause distinct human phenotypes and
+      which of those phenotypes are annotation-worthy biology.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would clarify whether WDR6 should receive disease- or
+      tissue-context biological-process annotations, or whether those observations
+      should remain contextual evidence around a conserved tRNA-modification
+      module.
+    resolution: &gt;-
+      Patient-variant functional assays, tissue-specific WDR6 perturbation, and
+      rescue with tRNA-modification-competent versus separation-of-function WDR6
+      alleles should connect genotype, tissue context, and molecular mechanism.
+    provenance:
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: &gt;-
+          WDR6 is ubiquitously expressed, but its specific functions may vary by
+          tissue. The mechanisms controlling tissue-specific WDR6 activity,
+          particularly in brain versus liver, need further investigation.
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: &gt;-
+          While WDR6 has been identified in GWAS for OCD and other conditions, the
+          functional consequences of specific variants and their contribution to
+          disease pathogenesis remain to be determined.
+      - reference_id: file:human/WDR6/WDR6-deep-research-falcon.md
+        supporting_text: &gt;-
+          While FTSJ1 variants are clearly implicated in NSXLID, the specific
+          contribution of WDR6 variants to human disease via loss of Nm34 has yet
+          to be systematically defined; separation-of-function alleles informed by
+          ortholog studies can address this (ACS Omega, Jun 2024;
+          https://doi.org/10.1021/acsomega.4c02313).
+          (funk2024identificationofamino pages 7-7)
 proposed_new_terms: []
 suggested_questions:
   - question: What structural features of WDR6 determine tRNA substrate

--- a/genes/human/WDR6/WDR6-ai-review.yaml
+++ b/genes/human/WDR6/WDR6-ai-review.yaml
@@ -586,6 +586,123 @@ references:
   - id: file:human/WDR6/WDR6-deep-research-cyberian.md
     title: Cyberian deep research on WDR6 function
     findings: []
+knowledge_gaps:
+  - gap_statement: >-
+      The structural basis by which human WDR6 selects and positions position-34
+      tRNA substrates for FTSJ1 remains incompletely resolved.
+    boundary: >-
+      The review already accepts WDR6 as the FTSJ1 regulatory/adaptor subunit for
+      wobble-position ribose methylation. The unresolved gap is the human
+      structure-function mechanism: which WDR6 surfaces, FTSJ1 interfaces, and
+      tRNA features determine Nm34 substrate selectivity.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: >-
+      Resolving this gap would strengthen the molecular-function representation
+      of WDR6 beyond generic adaptor and tRNA-binding terms, and would clarify
+      how human substrate specificity differs from yeast Trm7-Trm734.
+    resolution: >-
+      High-resolution human FTSJ1-WDR6-tRNA structures, paired with
+      separation-of-function WDR6 mutants and tRNA substrate panels, should define
+      the substrate-recognition determinants that support precise curation.
+    provenance:
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: >-
+          While the yeast structure has been solved, high-resolution structures of
+          the human FTSJ1-WDR6 complex with tRNA substrate would provide crucial
+          insights into the mechanism of position 34-specific methylation and
+          potential therapeutic targeting.
+      - reference_id: file:human/WDR6/WDR6-deep-research-falcon.md
+        supporting_text: >-
+          Human substrates and differences to yeast: The human FTSJ1–WDR6 complex
+          generates Gm34 on specific cytosolic tRNAs including tRNAPhe(GAA) and
+          tRNALeu(CAA), and displays substrate selectivity distinct from yeast
+          Trm7–Trm734 (e.g., some yeast targets such as tRNATrp(CCA) are not
+          modified by the human complex) (EMBO Reports, Jun 2020;
+          https://doi.org/10.15252/embr.202050095).
+          (li2020intellectualdisability‐associatedgene pages 9-11)
+  - gap_statement: >-
+      The relationship between WDR6's core tRNA-modification role and its reported
+      LKB1, insulin signaling, lipogenesis, viral restriction, autophagy, and
+      ubiquitin-ligase-associated phenotypes remains unresolved.
+    boundary: >-
+      The core function is WDR6-dependent FTSJ1 Nm34 tRNA modification. Existing
+      cell-cycle and autophagy annotations are kept as non-core or undecided
+      because current evidence does not distinguish direct WDR6 moonlighting
+      functions from downstream consequences of altered translation or
+      context-specific scaffolding.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would prevent broad process over-annotation while
+      identifying any bona fide WDR6-specific signaling or proteostasis functions
+      that should be curated separately from the FTSJ1-WDR6 tRNA pathway.
+    resolution: >-
+      Separation-of-function alleles that retain FTSJ1 binding or tRNA
+      modification while disrupting candidate signaling or ubiquitin-ligase
+      interfaces should be tested across the reported cellular contexts.
+    provenance:
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: >-
+          How WDR6's tRNA modification function relates to its roles in LKB1
+          signaling, insulin signaling, lipogenesis, and viral restriction remains
+          unclear. Are these independent functions, or does tRNA modification
+          status influence these pathways?
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: >-
+          Evidence for alternative functions (LKB1 interaction, insulin signaling,
+          lipogenesis, viral restriction) comes from independent yeast two-hybrid
+          screens, co-immunoprecipitation, and genetic manipulation studies, though
+          these functions may be secondary to or independent from the tRNA
+          modification role.
+  - gap_statement: >-
+      WDR6's tissue-specific and disease-relevant functions remain poorly defined,
+      especially for brain, liver, cancer, and variant-associated phenotypes.
+    boundary: >-
+      WDR6 is mechanistically linked to FTSJ1-dependent tRNA modification and has
+      disease-context evidence from FTSJ1 intellectual-disability biology,
+      metabolic studies, HCC studies, and GWAS signals. The gap is whether WDR6
+      variants or tissue-specific regulation cause distinct human phenotypes and
+      which of those phenotypes are annotation-worthy biology.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would clarify whether WDR6 should receive disease- or
+      tissue-context biological-process annotations, or whether those observations
+      should remain contextual evidence around a conserved tRNA-modification
+      module.
+    resolution: >-
+      Patient-variant functional assays, tissue-specific WDR6 perturbation, and
+      rescue with tRNA-modification-competent versus separation-of-function WDR6
+      alleles should connect genotype, tissue context, and molecular mechanism.
+    provenance:
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: >-
+          WDR6 is ubiquitously expressed, but its specific functions may vary by
+          tissue. The mechanisms controlling tissue-specific WDR6 activity,
+          particularly in brain versus liver, need further investigation.
+      - reference_id: file:human/WDR6/WDR6-deep-research-cyberian.md
+        supporting_text: >-
+          While WDR6 has been identified in GWAS for OCD and other conditions, the
+          functional consequences of specific variants and their contribution to
+          disease pathogenesis remain to be determined.
+      - reference_id: file:human/WDR6/WDR6-deep-research-falcon.md
+        supporting_text: >-
+          While FTSJ1 variants are clearly implicated in NSXLID, the specific
+          contribution of WDR6 variants to human disease via loss of Nm34 has yet
+          to be systematically defined; separation-of-function alleles informed by
+          ortholog studies can address this (ACS Omega, Jun 2024;
+          https://doi.org/10.1021/acsomega.4c02313).
+          (funk2024identificationofamino pages 7-7)
 proposed_new_terms: []
 suggested_questions:
   - question: What structural features of WDR6 determine tRNA substrate


### PR DESCRIPTION
## Summary
- add structured WDR6 knowledge gaps for the human FTSJ1-WDR6 structural mechanism, non-core pathway phenotypes, and tissue/disease specificity
- preserve the accepted core tRNA methylation function while flagging unresolved curation boundaries
- render the updated WDR6 review HTML

## Validation
- `just validate human WDR6`
- `just render human WDR6`
- `git diff --check`