### PR TITLE
Add AFAP1 knowledge gaps

### DIFF
--- a/genes/human/AFAP1/AFAP1-ai-review.html
+++ b/genes/human/AFAP1/AFAP1-ai-review.html
@@ -2341,6 +2341,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The structural mechanism separating AFAP1 actin cross-linking, multimerization, autoinhibition, and Src activation remains incompletely resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already captures AFAP1 as an actin-binding molecular adaptor that links Src/PKC signaling to actin structures. The unresolved gap is how AFAP1&#39;s domain rearrangements and oligomeric states tune direct actin cross-linking versus kinase-adaptor functions in different cellular contexts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine whether current actin-binding and molecular-adaptor terms are sufficient, or whether more specific terms for signal-regulated actin cross-linking/scaffold activity are needed.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> High-resolution AFAP1 structures and separation-of-function mutants that selectively disrupt actin binding, Src binding, PKC regulation, or multimerization should be tested in matched adhesion, podosome, invadopodia, and lactation-relevant assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"No experimentally determined high-resolution crystal or cryo-EM structure of AFAP1 or its domains is currently available. However, an AlphaFold-predicted structure is available through the AlphaFold Protein Structure Database (entry Q8N556), which may provide insights into domain organization and the auto-inhibitory mechanism. Experimental validation of the predicted structure and its conformational dynamics would greatly enhance understanding of AFAP1 function."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+                <li><em>"While it is clear that AFAP1 exists in multiple oligomeric states and that transitions between these states are regulated, the precise structural changes and the upstream signals that control them remain incompletely defined."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+                <li><em>"The relative roles of AFAP1-mediated Src activation versus AFAP1&#39;s direct actin cross-linking activity in promoting different cellular processes remain incompletely understood, and future studies using mutants specifically defective in either Src binding or actin binding might clarify these distinct contributions."</em> — file:human/AFAP1/AFAP1-deep-research-perplexity.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> AFAP1&#39;s contribution to cancer invasion, metastasis, and S403C variant-dependent Src activation remains incompletely resolved in vivo.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports AFAP1 roles in stress fibers, focal adhesions, Src/PKC signaling, and podosome/invadopodia biology. The unresolved gap is whether these cell-based phenotypes translate into direct metastatic dissemination mechanisms, prognostic utility, or genotype-specific cancer risk for AFAP1 protein variants.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would distinguish core cytoskeletal signaling functions from cancer-context observations and prevent assigning broad metastasis annotations without in vivo causal evidence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vivo metastasis models, patient genotype-expression analyses, and separation-of-function testing of AFAP1(403C), Src binding, and PKC-binding mutants should identify which cancer phenotypes are direct AFAP1 protein functions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Although AFAP1 is overexpressed in prostate and breast cancers and contributes to migration and invasion, its precise contribution to metastatic dissemination in vivo remains to be determined."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+                <li><em>"In cells with elevated c-Src expression, AFAP1(403C) directs c-Src activation and podosome formation independently of upstream signals, in contrast to wild-type AFAP1 which requires PKC activation."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+                <li><em>"The polymorphic variant AFAP1(403C) appears to constitutively activate c-Src, but the structural basis for this gain-of-function, and whether it contributes to cancer risk in the general population, requires further investigation."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> AFAP1 locus disease associations, including glaucoma risk and AFAP1-AS1 cancer biology, are not yet cleanly mapped to AFAP1 protein function.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> AFAP1 protein has established actin/Src adaptor functions, while the AFAP1 locus also contains GWAS signals and the AFAP1-AS1 antisense lncRNA. The unresolved gap is which disease observations reflect AFAP1 protein activity, isoform-specific biology, noncoding regulatory effects, or independent AFAP1-AS1 functions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would help curators avoid importing AFAP1-AS1 or locus association biology into AFAP1 protein annotations while preserving genuine ocular, neuronal, or tissue-specific protein functions if validated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Fine-mapped regulatory variants, isoform-resolved expression and perturbation in ocular and neuronal models, and experiments separating AFAP1-AS1 from AFAP1 protein expression should define the causal entity at the locus.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The GWAS association between AFAP1 variants and primary open-angle glaucoma is robust, but the mechanistic basis for this association remains unknown. Does AFAP1 play a direct role in trabecular meshwork function, retinal ganglion cell survival, or optic nerve health? Is the risk variant a gain- or loss-of-function allele?"</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+                <li><em>"AFAP1-AS1 has emerged as a topic of considerable research interest in cancer biology, independent of AFAP1 protein function."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+                <li><em>"While AFAP1-AS1 can influence AFAP1 protein expression in some contexts, it also has AFAP1-independent functions. The existence of this cancer-associated lncRNA at the AFAP1 locus adds another layer of complexity to understanding the biology of this genomic region, though the functional relationship between AFAP1-AS1 and AFAP1 protein remains an area of active investigation."</em> — file:human/AFAP1/AFAP1-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -3651,6 +3753,137 @@ core_functions:
         label: actin cytoskeleton
       - id: GO:0005886
         label: plasma membrane
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The structural mechanism separating AFAP1 actin cross-linking,
+      multimerization, autoinhibition, and Src activation remains incompletely
+      resolved.
+    boundary: &gt;-
+      The review already captures AFAP1 as an actin-binding molecular adaptor that
+      links Src/PKC signaling to actin structures. The unresolved gap is how
+      AFAP1&#39;s domain rearrangements and oligomeric states tune direct actin
+      cross-linking versus kinase-adaptor functions in different cellular
+      contexts.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine whether current actin-binding and
+      molecular-adaptor terms are sufficient, or whether more specific terms for
+      signal-regulated actin cross-linking/scaffold activity are needed.
+    resolution: &gt;-
+      High-resolution AFAP1 structures and separation-of-function mutants that
+      selectively disrupt actin binding, Src binding, PKC regulation, or
+      multimerization should be tested in matched adhesion, podosome, invadopodia,
+      and lactation-relevant assays.
+    provenance:
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          No experimentally determined high-resolution crystal or cryo-EM
+          structure of AFAP1 or its domains is currently available. However, an
+          AlphaFold-predicted structure is available through the AlphaFold Protein
+          Structure Database (entry Q8N556), which may provide insights into
+          domain organization and the auto-inhibitory mechanism. Experimental
+          validation of the predicted structure and its conformational dynamics
+          would greatly enhance understanding of AFAP1 function.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          While it is clear that AFAP1 exists in multiple oligomeric states and
+          that transitions between these states are regulated, the precise
+          structural changes and the upstream signals that control them remain
+          incompletely defined.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-perplexity.md
+        supporting_text: &gt;-
+          The relative roles of AFAP1-mediated Src activation versus AFAP1&#39;s
+          direct actin cross-linking activity in promoting different cellular
+          processes remain incompletely understood, and future studies using
+          mutants specifically defective in either Src binding or actin binding
+          might clarify these distinct contributions.
+  - gap_statement: &gt;-
+      AFAP1&#39;s contribution to cancer invasion, metastasis, and S403C
+      variant-dependent Src activation remains incompletely resolved in vivo.
+    boundary: &gt;-
+      The review supports AFAP1 roles in stress fibers, focal adhesions, Src/PKC
+      signaling, and podosome/invadopodia biology. The unresolved gap is whether
+      these cell-based phenotypes translate into direct metastatic dissemination
+      mechanisms, prognostic utility, or genotype-specific cancer risk for AFAP1
+      protein variants.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would distinguish core cytoskeletal signaling functions
+      from cancer-context observations and prevent assigning broad metastasis
+      annotations without in vivo causal evidence.
+    resolution: &gt;-
+      In vivo metastasis models, patient genotype-expression analyses, and
+      separation-of-function testing of AFAP1(403C), Src binding, and PKC-binding
+      mutants should identify which cancer phenotypes are direct AFAP1 protein
+      functions.
+    provenance:
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Although AFAP1 is overexpressed in prostate and breast cancers and
+          contributes to migration and invasion, its precise contribution to
+          metastatic dissemination in vivo remains to be determined.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          In cells with elevated c-Src expression, AFAP1(403C) directs c-Src
+          activation and podosome formation independently of upstream signals, in
+          contrast to wild-type AFAP1 which requires PKC activation.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          The polymorphic variant AFAP1(403C) appears to constitutively activate
+          c-Src, but the structural basis for this gain-of-function, and whether
+          it contributes to cancer risk in the general population, requires further
+          investigation.
+  - gap_statement: &gt;-
+      AFAP1 locus disease associations, including glaucoma risk and AFAP1-AS1
+      cancer biology, are not yet cleanly mapped to AFAP1 protein function.
+    boundary: &gt;-
+      AFAP1 protein has established actin/Src adaptor functions, while the AFAP1
+      locus also contains GWAS signals and the AFAP1-AS1 antisense lncRNA. The
+      unresolved gap is which disease observations reflect AFAP1 protein activity,
+      isoform-specific biology, noncoding regulatory effects, or independent
+      AFAP1-AS1 functions.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would help curators avoid importing AFAP1-AS1 or locus
+      association biology into AFAP1 protein annotations while preserving genuine
+      ocular, neuronal, or tissue-specific protein functions if validated.
+    resolution: &gt;-
+      Fine-mapped regulatory variants, isoform-resolved expression and perturbation
+      in ocular and neuronal models, and experiments separating AFAP1-AS1 from
+      AFAP1 protein expression should define the causal entity at the locus.
+    provenance:
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          The GWAS association between AFAP1 variants and primary open-angle
+          glaucoma is robust, but the mechanistic basis for this association
+          remains unknown. Does AFAP1 play a direct role in trabecular meshwork
+          function, retinal ganglion cell survival, or optic nerve health? Is the
+          risk variant a gain- or loss-of-function allele?
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          AFAP1-AS1 has emerged as a topic of considerable research interest in
+          cancer biology, independent of AFAP1 protein function.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          While AFAP1-AS1 can influence AFAP1 protein expression in some contexts,
+          it also has AFAP1-independent functions. The existence of this
+          cancer-associated lncRNA at the AFAP1 locus adds another layer of
+          complexity to understanding the biology of this genomic region, though
+          the functional relationship between AFAP1-AS1 and AFAP1 protein remains
+          an area of active investigation.
 </code></pre>
             </div>
         </details>

