### PR TITLE
Add TMEM70 knowledge gaps

### DIFF
--- a/genes/human/TMEM70/TMEM70-ai-review.html
+++ b/genes/human/TMEM70/TMEM70-ai-review.html
@@ -3152,6 +3152,104 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The structural mechanism by which TMEM70 promotes subunit-c membrane insertion, c-ring nucleation, and handoff to TMEM242 remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already accepts TMEM70 as an ATP synthase assembly scaffold and ATP synthase complex-binding factor. The gap is the precise structural and temporal mechanism of the TMEM70 oligomer, its transient subunit-c intermediates, and how TMEM242 acts downstream or in parallel.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would clarify whether current adaptor/scaffold annotations are sufficient or whether TMEM70 requires a more specific molecular-function term for ATP synthase c-ring assembly assistance.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structural studies of TMEM70 with subunit-c intermediates and TMEM242, together with import and pulse-chase assays for defined mutants, should map the sequence of insertion, oligomerization, and handoff events.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Structural mechanism: The precise structural basis for TMEM70’s assistance in TM2 lateral insertion and c-ring nucleation remains to be fully resolved; oligomerization state and transient complexes with subunit c and TMEM242 are priority targets for structural biology (markovic2023subunitcof pages 7-10, markovic2023subunitcof pages 23-26)."</em> — file:human/TMEM70/TMEM70-deep-research-falcon.md</li>
+
+                <li><em>"High-resolution structural information on TMEM70, particularly in complex with subunit c intermediates, would greatly enhance understanding of its molecular function."</em> — file:human/TMEM70/TMEM70-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> TMEM70&#39;s reported contribution to respiratory-chain complex I assembly or stability remains difficult to distinguish from secondary effects of complex V failure and cristae disruption.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The core curated function is mitochondrial ATP synthase complex assembly. Existing evidence also links TMEM70 to MCIA/complex I intermediates, but it is unresolved whether this represents a direct assembly role, shared membrane-subassembly stabilization, or indirect OXPHOS remodeling after complex V biogenesis fails.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether TMEM70 should be annotated to complex I assembly, retained only as complex V assembly factor, or described through a broader mitochondrial membrane-complex biogenesis process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Complex-I assembly assays in separation-of-function TMEM70 and TMEM242 mutants, controlled for cristae morphology and ATP synthase abundance, should test whether complex I effects persist independently of complex V defects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The dual role of TMEM70 in both Complex I and Complex V assembly requires further elucidation. Does TMEM70 perform similar functions for both complexes, or are the mechanisms distinct?"</em> — file:human/TMEM70/TMEM70-deep-research-cyberian.md</li>
+
+                <li><em>"Pathway spillover: The frequent secondary impact on complex I in TMEM70 deficiency suggests broader consequences for mitochondrial biogenesis/stability under stress or impaired complex V assembly, mirroring phenotypes seen with other mitochondrial chaperone/assembly disturbances (markovic2023subunitcof pages 94-97)."</em> — file:human/TMEM70/TMEM70-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The basis for tissue-specific severity and variable clinical outcome in TMEM70 deficiency remains incompletely understood.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> TMEM70 disease association and ATP synthase deficiency are well established. The unresolved issue is how residual TMEM70 activity, tissue energy demand, cristae/nucleoid remodeling, secondary OXPHOS effects, and intervention timing combine to produce distinct cardiac, neurologic, and survival outcomes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would improve variant interpretation and avoid over-specific clinical-process annotations that do not distinguish primary ATP synthase assembly failure from downstream tissue pathology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Patient genotype-phenotype cohorts, tissue-specific model systems, and calibrated rescue or metabolic-therapy studies should define the amount and timing of TMEM70 activity needed in high-demand tissues.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Why do some tissues show more severe consequences of TMEM70 deficiency than others? The observation of differential effects on cristae structure and nucleoid organization across tissues deserves further investigation."</em> — file:human/TMEM70/TMEM70-deep-research-cyberian.md</li>
+
+                <li><em>"Can gene therapy or other interventions effectively treat TMEM70 deficiency? The transgenic rescue experiments in rats are encouraging but translation to clinical applications remains to be developed."</em> — file:human/TMEM70/TMEM70-deep-research-cyberian.md</li>
+
+                <li><em>"Clinical translation: The preclinical benefits of ketogenic diet in murine models and the demonstration that very low TMEM70 rescues complex V content motivate evaluation of metabolic therapy protocols and gene-replacement approaches in carefully phenotyped patients (markovic2023subunitcof pages 94-97, markovic2023subunitcof pages 1-7)."</em> — file:human/TMEM70/TMEM70-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -4430,6 +4528,119 @@ core_functions:
       and membrane insertion. Multiple studies have demonstrated direct interaction
       between TMEM70 and subunit c using immunoprecipitation and mass spectrometry
       (PMID:31652072, PMID:33359711, PMID:33753518).
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The structural mechanism by which TMEM70 promotes subunit-c membrane
+      insertion, c-ring nucleation, and handoff to TMEM242 remains unresolved.
+    boundary: &gt;-
+      The review already accepts TMEM70 as an ATP synthase assembly scaffold and
+      ATP synthase complex-binding factor. The gap is the precise structural and
+      temporal mechanism of the TMEM70 oligomer, its transient subunit-c
+      intermediates, and how TMEM242 acts downstream or in parallel.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: &gt;-
+      Resolving this gap would clarify whether current adaptor/scaffold
+      annotations are sufficient or whether TMEM70 requires a more specific
+      molecular-function term for ATP synthase c-ring assembly assistance.
+    resolution: &gt;-
+      Structural studies of TMEM70 with subunit-c intermediates and TMEM242,
+      together with import and pulse-chase assays for defined mutants, should map
+      the sequence of insertion, oligomerization, and handoff events.
+    provenance:
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-falcon.md
+        supporting_text: &gt;-
+          Structural mechanism: The precise structural basis for TMEM70’s
+          assistance in TM2 lateral insertion and c-ring nucleation remains to be
+          fully resolved; oligomerization state and transient complexes with
+          subunit c and TMEM242 are priority targets for structural biology
+          (markovic2023subunitcof pages 7-10, markovic2023subunitcof pages
+          23-26).
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: &gt;-
+          High-resolution structural information on TMEM70, particularly in
+          complex with subunit c intermediates, would greatly enhance understanding
+          of its molecular function.
+  - gap_statement: &gt;-
+      TMEM70&#39;s reported contribution to respiratory-chain complex I assembly or
+      stability remains difficult to distinguish from secondary effects of complex
+      V failure and cristae disruption.
+    boundary: &gt;-
+      The core curated function is mitochondrial ATP synthase complex assembly.
+      Existing evidence also links TMEM70 to MCIA/complex I intermediates, but it
+      is unresolved whether this represents a direct assembly role, shared
+      membrane-subassembly stabilization, or indirect OXPHOS remodeling after
+      complex V biogenesis fails.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+      - ONTOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine whether TMEM70 should be annotated to
+      complex I assembly, retained only as complex V assembly factor, or described
+      through a broader mitochondrial membrane-complex biogenesis process.
+    resolution: &gt;-
+      Complex-I assembly assays in separation-of-function TMEM70 and TMEM242
+      mutants, controlled for cristae morphology and ATP synthase abundance, should
+      test whether complex I effects persist independently of complex V defects.
+    provenance:
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: &gt;-
+          The dual role of TMEM70 in both Complex I and Complex V assembly requires
+          further elucidation. Does TMEM70 perform similar functions for both
+          complexes, or are the mechanisms distinct?
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-falcon.md
+        supporting_text: &gt;-
+          Pathway spillover: The frequent secondary impact on complex I in TMEM70
+          deficiency suggests broader consequences for mitochondrial
+          biogenesis/stability under stress or impaired complex V assembly,
+          mirroring phenotypes seen with other mitochondrial chaperone/assembly
+          disturbances (markovic2023subunitcof pages 94-97).
+  - gap_statement: &gt;-
+      The basis for tissue-specific severity and variable clinical outcome in
+      TMEM70 deficiency remains incompletely understood.
+    boundary: &gt;-
+      TMEM70 disease association and ATP synthase deficiency are well established.
+      The unresolved issue is how residual TMEM70 activity, tissue energy demand,
+      cristae/nucleoid remodeling, secondary OXPHOS effects, and intervention
+      timing combine to produce distinct cardiac, neurologic, and survival
+      outcomes.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would improve variant interpretation and avoid
+      over-specific clinical-process annotations that do not distinguish primary
+      ATP synthase assembly failure from downstream tissue pathology.
+    resolution: &gt;-
+      Patient genotype-phenotype cohorts, tissue-specific model systems, and
+      calibrated rescue or metabolic-therapy studies should define the amount and
+      timing of TMEM70 activity needed in high-demand tissues.
+    provenance:
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Why do some tissues show more severe consequences of TMEM70 deficiency
+          than others? The observation of differential effects on cristae structure
+          and nucleoid organization across tissues deserves further investigation.
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Can gene therapy or other interventions effectively treat TMEM70
+          deficiency? The transgenic rescue experiments in rats are encouraging but
+          translation to clinical applications remains to be developed.
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-falcon.md
+        supporting_text: &gt;-
+          Clinical translation: The preclinical benefits of ketogenic diet in
+          murine models and the demonstration that very low TMEM70 rescues complex
+          V content motivate evaluation of metabolic therapy protocols and
+          gene-replacement approaches in carefully phenotyped patients
+          (markovic2023subunitcof pages 94-97, markovic2023subunitcof pages 1-7).
 </code></pre>
             </div>
         </details>

