### PR TITLE
Add AP4B1 knowledge gaps

### DIFF
--- a/genes/human/AP4B1/AP4B1-ai-review.html
+++ b/genes/human/AP4B1/AP4B1-ai-review.html
@@ -3502,6 +3502,31 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/AP4B1/AP4B1-deep-research-perplexity.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research review of AP4B1 function (perplexity)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Tepsin has specialized AP-4 accessory roles beyond passive coat assembly.</div>
+
+                        <div class="finding-text">"Tepsin depletion in cells results in partial accumulation of ATG9A at the TGN but causes distinct phenotypes compared to complete AP-4 depletion, indicating that tepsin has specialized functions beyond simply serving as a passive coat component, possibly participating in vesicle internalization or cargo delivery"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -3682,7 +3707,7 @@
 
                 <li><em>"How AP-4 forms coats on vesicles in the absence of clathrin is poorly understood. The role of tepsin-mediated cross-linking of AP-4 complexes in this process requires elucidation."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
 
-                <li><em>"Tepsin depletion in cells results in partial accumulation of ATG9A at the TGN but causes distinct phenotypes compared to complete AP-4 depletion, indicating that tepsin has specialized functions beyond simply serving as a passive coat component, possibly participating in vesicle internalization or cargo delivery"</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+                <li><em>"Tepsin depletion in cells results in partial accumulation of ATG9A at the TGN but causes distinct phenotypes compared to complete AP-4 depletion, indicating that tepsin has specialized functions beyond simply serving as a passive coat component, possibly participating in vesicle internalization or cargo delivery"</em> — file:human/AP4B1/AP4B1-deep-research-perplexity.md</li>
 
             </ul>
 
@@ -5335,6 +5360,17 @@ references:
         supporting_text: &#34;AP-4 recognizes a distinct type of tyrosine-based sorting
           signal with the consensus sequence YXXØE, where Ø represents a bulky hydrophobic
           residue [burgos-2010-app-sorting-abstract][mattera-2017-atg9a-export-abstract].&#34;
+  - id: file:human/AP4B1/AP4B1-deep-research-perplexity.md
+    title: Deep research review of AP4B1 function (perplexity)
+    findings:
+      - statement: Tepsin has specialized AP-4 accessory roles beyond passive coat
+          assembly.
+        supporting_text: &gt;-
+          Tepsin depletion in cells results in partial accumulation of ATG9A at the
+          TGN but causes distinct phenotypes compared to complete AP-4 depletion,
+          indicating that tepsin has specialized functions beyond simply serving as
+          a passive coat component, possibly participating in vesicle
+          internalization or cargo delivery
 
 core_functions:
   - description: &gt;-
@@ -5432,7 +5468,7 @@ knowledge_gaps:
           How AP-4 forms coats on vesicles in the absence of clathrin is poorly
           understood. The role of tepsin-mediated cross-linking of AP-4 complexes
           in this process requires elucidation.
-      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-perplexity.md
         supporting_text: &gt;-
           Tepsin depletion in cells results in partial accumulation of ATG9A at the
           TGN but causes distinct phenotypes compared to complete AP-4 depletion,