--- a/genes/human/AFAP1/AFAP1-ai-review.yaml
+++ b/genes/human/AFAP1/AFAP1-ai-review.yaml
@@ -498,3 +498,134 @@ core_functions:
         label: actin cytoskeleton
       - id: GO:0005886
         label: plasma membrane
+knowledge_gaps:
+  - gap_statement: >-
+      The structural mechanism separating AFAP1 actin cross-linking,
+      multimerization, autoinhibition, and Src activation remains incompletely
+      resolved.
+    boundary: >-
+      The review already captures AFAP1 as an actin-binding molecular adaptor that
+      links Src/PKC signaling to actin structures. The unresolved gap is how
+      AFAP1's domain rearrangements and oligomeric states tune direct actin
+      cross-linking versus kinase-adaptor functions in different cellular
+      contexts.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine whether current actin-binding and
+      molecular-adaptor terms are sufficient, or whether more specific terms for
+      signal-regulated actin cross-linking/scaffold activity are needed.
+    resolution: >-
+      High-resolution AFAP1 structures and separation-of-function mutants that
+      selectively disrupt actin binding, Src binding, PKC regulation, or
+      multimerization should be tested in matched adhesion, podosome, invadopodia,
+      and lactation-relevant assays.
+    provenance:
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          No experimentally determined high-resolution crystal or cryo-EM
+          structure of AFAP1 or its domains is currently available. However, an
+          AlphaFold-predicted structure is available through the AlphaFold Protein
+          Structure Database (entry Q8N556), which may provide insights into
+          domain organization and the auto-inhibitory mechanism. Experimental
+          validation of the predicted structure and its conformational dynamics
+          would greatly enhance understanding of AFAP1 function.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          While it is clear that AFAP1 exists in multiple oligomeric states and
+          that transitions between these states are regulated, the precise
+          structural changes and the upstream signals that control them remain
+          incompletely defined.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-perplexity.md
+        supporting_text: >-
+          The relative roles of AFAP1-mediated Src activation versus AFAP1's
+          direct actin cross-linking activity in promoting different cellular
+          processes remain incompletely understood, and future studies using
+          mutants specifically defective in either Src binding or actin binding
+          might clarify these distinct contributions.
+  - gap_statement: >-
+      AFAP1's contribution to cancer invasion, metastasis, and S403C
+      variant-dependent Src activation remains incompletely resolved in vivo.
+    boundary: >-
+      The review supports AFAP1 roles in stress fibers, focal adhesions, Src/PKC
+      signaling, and podosome/invadopodia biology. The unresolved gap is whether
+      these cell-based phenotypes translate into direct metastatic dissemination
+      mechanisms, prognostic utility, or genotype-specific cancer risk for AFAP1
+      protein variants.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would distinguish core cytoskeletal signaling functions
+      from cancer-context observations and prevent assigning broad metastasis
+      annotations without in vivo causal evidence.
+    resolution: >-
+      In vivo metastasis models, patient genotype-expression analyses, and
+      separation-of-function testing of AFAP1(403C), Src binding, and PKC-binding
+      mutants should identify which cancer phenotypes are direct AFAP1 protein
+      functions.
+    provenance:
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          Although AFAP1 is overexpressed in prostate and breast cancers and
+          contributes to migration and invasion, its precise contribution to
+          metastatic dissemination in vivo remains to be determined.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          In cells with elevated c-Src expression, AFAP1(403C) directs c-Src
+          activation and podosome formation independently of upstream signals, in
+          contrast to wild-type AFAP1 which requires PKC activation.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          The polymorphic variant AFAP1(403C) appears to constitutively activate
+          c-Src, but the structural basis for this gain-of-function, and whether
+          it contributes to cancer risk in the general population, requires further
+          investigation.
+  - gap_statement: >-
+      AFAP1 locus disease associations, including glaucoma risk and AFAP1-AS1
+      cancer biology, are not yet cleanly mapped to AFAP1 protein function.
+    boundary: >-
+      AFAP1 protein has established actin/Src adaptor functions, while the AFAP1
+      locus also contains GWAS signals and the AFAP1-AS1 antisense lncRNA. The
+      unresolved gap is which disease observations reflect AFAP1 protein activity,
+      isoform-specific biology, noncoding regulatory effects, or independent
+      AFAP1-AS1 functions.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would help curators avoid importing AFAP1-AS1 or locus
+      association biology into AFAP1 protein annotations while preserving genuine
+      ocular, neuronal, or tissue-specific protein functions if validated.
+    resolution: >-
+      Fine-mapped regulatory variants, isoform-resolved expression and perturbation
+      in ocular and neuronal models, and experiments separating AFAP1-AS1 from
+      AFAP1 protein expression should define the causal entity at the locus.
+    provenance:
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          The GWAS association between AFAP1 variants and primary open-angle
+          glaucoma is robust, but the mechanistic basis for this association
+          remains unknown. Does AFAP1 play a direct role in trabecular meshwork
+          function, retinal ganglion cell survival, or optic nerve health? Is the
+          risk variant a gain- or loss-of-function allele?
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          AFAP1-AS1 has emerged as a topic of considerable research interest in
+          cancer biology, independent of AFAP1 protein function.
+      - reference_id: file:human/AFAP1/AFAP1-deep-research-cyberian.md
+        supporting_text: >-
+          While AFAP1-AS1 can influence AFAP1 protein expression in some contexts,
+          it also has AFAP1-independent functions. The existence of this
+          cancer-associated lncRNA at the AFAP1 locus adds another layer of
+          complexity to understanding the biology of this genomic region, though
+          the functional relationship between AFAP1-AS1 and AFAP1 protein remains
+          an area of active investigation.


### PR DESCRIPTION
## Summary
- add structured AFAP1 knowledge gaps for actin/Src mechanism, cancer/metastasis and S403C boundaries, and AFAP1 locus disease-association interpretation
- distinguish AFAP1 protein function from AFAP1-AS1 and GWAS-locus biology
- render the updated AFAP1 review HTML

## Validation
- `just validate human AFAP1`
- `just render human AFAP1`
- `git diff --check`