### PR TITLE
Add FBXO17 knowledge gaps

### DIFF
--- a/genes/human/FBXO17/FBXO17-ai-review.html
+++ b/genes/human/FBXO17/FBXO17-ai-review.html
@@ -3938,6 +3938,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological glycoprotein substrates and glycan determinants recognized by FBXO17 remain unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already accepts FBXO17 carbohydrate binding and glycoprotein catabolism, and it rejects broad ERAD/high-mannose propagation. The remaining gap is which endogenous complex-type or sulfated glycoproteins are FBXO17 substrates and in what cytosolic or secretory-interface context FBXO17 encounters them.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would define the substrate-recognition specificity that distinguishes FBXO17 from high-mannose-binding FBA proteins and would prevent over-propagating ERAD/glycoprotein quality-control annotations from related family members.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous substrate discovery should pair FBXO17 perturbation with glycoproteomics and glycan-dependence assays, testing candidate complex-type and sulfated glycoproteins against FBA/G-domain binding-pocket mutants.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"FBXO17 bound heparin strongly and chondroitin sulfate weakly, suggesting that FBXO17 binds sulfated glycans."</em> — PMID:18203720</li>
+
+                <li><em>"Because FBXO17 did not bind high mannose glycans on the glycan array, its binding to lactoferrin likely reflects binding to the complex glycan moieties on the protein."</em> — PMID:18203720</li>
+
+                <li><em>"The “cytosolic N-glycans” review highlights that F-box proteins act as SCF substrate-recognition subunits and places FBXO17 in a phylogenetic context with related glycan-recognizing FBXOs, consistent with the idea that FBXO17 may possess carbohydrate-recognition-like features (though substrate glycan recognition is not directly validated in the retrieved core mechanistic papers)."</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether recognition of the validated GSK3-beta substrate is glycan-dependent and how broad FBXO17&#39;s protein-substrate repertoire is remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already treats GSK3-beta as a validated FBXO17 substrate and separates this protein-substrate evidence from the lectin/glycoprotein core. The unresolved issue is whether GSK3-beta recognition uses the same FBA/G glycan-recognition machinery, a separate protein-binding surface, or context-specific bridging factors.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would clarify whether FBXO17 should be represented as a lectin-specific substrate receptor, a broader protein-substrate receptor, or a dual-specificity adaptor with distinct substrate-recognition modes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct binding and ubiquitination assays comparing GSK3-beta, candidate glycoprotein substrates, FBA/G pocket mutants, and the mapped 151-200 GSK3-beta-binding region should establish whether the substrate classes are mechanistically separable.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"A detailed biochemical study in lung epithelial cells shows that **FBXO17 associates with GSK3β**, promotes **polyubiquitination** of GSK3β, and drives **proteasome-dependent turnover** of GSK3β."</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+                <li><em>"Mapping a **putative GSK3β-binding region** in FBXO17 (amino acids **151–200** required for association in the reported assays)."</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+                <li><em>"Beyond GSK3β and IRF3/PP2A scaffolding, additional direct substrates of FBXO17 in human tissues are not established in the retrieved corpus and represent a key opportunity for future work."</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How FBXO17 partitions canonical SCF substrate-receptor activity from F-box-independent IRF3/PP2A signaling and tissue-specific pathway effects remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review already captures canonical SCF substrate-adaptor function and records the IRF3/PP2A mechanism as a strong non-canonical lead. The remaining gap is how domains, post-translational signals, tissue context, or binding partners switch FBXO17 between ubiquitin-ligase adaptor and phosphatase-recruiting scaffold modes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this gap would determine which immune and cancer pathway annotations are direct FBXO17 functions and which are downstream or model-specific consequences of perturbing GSK3-beta, IRF3, or other substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Separation-of-function alleles that disrupt the F-box, FBA/G domain, IRF3/PP2A recruitment region, and GSK3-beta-binding region should be tested side by side in immune and cancer contexts with direct ubiquitination, dephosphorylation, and pathway readouts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"FBXO17 can regulate signaling **independently of its canonical SCF function** by recruiting **PP2A** to the transcription factor **IRF3** to promote IRF3 dephosphorylation and suppress type I interferon signaling. This is explicitly described as not requiring the F-box domain and using the “F-box associated region.”"</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+                <li><em>"Interpretation: these studies indicate FBXO17 influences major signaling hubs (GSK3β, Akt/ERK, Wnt/β-catenin), but the **directionality** of pathway changes is model-dependent and not yet reconciled into a single unified mechanism across tissues."</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+                <li><em>"Tissue-specific directionality (oncogenic vs tumor-suppressive) and reconciliation of pathway effects across cancer models remain unresolved."</em> — file:human/FBXO17/FBXO17-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -5063,6 +5165,131 @@ core_functions:
   directly_involved_in:
   - id: GO:0031146
     label: SCF-dependent proteasomal ubiquitin-dependent protein catabolic process
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The physiological glycoprotein substrates and glycan determinants recognized
+      by FBXO17 remain unresolved.
+    boundary: &gt;-
+      The review already accepts FBXO17 carbohydrate binding and glycoprotein
+      catabolism, and it rejects broad ERAD/high-mannose propagation. The
+      remaining gap is which endogenous complex-type or sulfated glycoproteins
+      are FBXO17 substrates and in what cytosolic or secretory-interface context
+      FBXO17 encounters them.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would define the substrate-recognition specificity that
+      distinguishes FBXO17 from high-mannose-binding FBA proteins and would
+      prevent over-propagating ERAD/glycoprotein quality-control annotations from
+      related family members.
+    resolution: &gt;-
+      Endogenous substrate discovery should pair FBXO17 perturbation with
+      glycoproteomics and glycan-dependence assays, testing candidate
+      complex-type and sulfated glycoproteins against FBA/G-domain binding-pocket
+      mutants.
+    provenance:
+      - reference_id: PMID:18203720
+        supporting_text: &gt;-
+          FBXO17 bound heparin strongly and chondroitin sulfate weakly,
+          suggesting that FBXO17 binds sulfated glycans.
+      - reference_id: PMID:18203720
+        supporting_text: &gt;-
+          Because FBXO17 did not bind high mannose glycans on the glycan array,
+          its binding to lactoferrin likely reflects binding to the complex
+          glycan moieties on the protein.
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          The “cytosolic N-glycans” review highlights that F-box proteins act as
+          SCF substrate-recognition subunits and places FBXO17 in a phylogenetic
+          context with related glycan-recognizing FBXOs, consistent with the idea
+          that FBXO17 may possess carbohydrate-recognition-like features (though
+          substrate glycan recognition is not directly validated in the retrieved
+          core mechanistic papers).
+  - gap_statement: &gt;-
+      Whether recognition of the validated GSK3-beta substrate is glycan-dependent
+      and how broad FBXO17&#39;s protein-substrate repertoire is remains unresolved.
+    boundary: &gt;-
+      The review already treats GSK3-beta as a validated FBXO17 substrate and
+      separates this protein-substrate evidence from the lectin/glycoprotein
+      core. The unresolved issue is whether GSK3-beta recognition uses the same
+      FBA/G glycan-recognition machinery, a separate protein-binding surface, or
+      context-specific bridging factors.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: &gt;-
+      Resolving this gap would clarify whether FBXO17 should be represented as a
+      lectin-specific substrate receptor, a broader protein-substrate receptor,
+      or a dual-specificity adaptor with distinct substrate-recognition modes.
+    resolution: &gt;-
+      Direct binding and ubiquitination assays comparing GSK3-beta, candidate
+      glycoprotein substrates, FBA/G pocket mutants, and the mapped 151-200
+      GSK3-beta-binding region should establish whether the substrate classes are
+      mechanistically separable.
+    provenance:
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          A detailed biochemical study in lung epithelial cells shows that
+          **FBXO17 associates with GSK3β**, promotes **polyubiquitination** of
+          GSK3β, and drives **proteasome-dependent turnover** of GSK3β.
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          Mapping a **putative GSK3β-binding region** in FBXO17 (amino acids
+          **151–200** required for association in the reported assays).
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          Beyond GSK3β and IRF3/PP2A scaffolding, additional direct substrates of
+          FBXO17 in human tissues are not established in the retrieved corpus and
+          represent a key opportunity for future work.
+  - gap_statement: &gt;-
+      How FBXO17 partitions canonical SCF substrate-receptor activity from
+      F-box-independent IRF3/PP2A signaling and tissue-specific pathway effects
+      remains unresolved.
+    boundary: &gt;-
+      The review already captures canonical SCF substrate-adaptor function and
+      records the IRF3/PP2A mechanism as a strong non-canonical lead. The
+      remaining gap is how domains, post-translational signals, tissue context,
+      or binding partners switch FBXO17 between ubiquitin-ligase adaptor and
+      phosphatase-recruiting scaffold modes.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Resolving this gap would determine which immune and cancer pathway
+      annotations are direct FBXO17 functions and which are downstream or
+      model-specific consequences of perturbing GSK3-beta, IRF3, or other
+      substrates.
+    resolution: &gt;-
+      Separation-of-function alleles that disrupt the F-box, FBA/G domain,
+      IRF3/PP2A recruitment region, and GSK3-beta-binding region should be tested
+      side by side in immune and cancer contexts with direct ubiquitination,
+      dephosphorylation, and pathway readouts.
+    provenance:
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          FBXO17 can regulate signaling **independently of its canonical SCF
+          function** by recruiting **PP2A** to the transcription factor **IRF3**
+          to promote IRF3 dephosphorylation and suppress type I interferon
+          signaling. This is explicitly described as not requiring the F-box
+          domain and using the “F-box associated region.”
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          Interpretation: these studies indicate FBXO17 influences major
+          signaling hubs (GSK3β, Akt/ERK, Wnt/β-catenin), but the
+          **directionality** of pathway changes is model-dependent and not yet
+          reconciled into a single unified mechanism across tissues.
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: &gt;-
+          Tissue-specific directionality (oncogenic vs tumor-suppressive) and
+          reconciliation of pathway effects across cancer models remain
+          unresolved.
 proposed_new_terms: []
 suggested_questions:
 - question: What are the physiological glycoprotein substrates that FBXO17 selects for SCF-dependent ubiquitination, and through which complex-type or sulfated glycan determinants are they recognized?