--- a/genes/human/AP4B1/AP4B1-ai-review.html
+++ b/genes/human/AP4B1/AP4B1-ai-review.html
@@ -3622,6 +3622,106 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The complete AP-4 cargo repertoire, and which AP4B1-dependent cargoes drive distinct disease-relevant phenotypes, remains incompletely defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already captures the AP-4 complex as a TGN export adaptor and lists well-supported cargoes such as ATG9A, APP, DAGLB, SERINC proteins, Sortilin, and glutamate receptors. The unresolved gap is the full set of AP-4-dependent cargoes and how each cargo contributes to autophagy, lysosome, neuronal polarity, and disease phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would sharpen AP4B1 process annotations by separating the general AP-4 sorting function from cargo-specific downstream biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic proximity labeling, AP-4 vesicle proteomics, cargo-motif mutagenesis, and rescue experiments in neuronal and non-neuronal models should identify cargoes that are direct, context-specific, or secondary.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"While ATG9A, APP, SERINCs, DAGLB, and glutamate receptors have been identified as AP-4 cargoes, the complete repertoire of AP-4 cargo proteins remains incompletely defined. Additional cargoes may be relevant to disease pathophysiology."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+                <li><em>"Cargos: ATG9A is a validated AP-4 cargo across multiple systems; missorting is a hallmark of AP-4 loss. Additional AP-4–dependent localization changes were reported for SERINC1/3 in proteomic mapping studies."</em> — file:human/AP4B1/AP4B1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism by which AP-4 forms a clathrin-independent coat, and the precise role of AP4B1-bound tepsin in that process, remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts AP-4 as a non-clathrin membrane coat and AP4B1 as the beta4 subunit that recruits tepsin through its ear domain. The unresolved point is whether tepsin acts mainly as a structural cross-linker, cargo or autophagy adaptor, vesicle-formation factor, delivery factor, or some combination of these roles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether AP4B1 needs more specific molecular-function representation than molecular adaptor activity and would clarify how to annotate tepsin-dependent AP-4 vesicle formation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstituted AP-4 membrane-budding assays, structural studies of AP-4 with tepsin and cargo, and beta4-ear/tepsin separation-of-function mutants should distinguish coat assembly from cargo delivery and autophagy-coupling roles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The precise role of tepsin in AP-4-mediated trafficking remains unclear. Whether tepsin functions as a structural component, a cargo adaptor, or both requires further investigation."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+                <li><em>"How AP-4 forms coats on vesicles in the absence of clathrin is poorly understood. The role of tepsin-mediated cross-linking of AP-4 complexes in this process requires elucidation."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+                <li><em>"Tepsin depletion in cells results in partial accumulation of ATG9A at the TGN but causes distinct phenotypes compared to complete AP-4 depletion, indicating that tepsin has specialized functions beyond simply serving as a passive coat component, possibly participating in vesicle internalization or cargo delivery"</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The neuronal selectivity of AP-4 deficiency and the balance between developmental cargo-missorting defects and progressive neurodegeneration are not fully resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> AP4B1 loss causes SPG47/AP-4 deficiency syndrome, and several cargo-level mechanisms are plausible, including ATG9A/autophagy, DAGLB/endocannabinoid signaling, Sortilin/lysosome function, and glutamate-receptor polarity. The unresolved gap is how these mechanisms combine across development and disease progression.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would prevent assigning a single downstream pathway as the AP4B1 disease mechanism when multiple cargo defects may contribute at different times or cell types.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Time-resolved neuronal models, cargo-specific rescue experiments, and longitudinal animal or patient-cell studies should determine which defects are causal, compensatory, developmental, or degenerative.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Although AP-4 is ubiquitously expressed, the severe neurological phenotype of AP-4 deficiency suggests particular importance in neurons. The molecular basis for this neuronal selectivity is not fully understood."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+                <li><em>"The relative contributions of developmental defects (e.g., impaired endocannabinoid signaling during axon growth) versus progressive neurodegeneration (e.g., impaired autophagy) to the clinical phenotype require further clarification."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+                <li><em>"The pathophysiology of AP-4 deficiency involves multiple mechanisms stemming from impaired cargo trafficking."</em> — file:human/AP4B1/AP4B1-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -5263,6 +5363,122 @@ core_functions:
     in_complex:
       id: GO:0030124
       label: AP-4 adaptor complex
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The complete AP-4 cargo repertoire, and which AP4B1-dependent cargoes drive
+      distinct disease-relevant phenotypes, remains incompletely defined.
+    boundary: &gt;-
+      The review already captures the AP-4 complex as a TGN export adaptor and
+      lists well-supported cargoes such as ATG9A, APP, DAGLB, SERINC proteins,
+      Sortilin, and glutamate receptors. The unresolved gap is the full set of
+      AP-4-dependent cargoes and how each cargo contributes to autophagy,
+      lysosome, neuronal polarity, and disease phenotypes.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: NARROWING
+    significance: &gt;-
+      Resolving this gap would sharpen AP4B1 process annotations by separating the
+      general AP-4 sorting function from cargo-specific downstream biology.
+    resolution: &gt;-
+      Systematic proximity labeling, AP-4 vesicle proteomics, cargo-motif
+      mutagenesis, and rescue experiments in neuronal and non-neuronal models
+      should identify cargoes that are direct, context-specific, or secondary.
+    provenance:
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          While ATG9A, APP, SERINCs, DAGLB, and glutamate receptors have been
+          identified as AP-4 cargoes, the complete repertoire of AP-4 cargo
+          proteins remains incompletely defined. Additional cargoes may be relevant
+          to disease pathophysiology.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Cargos: ATG9A is a validated AP-4 cargo across multiple systems;
+          missorting is a hallmark of AP-4 loss. Additional AP-4–dependent
+          localization changes were reported for SERINC1/3 in proteomic mapping
+          studies.
+  - gap_statement: &gt;-
+      The mechanism by which AP-4 forms a clathrin-independent coat, and the
+      precise role of AP4B1-bound tepsin in that process, remains unresolved.
+    boundary: &gt;-
+      The review accepts AP-4 as a non-clathrin membrane coat and AP4B1 as the
+      beta4 subunit that recruits tepsin through its ear domain. The unresolved
+      point is whether tepsin acts mainly as a structural cross-linker, cargo or
+      autophagy adaptor, vesicle-formation factor, delivery factor, or some
+      combination of these roles.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine whether AP4B1 needs more specific
+      molecular-function representation than molecular adaptor activity and would
+      clarify how to annotate tepsin-dependent AP-4 vesicle formation.
+    resolution: &gt;-
+      Reconstituted AP-4 membrane-budding assays, structural studies of AP-4 with
+      tepsin and cargo, and beta4-ear/tepsin separation-of-function mutants should
+      distinguish coat assembly from cargo delivery and autophagy-coupling roles.
+    provenance:
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          The precise role of tepsin in AP-4-mediated trafficking remains unclear.
+          Whether tepsin functions as a structural component, a cargo adaptor, or
+          both requires further investigation.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          How AP-4 forms coats on vesicles in the absence of clathrin is poorly
+          understood. The role of tepsin-mediated cross-linking of AP-4 complexes
+          in this process requires elucidation.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Tepsin depletion in cells results in partial accumulation of ATG9A at the
+          TGN but causes distinct phenotypes compared to complete AP-4 depletion,
+          indicating that tepsin has specialized functions beyond simply serving as
+          a passive coat component, possibly participating in vesicle
+          internalization or cargo delivery
+  - gap_statement: &gt;-
+      The neuronal selectivity of AP-4 deficiency and the balance between
+      developmental cargo-missorting defects and progressive neurodegeneration are
+      not fully resolved.
+    boundary: &gt;-
+      AP4B1 loss causes SPG47/AP-4 deficiency syndrome, and several cargo-level
+      mechanisms are plausible, including ATG9A/autophagy, DAGLB/endocannabinoid
+      signaling, Sortilin/lysosome function, and glutamate-receptor polarity. The
+      unresolved gap is how these mechanisms combine across development and
+      disease progression.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would prevent assigning a single downstream pathway as
+      the AP4B1 disease mechanism when multiple cargo defects may contribute at
+      different times or cell types.
+    resolution: &gt;-
+      Time-resolved neuronal models, cargo-specific rescue experiments, and
+      longitudinal animal or patient-cell studies should determine which defects
+      are causal, compensatory, developmental, or degenerative.
+    provenance:
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Although AP-4 is ubiquitously expressed, the severe neurological
+          phenotype of AP-4 deficiency suggests particular importance in neurons.
+          The molecular basis for this neuronal selectivity is not fully
+          understood.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          The relative contributions of developmental defects (e.g., impaired
+          endocannabinoid signaling during axon growth) versus progressive
+          neurodegeneration (e.g., impaired autophagy) to the clinical phenotype
+          require further clarification.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          The pathophysiology of AP-4 deficiency involves multiple mechanisms
+          stemming from impaired cargo trafficking.
 
 suggested_questions:
   - question: &gt;-