--- a/genes/human/TMEM70/TMEM70-ai-review.yaml
+++ b/genes/human/TMEM70/TMEM70-ai-review.yaml
@@ -731,3 +731,116 @@ core_functions:
       and membrane insertion. Multiple studies have demonstrated direct interaction
       between TMEM70 and subunit c using immunoprecipitation and mass spectrometry
       (PMID:31652072, PMID:33359711, PMID:33753518).
+knowledge_gaps:
+  - gap_statement: >-
+      The structural mechanism by which TMEM70 promotes subunit-c membrane
+      insertion, c-ring nucleation, and handoff to TMEM242 remains unresolved.
+    boundary: >-
+      The review already accepts TMEM70 as an ATP synthase assembly scaffold and
+      ATP synthase complex-binding factor. The gap is the precise structural and
+      temporal mechanism of the TMEM70 oligomer, its transient subunit-c
+      intermediates, and how TMEM242 acts downstream or in parallel.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: >-
+      Resolving this gap would clarify whether current adaptor/scaffold
+      annotations are sufficient or whether TMEM70 requires a more specific
+      molecular-function term for ATP synthase c-ring assembly assistance.
+    resolution: >-
+      Structural studies of TMEM70 with subunit-c intermediates and TMEM242,
+      together with import and pulse-chase assays for defined mutants, should map
+      the sequence of insertion, oligomerization, and handoff events.
+    provenance:
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-falcon.md
+        supporting_text: >-
+          Structural mechanism: The precise structural basis for TMEM70’s
+          assistance in TM2 lateral insertion and c-ring nucleation remains to be
+          fully resolved; oligomerization state and transient complexes with
+          subunit c and TMEM242 are priority targets for structural biology
+          (markovic2023subunitcof pages 7-10, markovic2023subunitcof pages
+          23-26).
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: >-
+          High-resolution structural information on TMEM70, particularly in
+          complex with subunit c intermediates, would greatly enhance understanding
+          of its molecular function.
+  - gap_statement: >-
+      TMEM70's reported contribution to respiratory-chain complex I assembly or
+      stability remains difficult to distinguish from secondary effects of complex
+      V failure and cristae disruption.
+    boundary: >-
+      The core curated function is mitochondrial ATP synthase complex assembly.
+      Existing evidence also links TMEM70 to MCIA/complex I intermediates, but it
+      is unresolved whether this represents a direct assembly role, shared
+      membrane-subassembly stabilization, or indirect OXPHOS remodeling after
+      complex V biogenesis fails.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+      - ONTOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine whether TMEM70 should be annotated to
+      complex I assembly, retained only as complex V assembly factor, or described
+      through a broader mitochondrial membrane-complex biogenesis process.
+    resolution: >-
+      Complex-I assembly assays in separation-of-function TMEM70 and TMEM242
+      mutants, controlled for cristae morphology and ATP synthase abundance, should
+      test whether complex I effects persist independently of complex V defects.
+    provenance:
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: >-
+          The dual role of TMEM70 in both Complex I and Complex V assembly requires
+          further elucidation. Does TMEM70 perform similar functions for both
+          complexes, or are the mechanisms distinct?
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-falcon.md
+        supporting_text: >-
+          Pathway spillover: The frequent secondary impact on complex I in TMEM70
+          deficiency suggests broader consequences for mitochondrial
+          biogenesis/stability under stress or impaired complex V assembly,
+          mirroring phenotypes seen with other mitochondrial chaperone/assembly
+          disturbances (markovic2023subunitcof pages 94-97).
+  - gap_statement: >-
+      The basis for tissue-specific severity and variable clinical outcome in
+      TMEM70 deficiency remains incompletely understood.
+    boundary: >-
+      TMEM70 disease association and ATP synthase deficiency are well established.
+      The unresolved issue is how residual TMEM70 activity, tissue energy demand,
+      cristae/nucleoid remodeling, secondary OXPHOS effects, and intervention
+      timing combine to produce distinct cardiac, neurologic, and survival
+      outcomes.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would improve variant interpretation and avoid
+      over-specific clinical-process annotations that do not distinguish primary
+      ATP synthase assembly failure from downstream tissue pathology.
+    resolution: >-
+      Patient genotype-phenotype cohorts, tissue-specific model systems, and
+      calibrated rescue or metabolic-therapy studies should define the amount and
+      timing of TMEM70 activity needed in high-demand tissues.
+    provenance:
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: >-
+          Why do some tissues show more severe consequences of TMEM70 deficiency
+          than others? The observation of differential effects on cristae structure
+          and nucleoid organization across tissues deserves further investigation.
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-cyberian.md
+        supporting_text: >-
+          Can gene therapy or other interventions effectively treat TMEM70
+          deficiency? The transgenic rescue experiments in rats are encouraging but
+          translation to clinical applications remains to be developed.
+      - reference_id: file:human/TMEM70/TMEM70-deep-research-falcon.md
+        supporting_text: >-
+          Clinical translation: The preclinical benefits of ketogenic diet in
+          murine models and the demonstration that very low TMEM70 rescues complex
+          V content motivate evaluation of metabolic therapy protocols and
+          gene-replacement approaches in carefully phenotyped patients
+          (markovic2023subunitcof pages 94-97, markovic2023subunitcof pages 1-7).


### PR DESCRIPTION
## Summary
- add structured TMEM70 knowledge gaps for c-ring assembly mechanism, complex I curation boundary, and tissue/clinical variability
- preserve the accepted ATP synthase assembly core function while flagging unresolved mechanistic edges
- render the updated TMEM70 review HTML

## Validation
- `just validate human TMEM70`
- `just render human TMEM70`
- `git diff --check`