--- a/genes/human/FBXO17/FBXO17-ai-review.yaml
+++ b/genes/human/FBXO17/FBXO17-ai-review.yaml
@@ -675,6 +675,131 @@ core_functions:
   directly_involved_in:
   - id: GO:0031146
     label: SCF-dependent proteasomal ubiquitin-dependent protein catabolic process
+knowledge_gaps:
+  - gap_statement: >-
+      The physiological glycoprotein substrates and glycan determinants recognized
+      by FBXO17 remain unresolved.
+    boundary: >-
+      The review already accepts FBXO17 carbohydrate binding and glycoprotein
+      catabolism, and it rejects broad ERAD/high-mannose propagation. The
+      remaining gap is which endogenous complex-type or sulfated glycoproteins
+      are FBXO17 substrates and in what cytosolic or secretory-interface context
+      FBXO17 encounters them.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would define the substrate-recognition specificity that
+      distinguishes FBXO17 from high-mannose-binding FBA proteins and would
+      prevent over-propagating ERAD/glycoprotein quality-control annotations from
+      related family members.
+    resolution: >-
+      Endogenous substrate discovery should pair FBXO17 perturbation with
+      glycoproteomics and glycan-dependence assays, testing candidate
+      complex-type and sulfated glycoproteins against FBA/G-domain binding-pocket
+      mutants.
+    provenance:
+      - reference_id: PMID:18203720
+        supporting_text: >-
+          FBXO17 bound heparin strongly and chondroitin sulfate weakly,
+          suggesting that FBXO17 binds sulfated glycans.
+      - reference_id: PMID:18203720
+        supporting_text: >-
+          Because FBXO17 did not bind high mannose glycans on the glycan array,
+          its binding to lactoferrin likely reflects binding to the complex
+          glycan moieties on the protein.
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          The “cytosolic N-glycans” review highlights that F-box proteins act as
+          SCF substrate-recognition subunits and places FBXO17 in a phylogenetic
+          context with related glycan-recognizing FBXOs, consistent with the idea
+          that FBXO17 may possess carbohydrate-recognition-like features (though
+          substrate glycan recognition is not directly validated in the retrieved
+          core mechanistic papers).
+  - gap_statement: >-
+      Whether recognition of the validated GSK3-beta substrate is glycan-dependent
+      and how broad FBXO17's protein-substrate repertoire is remains unresolved.
+    boundary: >-
+      The review already treats GSK3-beta as a validated FBXO17 substrate and
+      separates this protein-substrate evidence from the lectin/glycoprotein
+      core. The unresolved issue is whether GSK3-beta recognition uses the same
+      FBA/G glycan-recognition machinery, a separate protein-binding surface, or
+      context-specific bridging factors.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: NARROWING
+    significance: >-
+      Resolving this gap would clarify whether FBXO17 should be represented as a
+      lectin-specific substrate receptor, a broader protein-substrate receptor,
+      or a dual-specificity adaptor with distinct substrate-recognition modes.
+    resolution: >-
+      Direct binding and ubiquitination assays comparing GSK3-beta, candidate
+      glycoprotein substrates, FBA/G pocket mutants, and the mapped 151-200
+      GSK3-beta-binding region should establish whether the substrate classes are
+      mechanistically separable.
+    provenance:
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          A detailed biochemical study in lung epithelial cells shows that
+          **FBXO17 associates with GSK3β**, promotes **polyubiquitination** of
+          GSK3β, and drives **proteasome-dependent turnover** of GSK3β.
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          Mapping a **putative GSK3β-binding region** in FBXO17 (amino acids
+          **151–200** required for association in the reported assays).
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          Beyond GSK3β and IRF3/PP2A scaffolding, additional direct substrates of
+          FBXO17 in human tissues are not established in the retrieved corpus and
+          represent a key opportunity for future work.
+  - gap_statement: >-
+      How FBXO17 partitions canonical SCF substrate-receptor activity from
+      F-box-independent IRF3/PP2A signaling and tissue-specific pathway effects
+      remains unresolved.
+    boundary: >-
+      The review already captures canonical SCF substrate-adaptor function and
+      records the IRF3/PP2A mechanism as a strong non-canonical lead. The
+      remaining gap is how domains, post-translational signals, tissue context,
+      or binding partners switch FBXO17 between ubiquitin-ligase adaptor and
+      phosphatase-recruiting scaffold modes.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Resolving this gap would determine which immune and cancer pathway
+      annotations are direct FBXO17 functions and which are downstream or
+      model-specific consequences of perturbing GSK3-beta, IRF3, or other
+      substrates.
+    resolution: >-
+      Separation-of-function alleles that disrupt the F-box, FBA/G domain,
+      IRF3/PP2A recruitment region, and GSK3-beta-binding region should be tested
+      side by side in immune and cancer contexts with direct ubiquitination,
+      dephosphorylation, and pathway readouts.
+    provenance:
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          FBXO17 can regulate signaling **independently of its canonical SCF
+          function** by recruiting **PP2A** to the transcription factor **IRF3**
+          to promote IRF3 dephosphorylation and suppress type I interferon
+          signaling. This is explicitly described as not requiring the F-box
+          domain and using the “F-box associated region.”
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          Interpretation: these studies indicate FBXO17 influences major
+          signaling hubs (GSK3β, Akt/ERK, Wnt/β-catenin), but the
+          **directionality** of pathway changes is model-dependent and not yet
+          reconciled into a single unified mechanism across tissues.
+      - reference_id: file:human/FBXO17/FBXO17-deep-research-falcon.md
+        supporting_text: >-
+          Tissue-specific directionality (oncogenic vs tumor-suppressive) and
+          reconciliation of pathway effects across cancer models remain
+          unresolved.
 proposed_new_terms: []
 suggested_questions:
 - question: What are the physiological glycoprotein substrates that FBXO17 selects for SCF-dependent ubiquitination, and through which complex-type or sulfated glycan determinants are they recognized?


### PR DESCRIPTION
## Summary
- add structured FBXO17 knowledge gaps for physiological glycoprotein substrates, GSK3-beta substrate-recognition boundaries, and canonical versus non-canonical signaling modes
- preserve the existing ERAD over-annotation boundary while identifying unresolved substrate and context questions
- render the updated FBXO17 review HTML

## Validation
- `just validate human FBXO17`
- `just render human FBXO17`
- `git diff --check`