--- a/genes/human/AP4B1/AP4B1-ai-review.yaml
+++ b/genes/human/AP4B1/AP4B1-ai-review.yaml
@@ -817,6 +817,17 @@ references:
         supporting_text: "AP-4 recognizes a distinct type of tyrosine-based sorting
           signal with the consensus sequence YXXØE, where Ø represents a bulky hydrophobic
           residue [burgos-2010-app-sorting-abstract][mattera-2017-atg9a-export-abstract]."
+  - id: file:human/AP4B1/AP4B1-deep-research-perplexity.md
+    title: Deep research review of AP4B1 function (perplexity)
+    findings:
+      - statement: Tepsin has specialized AP-4 accessory roles beyond passive coat
+          assembly.
+        supporting_text: >-
+          Tepsin depletion in cells results in partial accumulation of ATG9A at the
+          TGN but causes distinct phenotypes compared to complete AP-4 depletion,
+          indicating that tepsin has specialized functions beyond simply serving as
+          a passive coat component, possibly participating in vesicle
+          internalization or cargo delivery
 
 core_functions:
   - description: >-
@@ -914,7 +925,7 @@ knowledge_gaps:
           How AP-4 forms coats on vesicles in the absence of clathrin is poorly
           understood. The role of tepsin-mediated cross-linking of AP-4 complexes
           in this process requires elucidation.
