### PR TITLE
Add AP3B2 knowledge gaps

### DIFF
--- a/genes/human/AP3B2/AP3B2-ai-review.html
+++ b/genes/human/AP3B2/AP3B2-ai-review.html
@@ -3397,6 +3397,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The relationship between AP3B2/AP-3 clathrin binding and Arf1-driven, clathrin-independent AP-3 coat initiation remains incompletely resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts AP3B2 as a beta subunit of the AP-3 adaptor complex and includes clathrin-cargo adaptor activity supported by older AP-3 biochemical evidence. Newer structural work supports an Arf1-mediated clathrin-independent coat-initiation model, leaving a curation boundary around when clathrin binding is mechanistically central versus accessory or context-dependent.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would clarify whether AP3B2 should be represented primarily as a clathrin-cargo adaptor, as part of an AP-3 cargo adaptor/coat assembly activity, or with context-specific annotations for different AP-3 carrier types.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstituted neuronal AP-3 assays comparing clathrin, Arf1, lipid composition, cargo class, and beta3B hinge/appendage mutants should define which AP3B2-dependent vesicles require clathrin and which are initiated by Arf1-dependent AP-3 polymerization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Clathrin dependence: While AP-3 possesses a clathrin-binding motif, multiple lines of evidence—including 2024 structural work—support clathrin-independent coat assembly by AP-3 on endosomal membranes (Dec 2024; https://doi.org/10.1073/pnas.2411974121; Oct 2019; https://doi.org/10.1146/annurev-cellbio-100818-125234) (begley2024astructurebasedmechanism pages 8-9, dellangelica2019coatopathiesgeneticdisorders pages 18-20)."</em> — file:human/AP3B2/AP3B2-deep-research-falcon.md</li>
+
+                <li><em>"While clathrin can associate with AP-3, the identification of other coat proteins such as VPS41 raises questions about the complete molecular composition of the AP-3 vesicle coat and whether different coat assemblies serve distinct functions."</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+                <li><em>"Direct interactions between AP-3 and membrane lipids have not been definitively identified. Understanding which phosphoinositides or other lipids regulate AP-3 recruitment and function could reveal new regulatory mechanisms."</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The complete neuronal AP-3 trafficking itinerary and cargo repertoire remain unresolved, including how AP3B2-containing AP-3 differs from ubiquitous AP3B1-containing AP-3 at shared endosomal compartments.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review captures established AP3B2 neuronal AP-3 functions in synaptic vesicle transport, high-frequency-responsive vesicles, ZnT3/ClC-3 sorting, VMAT2 polarity, and ATP8A1/TMEM30A recruitment. The gap is the full route and cargo-selection logic that separates neuronal AP-3, ubiquitous AP-3, BLOC-1, and parallel synaptic-vesicle pathways.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would prevent overgeneralizing all neuronal vesicle phenotypes to AP3B2 while enabling more precise process annotations for specific cargo classes, brain regions, and activity states.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Cargo proteomics, live trafficking, compartment-resolved perturbation of beta3B versus beta3A, and BLOC-1 interaction studies across neuronal subtypes should define direct AP3B2 cargoes and their route to functional vesicle pools.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The exact sequence of steps by which AP-3 mediates cargo transport from the TGN or endosomes to synaptic vesicles has not been fully elucidated. Whether AP-3 vesicles fuse directly with forming synaptic vesicles or pass through intermediate compartments remains unclear."</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+                <li><em>"The complete repertoire of neuronal AP-3 cargoes and how cargo selection differs between neuronal and ubiquitous AP-3 isoforms remains to be fully characterized."</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+                <li><em>"The functional relationship between AP-3 and BLOC-1 is not obligatory for all cargo proteins. Both AP-3 isoforms recognize distinct as well as overlapping membrane protein cargoes independently of BLOC-1, and not all synaptic vesicle proteins reach synaptic vesicle pools through an AP-3-BLOC-1 route"</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The causal chain from AP3B2 loss to DEE48 seizures, developmental delay, and region-specific synaptic dysfunction remains incompletely defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> AP3B2 loss-of-function disease association is established, and neuronal AP-3 defects affect synaptic vesicle composition and neurotransmitter release. The unresolved gap is which AP3B2-dependent cargoes, release modes, brain regions, and compensatory pathways drive the human DEE48 phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would connect AP3B2 molecular cargo-sorting functions to disease-relevant neuronal pathways without assigning broad epilepsy or neurodevelopmental process annotations from genetic association alone.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Patient-variant models, neuronal subtype-specific rescue, cargo-specific bypass experiments, and activity-dependent release assays should distinguish primary AP3B2 cargo defects from downstream network consequences.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Functional analysis of the mutations suggests a loss-of-function mechanism, consistent with the critical role of AP3B2 in neuronal synaptic vesicle trafficking and neurotransmitter release."</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+                <li><em>"The mechanisms underlying the differential effects of AP-3 loss in different brain regions (e.g., opposite effects on synaptic vesicle size in striatum versus dentate gyrus) warrant further investigation."</em> — file:human/AP3B2/AP3B2-deep-research-cyberian.md</li>
+
+                <li><em>"Future investigations should focus on elucidating the precise molecular mechanisms by which AP3B2 mutations impair synaptic vesicle biogenesis and neuronal function, characterizing the protein-protein interactions that regulate AP-3 activity in response to neuronal stimulation and calcium influx, and identifying novel AP-3 cargo proteins that may contribute to the pathogenesis of AP3B2-associated disease."</em> — file:human/AP3B2/AP3B2-deep-research-perplexity.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -4560,6 +4662,137 @@ core_functions:
     supporting_text: &#34;Our results suggest that concerted nonredundant functions of neuronal and ubiquitous AP-3 provide a mechanism to control the levels of selected membrane proteins in synaptic vesicles.&#34;
   - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
     supporting_text: &#34;AP-3 generates a subset of synaptic vesicles that respond specifically to high-frequency stimulation. Proteomics analysis identified the phospholipid flippase ATP8A1 and its auxiliary subunit TMEM30A as AP-3-dependent synaptic vesicle cargoes.&#34;
+knowledge_gaps:
+- gap_statement: &gt;-
+    The relationship between AP3B2/AP-3 clathrin binding and Arf1-driven,
+    clathrin-independent AP-3 coat initiation remains incompletely resolved.
+  boundary: &gt;-
+    The review accepts AP3B2 as a beta subunit of the AP-3 adaptor complex and
+    includes clathrin-cargo adaptor activity supported by older AP-3 biochemical
+    evidence. Newer structural work supports an Arf1-mediated
+    clathrin-independent coat-initiation model, leaving a curation boundary around
+    when clathrin binding is mechanistically central versus accessory or
+    context-dependent.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: NARROWING
+  significance: &gt;-
+    Resolving this gap would clarify whether AP3B2 should be represented primarily
+    as a clathrin-cargo adaptor, as part of an AP-3 cargo adaptor/coat assembly
+    activity, or with context-specific annotations for different AP-3 carrier
+    types.
+  resolution: &gt;-
+    Reconstituted neuronal AP-3 assays comparing clathrin, Arf1, lipid
+    composition, cargo class, and beta3B hinge/appendage mutants should define
+    which AP3B2-dependent vesicles require clathrin and which are initiated by
+    Arf1-dependent AP-3 polymerization.
+  provenance:
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-falcon.md
+    supporting_text: &gt;-
+      Clathrin dependence: While AP-3 possesses a clathrin-binding motif, multiple
+      lines of evidence—including 2024 structural work—support
+      clathrin-independent coat assembly by AP-3 on endosomal membranes (Dec
+      2024; https://doi.org/10.1073/pnas.2411974121; Oct 2019;
+      https://doi.org/10.1146/annurev-cellbio-100818-125234)
+      (begley2024astructurebasedmechanism pages 8-9,
+      dellangelica2019coatopathiesgeneticdisorders pages 18-20).
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      While clathrin can associate with AP-3, the identification of other coat
+      proteins such as VPS41 raises questions about the complete molecular
+      composition of the AP-3 vesicle coat and whether different coat assemblies
+      serve distinct functions.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      Direct interactions between AP-3 and membrane lipids have not been
+      definitively identified. Understanding which phosphoinositides or other
+      lipids regulate AP-3 recruitment and function could reveal new regulatory
+      mechanisms.
+- gap_statement: &gt;-
+    The complete neuronal AP-3 trafficking itinerary and cargo repertoire remain
+    unresolved, including how AP3B2-containing AP-3 differs from ubiquitous
+    AP3B1-containing AP-3 at shared endosomal compartments.
+  boundary: &gt;-
+    The review captures established AP3B2 neuronal AP-3 functions in synaptic
+    vesicle transport, high-frequency-responsive vesicles, ZnT3/ClC-3 sorting,
+    VMAT2 polarity, and ATP8A1/TMEM30A recruitment. The gap is the full route and
+    cargo-selection logic that separates neuronal AP-3, ubiquitous AP-3, BLOC-1,
+    and parallel synaptic-vesicle pathways.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would prevent overgeneralizing all neuronal vesicle
+    phenotypes to AP3B2 while enabling more precise process annotations for
+    specific cargo classes, brain regions, and activity states.
+  resolution: &gt;-
+    Cargo proteomics, live trafficking, compartment-resolved perturbation of beta3B
+    versus beta3A, and BLOC-1 interaction studies across neuronal subtypes should
+    define direct AP3B2 cargoes and their route to functional vesicle pools.
+  provenance:
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      The exact sequence of steps by which AP-3 mediates cargo transport from the
+      TGN or endosomes to synaptic vesicles has not been fully elucidated. Whether
+      AP-3 vesicles fuse directly with forming synaptic vesicles or pass through
+      intermediate compartments remains unclear.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      The complete repertoire of neuronal AP-3 cargoes and how cargo selection
+      differs between neuronal and ubiquitous AP-3 isoforms remains to be fully
+      characterized.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      The functional relationship between AP-3 and BLOC-1 is not obligatory for
+      all cargo proteins. Both AP-3 isoforms recognize distinct as well as
+      overlapping membrane protein cargoes independently of BLOC-1, and not all
+      synaptic vesicle proteins reach synaptic vesicle pools through an AP-3-BLOC-1
+      route
+- gap_statement: &gt;-
+    The causal chain from AP3B2 loss to DEE48 seizures, developmental delay, and
+    region-specific synaptic dysfunction remains incompletely defined.
+  boundary: &gt;-
+    AP3B2 loss-of-function disease association is established, and neuronal AP-3
+    defects affect synaptic vesicle composition and neurotransmitter release. The
+    unresolved gap is which AP3B2-dependent cargoes, release modes, brain regions,
+    and compensatory pathways drive the human DEE48 phenotype.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this gap would connect AP3B2 molecular cargo-sorting functions to
+    disease-relevant neuronal pathways without assigning broad epilepsy or
+    neurodevelopmental process annotations from genetic association alone.
+  resolution: &gt;-
+    Patient-variant models, neuronal subtype-specific rescue, cargo-specific
+    bypass experiments, and activity-dependent release assays should distinguish
+    primary AP3B2 cargo defects from downstream network consequences.
+  provenance:
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      Functional analysis of the mutations suggests a loss-of-function mechanism,
+      consistent with the critical role of AP3B2 in neuronal synaptic vesicle
+      trafficking and neurotransmitter release.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: &gt;-
+      The mechanisms underlying the differential effects of AP-3 loss in different
+      brain regions (e.g., opposite effects on synaptic vesicle size in striatum
+      versus dentate gyrus) warrant further investigation.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-perplexity.md
+    supporting_text: &gt;-
+      Future investigations should focus on elucidating the precise molecular
+      mechanisms by which AP3B2 mutations impair synaptic vesicle biogenesis and
+      neuronal function, characterizing the protein-protein interactions that
+      regulate AP-3 activity in response to neuronal stimulation and calcium
+      influx, and identifying novel AP-3 cargo proteins that may contribute to the
+      pathogenesis of AP3B2-associated disease.
 </code></pre>
             </div>
         </details>

--- a/genes/human/AP3B2/AP3B2-ai-review.yaml
+++ b/genes/human/AP3B2/AP3B2-ai-review.yaml
@@ -615,3 +615,134 @@ core_functions:
     supporting_text: "Our results suggest that concerted nonredundant functions of neuronal and ubiquitous AP-3 provide a mechanism to control the levels of selected membrane proteins in synaptic vesicles."
   - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
     supporting_text: "AP-3 generates a subset of synaptic vesicles that respond specifically to high-frequency stimulation. Proteomics analysis identified the phospholipid flippase ATP8A1 and its auxiliary subunit TMEM30A as AP-3-dependent synaptic vesicle cargoes."
+knowledge_gaps:
+- gap_statement: >-
+    The relationship between AP3B2/AP-3 clathrin binding and Arf1-driven,
+    clathrin-independent AP-3 coat initiation remains incompletely resolved.
+  boundary: >-
+    The review accepts AP3B2 as a beta subunit of the AP-3 adaptor complex and
+    includes clathrin-cargo adaptor activity supported by older AP-3 biochemical
+    evidence. Newer structural work supports an Arf1-mediated
+    clathrin-independent coat-initiation model, leaving a curation boundary around
+    when clathrin binding is mechanistically central versus accessory or
+    context-dependent.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: NARROWING
+  significance: >-
+    Resolving this gap would clarify whether AP3B2 should be represented primarily
+    as a clathrin-cargo adaptor, as part of an AP-3 cargo adaptor/coat assembly
+    activity, or with context-specific annotations for different AP-3 carrier
+    types.
+  resolution: >-
+    Reconstituted neuronal AP-3 assays comparing clathrin, Arf1, lipid
+    composition, cargo class, and beta3B hinge/appendage mutants should define
+    which AP3B2-dependent vesicles require clathrin and which are initiated by
+    Arf1-dependent AP-3 polymerization.
+  provenance:
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-falcon.md
+    supporting_text: >-
+      Clathrin dependence: While AP-3 possesses a clathrin-binding motif, multiple
+      lines of evidence—including 2024 structural work—support
+      clathrin-independent coat assembly by AP-3 on endosomal membranes (Dec
+      2024; https://doi.org/10.1073/pnas.2411974121; Oct 2019;
+      https://doi.org/10.1146/annurev-cellbio-100818-125234)
+      (begley2024astructurebasedmechanism pages 8-9,
+      dellangelica2019coatopathiesgeneticdisorders pages 18-20).
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      While clathrin can associate with AP-3, the identification of other coat
+      proteins such as VPS41 raises questions about the complete molecular
+      composition of the AP-3 vesicle coat and whether different coat assemblies
+      serve distinct functions.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      Direct interactions between AP-3 and membrane lipids have not been
+      definitively identified. Understanding which phosphoinositides or other
+      lipids regulate AP-3 recruitment and function could reveal new regulatory
+      mechanisms.
+- gap_statement: >-
+    The complete neuronal AP-3 trafficking itinerary and cargo repertoire remain
+    unresolved, including how AP3B2-containing AP-3 differs from ubiquitous
+    AP3B1-containing AP-3 at shared endosomal compartments.
+  boundary: >-
+    The review captures established AP3B2 neuronal AP-3 functions in synaptic
+    vesicle transport, high-frequency-responsive vesicles, ZnT3/ClC-3 sorting,
+    VMAT2 polarity, and ATP8A1/TMEM30A recruitment. The gap is the full route and
+    cargo-selection logic that separates neuronal AP-3, ubiquitous AP-3, BLOC-1,
+    and parallel synaptic-vesicle pathways.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would prevent overgeneralizing all neuronal vesicle
+    phenotypes to AP3B2 while enabling more precise process annotations for
+    specific cargo classes, brain regions, and activity states.
+  resolution: >-
+    Cargo proteomics, live trafficking, compartment-resolved perturbation of beta3B
+    versus beta3A, and BLOC-1 interaction studies across neuronal subtypes should
+    define direct AP3B2 cargoes and their route to functional vesicle pools.
+  provenance:
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      The exact sequence of steps by which AP-3 mediates cargo transport from the
+      TGN or endosomes to synaptic vesicles has not been fully elucidated. Whether
+      AP-3 vesicles fuse directly with forming synaptic vesicles or pass through
+      intermediate compartments remains unclear.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      The complete repertoire of neuronal AP-3 cargoes and how cargo selection
+      differs between neuronal and ubiquitous AP-3 isoforms remains to be fully
+      characterized.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      The functional relationship between AP-3 and BLOC-1 is not obligatory for
+      all cargo proteins. Both AP-3 isoforms recognize distinct as well as
+      overlapping membrane protein cargoes independently of BLOC-1, and not all
+      synaptic vesicle proteins reach synaptic vesicle pools through an AP-3-BLOC-1
+      route
+- gap_statement: >-
+    The causal chain from AP3B2 loss to DEE48 seizures, developmental delay, and
+    region-specific synaptic dysfunction remains incompletely defined.
+  boundary: >-
+    AP3B2 loss-of-function disease association is established, and neuronal AP-3
+    defects affect synaptic vesicle composition and neurotransmitter release. The
+    unresolved gap is which AP3B2-dependent cargoes, release modes, brain regions,
+    and compensatory pathways drive the human DEE48 phenotype.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Resolving this gap would connect AP3B2 molecular cargo-sorting functions to
+    disease-relevant neuronal pathways without assigning broad epilepsy or
+    neurodevelopmental process annotations from genetic association alone.
+  resolution: >-
+    Patient-variant models, neuronal subtype-specific rescue, cargo-specific
+    bypass experiments, and activity-dependent release assays should distinguish
+    primary AP3B2 cargo defects from downstream network consequences.
+  provenance:
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      Functional analysis of the mutations suggests a loss-of-function mechanism,
+      consistent with the critical role of AP3B2 in neuronal synaptic vesicle
+      trafficking and neurotransmitter release.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-cyberian.md
+    supporting_text: >-
+      The mechanisms underlying the differential effects of AP-3 loss in different
+      brain regions (e.g., opposite effects on synaptic vesicle size in striatum
+      versus dentate gyrus) warrant further investigation.
+  - reference_id: file:human/AP3B2/AP3B2-deep-research-perplexity.md
+    supporting_text: >-
+      Future investigations should focus on elucidating the precise molecular
+      mechanisms by which AP3B2 mutations impair synaptic vesicle biogenesis and
+      neuronal function, characterizing the protein-protein interactions that
+      regulate AP-3 activity in response to neuronal stimulation and calcium
+      influx, and identifying novel AP-3 cargo proteins that may contribute to the
+      pathogenesis of AP3B2-associated disease.


### PR DESCRIPTION
## Summary
- add structured AP3B2 knowledge gaps for AP-3 coat initiation, neuronal cargo/itinerary specificity, and DEE48 disease mechanism
- clarify curation boundaries around clathrin-dependent versus Arf1-driven AP-3 coat biology
- render the updated AP3B2 review HTML

## Validation
- `just validate human AP3B2`
- `just render human AP3B2`
- `git diff --check`