-      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-perplexity.md
         supporting_text: >-
           Tepsin depletion in cells results in partial accumulation of ATG9A at the
           TGN but causes distinct phenotypes compared to complete AP-4 depletion,

--- a/genes/human/AP4B1/AP4B1-ai-review.yaml
+++ b/genes/human/AP4B1/AP4B1-ai-review.yaml
@@ -845,6 +845,122 @@ core_functions:
     in_complex:
       id: GO:0030124
       label: AP-4 adaptor complex
+knowledge_gaps:
+  - gap_statement: >-
+      The complete AP-4 cargo repertoire, and which AP4B1-dependent cargoes drive
+      distinct disease-relevant phenotypes, remains incompletely defined.
+    boundary: >-
+      The review already captures the AP-4 complex as a TGN export adaptor and
+      lists well-supported cargoes such as ATG9A, APP, DAGLB, SERINC proteins,
+      Sortilin, and glutamate receptors. The unresolved gap is the full set of
+      AP-4-dependent cargoes and how each cargo contributes to autophagy,
+      lysosome, neuronal polarity, and disease phenotypes.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: NARROWING
+    significance: >-
+      Resolving this gap would sharpen AP4B1 process annotations by separating the
+      general AP-4 sorting function from cargo-specific downstream biology.
+    resolution: >-
+      Systematic proximity labeling, AP-4 vesicle proteomics, cargo-motif
+      mutagenesis, and rescue experiments in neuronal and non-neuronal models
+      should identify cargoes that are direct, context-specific, or secondary.
+    provenance:
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          While ATG9A, APP, SERINCs, DAGLB, and glutamate receptors have been
+          identified as AP-4 cargoes, the complete repertoire of AP-4 cargo
+          proteins remains incompletely defined. Additional cargoes may be relevant
+          to disease pathophysiology.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-falcon.md
+        supporting_text: >-
+          Cargos: ATG9A is a validated AP-4 cargo across multiple systems;
+          missorting is a hallmark of AP-4 loss. Additional AP-4–dependent
+          localization changes were reported for SERINC1/3 in proteomic mapping
+          studies.
+  - gap_statement: >-
+      The mechanism by which AP-4 forms a clathrin-independent coat, and the
+      precise role of AP4B1-bound tepsin in that process, remains unresolved.
+    boundary: >-
+      The review accepts AP-4 as a non-clathrin membrane coat and AP4B1 as the
+      beta4 subunit that recruits tepsin through its ear domain. The unresolved
+      point is whether tepsin acts mainly as a structural cross-linker, cargo or
+      autophagy adaptor, vesicle-formation factor, delivery factor, or some
+      combination of these roles.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine whether AP4B1 needs more specific
+      molecular-function representation than molecular adaptor activity and would
+      clarify how to annotate tepsin-dependent AP-4 vesicle formation.
+    resolution: >-
+      Reconstituted AP-4 membrane-budding assays, structural studies of AP-4 with
+      tepsin and cargo, and beta4-ear/tepsin separation-of-function mutants should
+      distinguish coat assembly from cargo delivery and autophagy-coupling roles.
+    provenance:
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          The precise role of tepsin in AP-4-mediated trafficking remains unclear.
+          Whether tepsin functions as a structural component, a cargo adaptor, or
+          both requires further investigation.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          How AP-4 forms coats on vesicles in the absence of clathrin is poorly
+          understood. The role of tepsin-mediated cross-linking of AP-4 complexes
+          in this process requires elucidation.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          Tepsin depletion in cells results in partial accumulation of ATG9A at the
+          TGN but causes distinct phenotypes compared to complete AP-4 depletion,
+          indicating that tepsin has specialized functions beyond simply serving as
+          a passive coat component, possibly participating in vesicle
+          internalization or cargo delivery
+  - gap_statement: >-
+      The neuronal selectivity of AP-4 deficiency and the balance between
+      developmental cargo-missorting defects and progressive neurodegeneration are
+      not fully resolved.
+    boundary: >-
+      AP4B1 loss causes SPG47/AP-4 deficiency syndrome, and several cargo-level
+      mechanisms are plausible, including ATG9A/autophagy, DAGLB/endocannabinoid
+      signaling, Sortilin/lysosome function, and glutamate-receptor polarity. The
+      unresolved gap is how these mechanisms combine across development and
+      disease progression.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would prevent assigning a single downstream pathway as
+      the AP4B1 disease mechanism when multiple cargo defects may contribute at
+      different times or cell types.
+    resolution: >-
+      Time-resolved neuronal models, cargo-specific rescue experiments, and
+      longitudinal animal or patient-cell studies should determine which defects
+      are causal, compensatory, developmental, or degenerative.
+    provenance:
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          Although AP-4 is ubiquitously expressed, the severe neurological
+          phenotype of AP-4 deficiency suggests particular importance in neurons.
+          The molecular basis for this neuronal selectivity is not fully
+          understood.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          The relative contributions of developmental defects (e.g., impaired
+          endocannabinoid signaling during axon growth) versus progressive
+          neurodegeneration (e.g., impaired autophagy) to the clinical phenotype
+          require further clarification.
+      - reference_id: file:human/AP4B1/AP4B1-deep-research-cyberian.md
+        supporting_text: >-
+          The pathophysiology of AP-4 deficiency involves multiple mechanisms
+          stemming from impaired cargo trafficking.
 
 suggested_questions:
   - question: >-


### PR DESCRIPTION
## Summary
- add structured AP4B1 knowledge gaps for cargo completeness, clathrin-independent coat/tepsin mechanism, and neuronal disease selectivity
- keep the established AP-4 transport role intact while clarifying unresolved curation boundaries
- render the updated AP4B1 review HTML

## Validation
- `just validate human AP4B1`
- `just render human AP4B1`
- `git diff --check`