### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/yeast/ECM30/ECM30-ai-review.html
+++ b/genes/yeast/ECM30/ECM30-ai-review.html
@@ -1,0 +1,3309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ECM30 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ECM30</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q06673" target="_blank" class="term-link">
+                        Q06673
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ECM30";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q06673" data-a="DESCRIPTION: ECM30 (YLR436C) is a large (1274 aa, ~145 kDa) cyt..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ECM30 (YLR436C) is a large (1274 aa, ~145 kDa) cytoplasmic protein of the HID1 family (Pfam Hid1 / InterPro IPR026705 HID1/Ecm30; PANTHER PTHR21575), the single-copy Saccharomyces cerevisiae ortholog of metazoan HID1, a peripheral trans-Golgi-network protein that functions in dense-core secretory-vesicle biogenesis. ECM30 has no experimentally established molecular function and is classified as a protein of unknown function. It has no transmembrane segment or recognizable catalytic domain and localizes to the cytoplasm, consistent with a peripheral membrane-associated scaffold rather than an enzyme or integral membrane protein. Its gene name derives from an &#34;extracellular mutant&#34; cell-surface screen: ecm30 loss alters calcofluor-white sensitivity and the relative cell-wall content of mannose and glucose, and ecm30 mutants have defects in the intracellular sorting and transport of the general amino acid permease Gap1. Genetic interactions place it in the membrane-trafficking network, including the GET tail-anchored-protein insertion pathway (GET1/GET2/GET3), Golgi and secretory components (ARL1, SEC14, COPI subunits SEC26/SEC28), and vacuolar/endosomal sorting factors (VPS1, VPS9, VPS17). ECM30 is non-essential and is phosphorylated on Ser635 and Ser1065.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) cytosol annotation propagated across the HID1 family (PANTHER PTN000491103). Consistent with the experimental yeast localization (cytoplasm, PMID:14562095) and with the cytosolic pool of the human ortholog HID1, which shuttles between cytosol and Golgi.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization is supported and consistent with experimental data, but a subcellular-location term is not itself a core function for a protein whose molecular activity is unknown.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-level, uninformative &#34;membrane&#34; propagated by IBA from the membrane-associated metazoan HID1 orthologs. ECM30 has no transmembrane segment or signal peptide and is experimentally cytoplasmic; at most it is a peripheral membrane associate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Root-level CC that adds no specific information; the membrane association is an electronic transfer from orthologs and is not supported by experimental yeast data or by sequence features (no TM/anchor predicted).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000491103</span>
+
+                                    &middot; HID1 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Node-level &#34;membrane&#34; reflects the peripheral/lipid-anchored membrane association of metazoan HID1; ECM30 has no TM/signal and is experimentally cytoplasmic, so an uninformative &#34;membrane&#34; parent should not be a confident annotation for the target.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007030" target="_blank" class="term-link">
+                                    GO:0007030
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0007030" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) Golgi-organization annotation seeded by the fission-yeast ortholog hid1 (GOA WITH/FROM PomBase:SPAC17A5.16), which carries direct experimental (IMP) Golgi-organization evidence and localizes to the Golgi in that fungus. There is, however, no direct S. cerevisiae evidence that ECM30 organizes the Golgi: ECM30 is experimentally cytoplasmic (PMID:14562095) with no yeast Golgi localization or Golgi-organization phenotype reported.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a phylogenetic transfer, not a demonstration in S. cerevisiae. The seed is a FUNGAL ortholog (S. pombe hid1, IMP to Golgi organization) rather than a metazoan, so the appropriate argument is the absence of any direct S. cerevisiae Golgi localization or Golgi-organization phenotype for ECM30 - not a claim that the process is absent from budding yeast (it is not). A Golgi/trafficking role for ECM30 remains a plausible but undemonstrated inference (supported indirectly by genetic interactions with ARL1, SEC14 and COPI subunits); the specific &#34;Golgi organization&#34; term should not stand as a confident annotation until direct S. cerevisiae evidence exists. See the CC-dark knowledge gap.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE WEAK OR INFERRED</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">SOURCE EVIDENCE WEAK</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PomBase:SPAC17A5.16</span>
+
+                                    &middot; hid1 (S. pombe, GOA WITH/FROM seed)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Actual IBA seed for this term. S. pombe hid1 has direct experimental (IMP) Golgi-organization evidence and Golgi (HDA) localization; that supports the SOURCE annotation but the transfer to S. cerevisiae ECM30 is unsafe because ECM30 has no direct yeast Golgi localization or Golgi-organization phenotype.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000491103</span>
+
+                                    &middot; HID1 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000138" target="_blank" class="term-link">
+                                    GO:0000138
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi trans cisterna</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0000138" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA transfer of the trans-Golgi-cisterna localization from human HID1 (which has IDA evidence at the TGN). ECM30 localizes to the cytoplasm in the one experimental yeast study and has no yeast Golgi-cisterna evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Overly specific compartment term electronically propagated from the metazoan ortholog; not supported by experimental localization of yeast ECM30 (cytoplasm, PMID:14562095).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">CONTEXT OR TISSUE MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q8IV36</span>
+
+                                    &middot; HID1 (human)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Human HID1 has IDA evidence at the trans-Golgi cisterna; ECM30 is experimentally cytoplasmic in yeast with no Golgi-cisterna evidence.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005797" target="_blank" class="term-link">
+                                    GO:0005797
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi medial cisterna</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0005797" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As for GO:0000138: an overly specific Golgi-cisterna compartment propagated by IBA from metazoan HID1, without supporting experimental evidence in yeast.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Electronic transfer of a specific metazoan Golgi compartment; ECM30 is experimentally cytoplasmic in yeast with no Golgi-cisterna evidence.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">CONTEXT OR TISSUE MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q8IV36</span>
+
+                                    &middot; HID1 (human)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Same basis as GO:0000138: a metazoan-ortholog Golgi compartment transferred by IBA without any supporting yeast localization for ECM30.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt SUBCELLULAR LOCATION &#34;Cytoplasm&#34; vocabulary, which itself is backed by the experimental GFP result. Correct and redundant with the HDA cytoplasm annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate localization consistent with the experimental (HDA) cytoplasm annotation to the same term; retained for consistency.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0005737" data-r="PMID:14562095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Best-supported localization for ECM30: high-throughput GFP-fusion analysis (Huh et al.) places the protein in the cytoplasm. This is the primary experimental cellular-component evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental (HDA) localization; the correct and best-evidenced compartment annotation for ECM30.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root &#34;molecular_function&#34; with ND correctly records that no molecular function has been experimentally established for ECM30 (a protein of unknown function).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND root annotation accurately captures the MF-dark status of this gene; an appropriate placeholder given the absence of any assigned biochemical activity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q06673" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root &#34;biological_process&#34; with ND correctly records that no biological process has been experimentally assigned to ECM30. Phenotypes (cell-wall composition, Gap1 sorting) and genetic interactions suggest a role in membrane trafficking, but no process has been directly established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND root annotation appropriately represents the BP-dark status; existing clues are phenotypic/genetic, not a curated experimental process assignment.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ECM30 has no experimentally established molecular function. It is the single-copy S. cerevisiae member of the HID1 family (Pfam Hid1; InterPro IPR026705), whose characterized metazoan ortholog HID1 is a peripheral trans-Golgi-network protein acting in secretory-vesicle biogenesis; the conserved element, if any, is most plausibly a Golgi/endosomal membrane-trafficking scaffold activity, offered as a hypothesis and not a demonstrated activity.</h3>
+                <span class="vote-buttons" data-g="Q06673" data-a="FUNCTION: ECM30 has no experimentally established molecular ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                PMID:14562095
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">into 22 distinct subcellular localization categories, and provide localization information for 70% of previously unlocalized proteins.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>At the cellular level, loss of ECM30 perturbs cell-surface / cell-wall assembly (the basis of the ECM &#34;extracellular mutant&#34; name), altering calcofluor-white sensitivity and the relative cell-wall content of mannose and glucose. Whether this reflects a direct cell-wall-biogenesis role or an indirect consequence of mis-sorting of trafficking cargo (as also seen for the general amino acid permease Gap1) is not established.</h3>
+                <span class="vote-buttons" data-g="Q06673" data-a="FUNCTION: At the cellular level, loss of ECM30 perturbs cell..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9335584" target="_blank" class="term-link">
+                                PMID:9335584
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We have identified genes involved in cell surface assembly by screening transposon-mutagenized cells for altered sensitivity to calcofluor white, followed by supplementary screens to further characterize mutant phenotypes.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP-fusion localization assigned ECM30 to the cytoplasm; this is the primary experimental subcellular-localization evidence for the protein.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9335584" target="_blank" class="term-link">
+                            PMID:9335584
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large scale identification of genes involved in cell surface biosynthesis and architecture in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The calcofluor-white cell-surface transposon-mutagenesis screen from which the ECM (&#34;extracellular mutant&#34;) series, including ECM30, was named; source of the UniProt FUNCTION statement that ECM30 is required for correct cell-wall composition.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17330950" target="_blank" class="term-link">
+                            PMID:17330950
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale phosphorylation analysis of alpha-factor-arrested Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ECM30 is phosphorylated at Ser1065 (large-scale phosphoproteomics).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18407956" target="_blank" class="term-link">
+                            PMID:18407956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A multidimensional chromatography technology for in-depth phosphoproteome analysis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ECM30 is phosphorylated at Ser635 (large-scale phosphoproteomics).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19779198" target="_blank" class="term-link">
+                            PMID:19779198
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of Cdk1 substrate phosphorylation sites provides insights into evolution.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ECM30 phosphosites Ser635 and Ser1065 detected in a Cdk1-substrate phosphoproteome, suggesting possible cell-cycle-associated phosphoregulation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does ECM30 physically associate with the Golgi/TGN or endosomal membranes in S. cerevisiae, as its metazoan HID1 ortholog does at the trans-Golgi network?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06673" data-a="Q: Does ECM30 physically associate with the Golgi/TGN..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the cell-wall (mannose/glucose) phenotype of ecm30 mutants a direct effect on wall biogenesis or an indirect consequence of defective intracellular sorting of trafficking cargo such as Gap1?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06673" data-a="Q: Is the cell-wall (mannose/glucose) phenotype of ec..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform affinity-purification mass spectrometry on endogenously tagged ECM30 to identify a specific, reproducible interaction partner set (filtering high-throughput background), combined with fluorescent co-localization to Golgi/TGN, endosome and vacuole markers, and cargo-trafficking assays (Gap1-GFP itinerary; cell-wall biosynthetic enzyme localization) in the ecm30 null.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ECM30 functions as a peripheral membrane-trafficking scaffold at the Golgi/ endosome, and its cell-wall and Gap1 phenotypes are downstream of impaired cargo sorting.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry, fluorescence microscopy, cargo-trafficking assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06673" data-a="EXPERIMENT: Perform affinity-purification mass spectrometry on..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Systematically test genetic epistasis and cargo phenotypes of ecm30 in combination with GET1/GET2/GET3, ARL1, SEC14 and VPS mutants to place ECM30 in a defined trafficking step.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ECM30 acts in the same functional module as the GET pathway and Golgi trafficking machinery revealed by its genetic interactions.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q06673" data-a="EXPERIMENT: Systematically test genetic epistasis and cargo ph..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of ECM30 is unknown. No enzymatic activity, defined biochemical function, or validated specific binding partner has been demonstrated; it is undetermined whether ECM30, like the metazoan HID1 ortholog, acts as a peripheral membrane-trafficking scaffold/adaptor.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is firmly established is only the domain architecture and localization: ECM30 is a 1274-aa HID1-family protein (Pfam Hid1; InterPro IPR026705 HID1/Ecm30; PANTHER PTHR21575), with several internal disordered/low-complexity segments, no transmembrane domain, no signal peptide, and no catalytic-domain signature; it is experimentally cytoplasmic.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> HID1 is a conserved, disease-linked family whose molecular activity is undefined in every organism; establishing an activity for the tractable single-copy yeast member would anchor function for the whole family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity purification / mass spectrometry from yeast to define a specific complex, in vitro reconstitution of any candidate membrane/lipid or cargo interaction, and structure-guided mutagenesis of the HID1 fold.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"into 22 distinct subcellular localization categories, and provide localization information for 70% of previously unlocalized proteins."</em> — PMID:14562095</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process ECM30 acts in, and the mechanism linking it to the cell-wall phenotype, are unknown. It is unresolved whether ECM30 contributes directly to cell-wall (mannan/glucan) biogenesis or does so indirectly by supporting the intracellular sorting of cell-wall-biosynthetic and permease cargo (e.g. the Gap1 sorting/transport defect of ecm30 mutants).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established phenotypically is that ecm30 loss alters calcofluor-white sensitivity and the relative mannose/glucose content of the cell wall, and that ecm30 mutants mis-sort the general amino acid permease Gap1; genetic interactions connect ECM30 to the GET pathway (GET1/GET2/GET3), Golgi/secretory factors (ARL1, SEC14, COPI subunits SEC26/SEC28) and vacuolar sorting (VPS1/VPS9/VPS17).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a direct cell-wall-biosynthetic role from an upstream membrane-trafficking role would explain a decades-old &#34;extracellular mutant&#34; phenotype and clarify how a cytosolic HID1-family protein controls cell-surface composition.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis and cargo-trafficking assays (Gap1 and cell-wall enzyme itineraries) in ecm30 versus GET/Golgi/VPS mutants, and direct measurement of cell-wall polysaccharide biosynthesis in the ecm30 null.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Eighty-two genes with apparent perturbation of the cell surface were identified, with mutations in 65 of them displaying at least one further cell surface phenotype in addition to their modified sensitivity to calcofluor."</em> — PMID:9335584</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether ECM30 associates with the Golgi/TGN in S. cerevisiae. A Golgi role is experimentally established for the FUNGAL ortholog S. pombe hid1 (IMP Golgi organization; Golgi localization) and for metazoan HID1 (trans-Golgi network), so a conserved Golgi function is a live possibility for ECM30; but the only S. cerevisiae localization datum places ECM30 in the cytoplasm, and the IBA Golgi-cisterna and Golgi-organization annotations are unverified phylogenetic transfers.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The only experimental localization of ECM30 (high-throughput GFP fusion) is cytoplasmic. The Golgi-organization annotation is an IBA seeded by S. pombe hid1 (a fungus with a Golgi and direct IMP evidence), while the Golgi trans/medial cisterna annotations are IBA transfers from metazoan HID1; none is backed by a direct S. cerevisiae Golgi localization or phenotype for ECM30.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determining whether budding-yeast ECM30 associates with the Golgi/TGN would either validate the phylogenetic Golgi annotations for the S. cerevisiae branch or confirm them as over-propagations, and would establish whether the Golgi role experimentally documented for the S. pombe ortholog is conserved across fungi.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous fluorescent-protein co-localization with Golgi/TGN and endosome markers under native and stressed conditions, and fractionation to test peripheral membrane association.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"into 22 distinct subcellular localization categories, and provide localization information for 70% of previously unlocalized proteins."</em> — PMID:14562095</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ECM30-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q06673" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">30 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T03:41:00.286186</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ECM30-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-ecm30-ylr436c-in-saccharomyces-cerevisiae">Comprehensive Research Report: ECM30 (YLR436C) in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h3>
+<p>ECM30 (systematic name YLR436C; UniProt Q06673) encodes the protein Ecm30 in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The gene was originally named "Extracellular Mutant protein 30" based on its identification in a screen for mutants with cell wall/extracellular matrix defects. Ecm30 belongs to the hid-1 protein family and contains the HID1/Ecm30 domain (IPR026705; Pfam PF12722). Ecm30 is not an enzyme itself; rather, available evidence indicates it functions as a regulatory or scaffolding component within a deubiquitinase complex and in membrane protein sorting pathways.</p>
+<h3 id="2-primary-molecular-function-stoichiometric-complex-with-the-ubp15-deubiquitinase">2. Primary Molecular Function: Stoichiometric Complex with the Ubp15 Deubiquitinase</h3>
+<p>The best-characterized molecular function of Ecm30 is its role as a binding partner and putative regulatory subunit of the Ubp15 ubiquitin-specific protease (deubiquitinase, DUB). Benschop et al. (2010) identified and validated a physical complex between Ecm30 and Ubp15 through coprecipitation experiments, describing it as a "putative Ubp15-Ecm30 ubiquitin protease complex" (benschop2010aconsensusof pages 6-7). This complex was identified as stoichiometric, suggesting a stable and dedicated association rather than a transient interaction.</p>
+<p>Ubp15 is a ubiquitin-specific protease of the USP/UBP family that favors K48-linked ubiquitin chains (suresh2020thestructureand pages 5-6). Ubp15 has well-documented roles in at least two functional contexts:</p>
+<ul>
+<li><strong>Cell cycle regulation</strong>: Ubp15 deubiquitinates the S-phase cyclin Clb5, counteracting its APC/C-Cdh1-mediated degradation and thereby promoting timely entry into S phase (zhou2016insightsintoapcc pages 6-8, zhou2016insightsintoapcc pages 15-16).</li>
+<li><strong>Plasma membrane quality control</strong>: Ubp15, together with Ubp2, deubiquitinates arrestin-related trafficking adaptors (ARTs), preventing their proteasomal degradation. This activity supports the ART-Rsp5 ubiquitin ligase network, which ubiquitinates damaged or misfolded membrane proteins to target them for vacuolar degradation (suresh2020thestructureand pages 9-9, suresh2020thestructureand pages 8-9).</li>
+</ul>
+<p>Because Ecm30 forms a stable complex with Ubp15, it is likely that Ecm30 modulates one or more of these Ubp15-dependent functions—most plausibly as a specificity factor or scaffold that directs Ubp15 activity toward particular substrates or cellular compartments. Consistent with this model, Costanzo et al. (2010) proposed that Ecm30 may modulate Gap1 (general amino acid permease) localization "perhaps by controlling its ubiquitination state" through its complex with Ubp15 (costanzo2010thegeneticlandscape pages 2-4).</p>
+<h3 id="3-role-in-gap1-amino-acid-permease-sorting">3. Role in Gap1 Amino Acid Permease Sorting</h3>
+<p>A landmark study by Costanzo et al. (2010), which mapped the global genetic interaction network of <em>S. cerevisiae</em>, identified ECM30 as one of three genes (along with PAR32 and UBP15) whose genetic interaction profiles were highly similar to those of known components of the Gap1-sorting module (costanzo2010thegeneticlandscape pages 2-4, ho2015candidaglabratanew pages 3-4). When deleted, all three genes led to Gap1 sorting and transport defects, experimentally validating the computational prediction (costanzo2010thegeneticlandscape pages 2-4). Gap1 is the general amino acid permease whose trafficking between the plasma membrane, Golgi, and vacuole is tightly regulated by nitrogen availability, primarily through the TORC1-Npr1 signaling axis.</p>
+<p>Par32 (also called Amu1) is a TORC1-Npr1-regulated phosphoprotein that controls ammonium transport and feeds back on TORC1 activity. Under conditions of nitrogen sufficiency, dephosphorylated Par32 accumulates at the cell surface and mediates inhibition of specific ammonium transport proteins (varlakhanova2018feedbackregulationof pages 20-25, varlakhanova2018feedbackregulationof pages 39-53, varlakhanova2018feedbackregulationof pages 16-20, varlakhanova2018feedbackregulationof pages 1-7). Importantly, Par32 also regulates Gap1 expression in an ammonium-dependent manner (varlakhanova2018feedbackregulationof pages 20-25, varlakhanova2018feedbackregulationof pages 39-53). While Par32's role in the TORC1 pathway has been extensively characterized, ECM30 was not directly investigated in these downstream mechanistic studies; its involvement in the Gap1-sorting module is therefore primarily supported by genetic interaction data and validated deletion phenotypes rather than by direct biochemical experiments.</p>
+<h3 id="4-regulation-of-methionine-biosynthesis">4. Regulation of Methionine Biosynthesis</h3>
+<p>Expression profiling of <em>ecm30Δ</em> and <em>ubp15Δ</em> deletion mutants revealed significantly altered mRNA levels for numerous genes involved in methionine biosynthesis and amino acid metabolism, including MET2, MET3, MET14, MET17, MET10, MET16, MET1, MET28, and GAP1 (benschop2010aconsensusof pages 6-7). The similar expression profiles between <em>ecm30Δ</em> and <em>ubp15Δ</em> mutants provide strong support for the functional coupling of these two gene products within the same complex. This methionine biosynthesis connection may relate to the broader role of the Ecm30-Ubp15 complex in amino acid sensing and permease regulation, as methionine pathway genes are known to be responsive to nitrogen and amino acid availability signals.</p>
+<h3 id="5-subcellular-localization">5. Subcellular Localization</h3>
+<p>High-throughput annotation in a genome-wide screen for negative regulators of sirtuin activity (Raisner and Madhani, 2008) listed Ecm30 as localized to the <strong>cytoplasm</strong> and annotated to "cell wall organization" based on its ECM designation (raisner2008genomewidescreenfor pages 4-5). The cytoplasmic localization is consistent with a role as a scaffolding/regulatory protein that associates with the cytosolic deubiquitinase Ubp15. However, no dedicated primary localization study using GFP-tagged Ecm30 in yeast has been identified in the present literature search, so the precise sub-compartmental distribution of Ecm30 (e.g., whether it associates with endomembranes or the Golgi apparatus as its metazoan orthologs do) remains an open question.</p>
+<h3 id="6-evolutionary-context-the-hid-1-protein-family">6. Evolutionary Context: The HID-1 Protein Family</h3>
+<p>Ecm30 belongs to the hid-1 protein family, which is conserved from yeast to humans. The founding member of this family, HID-1 (high-temperature-induced dauer formation defective-1), was characterized in <em>Caenorhabditis elegans</em> as a component of the peptidergic signaling pathway (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 12-14, mesa2011hid1anew pages 2-3, mesa2011hid1anew pages 1-2). Key findings about metazoan HID-1 include:</p>
+<ul>
+<li>HID-1 is a membrane-associated myristoylated protein that localizes to the trans-Golgi network (TGN) and post-Golgi compartments, including dense core vesicles (DCVs) (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 17-21, mesa2011hid1anew pages 14-15).</li>
+<li>In <em>C. elegans</em> neurons, HID-1 is transported to synaptic regions by the UNC-104 kinesin motor and is associated with neurosecretory vesicles (mesa2011hid1anew pages 6-7, mesa2011hid1anew pages 1-2).</li>
+<li>HID-1 functions at an early stage of DCV maturation, including biogenesis, acidification, or trafficking, upstream of peptide precursor processing (mesa2011hid1anew pages 12-14, mesa2011hid1anew pages 14-15).</li>
+<li>Murine HID-1 is 55% identical to <em>C. elegans</em> HID-1 and associates with vesicular and tubular structures in PC12 cells, partially colocalizing with TGN markers (mesa2011hid1anew pages 17-21, mesa2011hid1anew pages 6-7).</li>
+<li>Both invertebrate and vertebrate HID-1 require N-terminal myristoylation for proper membrane association and function (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 6-7).</li>
+</ul>
+<p>This conservation pattern suggests that the ancestral function of the HID-1/Ecm30 family involves membrane trafficking and cargo sorting at the Golgi or post-Golgi level—consistent with Ecm30's role in Gap1 permease sorting in yeast. However, direct demonstration of Ecm30 association with the Golgi or with trafficking vesicles in yeast has not been reported.</p>
+<h3 id="7-phenotypic-observations-and-stress-responses">7. Phenotypic Observations and Stress Responses</h3>
+<p>Several high-throughput studies have linked ECM30 to pleiotropic phenotypes:</p>
+<ul>
+<li><strong>Cell wall defects</strong>: The ECM designation derives from identification in a screen for yeast mutants with extracellular matrix/cell wall abnormalities, indicating that <em>ecm30Δ</em> mutants display altered cell wall properties (raisner2008genomewidescreenfor pages 4-5).</li>
+<li><strong>Sirtuin regulation</strong>: ECM30 was identified in a genome-wide screen for negative regulators of sirtuin activity, where <em>ecm30Δ</em> exhibited altered expression of the URA3 reporter gene adjacent to a silenced locus. However, this phenotype was not further characterized mechanistically (raisner2008genomewidescreenfor pages 4-5).</li>
+<li><strong>Thermotolerance</strong>: In an experimental evolution study for high-temperature tolerance in <em>S. cerevisiae</em>, a frameshift mutation in ECM30 was found in evolved strains, suggesting that a truncated Ecm30 may contribute to the thermotolerant phenotype (huang2018experimentalevolutionof pages 5-6).</li>
+</ul>
+<h3 id="8-pathways-and-functional-network">8. Pathways and Functional Network</h3>
+<p>The primary pathway in which Ecm30 functions is the <strong>ubiquitin-dependent regulation of amino acid permease trafficking</strong>, specifically the sorting of Gap1. This pathway intersects with the TORC1-Npr1 nitrogen signaling axis, which governs nutrient permease stability and localization at the plasma membrane. Within this network, the Ecm30-Ubp15 complex is proposed to modulate the ubiquitination state of Gap1 or of regulatory components (such as ARTs) that govern Gap1 trafficking (costanzo2010thegeneticlandscape pages 2-4). The downstream consequence of Ecm30-Ubp15 complex activity appears to be the proper sorting of Gap1 between the plasma membrane, the Golgi, and the vacuole in response to nitrogen availability signals.</p>
+<p>Additionally, through its complex with Ubp15, Ecm30 may indirectly participate in <strong>plasma membrane quality control</strong> via the ART-Rsp5 ubiquitin ligase network. Ubp15 deubiquitinates ART proteins, stabilizing them against proteasomal degradation and thereby supporting the ubiquitination and turnover of damaged membrane cargo (suresh2020thestructureand pages 9-9, suresh2020thestructureand pages 8-9).</p>
+<h3 id="9-summary-and-outstanding-questions">9. Summary and Outstanding Questions</h3>
+<p>Ecm30 is a cytoplasmic protein of the conserved HID-1 family that functions primarily as a regulatory partner of the Ubp15 deubiquitinase in <em>S. cerevisiae</em>. The Ecm30-Ubp15 complex participates in amino acid permease (Gap1) sorting and in the transcriptional regulation of methionine biosynthetic genes. Evolutionary inference from metazoan HID-1 orthologs suggests a role in membrane trafficking and cargo sorting at the Golgi or post-Golgi level, which is consistent with its yeast function in permease trafficking. Ecm30 is not known to possess enzymatic activity; it likely serves as a scaffold or specificity factor directing Ubp15 deubiquitinase activity toward appropriate substrates or subcellular compartments.</p>
+<p>Key outstanding questions include: (1) the precise subcellular localization of Ecm30 at high resolution in yeast; (2) whether Ecm30 directly contacts Gap1 or other permease substrates; (3) the specific substrates of the Ecm30-Ubp15 complex beyond what can be inferred from genetic interaction data; and (4) whether Ecm30 retains the membrane-trafficking functions of its metazoan HID-1 orthologs or has diverged to function primarily in the cytosolic ubiquitin regulatory pathway.</p>
+<table>
+<thead>
+<tr>
+<th>Gene name</th>
+<th>Systematic name</th>
+<th>Protein name</th>
+<th>Organism</th>
+<th>UniProt accession</th>
+<th>Protein family/domain</th>
+<th>Subcellular localization</th>
+<th>Physical interactors</th>
+<th>Predicted function</th>
+<th>Key pathways/processes</th>
+<th>GO / functional annotations</th>
+<th>Key references</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>ECM30</strong></td>
+<td><strong>YLR436C</strong></td>
+<td>Protein ECM30 / Extracellular mutant protein 30</td>
+<td><em>Saccharomyces cerevisiae</em> strain ATCC 204508 / S288c</td>
+<td><strong>Q06673</strong></td>
+<td>Belongs to the <strong>hid-1 family</strong>; contains <strong>HID1/Ecm30</strong> domain (IPR026705) / <strong>Hid1</strong> (PF12722); family-level evidence from metazoan HID-1 supports a membrane-trafficking role (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 17-21)</td>
+<td>Reported as <strong>cytoplasmic</strong> in a genome-wide screen table; no strong direct primary localization study for yeast ECM30 was retrieved, so localization remains only modestly supported in yeast-specific literature (raisner2008genomewidescreenfor pages 7-8, raisner2008genomewidescreenfor pages 4-5)</td>
+<td>Forms a <strong>stoichiometric complex with Ubp15</strong>; physical association validated by coprecipitation (benschop2010aconsensusof pages 6-7, costanzo2010thegeneticlandscape pages 2-4)</td>
+<td>Best-supported model: <strong>regulatory/scaffold-like factor associated with the Ubp15 deubiquitinase</strong>, contributing to <strong>Gap1 permease sorting/localization</strong> and broader control of amino acid metabolism; may modulate cargo ubiquitination state indirectly through the Ubp15 complex rather than acting as an enzyme itself (costanzo2010thegeneticlandscape pages 2-4, benschop2010aconsensusof pages 6-7)</td>
+<td><strong>Gap1 sorting module</strong>; <strong>amino acid uptake and nitrogen-responsive trafficking</strong>; linked to <strong>methionine biosynthesis / amino acid metabolic gene regulation</strong> via expression profiling of <strong>ecm30Δ</strong> and <strong>ubp15Δ</strong>; possible connection to plasma-membrane quality control through Ubp15’s role in ART/Rsp5 regulation, though ECM30 itself has not been directly shown in that mechanism (costanzo2010thegeneticlandscape pages 2-4, benschop2010aconsensusof pages 6-7, suresh2020thestructureand pages 9-9, suresh2020thestructureand pages 8-9)</td>
+<td>Annotated/associated with <strong>cell wall organization</strong> in one screen; predicted involvement in <strong>Gap1 sorting</strong> from genetic interaction mapping; also recovered in a screen for <strong>negative regulators of sirtuin activity</strong>, but this is likely a pleiotropic phenotype rather than the primary molecular function (raisner2008genomewidescreenfor pages 4-5, ho2015candidaglabratanew pages 3-4, raisner2008genomewidescreenfor pages 6-7)</td>
+<td>Costanzo et al., <em>Science</em> (2010), published Jan 22 2010, https://doi.org/10.1126/science.1180823 (costanzo2010thegeneticlandscape pages 2-4); Benschop et al., <em>Molecular Cell</em> (2010), published Jun 25 2010, https://doi.org/10.1016/j.molcel.2010.06.002 (benschop2010aconsensusof pages 6-7); Raisner &amp; Madhani, <em>Genetics</em> (2008), published Aug 2008, https://doi.org/10.1534/genetics.108.088443 (raisner2008genomewidescreenfor pages 4-5)</td>
+</tr>
+<tr>
+<td><strong>Context from family orthologs (not yeast ECM30 directly)</strong></td>
+<td>—</td>
+<td>HID-1 orthologs</td>
+<td>Conserved from nematodes to mammals</td>
+<td>—</td>
+<td>HID-1 family proteins are membrane-associated trafficking factors; metazoan HID-1 localizes partly to the <strong>trans-Golgi network</strong> and dense-core vesicle related compartments and functions in early secretory vesicle biogenesis/maturation (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 17-21, mesa2011hid1anew pages 14-15)</td>
+<td>TGN / post-Golgi / dense-core vesicle-associated in metazoans (mesa2011hid1anew pages 17-21, mesa2011hid1anew pages 14-15)</td>
+<td>—</td>
+<td>Supports inference that ECM30 may participate in <strong>membrane trafficking or cargo-sorting events</strong>, but this remains <strong>inference</strong>, not direct demonstration in budding yeast (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 14-15)</td>
+<td>Secretory trafficking / vesicle maturation in orthologous systems (mesa2011hid1anew pages 11-12, mesa2011hid1anew pages 14-15)</td>
+<td>Family-level evolutionary support only</td>
+<td>Mesa et al., <em>Genetics</em> (2011), published Feb 2011, https://doi.org/10.1534/genetics.110.121996 (mesa2011hid1anew pages 11-12)</td>
+</tr>
+<tr>
+<td><strong>Phenotypic / systems-level observations</strong></td>
+<td><strong>YLR436C</strong></td>
+<td>ECM30</td>
+<td><em>S. cerevisiae</em></td>
+<td><strong>Q06673</strong></td>
+<td>As above</td>
+<td>Cytoplasmic annotation from screen table (raisner2008genomewidescreenfor pages 4-5)</td>
+<td>Linked functionally to <strong>PAR32</strong> and <strong>UBP15</strong> by genetic interaction profile similarity in the Gap1-sorting module (costanzo2010thegeneticlandscape pages 2-4)</td>
+<td>Deletion causes <strong>Gap1 sorting and transport defects</strong>; a truncated/frameshifted ECM30 variant was suggested as a contributor in experimentally evolved <strong>high-temperature-tolerant</strong> yeast, implying that altering ECM30 function can affect stress adaptation (costanzo2010thegeneticlandscape pages 2-4, huang2018experimentalevolutionof pages 5-6)</td>
+<td>Nutrient permease trafficking; stress adaptation / thermotolerance (costanzo2010thegeneticlandscape pages 2-4, huang2018experimentalevolutionof pages 5-6)</td>
+<td>Functional-genomics prediction; stress-related phenotype rather than direct biochemical activity</td>
+<td>Huang et al., <em>Molecular Biology and Evolution</em> (2018), published Aug 2018, https://doi.org/10.1093/molbev/msy077 (huang2018experimentalevolutionof pages 5-6); Costanzo et al., <em>Science</em> (2010), https://doi.org/10.1126/science.1180823 (costanzo2010thegeneticlandscape pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key properties, evidence-supported functions, localization, interactions, and pathway associations of yeast ECM30/YLR436C. It is useful as a concise evidence map distinguishing direct yeast data from family-based functional inference.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(benschop2010aconsensusof pages 6-7): Joris J. Benschop, Nathalie Brabers, Dik van Leenen, Linda V. Bakker, Hanneke W.M. van Deutekom, Nynke L. van Berkum, Eva Apweiler, Philip Lijnzaad, Frank C.P. Holstege, and Patrick Kemmeren. A consensus of core protein complex compositions for saccharomyces cerevisiae. Molecular cell, 38 6:916-28, Jun 2010. URL: https://doi.org/10.1016/j.molcel.2010.06.002, doi:10.1016/j.molcel.2010.06.002. This article has 96 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 5-6): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Open Biology, Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2016insightsintoapcc pages 6-8): Zhuan Zhou, Mingjing He, Anil A. Shah, and Yong Wan. Insights into apc/c: from cellular function to diseases and therapeutics. Cell Division, Mar 2016. URL: https://doi.org/10.1186/s13008-016-0021-6, doi:10.1186/s13008-016-0021-6. This article has 176 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2016insightsintoapcc pages 15-16): Zhuan Zhou, Mingjing He, Anil A. Shah, and Yong Wan. Insights into apc/c: from cellular function to diseases and therapeutics. Cell Division, Mar 2016. URL: https://doi.org/10.1186/s13008-016-0021-6, doi:10.1186/s13008-016-0021-6. This article has 176 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 9-9): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Open Biology, Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suresh2020thestructureand pages 8-9): Harsha Garadi Suresh, Natasha Pascoe, and Brenda Andrews. The structure and function of deubiquitinases: lessons from budding yeast. Open Biology, Oct 2020. URL: https://doi.org/10.1098/rsob.200279, doi:10.1098/rsob.200279. This article has 62 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(costanzo2010thegeneticlandscape pages 2-4): Michael Costanzo, Anastasia Baryshnikova, Jeremy Bellay, Yungil Kim, Eric D. Spear, Carolyn S. Sevier, Huiming Ding, Judice L.Y. Koh, Kiana Toufighi, Sara Mostafavi, Jeany Prinz, Robert P. St. Onge, Benjamin VanderSluis, Taras Makhnevych, Franco J. Vizeacoumar, Solmaz Alizadeh, Sondra Bahr, Renee L. Brost, Yiqun Chen, Murat Cokol, Raamesh Deshpande, Zhijian Li, Zhen-Yuan Lin, Wendy Liang, Michaela Marback, Jadine Paw, Bryan-Joseph San Luis, Ermira Shuteriqi, Amy Hin Yan Tong, Nydia van Dyk, Iain M. Wallace, Joseph A. Whitney, Matthew T. Weirauch, Guoqing Zhong, Hongwei Zhu, Walid A. Houry, Michael Brudno, Sasan Ragibizadeh, Balázs Papp, Csaba Pál, Frederick P. Roth, Guri Giaever, Corey Nislow, Olga G. Troyanskaya, Howard Bussey, Gary D. Bader, Anne-Claude Gingras, Quaid D. Morris, Philip M. Kim, Chris A. Kaiser, Chad L. Myers, Brenda J. Andrews, and Charles Boone. The genetic landscape of a cell. Science, 327:425-431, Jan 2010. URL: https://doi.org/10.1126/science.1180823, doi:10.1126/science.1180823. This article has 2665 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ho2015candidaglabratanew pages 3-4): Hsueh-lui Ho and Ken Haynes. Candida glabrata: new tools and technologies—expanding the toolkit. FEMS Yeast Research, 15:fov066, Jul 2015. URL: https://doi.org/10.1093/femsyr/fov066, doi:10.1093/femsyr/fov066. This article has 44 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(varlakhanova2018feedbackregulationof pages 20-25): Natalia V. Varlakhanova, Bryan A. Tornabene, and Marijn G. J. Ford. Feedback regulation of torc1 by its downstream effectors npr1 and par32. Nov 2018. URL: https://doi.org/10.1091/mbc.e18-03-0158, doi:10.1091/mbc.e18-03-0158. This article has 14 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(varlakhanova2018feedbackregulationof pages 39-53): Natalia V. Varlakhanova, Bryan A. Tornabene, and Marijn G. J. Ford. Feedback regulation of torc1 by its downstream effectors npr1 and par32. Nov 2018. URL: https://doi.org/10.1091/mbc.e18-03-0158, doi:10.1091/mbc.e18-03-0158. This article has 14 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(varlakhanova2018feedbackregulationof pages 16-20): Natalia V. Varlakhanova, Bryan A. Tornabene, and Marijn G. J. Ford. Feedback regulation of torc1 by its downstream effectors npr1 and par32. Nov 2018. URL: https://doi.org/10.1091/mbc.e18-03-0158, doi:10.1091/mbc.e18-03-0158. This article has 14 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(varlakhanova2018feedbackregulationof pages 1-7): Natalia V. Varlakhanova, Bryan A. Tornabene, and Marijn G. J. Ford. Feedback regulation of torc1 by its downstream effectors npr1 and par32. Nov 2018. URL: https://doi.org/10.1091/mbc.e18-03-0158, doi:10.1091/mbc.e18-03-0158. This article has 14 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raisner2008genomewidescreenfor pages 4-5): Ryan M Raisner and Hiten D Madhani. Genomewide screen for negative regulators of sirtuin activity in saccharomyces cerevisiae reveals 40 loci and links to metabolism. Genetics, 179:1933-1944, Aug 2008. URL: https://doi.org/10.1534/genetics.108.088443, doi:10.1534/genetics.108.088443. This article has 24 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 11-12): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 12-14): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 2-3): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 1-2): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 17-21): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 14-15): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mesa2011hid1anew pages 6-7): Rosana Mesa, Shuo Luo, Christopher M Hoover, Kenneth Miller, Alicia Minniti, Nibaldo Inestrosa, and Michael L Nonet. Hid-1, a new component of the peptidergic signaling pathway. Genetics, 187:467-483, Feb 2011. URL: https://doi.org/10.1534/genetics.110.121996, doi:10.1534/genetics.110.121996. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huang2018experimentalevolutionof pages 5-6): Chih-Jen Huang, Mei-Yeh Lu, Ya-Wen Chang, and Wen-Hsiung Li. Experimental evolution of yeast for high-temperature tolerance. Molecular Biology and Evolution, 35:1823–1839, Aug 2018. URL: https://doi.org/10.1093/molbev/msy077, doi:10.1093/molbev/msy077. This article has 138 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raisner2008genomewidescreenfor pages 7-8): Ryan M Raisner and Hiten D Madhani. Genomewide screen for negative regulators of sirtuin activity in saccharomyces cerevisiae reveals 40 loci and links to metabolism. Genetics, 179:1933-1944, Aug 2008. URL: https://doi.org/10.1534/genetics.108.088443, doi:10.1534/genetics.108.088443. This article has 24 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(raisner2008genomewidescreenfor pages 6-7): Ryan M Raisner and Hiten D Madhani. Genomewide screen for negative regulators of sirtuin activity in saccharomyces cerevisiae reveals 40 loci and links to metabolism. Genetics, 179:1933-1944, Aug 2008. URL: https://doi.org/10.1534/genetics.108.088443, doi:10.1534/genetics.108.088443. This article has 24 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ECM30-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>benschop2010aconsensusof pages 6-7</li>
+<li>suresh2020thestructureand pages 5-6</li>
+<li>costanzo2010thegeneticlandscape pages 2-4</li>
+<li>raisner2008genomewidescreenfor pages 4-5</li>
+<li>huang2018experimentalevolutionof pages 5-6</li>
+<li>zhou2016insightsintoapcc pages 6-8</li>
+<li>zhou2016insightsintoapcc pages 15-16</li>
+<li>suresh2020thestructureand pages 9-9</li>
+<li>suresh2020thestructureand pages 8-9</li>
+<li>ho2015candidaglabratanew pages 3-4</li>
+<li>varlakhanova2018feedbackregulationof pages 20-25</li>
+<li>varlakhanova2018feedbackregulationof pages 39-53</li>
+<li>varlakhanova2018feedbackregulationof pages 16-20</li>
+<li>varlakhanova2018feedbackregulationof pages 1-7</li>
+<li>raisner2008genomewidescreenfor pages 7-8</li>
+<li>raisner2008genomewidescreenfor pages 6-7</li>
+<li>https://doi.org/10.1126/science.1180823</li>
+<li>https://doi.org/10.1016/j.molcel.2010.06.002</li>
+<li>https://doi.org/10.1534/genetics.108.088443</li>
+<li>https://doi.org/10.1534/genetics.110.121996</li>
+<li>https://doi.org/10.1093/molbev/msy077</li>
+<li>https://doi.org/10.1016/j.molcel.2010.06.002,</li>
+<li>https://doi.org/10.1098/rsob.200279,</li>
+<li>https://doi.org/10.1186/s13008-016-0021-6,</li>
+<li>https://doi.org/10.1126/science.1180823,</li>
+<li>https://doi.org/10.1093/femsyr/fov066,</li>
+<li>https://doi.org/10.1091/mbc.e18-03-0158,</li>
+<li>https://doi.org/10.1534/genetics.108.088443,</li>
+<li>https://doi.org/10.1534/genetics.110.121996,</li>
+<li>https://doi.org/10.1093/molbev/msy077,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ECM30-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q06673" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ecm30-ylr436c-q06673-curation-notes">ECM30 (YLR436C / Q06673) curation notes</h1>
+<p>Journal of research for the AI GO-annotation review. ECM30 is an <strong>understudied ("dark")<br />
+gene</strong>: SGD classifies it as a "protein of unknown function" with molecular_function and<br />
+biological_process annotated ND. The primary deliverable of this review is therefore an<br />
+honest, sharply-delimited <code>knowledge_gaps</code> section plus carefully-reasoned, evidence-limited<br />
+<code>description</code>/<code>core_functions</code>.</p>
+<h2 id="identity-and-family">Identity and family</h2>
+<ul>
+<li>UniProt entry <strong>HID1_YEAST / Q06673</strong>, RecName "Protein ECM30", AltName "Extracellular<br />
+  mutant protein 30". Systematic name <strong>YLR436C</strong>, chromosome XII. 1274 aa, 145 kDa.<br />
+  [file:yeast/ECM30/ECM30-uniprot.txt]</li>
+<li>Gene name origin: <strong>"ExtraCellular Mutant"</strong> — the ECM series comes from the Lussier et al.<br />
+  1997 calcofluor-white / cell-surface transposon-mutagenesis screen<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9335584" title="screening transposon-mutagenized cells for altered sensitivity to calcofluor   white">PMID:9335584</a>. SGD attributes the ECM30 gene name to this paper. This paper is the source of<br />
+  UniProt's FUNCTION line ("Required to form the correct cell wall composition"<br />
+  {ECO:0000269|PubMed:9335584}). NOTE: the cached PMID_9335584 is <strong>abstract-only</strong><br />
+  (<code>full_text_available: false</code>); the abstract reports 82 genes but does not name ECM30<br />
+  individually — the gene-specific data are in the full text, which I have not read. Per<br />
+  curation policy I do NOT remove/contradict this experimental cell-wall attribution.</li>
+<li><strong>Family = HID1 family</strong> (UniProt "Belongs to the hid-1 family"; Pfam <strong>PF12722 Hid1</strong>;<br />
+  InterPro <strong>IPR026705 HID1/Ecm30</strong>; PANTHER <strong>PTHR21575 "PROTEIN HID1"</strong>).<br />
+  [file:yeast/ECM30/ECM30-uniprot.txt]</li>
+<li>MNEMONIC-COLLISION CAVEAT: UniProt's mnemonic "HID1_YEAST" reflects family membership, not<br />
+  a human-disease connection. ECM30 is the <em>S. cerevisiae</em> ortholog of metazoan HID1.</li>
+<li><strong>No paralog in S. cerevisiae.</strong> SGD lists an empty paralogs array for ECM30<br />
+  [SGD backend locus S000004428, <code>paralogs: []</code>]. (The task brief's suggestion of a paralog<br />
+  "YKL215C" is NOT supported by SGD; YKL215C = OXP1, 5-oxoprolinase, unrelated.) ECM30 is the<br />
+  single-copy yeast member of PTHR21575. By contrast <em>S. pombe</em> has <strong>three</strong> HID1-family<br />
+  paralogs — hid1 (SPAP27G11.12 / O13776), hid2 (Q9HDV3), hid3 (Q9P7M6)<br />
+  [file:interpro/panther/PTHR21575/PTHR21575-entries.csv].</li>
+</ul>
+<h2 id="panther-family-membership-pthr21575-reviewed-members">PANTHER family membership (PTHR21575) — reviewed members</h2>
+<p>From <code>interpro/panther/PTHR21575/PTHR21575-entries.csv</code> (8 reviewed proteins, 4027 total,<br />
+7556 taxa):</p>
+<table>
+<thead>
+<tr>
+<th>UniProt</th>
+<th>Protein</th>
+<th>Organism</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Q06673</td>
+<td>Protein ECM30</td>
+<td>S. cerevisiae</td>
+</tr>
+<tr>
+<td>O13776</td>
+<td>Hid-1 family protein hid1</td>
+<td>S. pombe</td>
+</tr>
+<tr>
+<td>Q9HDV3</td>
+<td>Hid-1 family protein hid2</td>
+<td>S. pombe</td>
+</tr>
+<tr>
+<td>Q9P7M6</td>
+<td>Hid-1 family protein hid3</td>
+<td>S. pombe</td>
+</tr>
+<tr>
+<td>Q8IV36</td>
+<td>Protein HID1</td>
+<td>Human</td>
+</tr>
+<tr>
+<td>Q8R1F6</td>
+<td>Protein HID1</td>
+<td>Mouse</td>
+</tr>
+<tr>
+<td>D4A0C3</td>
+<td>Protein HID1</td>
+<td>Rat</td>
+</tr>
+<tr>
+<td>Q54JJ6</td>
+<td>Protein HID1</td>
+<td>Dictyostelium</td>
+</tr>
+</tbody>
+</table>
+<h2 id="metazoan-ortholog-human-hid1-q8iv36-for-orthology-reasoning-only">Metazoan ortholog (human HID1, Q8IV36) — for orthology reasoning ONLY</h2>
+<ul>
+<li>Human HID1 FUNCTION (UniProt Q8IV36): "Plays a role in the biogenesis of large dense core<br />
+  vesicles (LDCVs) at the trans-Golgi network; necessary for the proper sorting of cargo into<br />
+  LDCVs and is required for proper regulated exocytosis (also known as regulated secretory<br />
+  pathway)." {ECO:0000269|PubMed:37751424}<br />
+  [https://rest.uniprot.org/uniprotkb/Q8IV36.txt]</li>
+<li>Human HID1 localization: Cytoplasm; Golgi apparatus, trans-Golgi network membrane<br />
+  (lipid-anchor); "Shuttles between the cytosol and the Golgi apparatus."<br />
+  [https://rest.uniprot.org/uniprotkb/Q8IV36.txt]</li>
+<li>Human HID1 experimental GO (QuickGO, Q8IV36): IDA to Golgi trans cisterna (GO:0000138),<br />
+  Golgi medial cisterna (GO:0005797), Golgi apparatus (GO:0005794), cytosol (GO:0005829);<br />
+  IMP/ISS to dense core granule biogenesis (GO:0061110); IBA to secretory granule maturation<br />
+  (GO:0061792) and Golgi organization (GO:0007030). [QuickGO annotation search Q8IV36]</li>
+<li>KEY CAVEAT for propagation: LDCVs / regulated dense-core secretory granules are a<br />
+<strong>metazoan/neuroendocrine</strong> feature. <em>S. cerevisiae</em> has no regulated dense-core secretory<br />
+  pathway, so the metazoan-specific processes/compartments of HID1 do NOT transfer wholesale.<br />
+  The conserved element is more plausibly a general Golgi-associated membrane-trafficking role.</li>
+</ul>
+<h2 id="what-is-known-about-ecm30-evidence-anchored">What is KNOWN about ECM30 (evidence-anchored)</h2>
+<ol>
+<li><strong>Subcellular localization: cytoplasm</strong> (cytosolic), from GFP-fusion high-throughput<br />
+   analysis [PMID:14562095 (Huh et al. global GFP localization); GOA HDA GO:0005737]. UniProt<br />
+   SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:14562095}. Consistent with the human<br />
+   ortholog's cytosol↔Golgi shuttling (peripheral, not integral membrane).</li>
+<li><strong>Cell-wall phenotype</strong> (source of the gene name): ecm30 mutants show altered calcofluor-<br />
+   white sensitivity and abnormal relative levels of mannose and glucose [PMID:9335584; SGD<br />
+   description "may play a role in cell wall biosynthesis, mutants have abormal relative<br />
+   levels of mannose and glucose"].</li>
+<li><strong>Gap1p (general amino acid permease) sorting and transport defects</strong> in ecm30 mutants<br />
+   [SGD locus description, S000004428: "have Gap1p sorting and transport defects"]. This is a<br />
+   membrane-cargo intracellular-sorting phenotype (Gap1 traffics TGN → endosome → vacuole vs<br />
+   plasma membrane depending on nitrogen source). I could not resolve a single primary PMID<br />
+   naming ECM30 for this Gap1 defect from public search; recording it as an SGD-curated<br />
+   free-text phenotype, not asserting a specific citation.</li>
+<li><strong>Genetic interaction network centered on membrane trafficking</strong> (SGD interaction_details,<br />
+   BioGRID; n=87 genetic partners). Notable, functionally coherent hits:</li>
+<li><strong>GET pathway</strong>: GET1 (Phenotypic Suppression), GET2 (Negative Genetic + Phenotypic<br />
+     Suppression), GET3 (Phenotypic Suppression) — tail-anchored membrane-protein insertion<br />
+     at the ER.</li>
+<li><strong>Golgi/secretory</strong>: ARL1 (Phenotypic Enhancement; Golgi Arf-like GTPase), SEC14<br />
+     (Synthetic Growth Defect; TGN PI/PC transfer protein), SEC26 &amp; SEC28 (Negative Genetic;<br />
+     COPI coatomer subunits).</li>
+<li><strong>Vacuolar/endosomal sorting</strong>: VPS1 (dynamin), VPS9, VPS17 (retromer).</li>
+<li><strong>Physical interactions</strong> (SGD/BioGRID, n=30 physical partners; mostly single-method<br />
+   high-throughput AC-MS). Trafficking-relevant: <strong>LAA1</strong> (Affinity Capture-MS; TGN AP-1<br />
+   clathrin-adaptor-associated / AP-3 accessory), <strong>VAM6/VPS39</strong> (Affinity Capture-MS; HOPS<br />
+   tethering complex, vacuole fusion), <strong>UBP15</strong> (AC-MS + AC-Western; ubiquitin protease).<br />
+   Many other AC-MS hits (histones HHT1/HHT2/HTB1/HTB2, RNA-binding CAF20/PUF2/PUF3/DHH1,<br />
+   Pol II RPO21) are typical abundant-protein / RNA-tethered background for a large 145 kDa<br />
+   cytosolic protein and are not treated as functional.</li>
+<li><strong>Post-translational modification</strong>: phosphoserine at Ser635 and Ser1065 (large-scale<br />
+   phosphoproteomics) [UniProt MOD_RES; PMID:17330950, PMID:18407956, PMID:19779198]. Ser1065<br />
+   is a mitotic/Cdk1-context site (Holt et al.). Regulatory significance unknown.</li>
+<li><strong>Sequence architecture</strong>: 1274 aa, HID1 α-solenoid-type fold (Pfam Hid1 ×2 across the<br />
+   protein), multiple internal disordered/low-complexity stretches (MobiDB-lite regions at<br />
+   ~23-42, 405-439, 494-517, 803-842, 1100-1149). No transmembrane domain, no signal peptide,<br />
+   no catalytic-domain signature → consistent with a peripheral/cytosolic scaffold rather than<br />
+   an enzyme or integral membrane protein. [file:yeast/ECM30/ECM30-uniprot.txt]</li>
+</ol>
+<h2 id="what-is-not-known-the-real-gaps">What is NOT known (the real gaps)</h2>
+<ul>
+<li><strong>Molecular function (MF-dark).</strong> No biochemical activity assigned; SGD/UniProt MF = ND.<br />
+  The HID1 fold has no catalytic assignment in any organism. Whether ECM30 acts as a<br />
+  membrane-trafficking scaffold/adaptor (like human HID1 at the TGN) is inferred, not shown.</li>
+<li><strong>Direct molecular partners.</strong> No validated, specific binding partner defines its activity;<br />
+  the AC-MS hits are unfiltered high-throughput. The mechanistic link to LAA1/GET/ARL1 is<br />
+  genetic/HT-physical, not a defined complex.</li>
+<li><strong>Biological role / mechanism of the cell-wall phenotype.</strong> Why an ecm30 null perturbs<br />
+  cell-wall mannose/glucose and calcofluor sensitivity is unexplained — likely indirect via<br />
+  mis-sorting of cell-wall-biosynthetic cargo (cf. Gap1 mis-sorting), but this is a<br />
+  hypothesis, not established.</li>
+<li><strong>Whether the metazoan HID1 Golgi/secretory role is conserved in yeast.</strong> ECM30 localizes<br />
+  to cytoplasm in the one HT study; it has no experimental Golgi localization in yeast. The<br />
+  IBA Golgi-cisterna/Golgi-organization annotations derive from metazoan orthologs performing<br />
+  a process (regulated dense-core secretion) that S. cerevisiae lacks.</li>
+<li><strong>Redundancy / genetic buffering.</strong> ECM30 is non-essential and single-copy in S. cerevisiae<br />
+  (no paralog), yet the null is only modestly sick — implies functional buffering by parallel<br />
+  trafficking pathways rather than a dedicated paralog.</li>
+</ul>
+<h2 id="go-annotation-review-plan-existing_annotations-9-total">GO annotation review plan (existing_annotations, 9 total)</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>term</th>
+<th>evid</th>
+<th>source</th>
+<th>plan</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>GO:0005829 cytosol</td>
+<td>IBA</td>
+<td>GO_REF:0000033 (PANTHER PTN000491103)</td>
+<td>ACCEPT (KEEP_AS_NON_CORE): cytosolic localization is consistent with HT GFP data &amp; human ortholog cytosol pool.</td>
+</tr>
+<tr>
+<td>2</td>
+<td>GO:0016020 membrane</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MARK_AS_OVER_ANNOTATED: uninformative root-ish CC; ECM30 has no TM and is peripheral at best; propagated from membrane-associated metazoan HID1.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>GO:0007030 Golgi organization</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MARK_AS_OVER_ANNOTATED: metazoan-HID1-derived; no yeast evidence ECM30 organizes the Golgi; yeast lacks the regulated-secretion context.</td>
+</tr>
+<tr>
+<td>4</td>
+<td>GO:0000138 Golgi trans cisterna</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MARK_AS_OVER_ANNOTATED: from human HID1 IDA at TGN; ECM30 localizes cytoplasm in yeast, no yeast Golgi-cisterna evidence.</td>
+</tr>
+<tr>
+<td>5</td>
+<td>GO:0005797 Golgi medial cisterna</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MARK_AS_OVER_ANNOTATED: same as #4; overly specific metazoan compartment.</td>
+</tr>
+<tr>
+<td>6</td>
+<td>GO:0005737 cytoplasm</td>
+<td>IEA</td>
+<td>GO_REF:0000044 (UniProt SubCell)</td>
+<td>ACCEPT/KEEP_AS_NON_CORE: matches HDA + UniProt SUBCELLULAR LOCATION.</td>
+</tr>
+<tr>
+<td>7</td>
+<td>GO:0005737 cytoplasm</td>
+<td>HDA</td>
+<td>PMID:14562095</td>
+<td>ACCEPT (best-supported localization; experimental HT GFP).</td>
+</tr>
+<tr>
+<td>8</td>
+<td>GO:0003674 molecular_function</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT: correctly records MF-dark status (root ND).</td>
+</tr>
+<tr>
+<td>9</td>
+<td>GO:0008150 biological_process</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT: correctly records BP-dark status (root ND).</td>
+</tr>
+</tbody>
+</table>
+<p>Rationale for the Golgi IBA calls: I am NOT removing an experimental annotation. These are<br />
+<strong>IBA electronic</strong> inferences over-propagated from metazoan HID1 (dense-core-vesicle<br />
+biogenesis at the TGN), a process absent in S. cerevisiae. Per CLAUDE.md, over-propagated<br />
+IEA/IBA inferences that can be argued against on biological grounds are legitimate<br />
+MARK_AS_OVER_ANNOTATED / MODIFY candidates. I keep cytosol/cytoplasm (supported) and record<br />
+the honest dark-gene status via the ND roots and the knowledge_gaps section.</p>
+<h2 id="deep-research-status">Deep research status</h2>
+<p>Automated deep research did not yield a provider file. Falcon (Edison) timed out at 600s<br />
+on the initial run and again on a single retry (the shared Edison endpoint was saturated by<br />
+many concurrent sibling jobs at the time); the perplexity-lite fallback returned HTTP 401<br />
+(quota exhausted). No <code>-deep-research-{provider}.md</code> file was produced. This review is<br />
+therefore grounded directly in primary/curated sources: the UniProt record (Q06673), the<br />
+GOA TSV, cached publications (PMID:9335584, PMID:14562095, and the phosphoproteomics PMIDs),<br />
+the SGD locus record (S000004428: description, phenotypes, interactions, empty paralog list),<br />
+the PANTHER PTHR21575 family membership file, QuickGO annotations for the human ortholog HID1<br />
+(Q8IV36), and the human HID1 UniProt FUNCTION/localization. All assertions above carry inline<br />
+provenance. Per project policy, no self-authored content is named as a provider deep-research<br />
+file.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q06673
+gene_symbol: ECM30
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ECM30 (YLR436C) is a large (1274 aa, ~145 kDa) cytoplasmic protein of the HID1
+  family (Pfam Hid1 / InterPro IPR026705 HID1/Ecm30; PANTHER PTHR21575), the
+  single-copy Saccharomyces cerevisiae ortholog of metazoan HID1, a peripheral
+  trans-Golgi-network protein that functions in dense-core secretory-vesicle
+  biogenesis. ECM30 has no experimentally established molecular function and is
+  classified as a protein of unknown function. It has no transmembrane segment or
+  recognizable catalytic domain and localizes to the cytoplasm, consistent with a
+  peripheral membrane-associated scaffold rather than an enzyme or integral membrane
+  protein. Its gene name derives from an &#34;extracellular mutant&#34; cell-surface screen:
+  ecm30 loss alters calcofluor-white sensitivity and the relative cell-wall content
+  of mannose and glucose, and ecm30 mutants have defects in the intracellular sorting
+  and transport of the general amino acid permease Gap1. Genetic interactions place
+  it in the membrane-trafficking network, including the GET tail-anchored-protein
+  insertion pathway (GET1/GET2/GET3), Golgi and secretory components (ARL1, SEC14,
+  COPI subunits SEC26/SEC28), and vacuolar/endosomal sorting factors (VPS1, VPS9,
+  VPS17). ECM30 is non-essential and is phosphorylated on Ser635 and Ser1065.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:14562095
+    title: Global analysis of protein localization in budding yeast.
+    findings:
+      - statement: &gt;-
+          Genome-wide GFP-fusion localization assigned ECM30 to the cytoplasm; this is
+          the primary experimental subcellular-localization evidence for the protein.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Huh et al. global GFP-localization study; source of the HDA
+        cytoplasm annotation (GO:0005737) and the UniProt SUBCELLULAR LOCATION
+        Cytoplasm {ECO:0000269|PubMed:14562095}. Cached record is abstract-only but
+        the localization datum is a curated high-throughput result.
+  - id: PMID:9335584
+    title: Large scale identification of genes involved in cell surface biosynthesis
+      and architecture in Saccharomyces cerevisiae.
+    findings:
+      - statement: &gt;-
+          The calcofluor-white cell-surface transposon-mutagenesis screen from which
+          the ECM (&#34;extracellular mutant&#34;) series, including ECM30, was named; source
+          of the UniProt FUNCTION statement that ECM30 is required for correct cell-wall
+          composition.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Lussier et al. 1997; SGD attributes the ECM30 gene name to
+        this paper and it is the ECO:0000269 source for UniProt&#39;s cell-wall FUNCTION
+        line. Cached entry is abstract-only (full_text_available: false); the abstract
+        describes the screen but does not name ECM30 individually, so the gene-specific
+        cell-wall data reside in the full text (not read here). Not contradicted.
+  - id: PMID:17330950
+    title: Large-scale phosphorylation analysis of alpha-factor-arrested Saccharomyces
+      cerevisiae.
+    findings:
+      - statement: ECM30 is phosphorylated at Ser1065 (large-scale phosphoproteomics).
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Large-scale phosphoproteomics; contributes a phosphosite
+        (Ser1065) but no functional insight into ECM30.
+  - id: PMID:18407956
+    title: A multidimensional chromatography technology for in-depth phosphoproteome
+      analysis.
+    findings:
+      - statement: ECM30 is phosphorylated at Ser635 (large-scale phosphoproteomics).
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: PubMed-verified. Phosphosite Ser635; no functional insight.
+  - id: PMID:19779198
+    title: Global analysis of Cdk1 substrate phosphorylation sites provides insights
+      into evolution.
+    findings:
+      - statement: &gt;-
+          ECM30 phosphosites Ser635 and Ser1065 detected in a Cdk1-substrate
+          phosphoproteome, suggesting possible cell-cycle-associated phosphoregulation.
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Cdk1 substrate phosphoproteome (Holt et al.); phosphosites
+        only, regulatory significance for ECM30 not established.
+existing_annotations:
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Phylogenetic (IBA) cytosol annotation propagated across the HID1 family
+        (PANTHER PTN000491103). Consistent with the experimental yeast localization
+        (cytoplasm, PMID:14562095) and with the cytosolic pool of the human ortholog
+        HID1, which shuttles between cytosol and Golgi.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Localization is supported and consistent with experimental data, but a
+        subcellular-location term is not itself a core function for a protein whose
+        molecular activity is unknown.
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        High-level, uninformative &#34;membrane&#34; propagated by IBA from the
+        membrane-associated metazoan HID1 orthologs. ECM30 has no transmembrane
+        segment or signal peptide and is experimentally cytoplasmic; at most it is a
+        peripheral membrane associate.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Root-level CC that adds no specific information; the membrane association is an
+        electronic transfer from orthologs and is not supported by experimental yeast
+        data or by sequence features (no TM/anchor predicted).
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - GRANULARITY_MISMATCH
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN000491103
+            source_label: HID1 family node
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Node-level &#34;membrane&#34; reflects the peripheral/lipid-anchored membrane
+              association of metazoan HID1; ECM30 has no TM/signal and is experimentally
+              cytoplasmic, so an uninformative &#34;membrane&#34; parent should not be a
+              confident annotation for the target.
+  - term:
+      id: GO:0007030
+      label: Golgi organization
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Phylogenetic (IBA) Golgi-organization annotation seeded by the fission-yeast
+        ortholog hid1 (GOA WITH/FROM PomBase:SPAC17A5.16), which carries direct
+        experimental (IMP) Golgi-organization evidence and localizes to the Golgi in
+        that fungus. There is, however, no direct S. cerevisiae evidence that ECM30
+        organizes the Golgi: ECM30 is experimentally cytoplasmic (PMID:14562095) with
+        no yeast Golgi localization or Golgi-organization phenotype reported.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        This is a phylogenetic transfer, not a demonstration in S. cerevisiae. The seed
+        is a FUNGAL ortholog (S. pombe hid1, IMP to Golgi organization) rather than a
+        metazoan, so the appropriate argument is the absence of any direct S. cerevisiae
+        Golgi localization or Golgi-organization phenotype for ECM30 - not a claim that
+        the process is absent from budding yeast (it is not). A Golgi/trafficking role
+        for ECM30 remains a plausible but undemonstrated inference (supported indirectly
+        by genetic interactions with ARL1, SEC14 and COPI subunits); the specific &#34;Golgi
+        organization&#34; term should not stand as a confident annotation until direct
+        S. cerevisiae evidence exists. See the CC-dark knowledge gap.
+      propagation_review:
+        root_cause: SOURCE_WEAK_OR_INFERRED
+        failure_modes:
+          - SOURCE_EVIDENCE_WEAK
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: PomBase:SPAC17A5.16
+            source_label: hid1 (S. pombe, GOA WITH/FROM seed)
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Actual IBA seed for this term. S. pombe hid1 has direct experimental (IMP)
+              Golgi-organization evidence and Golgi (HDA) localization; that supports the
+              SOURCE annotation but the transfer to S. cerevisiae ECM30 is unsafe because
+              ECM30 has no direct yeast Golgi localization or Golgi-organization
+              phenotype.
+          - source_id: PANTHER:PTN000491103
+            source_label: HID1 family node
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+  - term:
+      id: GO:0000138
+      label: Golgi trans cisterna
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        IBA transfer of the trans-Golgi-cisterna localization from human HID1 (which
+        has IDA evidence at the TGN). ECM30 localizes to the cytoplasm in the one
+        experimental yeast study and has no yeast Golgi-cisterna evidence.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Overly specific compartment term electronically propagated from the metazoan
+        ortholog; not supported by experimental localization of yeast ECM30
+        (cytoplasm, PMID:14562095).
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+          - CONTEXT_OR_TISSUE_MISMATCH
+        source_entities:
+          - source_id: UniProtKB:Q8IV36
+            source_label: HID1 (human)
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Human HID1 has IDA evidence at the trans-Golgi cisterna; ECM30 is
+              experimentally cytoplasmic in yeast with no Golgi-cisterna evidence.
+  - term:
+      id: GO:0005797
+      label: Golgi medial cisterna
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        As for GO:0000138: an overly specific Golgi-cisterna compartment propagated by
+        IBA from metazoan HID1, without supporting experimental evidence in yeast.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Electronic transfer of a specific metazoan Golgi compartment; ECM30 is
+        experimentally cytoplasmic in yeast with no Golgi-cisterna evidence.
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+          - CONTEXT_OR_TISSUE_MISMATCH
+        source_entities:
+          - source_id: UniProtKB:Q8IV36
+            source_label: HID1 (human)
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Same basis as GO:0000138: a metazoan-ortholog Golgi compartment
+              transferred by IBA without any supporting yeast localization for ECM30.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic mapping from the UniProt SUBCELLULAR LOCATION &#34;Cytoplasm&#34;
+        vocabulary, which itself is backed by the experimental GFP result. Correct and
+        redundant with the HDA cytoplasm annotation.
+      action: ACCEPT
+      reason: &gt;-
+        Accurate localization consistent with the experimental (HDA) cytoplasm
+        annotation to the same term; retained for consistency.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: HDA
+    original_reference_id: PMID:14562095
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Best-supported localization for ECM30: high-throughput GFP-fusion analysis
+        (Huh et al.) places the protein in the cytoplasm. This is the primary
+        experimental cellular-component evidence.
+      action: ACCEPT
+      reason: &gt;-
+        Directly supported experimental (HDA) localization; the correct and
+        best-evidenced compartment annotation for ECM30.
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root &#34;molecular_function&#34; with ND correctly records that no molecular function
+        has been experimentally established for ECM30 (a protein of unknown function).
+      action: ACCEPT
+      reason: &gt;-
+        The ND root annotation accurately captures the MF-dark status of this gene; an
+        appropriate placeholder given the absence of any assigned biochemical activity.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root &#34;biological_process&#34; with ND correctly records that no biological process
+        has been experimentally assigned to ECM30. Phenotypes (cell-wall composition,
+        Gap1 sorting) and genetic interactions suggest a role in membrane trafficking,
+        but no process has been directly established.
+      action: ACCEPT
+      reason: &gt;-
+        The ND root annotation appropriately represents the BP-dark status; existing
+        clues are phenotypic/genetic, not a curated experimental process assignment.
+core_functions:
+  - description: &gt;-
+      ECM30 has no experimentally established molecular function. It is the single-copy
+      S. cerevisiae member of the HID1 family (Pfam Hid1; InterPro IPR026705), whose
+      characterized metazoan ortholog HID1 is a peripheral trans-Golgi-network protein
+      acting in secretory-vesicle biogenesis; the conserved element, if any, is most
+      plausibly a Golgi/endosomal membrane-trafficking scaffold activity, offered as a
+      hypothesis and not a demonstrated activity.
+    supported_by:
+      - reference_id: PMID:14562095
+        supporting_text: &gt;-
+          into 22 distinct subcellular localization categories, and provide localization
+          information for 70% of previously unlocalized proteins.
+  - description: &gt;-
+      At the cellular level, loss of ECM30 perturbs cell-surface / cell-wall assembly
+      (the basis of the ECM &#34;extracellular mutant&#34; name), altering calcofluor-white
+      sensitivity and the relative cell-wall content of mannose and glucose. Whether
+      this reflects a direct cell-wall-biogenesis role or an indirect consequence of
+      mis-sorting of trafficking cargo (as also seen for the general amino acid permease
+      Gap1) is not established.
+    supported_by:
+      - reference_id: PMID:9335584
+        supporting_text: &gt;-
+          We have identified genes involved in cell surface assembly by screening
+          transposon-mutagenized cells for altered sensitivity to calcofluor white,
+          followed by supplementary screens to further characterize mutant phenotypes.
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular activity of ECM30 is unknown. No enzymatic activity, defined
+      biochemical function, or validated specific binding partner has been demonstrated;
+      it is undetermined whether ECM30, like the metazoan HID1 ortholog, acts as a
+      peripheral membrane-trafficking scaffold/adaptor.
+    boundary: &gt;-
+      What is firmly established is only the domain architecture and localization:
+      ECM30 is a 1274-aa HID1-family protein (Pfam Hid1; InterPro IPR026705 HID1/Ecm30;
+      PANTHER PTHR21575), with several internal disordered/low-complexity segments, no
+      transmembrane domain, no signal peptide, and no catalytic-domain signature; it is
+      experimentally cytoplasmic.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      HID1 is a conserved, disease-linked family whose molecular activity is undefined
+      in every organism; establishing an activity for the tractable single-copy yeast
+      member would anchor function for the whole family.
+    resolution: &gt;-
+      Affinity purification / mass spectrometry from yeast to define a specific complex,
+      in vitro reconstitution of any candidate membrane/lipid or cargo interaction, and
+      structure-guided mutagenesis of the HID1 fold.
+    provenance:
+      - reference_id: PMID:14562095
+        supporting_text: &gt;-
+          into 22 distinct subcellular localization categories, and provide localization
+          information for 70% of previously unlocalized proteins.
+  - gap_statement: &gt;-
+      The biological process ECM30 acts in, and the mechanism linking it to the
+      cell-wall phenotype, are unknown. It is unresolved whether ECM30 contributes
+      directly to cell-wall (mannan/glucan) biogenesis or does so indirectly by
+      supporting the intracellular sorting of cell-wall-biosynthetic and permease cargo
+      (e.g. the Gap1 sorting/transport defect of ecm30 mutants).
+    boundary: &gt;-
+      What is established phenotypically is that ecm30 loss alters calcofluor-white
+      sensitivity and the relative mannose/glucose content of the cell wall, and that
+      ecm30 mutants mis-sort the general amino acid permease Gap1; genetic interactions
+      connect ECM30 to the GET pathway (GET1/GET2/GET3), Golgi/secretory factors (ARL1,
+      SEC14, COPI subunits SEC26/SEC28) and vacuolar sorting (VPS1/VPS9/VPS17).
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Distinguishing a direct cell-wall-biosynthetic role from an upstream
+      membrane-trafficking role would explain a decades-old &#34;extracellular mutant&#34;
+      phenotype and clarify how a cytosolic HID1-family protein controls cell-surface
+      composition.
+    resolution: &gt;-
+      Epistasis and cargo-trafficking assays (Gap1 and cell-wall enzyme itineraries) in
+      ecm30 versus GET/Golgi/VPS mutants, and direct measurement of cell-wall
+      polysaccharide biosynthesis in the ecm30 null.
+    provenance:
+      - reference_id: PMID:9335584
+        supporting_text: &gt;-
+          Eighty-two genes with apparent perturbation of the cell surface were
+          identified, with mutations in 65 of them displaying at least one further cell
+          surface phenotype in addition to their modified sensitivity to calcofluor.
+  - gap_statement: &gt;-
+      It is unknown whether ECM30 associates with the Golgi/TGN in S. cerevisiae. A
+      Golgi role is experimentally established for the FUNGAL ortholog S. pombe hid1
+      (IMP Golgi organization; Golgi localization) and for metazoan HID1 (trans-Golgi
+      network), so a conserved Golgi function is a live possibility for ECM30; but the
+      only S. cerevisiae localization datum places ECM30 in the cytoplasm, and the IBA
+      Golgi-cisterna and Golgi-organization annotations are unverified phylogenetic
+      transfers.
+    boundary: &gt;-
+      The only experimental localization of ECM30 (high-throughput GFP fusion) is
+      cytoplasmic. The Golgi-organization annotation is an IBA seeded by S. pombe hid1
+      (a fungus with a Golgi and direct IMP evidence), while the Golgi trans/medial
+      cisterna annotations are IBA transfers from metazoan HID1; none is backed by a
+      direct S. cerevisiae Golgi localization or phenotype for ECM30.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Determining whether budding-yeast ECM30 associates with the Golgi/TGN would either
+      validate the phylogenetic Golgi annotations for the S. cerevisiae branch or confirm
+      them as over-propagations, and would establish whether the Golgi role experimentally
+      documented for the S. pombe ortholog is conserved across fungi.
+    resolution: &gt;-
+      Endogenous fluorescent-protein co-localization with Golgi/TGN and endosome
+      markers under native and stressed conditions, and fractionation to test peripheral
+      membrane association.
+    provenance:
+      - reference_id: PMID:14562095
+        supporting_text: &gt;-
+          into 22 distinct subcellular localization categories, and provide localization
+          information for 70% of previously unlocalized proteins.
+suggested_questions:
+  - question: &gt;-
+      Does ECM30 physically associate with the Golgi/TGN or endosomal membranes in
+      S. cerevisiae, as its metazoan HID1 ortholog does at the trans-Golgi network?
+  - question: &gt;-
+      Is the cell-wall (mannose/glucose) phenotype of ecm30 mutants a direct effect on
+      wall biogenesis or an indirect consequence of defective intracellular sorting of
+      trafficking cargo such as Gap1?
+suggested_experiments:
+  - hypothesis: &gt;-
+      ECM30 functions as a peripheral membrane-trafficking scaffold at the Golgi/
+      endosome, and its cell-wall and Gap1 phenotypes are downstream of impaired
+      cargo sorting.
+    description: &gt;-
+      Perform affinity-purification mass spectrometry on endogenously tagged ECM30 to
+      identify a specific, reproducible interaction partner set (filtering high-throughput
+      background), combined with fluorescent co-localization to Golgi/TGN, endosome and
+      vacuole markers, and cargo-trafficking assays (Gap1-GFP itinerary; cell-wall
+      biosynthetic enzyme localization) in the ecm30 null.
+    experiment_type: affinity purification-mass spectrometry, fluorescence microscopy, cargo-trafficking assay
+  - hypothesis: &gt;-
+      ECM30 acts in the same functional module as the GET pathway and Golgi trafficking
+      machinery revealed by its genetic interactions.
+    description: &gt;-
+      Systematically test genetic epistasis and cargo phenotypes of ecm30 in combination
+      with GET1/GET2/GET3, ARL1, SEC14 and VPS mutants to place ECM30 in a defined
+      trafficking step.
+    experiment_type: genetic epistasis analysis
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/MRX20/MRX20-ai-review.html
+++ b/genes/yeast/MRX20/MRX20-ai-review.html
@@ -1,0 +1,2913 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MRX20 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MRX20</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P43617" target="_blank" class="term-link">
+                        P43617
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YFR045W</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MRX20";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P43617" data-a="DESCRIPTION: MRX20 (YFR045W) is an uncharacterized inner-membra..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MRX20 (YFR045W) is an uncharacterized inner-membrane protein of Saccharomyces cerevisiae mitochondria that belongs to the mitochondrial carrier family (SLC25/MCF; TC 2.A.29). Its sequence has the canonical mitochondrial-carrier architecture: three tandem Solcar repeats and six predicted transmembrane helices forming the pseudo-threefold-symmetric fold typical of metabolite carriers, and it retains the conserved carrier signature residues found in functionally characterized carriers. Within its family it falls in a fungal-specific subfamily whose members are all uncharacterized, so no specific transported substrate has been established for MRX20; the protein is therefore best described as a putative mitochondrial metabolite carrier of unknown substrate. The gene is non-essential, expressed at low abundance, and its transcription is induced under stress. It was given the &#34;Mrx&#34; name after it co-purified with native mitochondrial-ribosome (MIOREX) complexes in a proteomic study, but a direct role in mitochondrial gene expression has not been demonstrated.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but non-specific mitochondrial localization from phylogenetic propagation. MRX20 is an integral mitochondrial inner-membrane carrier, so &#34;mitochondrion&#34; is accurate but subsumed by the more specific inner-membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the mitochondrial-carrier family assignment and the ISS inner-membrane annotation, but less informative than GO:0005743 (mitochondrial inner membrane).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071913" target="_blank" class="term-link">
+                                    GO:0071913
+                                </a>
+                            </span>
+                            <span class="term-label">citrate secondary active transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0071913" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-specific molecular-function propagation. The citrate-transporter activity is driven by the characterized tricarboxylate/citrate carriers in the broad PANTHER family PTHR45788 (CTP1, human SLC25A1, SFC1), but MRX20 falls in the fungal-specific subfamily PTHR45788:SF5 whose members are all uncharacterized mitochondrial carriers with no demonstrated substrate. No citrate-transport activity has been shown for MRX20, and its specific substrate is unknown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Family-level IBA over-propagation of a specific substrate to a gene in an uncharacterized subfamily; the transported substrate of MRX20 is genuinely unknown. The general carrier/transporter nature is retained in core_functions as transmembrane transporter activity without asserting citrate.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTHR45788</span>
+
+                                    &middot; SUCCINATE/FUMARATE MITOCHONDRIAL TRANSPORTER-RELATED
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Broad family node carrying the citrate-carrier signal from characterized members (CTP1, human SLC25A1, SFC1); too general to fix the substrate for MRX20.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTHR45788:SF5</span>
+
+                                    &middot; AFR253WP
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">MRX20&#39;s own subfamily; all members (P43617, SCY_1795, SCRG_05595, AWRI1631_61110) are uncharacterized mitochondrial carriers with no demonstrated citrate transport.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022857" target="_blank" class="term-link">
+                                    transmembrane transporter activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006843" target="_blank" class="term-link">
+                                    GO:0006843
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial citrate transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0006843" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-specific biological-process propagation, mirroring the citrate-transporter molecular-function annotation. The citrate-transport process is inferred from the characterized citrate carriers of the family, not from MRX20 or its uncharacterized subfamily.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same family-level over-propagation as the citrate transporter activity; MRX20&#39;s transported substrate is unknown. A general transmembrane-transport process is retained instead.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTHR45788</span>
+
+                                    &middot; SUCCINATE/FUMARATE MITOCHONDRIAL TRANSPORTER-RELATED
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Citrate-transport process propagated from characterized citrate carriers in the broad family, not from MRX20 or its uncharacterized subfamily.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTHR45788:SF5</span>
+
+                                    &middot; AFR253WP
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">MRX20&#39;s subfamily is uncharacterized; no member has a demonstrated citrate-transport process.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990542" target="_blank" class="term-link">
+                                    mitochondrial transmembrane transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inner-membrane localization from UniProt Subcellular Location mapping, consistent with the multi-pass mitochondrial-carrier assignment and with the ISS annotation from PMID:10930523. This is the best-supported and most specific localization for MRX20.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Agrees with the mitochondrial carrier (SLC25/MCF) family membership, six predicted transmembrane helices, and the independent ISS inner-membrane call.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General transmembrane-transport process from the InterPro mitochondrial-carrier domain signature. Appropriately generic for a carrier whose specific substrate is unknown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by the mitochondrial-carrier domain architecture; does not overreach on substrate specificity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10930523
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The yeast mitochondrial transport proteins: new sequences an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0005743" data-r="PMID:10930523" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inner-membrane localization inferred by SGD from sequence/structural similarity, based on the mitochondrial transport protein survey. Concordant with the UniProt SubCell IEA and with the family assignment; this is the core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MRX20 has the canonical mitochondrial-carrier fold (three Solcar repeats, six TM helices) and retains the carrier consensus residues; inner-membrane localization is strongly supported.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function with ND (no biological data). This honestly records that no specific molecular function has been experimentally determined for MRX20. Given that the transported substrate is unknown and the subfamily is uncharacterized, retaining ND is appropriate rather than asserting a specific activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly represents the genuine absence of a demonstrated molecular function; a general transmembrane transporter activity is proposed in core_functions on family grounds but no specific catalytic/substrate activity is experimentally established.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006839" target="_blank" class="term-link">
+                                    GO:0006839
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10930523
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The yeast mitochondrial transport proteins: new sequences an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0006839" data-r="PMID:10930523" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General mitochondrial-transport process inferred by SGD from similarity to characterized mitochondrial transport proteins. Appropriately generic and consistent with the carrier-family assignment without committing to a substrate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by mitochondrial-carrier family membership; correctly avoids substrate-specific over-annotation. Retained as a general (non-core-defining) process for this dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022857" target="_blank" class="term-link">
+                                    GO:0022857
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10930523
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The yeast mitochondrial transport proteins: new sequences an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:0022857" data-r="PMID:10930523" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed general molecular-function annotation replacing the over-specific citrate-transporter IBA. MRX20 has the mitochondrial-carrier fold and retained carrier consensus residues, supporting a transmembrane transporter activity without committing to a substrate that has not been experimentally determined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures the defensible, substrate-agnostic transporter activity of this carrier on domain/family grounds, in place of the family-level citrate over-propagation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990542" target="_blank" class="term-link">
+                                    GO:1990542
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10930523
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The yeast mitochondrial transport proteins: new sequences an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P43617" data-a="GO:1990542" data-r="PMID:10930523" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed mitochondrial transmembrane-transport process replacing the over-specific mitochondrial citrate transport IBA. Reflects the carrier&#39;s role in moving a solute across the mitochondrial inner membrane without asserting citrate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Provides the correctly scoped process term for a mitochondrial carrier of unknown substrate, consistent with the accepted general transmembrane-transport annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Putative mitochondrial inner-membrane metabolite carrier. MRX20 has the canonical SLC25/mitochondrial-carrier fold (three Solcar repeats, six transmembrane helices) and retains the conserved carrier signature residues, indicating a solute transmembrane transport activity across the mitochondrial inner membrane. The specific transported substrate is not established, so only a general transporter activity is asserted.</h3>
+                <span class="vote-buttons" data-g="P43617" data-a="FUNCTION: Putative mitochondrial inner-membrane metabolite c..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022857" target="_blank" class="term-link">
+                            transmembrane transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990542" target="_blank" class="term-link">
+                                mitochondrial transmembrane transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link">
+                                PMID:10930523
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Mitochondrial transport proteins (MTP) typically are homodimeric with a 30-kDa subunit with six transmembrane helices.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link">
+                                PMID:10930523
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We do now find these five consensus residues also in the new sequences of YNL083W and YFR045W.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10930523" target="_blank" class="term-link">
+                            PMID:10930523
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The yeast mitochondrial transport proteins: new sequences and consensus residues, lack of direct relation between consensus residues and transmembrane helices, expression patterns of the transport protein genes, and protein-protein interactions with other proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YFR045W is one of the 35 S. cerevisiae mitochondrial transport protein (MTP) genes; MTPs have the six-transmembrane-helix, three-repeat carrier architecture.</div>
+
+                        <div class="finding-text">"Mitochondrial transport proteins (MTP) typically are homodimeric with a 30-kDa subunit with six transmembrane helices."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">After resequencing, YFR045W was found to retain the five carrier consensus residues shared by MTPs with identified transport function.</div>
+
+                        <div class="finding-text">"We do now find these five consensus residues also in the new sequences of YNL083W and YFR045W."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Expression of YFR045W is induced by stress.</div>
+
+                        <div class="finding-text">"the expressions of YFR045W, YPR021C, and YDR470C are induced by various stress situations."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25683707" target="_blank" class="term-link">
+                            PMID:25683707
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Organization of Mitochondrial Gene Expression in Two Distinct Ribosome-Containing Assemblies.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Native mitochondrial-ribosome complexes (MIOREX) were purified and their interactome defined by quantitative mass spectrometry; this study is the source of the &#34;Mrx&#34; gene-name series (including MRX20) for previously uncharacterized co-purifying proteins.</div>
+
+                        <div class="finding-text">"These interactions result in large expressosome-like assemblies that we termed mitochondrial organization of gene expression (MIOREX) complexes."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What metabolite(s) does MRX20 transport across the mitochondrial inner membrane, and is the family-level citrate assignment correct for the fungal PTHR45788:SF5 subfamily?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43617" data-a="Q: What metabolite(s) does MRX20 transport across the..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the co-purification of MRX20 with MIOREX/mitochondrial-ribosome complexes a direct, functionally meaningful interaction, or an abundance-driven artifact of a membrane protein?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43617" data-a="Q: Is the co-purification of MRX20 with MIOREX/mitoch..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant MRX20, reconstitute into proteoliposomes, and assay uptake/exchange of candidate solutes (citrate and other di-/tricarboxylates, amino acids, nucleotides, cofactors) to identify the transported substrate.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MRX20 is a functional mitochondrial metabolite carrier with a substrate distinct from citrate.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro transport reconstitution</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43617" data-a="EXPERIMENT: Express and purify recombinant MRX20, reconstitute..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Phenotype the MRX20 deletion across respiratory/non-fermentable carbon sources and stress conditions, with mitochondrial metabolomics and synthetic genetic array analysis to place MRX20 in a pathway.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of MRX20 perturbs a specific mitochondrial process under particular growth or stress conditions.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: conditional phenotyping and genetic interaction mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43617" data-a="EXPERIMENT: Phenotype the MRX20 deletion across respiratory/no..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate transported by MRX20 is unknown. It has the mitochondrial-carrier fold and the conserved carrier signature residues, but its specific solute (whether a tricarboxylate/citrate as in related family members, another metabolite, or none) has never been measured, and no transport assay for MRX20 exists.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that MRX20 is an integral mitochondrial inner-membrane protein of the SLC25/mitochondrial-carrier family with the canonical three-repeat, six-transmembrane-helix architecture and retained carrier consensus residues. What is unknown is the identity of the transported substrate; the GOA citrate-transporter annotations derive from characterized citrate carriers elsewhere in the family, not from MRX20 or its uncharacterized fungal subfamily (PTHR45788:SF5).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning MRX20&#39;s substrate would convert a &#34;putative carrier of unknown substrate&#34; into a defined metabolite-transport function and would test whether the family-level citrate propagation is correct or an over-annotation for the fungal subfamily.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstitute recombinant MRX20 into liposomes and screen candidate solutes (di-/tricarboxylates, amino acids, nucleotides, cofactors) for transport, and/or perform targeted mitochondrial metabolomics in an MRX20 deletion strain.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"RecName: Full=Uncharacterized mitochondrial carrier YFR045W;"</em> — file:yeast/MRX20/MRX20-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether MRX20 has any direct role in mitochondrial gene expression is unknown. The &#34;Mrx&#34; name reflects only proteomic co-purification with mitochondrial-ribosome (MIOREX) complexes, and no experiment has shown that MRX20 participates in transcription, RNA processing, translation, or ribosome assembly.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> MRX20 was recovered in the interactome of native mitochondrial-ribosome (MIOREX) complexes and named accordingly. It is otherwise characterized only as a membrane-embedded carrier-family protein; a functional (as opposed to co-purification) link to gene-expression machinery has not been demonstrated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A carrier that genuinely couples metabolite transport to the organization of mitochondrial gene expression would be mechanistically novel; conversely, confirming it is a bystander of the pulldown would clarify that the &#34;Mrx&#34; name is associative only.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test MRX20 deletion/depletion for mitochondrial transcription, mt-mRNA stability, and translation phenotypes, and determine whether the MIOREX association is direct and stoichiometric or an abundance-driven co-purification.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"These interactions result in large expressosome-like assemblies that we termed mitochondrial organization of gene expression (MIOREX) complexes."</em> — PMID:25683707</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process MRX20 serves and the basis of its loss-of-function phenotypes are unknown. The deletion is viable with only weak, pleiotropic high-throughput phenotypes, none of which points to a specific pathway.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> MRX20 is non-essential, expressed at low abundance, and stress-inducible. Reported deletion phenotypes are mild and non-specific, so they do not define the pathway in which MRX20 acts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Linking MRX20 to a defined metabolic or mitochondrial-maintenance pathway would turn a stress-inducible dark carrier into an interpretable node of mitochondrial physiology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Condition-specific phenotyping (respiratory/non-fermentable carbon sources, metabolic and oxidative stresses) combined with synthetic-genetic-array and metabolomic profiling of the deletion strain.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the expressions of YFR045W, YPR021C, and YDR470C are induced by various stress situations."</em> — PMID:10930523</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MRX20-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P43617" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mrx20-yfr045w-p43617-curation-notes">MRX20 (YFR045W / P43617) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> MRX20.<br />
+Provenance is recorded inline as [SOURCE "verbatim supporting text"] where possible.</p>
+<h2 id="identity-resolved-carefully-there-is-a-genuine-namefunction-tension">Identity (resolved carefully — there is a genuine name/function tension)</h2>
+<ul>
+<li>SGD <strong>standard name = MRX20</strong>; systematic name <strong>YFR045W</strong>; UniProt <strong>P43617</strong><br />
+  (entry name YFL5_YEAST). SGD confirms MRX20 is the standard name and expands it<br />
+  as "Mitochondrial oRganization of gene eXpression"<br />
+  [https://www.yeastgenome.org/locus/YFR045W].</li>
+<li><strong>Important</strong>: UniProt P43617 itself does NOT carry the MRX20 gene name; it lists<br />
+  only <code>OrderedLocusNames=YFR045W</code> and describes the protein as<br />
+  "Uncharacterized mitochondrial carrier YFR045W" (RecName)<br />
+  [genes/yeast/MRX20/MRX20-uniprot.txt line 6-7].</li>
+<li>The <strong>"Mrx" name series (Mrx1–Mrx21)</strong> was coined by the MIOREX study<br />
+  (Kehrein et al. 2015, Cell Reports, PMID:25683707): previously uncharacterized<br />
+  proteins that co-purified by quantitative mass spectrometry with native<br />
+  mitochondrial-ribosome ("MIOREX") complexes were given Mrx numbers. SGD's<br />
+  "name description" reference for MRX20 is this paper. <strong>Being pulled down with<br />
+  MIOREX complexes is a proteomic association, not a demonstrated molecular<br />
+  function.</strong> The abstract describes MIOREX as ribosome interactomes<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25683707" title="These interactions result in large expressosome-like assemblies   that we termed mitochondrial organization of gene expression (MIOREX) complexes.">PMID:25683707</a>.<br />
+  I could NOT obtain the full text (not open access; PubMed MCP unauthenticated),<br />
+  so I do not have a verbatim, MRX20-specific quote from this paper and treat its<br />
+  MRX20-specific content as an association only.</li>
+</ul>
+<h3 id="the-core-tension">The core tension</h3>
+<p>The name "MRX20" suggests a role in mitochondrial gene expression, but every<br />
+structural/sequence line of evidence says this is a <strong>mitochondrial carrier<br />
+(SLC25 / MCF; TC 2.A.29) family</strong> inner-membrane transporter. These two facts are<br />
+not contradictory — an integral inner-membrane carrier could plausibly be found in<br />
+the vicinity of membrane-tethered translation machinery — but they mean the gene's<br />
+<strong>actual molecular function (what it transports, if anything) is unknown</strong>.</p>
+<h2 id="domain-sequence-analysis-done-inline-from-the-uniprot-record">Domain / sequence analysis (done inline from the UniProt record)</h2>
+<p>Source: genes/yeast/MRX20/MRX20-uniprot.txt</p>
+<ul>
+<li>309 aa, ~34.4 kDa. PE=3 (inferred from homology). No experimental structure; AlphaFold model exists.</li>
+<li><strong>Mitochondrial carrier family (MCF/SLC25)</strong>: <code>SIMILARITY ... Belongs to the
+  mitochondrial carrier (TC 2.A.29) family</code> (line 73). Pfam PF00153 Mito_carr ×3;<br />
+  PROSITE PS50920 SOLCAR ×3; PRINTS MITOCARRIER; InterPro IPR002067 (MCP),<br />
+  IPR023395 (MCP_dom_sf), IPR018108 (MCP_transmembrane), IPR049563 (TXTP-like);<br />
+  Gene3D 1.50.40.10 mitochondrial carrier domain; SUPFAM SSF103506 (lines 116–126).</li>
+<li><strong>Six TM helices</strong> (12–32, 47–67, 100–120, 184–204, 222–242, 285–305) and<br />
+<strong>three tandem Solcar repeats</strong> (6–83, 97–211, 216–302) (lines 133–156) — the<br />
+  canonical MCF three-repeat / six-TM architecture (pseudo-3-fold symmetry).</li>
+<li><strong>Subcellular location</strong>: <code>Mitochondrion inner membrane {ECO:0000305};
+  Multi-pass membrane protein {ECO:0000305}</code> (lines 71–72). KW Mitochondrion,<br />
+  Mitochondrion inner membrane, Transmembrane, Transport (lines 128–129).</li>
+<li>PANTHER: family <strong>PTHR45788</strong> "SUCCINATE/FUMARATE MITOCHONDRIAL<br />
+  TRANSPORTER-RELATED"; <strong>subfamily PTHR45788:SF5 "AFR253WP"</strong> (lines 121–122).</li>
+</ul>
+<h3 id="subfamily-context-is-decisive-for-judging-the-iba-citrate-annotations">Subfamily context is decisive for judging the IBA "citrate" annotations</h3>
+<p>From interpro/panther/PTHR45788/PTHR45788-entries.csv (reviewed members):<br />
+- The <strong>broad family PTHR45788</strong> contains the characterized tricarboxylate/citrate<br />
+  carriers CTP1 (P38152, <em>S. cerevisiae</em>), SLC25A1 (human P53007, bovine P79110,<br />
+  rat P32089, mouse), SFC1 succinate/fumarate carrier (P33303, <em>S. cerevisiae</em>),<br />
+  plant SFC1 (Q9M038), Aspergillus ctpA/B/C, etc.<br />
+- <strong>But MRX20's own subfamily PTHR45788:SF5 ("AFR253WP")</strong> contains ONLY<br />
+<em>Saccharomyces</em>-lineage <strong>uncharacterized</strong> carriers: P43617 (YFR045W itself),<br />
+  A7A285 (SCY_1795), B3LUQ6 (SCRG_05595), B5VI70 (AWRI1631_61110) — all annotated<br />
+  "Uncharacterized mitochondrial carrier". No SF5 member has a demonstrated<br />
+  substrate.<br />
+- =&gt; The GOA IBA annotations for <strong>citrate secondary active transmembrane<br />
+  transporter activity</strong> (GO:0071913) and <strong>mitochondrial citrate transmembrane<br />
+  transport</strong> (GO:0006843) are propagated from the <strong>family level</strong> (driven by the<br />
+  CTP1/SLC25A1 clade), NOT from MRX20's own uncharacterized subfamily. This is a<br />
+  classic over-specific IBA propagation: MRX20 is very likely a carrier, but the<br />
+<em>citrate</em> substrate assignment is not supported for it specifically.</p>
+<h2 id="literature-sparse-this-is-a-dark-gene">Literature (sparse — this is a dark gene)</h2>
+<ol>
+<li><strong>Belenkiy et al. 2000, Biochim Biophys Acta, PMID:10930523</strong> (abstract only).</li>
+<li>Systematic survey/resequencing of the 35 yeast mitochondrial transport<br />
+     proteins (MTPs); YFR045W is one of them.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10930523" title="Mitochondrial transport proteins (MTP) typically are      homodimeric with a 30-kDa subunit with six transmembrane helices.">PMID:10930523</a></li>
+<li>The five MTP consensus residues (present in MTPs with identified transport<br />
+     function) were confirmed present in YFR045W after resequencing<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10930523" title="We do now find these five consensus residues also in the new      sequences of YNL083W and YFR045W.">PMID:10930523</a>.</li>
+<li>Expression of YFR045W is stress-inducible<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10930523" title="the expressions of YFR045W, YPR021C, and YDR470C are induced      by various stress situations.">PMID:10930523</a>.</li>
+<li>This is the <strong>ISS source</strong> SGD used for the "mitochondrial inner membrane"<br />
+     and "mitochondrial transport" annotations (GOA original_reference_id<br />
+     PMID:10930523; note SGD's with/from points to paralogs SGD:S000003838 and<br />
+     SGD:S000005027).</li>
+<li>
+<p>NOTE: abstract reports YFR045W resequenced to 285 aa; current UniProt sequence<br />
+     is 309 aa (SEQUENCE CAUTION notes an earlier erroneous gene model / frameshift,<br />
+     lines 75–78) — the annotation predates the corrected model but the MCF family<br />
+     assignment is unaffected.</p>
+</li>
+<li>
+<p><strong>Kehrein et al. 2015, Cell Reports, PMID:25683707</strong> (abstract only).</p>
+</li>
+<li>
+<p>Source of the MRX20 name; MIOREX (mitochondrial ribosome) co-purification by<br />
+     quantitative MS. Provides only an <em>association</em>, no molecular function for<br />
+     MRX20. (See "Identity" above.)</p>
+</li>
+<li>
+<p><strong>SGD large-scale phenotype data</strong> (https://www.yeastgenome.org/locus/YFR045W):<br />
+   null mutant is <strong>viable</strong>; "decreased levels of chitin and normal resistance to<br />
+   calcofluor white"; high-throughput screens additionally report decreased chitin<br />
+   deposition, decreased competitive fitness, increased chronological lifespan, and<br />
+   abnormal vacuolar morphology. All non-specific/pleiotropic; none pins a molecular<br />
+   function. Protein abundance ~710 molecules/cell (low). Not recorded as a<br />
+   dedicated citable PMID here; treated as background, not used for a specific GO<br />
+   claim.</p>
+</li>
+</ol>
+<h2 id="assessment-summary-what-is-known-vs-not-known">Assessment summary (what is KNOWN vs NOT known)</h2>
+<p>KNOWN (well supported):<br />
+- Integral <strong>mitochondrial inner-membrane</strong> protein, multi-pass (6 TM). [homology/ISS/subcell]<br />
+- Member of the <strong>mitochondrial carrier (SLC25/MCF) family</strong> with canonical<br />
+  three-repeat architecture. [Pfam/PROSITE/PANTHER/InterPro]<br />
+- Almost certainly functions in <strong>transmembrane transport</strong> (family-level). [InterPro IEA + family]<br />
+- Stress-inducible expression; non-essential; low abundance. [PMID:10930523; SGD HTP]</p>
+<p>NOT known (genuine knowledge gaps):<br />
+- <strong>Transported substrate / specific molecular function</strong> — SF5 subfamily is<br />
+  entirely uncharacterized; citrate assignment is a family-level IBA over-propagation.<br />
+- Whether MRX20 has any <strong>direct role in mitochondrial gene expression</strong> (the "MRX"<br />
+  name reflects only MIOREX proteomic co-purification, not a demonstrated function).<br />
+- <strong>Physiological process / pathway</strong> it serves; loss-of-function phenotypes are<br />
+  weak and pleiotropic.<br />
+- Whether it is a genuine transporter or a pseudo-transporter (no substrate assay exists).</p>
+<h2 id="curation-decisions-rationale">Curation decisions (rationale)</h2>
+<ul>
+<li>C: mitochondrial inner membrane (ISS, PMID:10930523) → ACCEPT (core; strong homology + MCF membrane protein).</li>
+<li>C: mitochondrial inner membrane (IEA, GO_REF:0000044 SubCell) → ACCEPT (consistent, redundant with ISS).</li>
+<li>C: mitochondrion (IBA) → ACCEPT as non-core (correct but less specific than inner membrane).</li>
+<li>P: transmembrane transport (IEA InterPro) → ACCEPT (family-level; correct general process).</li>
+<li>P: mitochondrial transport (ISS, PMID:10930523) → ACCEPT/KEEP (general, defensible).</li>
+<li>F: citrate secondary active transmembrane transporter activity (IBA) → MARK_AS_OVER_ANNOTATED<br />
+  (family-level propagation; MRX20's SF5 subfamily has no citrate-transport member; substrate unknown).</li>
+<li>P: mitochondrial citrate transmembrane transport (IBA) → MARK_AS_OVER_ANNOTATED (same reason).</li>
+<li>F: molecular_function (ND) → ACCEPT (honestly records that MF is unknown; do not invent one).</li>
+</ul>
+<p>core_functions: only the defensible general MF ("transmembrane transporter activity",<br />
+GO:0022857) with location mitochondrial inner membrane (GO:0005743). No specific<br />
+substrate claimed.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P43617
+gene_symbol: MRX20
+aliases:
+- YFR045W
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  MRX20 (YFR045W) is an uncharacterized inner-membrane protein of Saccharomyces
+  cerevisiae mitochondria that belongs to the mitochondrial carrier family
+  (SLC25/MCF; TC 2.A.29). Its sequence has the canonical mitochondrial-carrier
+  architecture: three tandem Solcar repeats and six predicted transmembrane
+  helices forming the pseudo-threefold-symmetric fold typical of metabolite
+  carriers, and it retains the conserved carrier signature residues found in
+  functionally characterized carriers. Within its family it falls in a fungal-specific
+  subfamily whose members are all uncharacterized, so no specific transported
+  substrate has been established for MRX20; the protein is therefore best described
+  as a putative mitochondrial metabolite carrier of unknown substrate. The gene is
+  non-essential, expressed at low abundance, and its transcription is induced under
+  stress. It was given the &#34;Mrx&#34; name after it co-purified with native
+  mitochondrial-ribosome (MIOREX) complexes in a proteomic study, but a direct role
+  in mitochondrial gene expression has not been demonstrated.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:10930523
+  title: &#39;The yeast mitochondrial transport proteins: new sequences and consensus
+    residues, lack of direct relation between consensus residues and transmembrane
+    helices, expression patterns of the transport protein genes, and protein-protein
+    interactions with other proteins.&#39;
+  findings:
+  - statement: &gt;-
+      YFR045W is one of the 35 S. cerevisiae mitochondrial transport protein (MTP)
+      genes; MTPs have the six-transmembrane-helix, three-repeat carrier architecture.
+    supporting_text: &gt;-
+      Mitochondrial transport proteins (MTP) typically are homodimeric with a 30-kDa
+      subunit with six transmembrane helices.
+  - statement: &gt;-
+      After resequencing, YFR045W was found to retain the five carrier consensus
+      residues shared by MTPs with identified transport function.
+    supporting_text: &gt;-
+      We do now find these five consensus residues also in the new sequences of
+      YNL083W and YFR045W.
+  - statement: Expression of YFR045W is induced by stress.
+    supporting_text: &gt;-
+      the expressions of YFR045W, YPR021C, and YDR470C are induced by various stress
+      situations.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache (full_text_available: false). PubMed-verified: this is the
+      survey of the 35 yeast mitochondrial transport proteins that includes YFR045W
+      and is the ISS source SGD used for the inner-membrane and mitochondrial-transport
+      annotations. Supporting_text quotes are verbatim from the cached abstract.
+- id: PMID:25683707
+  title: Organization of Mitochondrial Gene Expression in Two Distinct Ribosome-Containing
+    Assemblies.
+  findings:
+  - statement: &gt;-
+      Native mitochondrial-ribosome complexes (MIOREX) were purified and their
+      interactome defined by quantitative mass spectrometry; this study is the source
+      of the &#34;Mrx&#34; gene-name series (including MRX20) for previously uncharacterized
+      co-purifying proteins.
+    supporting_text: &gt;-
+      These interactions result in large expressosome-like assemblies that we termed
+      mitochondrial organization of gene expression (MIOREX) complexes.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache (not open access; full text could not be retrieved). This is
+      the MIOREX study that assigned the Mrx1-Mrx21 names (SGD &#34;name description&#34;
+      reference for MRX20). It establishes proteomic co-purification of MRX20 with
+      mitochondrial-ribosome complexes but does NOT demonstrate a molecular function;
+      the MRX20-specific assignment is in the supplementary data, not the abstract, so
+      no MRX20-specific verbatim quote is cited.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Correct but non-specific mitochondrial localization from phylogenetic
+      propagation. MRX20 is an integral mitochondrial inner-membrane carrier, so
+      &#34;mitochondrion&#34; is accurate but subsumed by the more specific inner-membrane
+      annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the mitochondrial-carrier family assignment and the ISS
+      inner-membrane annotation, but less informative than GO:0005743
+      (mitochondrial inner membrane).
+- term:
+    id: GO:0071913
+    label: citrate secondary active transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Over-specific molecular-function propagation. The citrate-transporter activity
+      is driven by the characterized tricarboxylate/citrate carriers in the broad
+      PANTHER family PTHR45788 (CTP1, human SLC25A1, SFC1), but MRX20 falls in the
+      fungal-specific subfamily PTHR45788:SF5 whose members are all uncharacterized
+      mitochondrial carriers with no demonstrated substrate. No citrate-transport
+      activity has been shown for MRX20, and its specific substrate is unknown.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Family-level IBA over-propagation of a specific substrate to a gene in an
+      uncharacterized subfamily; the transported substrate of MRX20 is genuinely
+      unknown. The general carrier/transporter nature is retained in core_functions
+      as transmembrane transporter activity without asserting citrate.
+    proposed_replacement_terms:
+    - id: GO:0022857
+      label: transmembrane transporter activity
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTHR45788
+        source_label: SUCCINATE/FUMARATE MITOCHONDRIAL TRANSPORTER-RELATED
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Broad family node carrying the citrate-carrier signal from characterized
+          members (CTP1, human SLC25A1, SFC1); too general to fix the substrate for
+          MRX20.
+      - source_id: PANTHER:PTHR45788:SF5
+        source_label: AFR253WP
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          MRX20&#39;s own subfamily; all members (P43617, SCY_1795, SCRG_05595,
+          AWRI1631_61110) are uncharacterized mitochondrial carriers with no
+          demonstrated citrate transport.
+- term:
+    id: GO:0006843
+    label: mitochondrial citrate transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Over-specific biological-process propagation, mirroring the citrate-transporter
+      molecular-function annotation. The citrate-transport process is inferred from
+      the characterized citrate carriers of the family, not from MRX20 or its
+      uncharacterized subfamily.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Same family-level over-propagation as the citrate transporter activity; MRX20&#39;s
+      transported substrate is unknown. A general transmembrane-transport process is
+      retained instead.
+    proposed_replacement_terms:
+    - id: GO:1990542
+      label: mitochondrial transmembrane transport
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTHR45788
+        source_label: SUCCINATE/FUMARATE MITOCHONDRIAL TRANSPORTER-RELATED
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Citrate-transport process propagated from characterized citrate carriers in
+          the broad family, not from MRX20 or its uncharacterized subfamily.
+      - source_id: PANTHER:PTHR45788:SF5
+        source_label: AFR253WP
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          MRX20&#39;s subfamily is uncharacterized; no member has a demonstrated
+          citrate-transport process.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Inner-membrane localization from UniProt Subcellular Location mapping,
+      consistent with the multi-pass mitochondrial-carrier assignment and with the
+      ISS annotation from PMID:10930523. This is the best-supported and most specific
+      localization for MRX20.
+    action: ACCEPT
+    reason: &gt;-
+      Agrees with the mitochondrial carrier (SLC25/MCF) family membership, six
+      predicted transmembrane helices, and the independent ISS inner-membrane call.
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General transmembrane-transport process from the InterPro mitochondrial-carrier
+      domain signature. Appropriately generic for a carrier whose specific substrate
+      is unknown.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by the mitochondrial-carrier domain architecture; does not
+      overreach on substrate specificity.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: ISS
+  original_reference_id: PMID:10930523
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Inner-membrane localization inferred by SGD from sequence/structural similarity,
+      based on the mitochondrial transport protein survey. Concordant with the UniProt
+      SubCell IEA and with the family assignment; this is the core localization.
+    action: ACCEPT
+    reason: &gt;-
+      MRX20 has the canonical mitochondrial-carrier fold (three Solcar repeats, six TM
+      helices) and retains the carrier consensus residues; inner-membrane localization
+      is strongly supported.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function with ND (no biological data). This honestly records that
+      no specific molecular function has been experimentally determined for MRX20.
+      Given that the transported substrate is unknown and the subfamily is
+      uncharacterized, retaining ND is appropriate rather than asserting a specific
+      activity.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly represents the genuine absence of a demonstrated molecular function;
+      a general transmembrane transporter activity is proposed in core_functions on
+      family grounds but no specific catalytic/substrate activity is experimentally
+      established.
+- term:
+    id: GO:0006839
+    label: mitochondrial transport
+  evidence_type: ISS
+  original_reference_id: PMID:10930523
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      General mitochondrial-transport process inferred by SGD from similarity to
+      characterized mitochondrial transport proteins. Appropriately generic and
+      consistent with the carrier-family assignment without committing to a substrate.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by mitochondrial-carrier family membership; correctly avoids
+      substrate-specific over-annotation. Retained as a general (non-core-defining)
+      process for this dark gene.
+- term:
+    id: GO:0022857
+    label: transmembrane transporter activity
+  evidence_type: ISS
+  original_reference_id: PMID:10930523
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed general molecular-function annotation replacing the over-specific
+      citrate-transporter IBA. MRX20 has the mitochondrial-carrier fold and retained
+      carrier consensus residues, supporting a transmembrane transporter activity
+      without committing to a substrate that has not been experimentally determined.
+    action: NEW
+    reason: &gt;-
+      Captures the defensible, substrate-agnostic transporter activity of this carrier
+      on domain/family grounds, in place of the family-level citrate over-propagation.
+- term:
+    id: GO:1990542
+    label: mitochondrial transmembrane transport
+  evidence_type: ISS
+  original_reference_id: PMID:10930523
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed mitochondrial transmembrane-transport process replacing the
+      over-specific mitochondrial citrate transport IBA. Reflects the carrier&#39;s role in
+      moving a solute across the mitochondrial inner membrane without asserting citrate.
+    action: NEW
+    reason: &gt;-
+      Provides the correctly scoped process term for a mitochondrial carrier of unknown
+      substrate, consistent with the accepted general transmembrane-transport
+      annotations.
+core_functions:
+- description: &gt;-
+    Putative mitochondrial inner-membrane metabolite carrier. MRX20 has the canonical
+    SLC25/mitochondrial-carrier fold (three Solcar repeats, six transmembrane helices)
+    and retains the conserved carrier signature residues, indicating a solute
+    transmembrane transport activity across the mitochondrial inner membrane. The
+    specific transported substrate is not established, so only a general transporter
+    activity is asserted.
+  molecular_function:
+    id: GO:0022857
+    label: transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:1990542
+    label: mitochondrial transmembrane transport
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:10930523
+    supporting_text: &gt;-
+      Mitochondrial transport proteins (MTP) typically are homodimeric with a 30-kDa
+      subunit with six transmembrane helices.
+  - reference_id: PMID:10930523
+    supporting_text: &gt;-
+      We do now find these five consensus residues also in the new sequences of
+      YNL083W and YFR045W.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The physiological substrate transported by MRX20 is unknown. It has the
+    mitochondrial-carrier fold and the conserved carrier signature residues, but its
+    specific solute (whether a tricarboxylate/citrate as in related family members,
+    another metabolite, or none) has never been measured, and no transport assay for
+    MRX20 exists.
+  boundary: &gt;-
+    It is firmly established that MRX20 is an integral mitochondrial inner-membrane
+    protein of the SLC25/mitochondrial-carrier family with the canonical three-repeat,
+    six-transmembrane-helix architecture and retained carrier consensus residues. What
+    is unknown is the identity of the transported substrate; the GOA citrate-transporter
+    annotations derive from characterized citrate carriers elsewhere in the family, not
+    from MRX20 or its uncharacterized fungal subfamily (PTHR45788:SF5).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning MRX20&#39;s substrate would convert a &#34;putative carrier of unknown substrate&#34;
+    into a defined metabolite-transport function and would test whether the
+    family-level citrate propagation is correct or an over-annotation for the fungal
+    subfamily.
+  resolution: &gt;-
+    Reconstitute recombinant MRX20 into liposomes and screen candidate solutes
+    (di-/tricarboxylates, amino acids, nucleotides, cofactors) for transport, and/or
+    perform targeted mitochondrial metabolomics in an MRX20 deletion strain.
+  provenance:
+  - reference_id: file:yeast/MRX20/MRX20-uniprot.txt
+    supporting_text: &gt;-
+      RecName: Full=Uncharacterized mitochondrial carrier YFR045W;
+- gap_statement: &gt;-
+    Whether MRX20 has any direct role in mitochondrial gene expression is unknown. The
+    &#34;Mrx&#34; name reflects only proteomic co-purification with mitochondrial-ribosome
+    (MIOREX) complexes, and no experiment has shown that MRX20 participates in
+    transcription, RNA processing, translation, or ribosome assembly.
+  boundary: &gt;-
+    MRX20 was recovered in the interactome of native mitochondrial-ribosome (MIOREX)
+    complexes and named accordingly. It is otherwise characterized only as a
+    membrane-embedded carrier-family protein; a functional (as opposed to
+    co-purification) link to gene-expression machinery has not been demonstrated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A carrier that genuinely couples metabolite transport to the organization of
+    mitochondrial gene expression would be mechanistically novel; conversely,
+    confirming it is a bystander of the pulldown would clarify that the &#34;Mrx&#34; name is
+    associative only.
+  resolution: &gt;-
+    Test MRX20 deletion/depletion for mitochondrial transcription, mt-mRNA stability,
+    and translation phenotypes, and determine whether the MIOREX association is direct
+    and stoichiometric or an abundance-driven co-purification.
+  provenance:
+  - reference_id: PMID:25683707
+    supporting_text: &gt;-
+      These interactions result in large expressosome-like assemblies that we termed
+      mitochondrial organization of gene expression (MIOREX) complexes.
+- gap_statement: &gt;-
+    The biological process MRX20 serves and the basis of its loss-of-function
+    phenotypes are unknown. The deletion is viable with only weak, pleiotropic
+    high-throughput phenotypes, none of which points to a specific pathway.
+  boundary: &gt;-
+    MRX20 is non-essential, expressed at low abundance, and stress-inducible. Reported
+    deletion phenotypes are mild and non-specific, so they do not define the pathway in
+    which MRX20 acts.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Linking MRX20 to a defined metabolic or mitochondrial-maintenance pathway would
+    turn a stress-inducible dark carrier into an interpretable node of mitochondrial
+    physiology.
+  resolution: &gt;-
+    Condition-specific phenotyping (respiratory/non-fermentable carbon sources,
+    metabolic and oxidative stresses) combined with synthetic-genetic-array and
+    metabolomic profiling of the deletion strain.
+  provenance:
+  - reference_id: PMID:10930523
+    supporting_text: &gt;-
+      the expressions of YFR045W, YPR021C, and YDR470C are induced by various stress
+      situations.
+suggested_questions:
+- question: &gt;-
+    What metabolite(s) does MRX20 transport across the mitochondrial inner membrane,
+    and is the family-level citrate assignment correct for the fungal PTHR45788:SF5
+    subfamily?
+- question: &gt;-
+    Is the co-purification of MRX20 with MIOREX/mitochondrial-ribosome complexes a
+    direct, functionally meaningful interaction, or an abundance-driven artifact of a
+    membrane protein?
+suggested_experiments:
+- hypothesis: &gt;-
+    MRX20 is a functional mitochondrial metabolite carrier with a substrate distinct
+    from citrate.
+  description: &gt;-
+    Express and purify recombinant MRX20, reconstitute into proteoliposomes, and assay
+    uptake/exchange of candidate solutes (citrate and other di-/tricarboxylates,
+    amino acids, nucleotides, cofactors) to identify the transported substrate.
+  experiment_type: in vitro transport reconstitution
+- hypothesis: &gt;-
+    Loss of MRX20 perturbs a specific mitochondrial process under particular growth or
+    stress conditions.
+  description: &gt;-
+    Phenotype the MRX20 deletion across respiratory/non-fermentable carbon sources and
+    stress conditions, with mitochondrial metabolomics and synthetic genetic array
+    analysis to place MRX20 in a pathway.
+  experiment_type: conditional phenotyping and genetic interaction mapping
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/OCA6/OCA6-ai-review.html
+++ b/genes/yeast/OCA6/OCA6-ai-review.html
@@ -1,0 +1,2508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OCA6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>OCA6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q12454" target="_blank" class="term-link">
+                        Q12454
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "OCA6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q12454" data-a="DESCRIPTION: OCA6 (YDR067C) is a small (224-residue) cytoplasmi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>OCA6 (YDR067C) is a small (224-residue) cytoplasmic protein of the budding yeast Saccharomyces cerevisiae that adopts a protein-tyrosine-phosphatase (PTP) superfamily fold and belongs to the fungal OCA family of PFA-DSP (Plant-and-Fungi Atypical Dual-Specificity Phosphatase)-related proteins, together with Oca1, Oca2, Siw14/Oca3, Oca4 and Oca5. Although classified within the PTP/DSP structural family (Pfam Y_phosphatase2 / Siw14-like; CDD PFA-DSP_Oca6) and carrying a predicted phosphocysteine active-site residue, its canonical CX5R catalytic loop is degenerate — the invariant phosphate-binding arginine is not present — so OCA6 is likely a catalytically impaired or pseudophosphatase member of the family rather than a bona fide protein-tyrosine phosphatase. The biochemically active prototype of the family, Siw14/Oca3, is an inositol-pyrophosphate (5-InsP7) phosphatase, not a phosphotyrosine phosphatase. OCA6 is genetically linked to the other OCA-family members and is implicated in cellular responses to caffeine, rapamycin and oxidative stress, and its deletion reduces replication of Brome mosaic virus in yeast. Its own catalytic status, physiological substrate, and precise role within the OCA family remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016791" target="_blank" class="term-link">
+                                    GO:0016791
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12454" data-a="GO:0016791" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General phosphatase activity inferred phylogenetically from membership in the PTP/PFA-DSP fold family. The fold is genuinely present, but OCA6&#39;s canonical CX5R catalytic loop is degenerate (missing the invariant P-loop arginine), so any catalytic activity is uncertain. Retained as a cautious, general, non-core molecular function that reflects the family fold without over-committing to a specific catalytic role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA reflects the ancestral phosphatase fold of the PFA-DSP/PTP family, of which OCA6 is a member (PMID:21409566). &#34;phosphatase activity&#34; (GO:0016791) is general enough to be defensible at the family level and is not contradicted outright by the fold. However, direct catalytic activity of OCA6 has never been demonstrated and its CX5R P-loop arginine is absent (reviewer sequence analysis in OCA6-notes.md; corroborated by a fungal pseudophosphatome analysis reporting catalytic-motif substitutions in Oca1/Oca2/Oca6), so this is kept as non-core and not promoted to any specific catalytic term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21409566" target="_blank" class="term-link">
+                                        PMID:21409566
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Bioinformatic analysis revealed the existence of novel PFA-DSP-related proteins in fungi (Oca1, Oca2, Oca4 and Oca6 in Saccharomyces cerevisiae) and protozoa</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004725" target="_blank" class="term-link">
+                                    GO:0004725
+                                </a>
+                            </span>
+                            <span class="term-label">protein tyrosine phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q12454" data-a="GO:0004725" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Specific protein-tyrosine-phosphatase catalytic activity, assigned electronically from the &#34;Putative&#34; EC 3.1.3.48 in UniProt. This is an over-annotation: it asserts a specific catalysis (phosphotyrosine hydrolysis) that is (i) not supported by OCA6&#39;s degenerate CX5R catalytic loop, and (ii) biochemically inconsistent with the family — the active family prototype Siw14/Oca3 is an inositol-pyrophosphate (5-InsP7) phosphatase, not a protein-tyrosine phosphatase. The EC number is explicitly marked &#34;Putative&#34; in UniProt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Electronic mapping from the UniProt &#34;Putative&#34; EC 3.1.3.48. There is no experimental evidence that OCA6 hydrolyzes phosphotyrosine, its P-loop arginine of the CX5R catalytic motif is absent (reviewer sequence analysis in OCA6-notes.md), and the characterized activity in this atypical DSP family is inositol-pyrophosphate phosphatase (Siw14/Oca3), not phosphotyrosine phosphatase. Asserting a specific PTP activity over-annotates a likely pseudophosphatase; the general fold-level phosphatase term (GO:0016791) already captures what the family membership supports.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21409566" target="_blank" class="term-link">
+                                        PMID:21409566
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Siw14/Oca3 was an active phosphatase in vitro, whereas no phosphatase activity could be detected for Oca1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12454" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization asserted electronically from the UniProt subcellular-location vocabulary. Consistent with the experimental HDA localization and with the protein carrying no signal peptide or transmembrane segment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; this IEA (SubCell mapping) is concordant with the experimentally supported HDA cytoplasm annotation from PMID:14562095. Cytoplasm is the core cellular component of OCA6.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12454" data-a="GO:0005737" data-r="PMID:14562095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization from the genome-wide GFP-fusion localization study. This is the single highest-confidence attribute of OCA6 and is consistent with a soluble cytoplasmic protein lacking signal/transmembrane features.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct high-throughput experimental localization evidence (GFP-tagged full-length protein). Cytoplasm is well supported and is the core cellular-component assignment for OCA6.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                        PMID:14562095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we describe the construction and analysis of a collection of yeast strains expressing full-length, chromosomally tagged green fluorescent protein fusion proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12454" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function with the ND (No biological Data) evidence code — the honest curator placeholder recording that no molecular function has been experimentally established for OCA6. This is accurate: OCA6&#39;s catalytic status and substrate are undetermined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND correctly reflects the absence of experimentally demonstrated molecular function for OCA6. Retained as-is; the associated knowledge gap is captured in core_functions.knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12454" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with the ND evidence code — placeholder recording that no specific biological process has been experimentally established for OCA6 at annotation-grade evidence. Family-level genetic links to caffeine/rapamycin/oxidative-stress responses and a BMV-screen phenotype exist but are not curated here as specific BP annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND appropriately reflects the lack of an annotation-grade, OCA6-specific biological process. The genome-wide BMV-replication phenotype (PMID:14671320) and family-level caffeine/rapamycin genetic linkage (PMID:21409566) are documented in the notes and knowledge gaps rather than asserted as specific process annotations, given their low specificity for OCA6 alone.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cytoplasmic protein adopting a protein-tyrosine-phosphatase (PTP) superfamily / PFA-DSP fold and belonging to the fungal OCA family of atypical dual-specificity-phosphatase-related proteins (with Oca1, Oca2, Siw14/Oca3, Oca4, Oca5). OCA6 is genetically linked to the other OCA members in cellular responses to caffeine, rapamycin and oxidative stress, and its own catalytic activity is doubtful because the canonical CX5R catalytic P-loop is degenerate (the invariant catalytic arginine is absent). It is best regarded as a likely catalytically impaired / pseudophosphatase family member whose specific molecular activity and substrate are not established; the one high-confidence attribute is cytoplasmic localization.</h3>
+                <span class="vote-buttons" data-g="Q12454" data-a="FUNCTION: Cytoplasmic protein adopting a protein-tyrosine-ph..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                PMID:14562095
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we describe the construction and analysis of a collection of yeast strains expressing full-length, chromosomally tagged green fluorescent protein fusion proteins.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21409566" target="_blank" class="term-link">
+                                PMID:21409566
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Oca1, Oca2, Siw14/Oca3, Oca4, and Oca6 were involved in the yeast response to caffeine and rapamycin stresses.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP-fusion localization assigned OCA6 to the cytoplasm; this is the basis of the HDA cytoplasm annotation.</div>
+
+                        <div class="finding-text">"we describe the construction and analysis of a collection of yeast strains expressing full-length, chromosomally tagged green fluorescent protein fusion proteins."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14671320" target="_blank" class="term-link">
+                            PMID:14671320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Systematic, genome-wide identification of host genes affecting replication of a positive-strand RNA virus.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OCA6 was identified in a genome-wide yeast single-gene-deletion screen as one of ~100 host genes whose loss altered Brome mosaic virus (BMV) RNA replication; this is the basis of the UniProt &#34;Required for replication of BMV&#34; function statement.</div>
+
+                        <div class="finding-text">"This functional genomics approach revealed nearly 100 genes whose absence inhibited or stimulated BMV RNA replication and/or gene expression by 3- to &gt;25-fold."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21409566" target="_blank" class="term-link">
+                            PMID:21409566
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phylogenetic and genetic linkage between novel atypical dual-specificity phosphatases from non-metazoan organisms.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OCA6 is one of the fungal PFA-DSP-related atypical dual-specificity phosphatase proteins of S. cerevisiae; the closest characterized homolog is the active PFA-DSP Siw14/Oca3.</div>
+
+                        <div class="finding-text">"Bioinformatic analysis revealed the existence of novel PFA-DSP-related proteins in fungi (Oca1, Oca2, Oca4 and Oca6 in Saccharomyces cerevisiae) and protozoa"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OCA6, together with the other OCA-family members, is involved in the yeast response to caffeine and rapamycin stresses, and oca6 caffeine sensitivity is suppressed by overexpression of the active family member Siw14/Oca3 (genetic linkage).</div>
+
+                        <div class="finding-text">"Oca1, Oca2, Siw14/Oca3, Oca4, and Oca6 were involved in the yeast response to caffeine and rapamycin stresses."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Within the family, catalytic activity is not uniform: Siw14/Oca3 is an active phosphatase in vitro while no activity could be detected for Oca1 — direct catalytic activity of OCA6 itself was not demonstrated.</div>
+
+                        <div class="finding-text">"Siw14/Oca3 was an active phosphatase in vitro, whereas no phosphatase activity could be detected for Oca1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18407956" target="_blank" class="term-link">
+                            PMID:18407956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A multidimensional chromatography technology for in-depth phosphoproteome analysis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">OCA6 is phosphorylated on Thr2, detected by large-scale mass-spectrometry phosphoproteomics.</div>
+
+                        <div class="finding-text">"A multidimensional chromatography technology for in-depth phosphoproteome analysis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11408586" target="_blank" class="term-link">
+                            PMID:11408586
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a Saccharomyces cerevisiae gene that is required for G1 arrest in response to the lipid oxidation product linoleic acid hydroperoxide.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is OCA6 a catalytically active phosphatase, and if so what is its physiological substrate — a phosphoprotein or an inositol pyrophosphate such as 5-InsP7?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Protein/inositol-pyrophosphate phosphatase biochemists, PTP/dual-specificity-phosphatase structural biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12454" data-a="Q: Is OCA6 a catalytically active phosphatase, and if..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the composition of the OCA complex, and does OCA6 function within it as a catalytic subunit, a regulatory subunit, or a redundant paralog?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Yeast signaling / stress-response biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12454" data-a="Q: What is the composition of the OCA complex, and do..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant OCA6 and assay phosphatase activity against generic phosphatase substrates, phosphotyrosine peptides, and an inositol-pyrophosphate panel (including 5-InsP7), comparing wild type with active-site and P-loop-arginine-restored mutants to test whether the degenerate CX5R loop can be catalytically rescued.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: In-vitro enzymology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12454" data-a="EXPERIMENT: Express and purify recombinant OCA6 and assay phos..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged OCA6 from yeast and identify interacting OCA-family members and other partners to define the OCA complex and place OCA6 within it.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Affinity purification / mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12454" data-a="EXPERIMENT: Affinity-purify tagged OCA6 from yeast and identif..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Characterize oca6 deletion phenotypes under oxidative stress, caffeine, and rapamycin, and in the BMV-replication assay, with epistasis against SIW14/OCA3 and the other OCA genes to determine OCA6&#39;s specific and redundant contributions.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Phenotypic / genetic analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12454" data-a="EXPERIMENT: Characterize oca6 deletion phenotypes under oxidat..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(OCA6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12454" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="oca6-ydr067c-s-cerevisiae-curation-notes">OCA6 (YDR067C) — S. cerevisiae — curation notes</h1>
+<p>Reviewer journal. Provenance recorded inline as <code>[PMID:xxxx "verbatim supporting text"]</code> or <code>[source URL]</code>.<br />
+This is a DARK / understudied gene: the primary deliverable is an honest <code>knowledge_gaps</code> section<br />
+plus carefully-reasoned <code>description</code>/<code>core_functions</code> grounded in domain, orthology, and literature.<br />
+OCA6-specific evidence is carefully separated from evidence about other OCA-family members.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>UniProt: Q12454 (OCA6_YEAST), 224 aa, MW ~26 kDa.</li>
+<li>Systematic name: YDR067C; SGD: S000002474; standard name OCA6 = "Oxidant-induced Cell-cycle Arrest protein 6".</li>
+<li>UniProt RecName: "Putative tyrosine-protein phosphatase OCA6"; EC=3.1.3.48 (marked <em>Putative</em>).</li>
+<li>PANTHER family PTHR31126 (TYROSINE-PROTEIN PHOSPHATASE); subfamily PTHR31126:SF14 (TYROSINE-PROTEIN PHOSPHATASE OCA6-RELATED).</li>
+<li>CDD: cd17663 = <strong>PFA-DSP_Oca6</strong> (Plant-and-Fungi Atypical Dual-Specificity Phosphatase, Oca6 clade).</li>
+<li>Pfam: PF03162 (Y_phosphatase2 / Siw14-like); InterPro IPR004861 (Siw14-like), IPR029021 (PTP-like fold),<br />
+  IPR020422 (TYR_PHOSPHATASE_DUAL). Gene3D 3.90.190.10 (PTP superfamily fold). SUPFAM SSF52799.</li>
+</ul>
+<h2 id="domain-catalytic-motif-analysis-done-inline-from-oca6-uniprottxt-sequence">Domain / catalytic-motif analysis (done INLINE from OCA6-uniprot.txt sequence)</h2>
+<p>Full sequence (224 aa):</p>
+<div class="codehilite"><pre><span></span><code>MTLVTPLQFS TVQPNLYRGS YPREINLPFL RTLRLKYILS LTPEPLSTDP   (1-50)
+LMVKFCEENN IKTIHIKCQS ERKADKTKPK IKRKKKTVPI EYDVVVRCVK   (51-100)
+FLIDKGHYPC YMHCTNGELI ISLVVACMRK FSYWSTVSIL NEFLVYNSSI   (101-150)
+NIHERNFIEN FNSEIEVDDL DIKDKVPWIT VRYIARTATE SKDELRVDDA   (151-200)
+NASEKVARVS SVSNSLPKLK FHSM                               (201-224)
+</code></pre></div>
+
+<ul>
+<li>UniProt annotates a single PTP DOMAIN (residues 8–170) and ACT_SITE at <strong>Cys114</strong> ("Phosphocysteine intermediate",<br />
+  ECO:0000255 PROSITE-ProRule PRU00160 — i.e. a rule/profile prediction, NOT experimental).</li>
+<li>The catalytic P-loop of PTP/DSP enzymes (and of the PFA-DSP family specifically) is the <strong>CX5R</strong> signature:<br />
+  the nucleophilic Cys, then five residues, then an invariant Arg that binds the substrate phosphate.<br />
+  [CDD PFA-DSP family: "C x x x x x R" active site, 7 residue positions — https://www.ncbi.nlm.nih.gov/Structure/cdd/cddsrv.cgi?uid=350351]</li>
+<li><strong>Inline finding: OCA6 has NO intact CX5R motif.</strong> Region around the predicted catalytic Cys is<br />
+<code>...HYP C(110) YMH C(114) TNGELI I(120) I(121) S...</code>. Taking Cys114 as the nucleophile, positions 115–120 are<br />
+<code>T-N-G-E-L-I</code>; the P-loop +6 position (where the invariant catalytic Arg must sit) is <strong>Ile120, not Arg</strong>.<br />
+  A regex scan of the whole protein for <code>C.{5}R</code> (CX5R) and <code>HC.{5}R</code> returns <strong>zero matches</strong> anywhere.<br />
+  All Cys are at 56,68,98,110,114,127; all Arg at 18,23,31,34,72,83,97,129,155,182,186,196,208 — none form a CX5R.</li>
+<li>
+<p>Interpretation: the invariant P-loop arginine of the CX5R catalytic loop appears <strong>absent/substituted</strong> in OCA6.<br />
+  This is the classic signature of a <strong>pseudophosphatase</strong> (fold retained, catalytic machinery degenerate).<br />
+  This is my own sequence-level analysis; it should be treated as strong but not laboratory-confirmed.</p>
+</li>
+<li>
+<p>Independent literature corroboration of a degenerate motif in OCA6:<br />
+  the fungal pseudophosphatome analysis reports that "the <strong>Oca1, Oca2, and Oca6 contain residue substitutions<br />
+  at the core catalytic motif</strong>, while Oca4 appears to lose the entire catalytic motif."<br />
+  [ACS Omega "Pseudophosphatase Scanner for Genome-Wide Fungal Pseudophosphatome Analysis",<br />
+   https://pubs.acs.org/doi/10.1021/acsomega.6c00759 — abstract/summary via web search 2026-07-05]<br />
+  NOTE: full text 403-gated; recorded as web evidence, not a cached PMID quote.</p>
+</li>
+<li>CAVEAT / conflicting signal: one secondary web summary states "Oca1, Siw14/Oca3, and Oca6 are supposed to be<br />
+  active enzymes." This is a secondary assertion; it conflicts with (a) my motif analysis and (b) the<br />
+  pseudophosphatase-scanner classification. <strong>No paper in the cache directly measures OCA6 catalytic activity.</strong><br />
+  Therefore catalytic status is treated as UNRESOLVED, leaning inactive, in the review.</li>
+<li>MOD_RES: Thr2 phosphorylated (large-scale phosphoproteomics) <a href="https://pubmed.ncbi.nlm.nih.gov/18407956">PMID:18407956</a>. Peripheral to function.</li>
+</ul>
+<h2 id="what-is-known-about-oca6-specifically-with-attribution">What is KNOWN about OCA6 specifically (with attribution)</h2>
+<ol>
+<li><strong>Subcellular location = cytoplasm.</strong> Genome-wide GFP-fusion localization.<br />
+   [PMID:14562095 — "Global analysis of protein localization in budding yeast"; abstract-only cache].<br />
+   GOA carries this as HDA (cytoplasm) plus a UniProt IEA (SubCell) duplicate.</li>
+<li><strong>Deletion reduces Brome mosaic virus (BMV) RNA replication in yeast.</strong> OCA6 is one of ~100 host genes from a<br />
+   genome-wide single-gene-deletion screen whose loss altered BMV replication.<br />
+   [PMID:14671320 — "Systematic, genome-wide identification of host genes affecting replication of a<br />
+   positive-strand RNA virus"; abstract-only]. This is a low-specificity, high-throughput hit; the abstract does<br />
+   NOT describe an OCA6-specific mechanism ("nearly 100 genes whose absence inhibited or stimulated BMV RNA<br />
+   replication"). UniProt promotes this to <code>-!- FUNCTION: Required for replication of Brome mosaic virus (BMV)</code><br />
+   with ECO:0000269, but it is a screen-level phenotype, not a demonstrated biochemical role.</li>
+<li><strong>OCA6 is a member of the fungal OCA family of PFA-DSP-related atypical DSPs.</strong><br />
+   [PMID:21409566 — "novel PFA-DSP-related proteins in fungi (Oca1, Oca2, Oca4 and Oca6 in Saccharomyces<br />
+   cerevisiae)"; "The closest yeast homolog for these proteins was the PFA-DSP from S. cerevisiae<br />
+   ScPFA-DSP1/Siw14/Oca3."].</li>
+<li><strong>OCA6 participates in caffeine/rapamycin stress responses, genetically linked to the OCA family.</strong><br />
+   [PMID:21409566 — "Oca1, Oca2, Siw14/Oca3, Oca4, and Oca6 were involved in the yeast response to caffeine and<br />
+   rapamycin stresses"; "overexpression of Siw14/Oca3 suppressed the caffeine sensitivity of oca1, oca2, oca4,<br />
+   and oca6 deleted strains, indicating a genetic linkage and suggesting a functional relationship for these<br />
+   proteins."]. So OCA6-null caffeine sensitivity is rescued by the <em>active</em> paralog Siw14 — consistent with OCA6<br />
+   working in a shared pathway rather than providing unique catalysis.</li>
+<li><strong>SGD phenotype survey (large-scale):</strong> oca6Δ shows decreased oxidative-stress resistance, decreased chemical<br />
+   resistance, abnormal chemical-compound accumulation, decreased competitive fitness, vacuolar morphology<br />
+   abnormalities. [SGD locus S000002474, https://www.yeastgenome.org/locus/S000002474 — SGD summarizes<br />
+   "biological role is unknown"; molecular function ND].</li>
+<li><strong>OCA "complex".</strong> Transcriptional profiles of oca1/oca2/oca3(SIW14)/oca5/oca6 deletion strains are highly<br />
+   similar and there is evidence for physical interactions among OCA proteins — hence the "OCA complex" framing.<br />
+   [web summary of high-throughput yeast complex/chemical-stress mapping; PMID:22282571 (Hillenmeyer et al. /<br />
+   related large-scale complex mapping) — NOT directly quoted from cache; treat as supporting, not primary].</li>
+</ol>
+<h2 id="what-is-not-known-about-oca6-knowledge-gaps">What is NOT known about OCA6 (knowledge gaps)</h2>
+<ul>
+<li><strong>Is OCA6 catalytically active?</strong> No direct assay of OCA6 phosphatase activity exists in the cache. The 2011<br />
+  paper measured Siw14 (active) and Oca1 (inactive), NOT OCA6. Sequence analysis (no CX5R Arg) and the<br />
+  pseudophosphatase-scanner classification both point to <em>likely catalytically dead / pseudophosphatase</em>, but this<br />
+  is inferred, not measured.</li>
+<li><strong>What is its physiological substrate?</strong> The active family prototype Siw14/Oca3 is a 5-InsP7 inositol<br />
+  pyrophosphate phosphatase (not a protein-tyrosine phosphatase). Whether OCA6 has any residual activity on<br />
+  inositol pyrophosphates, on a phosphoprotein, or acts purely as a non-catalytic scaffold/regulator within the<br />
+  OCA complex is unknown.</li>
+<li><strong>Its specific role in the OCA complex / oxidative-stress response.</strong> The "OCA" (oxidant-induced cell-cycle<br />
+  arrest) name derives from OCA1/YNL099C [PMID:11408586, Alic et al. 2001: YNL099C required for G1 arrest on<br />
+  linoleic-acid-hydroperoxide]. OCA6 was named by family membership; there is no direct demonstration that OCA6<br />
+  itself mediates oxidant-induced cell-cycle arrest. Whether OCA6 is a catalytic subunit, a regulatory subunit,<br />
+  or functionally redundant within the complex is unresolved.</li>
+<li><strong>Mechanism of the BMV-replication phenotype.</strong> Whether OCA6 acts directly on viral replication or indirectly<br />
+  (via stress signaling / membrane lipid / inositol-pyrophosphate homeostasis) is unknown.</li>
+</ul>
+<h2 id="attribution-discipline-oca6-vs-other-oca-members">Attribution discipline: OCA6 vs other OCA members</h2>
+<ul>
+<li><strong>Siw14/Oca3</strong>: the biochemically characterized active PFA-DSP (5-InsP7 phosphatase). Do NOT transfer its<br />
+  measured catalytic activity to OCA6.</li>
+<li><strong>Oca1/YNL099C</strong>: founding OCA gene (oxidant-induced G1 arrest); shown catalytically inactive in vitro.</li>
+<li><strong>Oca2, Oca4, Oca5</strong>: other family members; Oca4 has lost its catalytic motif; Oca5 reported as an inositol<br />
+  pyrophosphatase in another study. None of their specific data should be attributed to OCA6.</li>
+<li>OCA6-specific direct evidence is limited to: cytoplasmic localization (HTP), BMV-screen phenotype,<br />
+  caffeine-sensitivity/genetic-linkage as an oca6Δ member of the family, SGD phenotype survey, and the Thr2<br />
+  phosphosite. Everything else is family-level or orthology-based inference.</li>
+</ul>
+<h2 id="annotation-review-plan-6-goa-annotations">Annotation review plan (6 GOA annotations)</h2>
+<ol>
+<li>GO:0016791 phosphatase activity (IBA, GO_REF:0000033) — family/fold supports a phosphatase-like domain; but<br />
+   catalytic Arg is degenerate. Keep as a cautious non-core general MF (KEEP_AS_NON_CORE) — IBA reflects the fold,<br />
+   and "phosphatase activity" is general enough to be defensible for the family; flag catalytic uncertainty in<br />
+   reason. (Do not promote to a specific PTP activity.)</li>
+<li>GO:0004725 protein tyrosine phosphatase activity (IEA, GO_REF:0000120 = UniProtKB-EC from the <em>Putative</em> EC<br />
+   3.1.3.48) — this is the over-annotation. It asserts a <em>specific</em> protein-tyrosine-phosphatase catalysis that<br />
+   (a) is contradicted by the degenerate CX5R motif, and (b) is biochemically wrong even for the active family<br />
+   member (Siw14 is an inositol-pyrophosphate phosphatase, not a PTP). MARK_AS_OVER_ANNOTATED (specific PTP<br />
+   activity not supported; likely pseudophosphatase).</li>
+<li>GO:0005737 cytoplasm (IEA, GO_REF:0000044 SubCell) — ACCEPT (or non-core); supported.</li>
+<li>GO:0005737 cytoplasm (HDA, PMID:14562095) — ACCEPT; direct HTP localization evidence, this is the core CC.</li>
+<li>GO:0003674 molecular_function (ND, GO_REF:0000015) — ACCEPT as ND placeholder (SGD's honest "unknown").</li>
+<li>GO:0008150 biological_process (ND, GO_REF:0000015) — ACCEPT as ND placeholder.</li>
+</ol>
+<p>Core function: uncertain molecular function within a PTP-superfamily / PFA-DSP fold, acting in the cytoplasm as<br />
+a member of the OCA family implicated in caffeine/rapamycin and oxidative-stress responses; likely a<br />
+pseudophosphatase (degenerate CX5R). Location cytoplasm is the one high-confidence attribute.</p>
+<h2 id="deep-research-infra-failure-documented-not-fabricated">Deep research (infra failure — documented, not fabricated)</h2>
+<p>Automated deep research could not be produced for OCA6:<br />
+- <code>just deep-research-falcon yeast OCA6 --fallback perplexity-lite</code> was run TWICE (initial + one retry per policy).<br />
+  Both runs HUNG with no output and were killed (~20 min then an 8-min bounded retry; SIGTERM exit 143).<br />
+- The perplexity-lite fallback returned HTTP 401 <code>insufficient_quota</code> (Perplexity API out of quota).</p>
+<p>Per repository policy I did NOT fabricate a <code>-deep-research-{provider}.md</code> file. All findings in this review are<br />
+grounded directly in: the cached UniProt record (Q12454), the GOA TSV, cached PMIDs<br />
+(14562095, 14671320, 21409566, 18407956, 11408586), SGD (S000002474), CDD (cd17663 / PFA-DSP family),<br />
+PANTHER (PTHR31126 / SF14), and the reviewer's own inline CX5R catalytic-motif analysis of the UniProt sequence.<br />
+The review therefore does not depend on an automated deep-research file.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q12454
+gene_symbol: OCA6
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  OCA6 (YDR067C) is a small (224-residue) cytoplasmic protein of the budding yeast
+  Saccharomyces cerevisiae that adopts a protein-tyrosine-phosphatase (PTP) superfamily
+  fold and belongs to the fungal OCA family of PFA-DSP (Plant-and-Fungi Atypical
+  Dual-Specificity Phosphatase)-related proteins, together with Oca1, Oca2, Siw14/Oca3,
+  Oca4 and Oca5. Although classified within the PTP/DSP structural family (Pfam Y_phosphatase2 /
+  Siw14-like; CDD PFA-DSP_Oca6) and carrying a predicted phosphocysteine active-site residue,
+  its canonical CX5R catalytic loop is degenerate — the invariant phosphate-binding arginine
+  is not present — so OCA6 is likely a catalytically impaired or pseudophosphatase member of
+  the family rather than a bona fide protein-tyrosine phosphatase. The biochemically active
+  prototype of the family, Siw14/Oca3, is an inositol-pyrophosphate (5-InsP7) phosphatase, not
+  a phosphotyrosine phosphatase. OCA6 is genetically linked to the other OCA-family members and
+  is implicated in cellular responses to caffeine, rapamycin and oxidative stress, and its
+  deletion reduces replication of Brome mosaic virus in yeast. Its own catalytic status,
+  physiological substrate, and precise role within the OCA family remain undetermined.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:14562095
+  title: Global analysis of protein localization in budding yeast.
+  findings:
+  - statement: &gt;-
+      Genome-wide GFP-fusion localization assigned OCA6 to the cytoplasm; this is the
+      basis of the HDA cytoplasm annotation.
+    supporting_text: &gt;-
+      we describe the construction and analysis of a collection of yeast strains
+      expressing full-length, chromosomally tagged green fluorescent protein fusion
+      proteins.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified high-throughput GFP-localization resource (abstract-only cache).
+      Supports the cytoplasmic localization of OCA6. Assigns location, not molecular function.
+- id: PMID:14671320
+  title: Systematic, genome-wide identification of host genes affecting replication of
+    a positive-strand RNA virus.
+  findings:
+  - statement: &gt;-
+      OCA6 was identified in a genome-wide yeast single-gene-deletion screen as one of ~100
+      host genes whose loss altered Brome mosaic virus (BMV) RNA replication; this is the
+      basis of the UniProt &#34;Required for replication of BMV&#34; function statement.
+    supporting_text: &gt;-
+      This functional genomics approach revealed nearly 100 genes whose absence inhibited or
+      stimulated BMV RNA replication and/or gene expression by 3- to &gt;25-fold.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (abstract-only cache). OCA6 is a hit in a large,
+      low-specificity genome-wide screen; the abstract describes ~100 genes and does not
+      establish an OCA6-specific mechanism. Supports a BMV-replication phenotype, not a
+      defined biochemical function.
+- id: PMID:21409566
+  title: Phylogenetic and genetic linkage between novel atypical dual-specificity phosphatases
+    from non-metazoan organisms.
+  findings:
+  - statement: &gt;-
+      OCA6 is one of the fungal PFA-DSP-related atypical dual-specificity phosphatase proteins
+      of S. cerevisiae; the closest characterized homolog is the active PFA-DSP Siw14/Oca3.
+    supporting_text: &gt;-
+      Bioinformatic analysis revealed the existence of novel PFA-DSP-related proteins in fungi
+      (Oca1, Oca2, Oca4 and Oca6 in Saccharomyces cerevisiae) and protozoa
+  - statement: &gt;-
+      OCA6, together with the other OCA-family members, is involved in the yeast response to
+      caffeine and rapamycin stresses, and oca6 caffeine sensitivity is suppressed by
+      overexpression of the active family member Siw14/Oca3 (genetic linkage).
+    supporting_text: &gt;-
+      Oca1, Oca2, Siw14/Oca3, Oca4, and Oca6 were involved in the yeast response to caffeine
+      and rapamycin stresses.
+  - statement: &gt;-
+      Within the family, catalytic activity is not uniform: Siw14/Oca3 is an active phosphatase
+      in vitro while no activity could be detected for Oca1 — direct catalytic activity of OCA6
+      itself was not demonstrated.
+    supporting_text: &gt;-
+      Siw14/Oca3 was an active phosphatase in vitro, whereas no phosphatase activity could be
+      detected for Oca1.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (abstract-only cache) and the key OCA-family reference.
+      Establishes OCA6 as a PFA-DSP-related fungal atypical DSP, its genetic linkage to the
+      OCA family in caffeine/rapamycin stress responses, and that catalytic activity varies
+      across the family (Siw14 active, Oca1 inactive; OCA6 not directly assayed). Does NOT
+      demonstrate OCA6 catalytic activity or a protein-tyrosine-phosphatase function.
+- id: PMID:18407956
+  title: A multidimensional chromatography technology for in-depth phosphoproteome analysis.
+  findings:
+  - statement: &gt;-
+      OCA6 is phosphorylated on Thr2, detected by large-scale mass-spectrometry phosphoproteomics.
+    supporting_text: &gt;-
+      A multidimensional chromatography technology for in-depth phosphoproteome analysis
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified large-scale phosphoproteomics paper (abstract-only cache). Provides the
+      Thr2 phosphosite on OCA6; peripheral to its molecular function.
+- id: PMID:11408586
+  title: Identification of a Saccharomyces cerevisiae gene that is required for G1 arrest
+    in response to the lipid oxidation product linoleic acid hydroperoxide.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Founding paper of the OCA (Oxidant-induced Cell-cycle Arrest) gene name — OCA1/YNL099C.
+      OCA6 is named by family membership, not by demonstration of its own role in oxidant-induced
+      G1 arrest; cited to document the origin of the OCA nomenclature, not OCA6-specific function.
+      Not used to support any positive OCA6 annotation.
+existing_annotations:
+- term:
+    id: GO:0016791
+    label: phosphatase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      General phosphatase activity inferred phylogenetically from membership in the
+      PTP/PFA-DSP fold family. The fold is genuinely present, but OCA6&#39;s canonical CX5R
+      catalytic loop is degenerate (missing the invariant P-loop arginine), so any catalytic
+      activity is uncertain. Retained as a cautious, general, non-core molecular function that
+      reflects the family fold without over-committing to a specific catalytic role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA reflects the ancestral phosphatase fold of the PFA-DSP/PTP family, of which OCA6 is a
+      member (PMID:21409566). &#34;phosphatase activity&#34; (GO:0016791) is general enough to be
+      defensible at the family level and is not contradicted outright by the fold. However,
+      direct catalytic activity of OCA6 has never been demonstrated and its CX5R P-loop arginine
+      is absent (reviewer sequence analysis in OCA6-notes.md; corroborated by a fungal
+      pseudophosphatome analysis reporting catalytic-motif substitutions in Oca1/Oca2/Oca6), so
+      this is kept as non-core and not promoted to any specific catalytic term.
+    supported_by:
+    - reference_id: PMID:21409566
+      supporting_text: &gt;-
+        Bioinformatic analysis revealed the existence of novel PFA-DSP-related proteins in fungi
+        (Oca1, Oca2, Oca4 and Oca6 in Saccharomyces cerevisiae) and protozoa
+- term:
+    id: GO:0004725
+    label: protein tyrosine phosphatase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Specific protein-tyrosine-phosphatase catalytic activity, assigned electronically from the
+      &#34;Putative&#34; EC 3.1.3.48 in UniProt. This is an over-annotation: it asserts a specific
+      catalysis (phosphotyrosine hydrolysis) that is (i) not supported by OCA6&#39;s degenerate CX5R
+      catalytic loop, and (ii) biochemically inconsistent with the family — the active family
+      prototype Siw14/Oca3 is an inositol-pyrophosphate (5-InsP7) phosphatase, not a
+      protein-tyrosine phosphatase. The EC number is explicitly marked &#34;Putative&#34; in UniProt.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Electronic mapping from the UniProt &#34;Putative&#34; EC 3.1.3.48. There is no experimental
+      evidence that OCA6 hydrolyzes phosphotyrosine, its P-loop arginine of the CX5R catalytic
+      motif is absent (reviewer sequence analysis in OCA6-notes.md), and the characterized
+      activity in this atypical DSP family is inositol-pyrophosphate phosphatase (Siw14/Oca3), not
+      phosphotyrosine phosphatase. Asserting a specific PTP activity over-annotates a likely
+      pseudophosphatase; the general fold-level phosphatase term (GO:0016791) already captures what
+      the family membership supports.
+    supported_by:
+    - reference_id: PMID:21409566
+      supporting_text: &gt;-
+        Siw14/Oca3 was an active phosphatase in vitro, whereas no phosphatase activity could be
+        detected for Oca1.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization asserted electronically from the UniProt subcellular-location
+      vocabulary. Consistent with the experimental HDA localization and with the protein carrying
+      no signal peptide or transmembrane segment.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization; this IEA (SubCell mapping) is concordant with the experimentally
+      supported HDA cytoplasm annotation from PMID:14562095. Cytoplasm is the core cellular
+      component of OCA6.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: HDA
+  original_reference_id: PMID:14562095
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization from the genome-wide GFP-fusion localization study. This is the
+      single highest-confidence attribute of OCA6 and is consistent with a soluble cytoplasmic
+      protein lacking signal/transmembrane features.
+    action: ACCEPT
+    reason: &gt;-
+      Direct high-throughput experimental localization evidence (GFP-tagged full-length protein).
+      Cytoplasm is well supported and is the core cellular-component assignment for OCA6.
+    supported_by:
+    - reference_id: PMID:14562095
+      supporting_text: &gt;-
+        we describe the construction and analysis of a collection of yeast strains
+        expressing full-length, chromosomally tagged green fluorescent protein fusion
+        proteins.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function with the ND (No biological Data) evidence code — the honest curator
+      placeholder recording that no molecular function has been experimentally established for OCA6.
+      This is accurate: OCA6&#39;s catalytic status and substrate are undetermined.
+    action: ACCEPT
+    reason: &gt;-
+      ND correctly reflects the absence of experimentally demonstrated molecular function for OCA6.
+      Retained as-is; the associated knowledge gap is captured in core_functions.knowledge_gaps.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process with the ND evidence code — placeholder recording that no specific
+      biological process has been experimentally established for OCA6 at annotation-grade evidence.
+      Family-level genetic links to caffeine/rapamycin/oxidative-stress responses and a BMV-screen
+      phenotype exist but are not curated here as specific BP annotations.
+    action: ACCEPT
+    reason: &gt;-
+      ND appropriately reflects the lack of an annotation-grade, OCA6-specific biological process.
+      The genome-wide BMV-replication phenotype (PMID:14671320) and family-level caffeine/rapamycin
+      genetic linkage (PMID:21409566) are documented in the notes and knowledge gaps rather than
+      asserted as specific process annotations, given their low specificity for OCA6 alone.
+core_functions:
+- description: &gt;-
+    Cytoplasmic protein adopting a protein-tyrosine-phosphatase (PTP) superfamily / PFA-DSP fold
+    and belonging to the fungal OCA family of atypical dual-specificity-phosphatase-related proteins
+    (with Oca1, Oca2, Siw14/Oca3, Oca4, Oca5). OCA6 is genetically linked to the other OCA members
+    in cellular responses to caffeine, rapamycin and oxidative stress, and its own catalytic activity
+    is doubtful because the canonical CX5R catalytic P-loop is degenerate (the invariant catalytic
+    arginine is absent). It is best regarded as a likely catalytically impaired / pseudophosphatase
+    family member whose specific molecular activity and substrate are not established; the one
+    high-confidence attribute is cytoplasmic localization.
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:14562095
+    supporting_text: &gt;-
+      we describe the construction and analysis of a collection of yeast strains
+      expressing full-length, chromosomally tagged green fluorescent protein fusion
+      proteins.
+  - reference_id: PMID:21409566
+    supporting_text: &gt;-
+      Oca1, Oca2, Siw14/Oca3, Oca4, and Oca6 were involved in the yeast response to caffeine
+      and rapamycin stresses.
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      Whether OCA6 is a catalytically active phosphatase at all is undetermined. It carries the
+      PFA-DSP/PTP fold and a predicted active-site cysteine, but its CX5R catalytic loop is
+      degenerate (the invariant phosphate-binding arginine is missing), and no direct enzymatic
+      assay of OCA6 has been reported.
+    boundary: &gt;-
+      The active family prototype Siw14/Oca3 was shown to be an active phosphatase in vitro and
+      Oca1 was shown to be inactive; OCA6 itself was not assayed. OCA6&#39;s fold assignment and
+      cytoplasmic localization are firmly established.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Distinguishing an active atypical DSP from a non-catalytic pseudophosphatase determines
+      whether OCA6 acts enzymatically or as a scaffolding/regulatory subunit of the OCA family.
+    resolution: &gt;-
+      In-vitro phosphatase assays of recombinant OCA6 against candidate substrates (including
+      inositol pyrophosphates such as 5-InsP7) and catalytic-residue mutagenesis.
+    provenance:
+    - reference_id: PMID:21409566
+      supporting_text: &gt;-
+        Siw14/Oca3 was an active phosphatase in vitro, whereas no phosphatase activity could be
+        detected for Oca1.
+  - gap_statement: &gt;-
+      The physiological substrate of OCA6 is unknown. Even if it retains activity, whether it acts
+      on a phosphoprotein (as the &#34;protein tyrosine phosphatase&#34; name implies), on inositol
+      pyrophosphates (as the active family member Siw14/Oca3 does), or on some other substrate is
+      undetermined.
+    boundary: &gt;-
+      Siw14/Oca3, the characterized member of this fungal PFA-DSP family, is a 5-InsP7
+      inositol-pyrophosphate phosphatase rather than a protein-tyrosine phosphatase, so the
+      UniProt &#34;tyrosine-protein phosphatase&#34; name is a family-level inference, not a measured
+      OCA6 substrate.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    resolution: &gt;-
+      Substrate-profiling of recombinant OCA6 (protein-phosphotyrosine vs inositol-pyrophosphate
+      panels) and identification of in-vivo interactors/substrates.
+    provenance:
+    - reference_id: PMID:21409566
+      supporting_text: &gt;-
+        Bioinformatic analysis revealed the existence of novel PFA-DSP-related proteins in fungi
+        (Oca1, Oca2, Oca4 and Oca6 in Saccharomyces cerevisiae) and protozoa
+  - gap_statement: &gt;-
+      OCA6&#39;s specific role within the OCA family / OCA complex and in the oxidative-stress response
+      is unresolved — whether it is a catalytic subunit, a regulatory/scaffolding subunit, or
+      functionally redundant with its paralogs, and how it contributes mechanistically to
+      caffeine/rapamycin/oxidant responses and to Brome mosaic virus replication.
+    boundary: &gt;-
+      OCA6 is genetically linked to the OCA family in caffeine/rapamycin responses (oca6 caffeine
+      sensitivity is suppressed by overexpressed Siw14/Oca3), its deletion reduces BMV replication
+      in a genome-wide screen, and SGD&#39;s large-scale phenotype surveys report reduced oxidative-stress
+      resistance for oca6 deletants; but no OCA6-specific mechanism has been defined, and the OCA
+      &#34;oxidant-induced cell-cycle arrest&#34; name derives from OCA1, not OCA6.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    resolution: &gt;-
+      Affinity purification of tagged OCA6 to define OCA-complex composition, epistasis within the
+      OCA family, and directed assays of oca6 phenotypes in oxidative-stress and BMV-replication
+      contexts.
+    provenance:
+    - reference_id: PMID:21409566
+      supporting_text: &gt;-
+        overexpression of Siw14/Oca3 suppressed the caffeine sensitivity of oca1, oca2, oca4, and
+        oca6 deleted strains, indicating a genetic linkage and suggesting a functional relationship
+        for these proteins.
+suggested_questions:
+- question: &gt;-
+    Is OCA6 a catalytically active phosphatase, and if so what is its physiological substrate —
+    a phosphoprotein or an inositol pyrophosphate such as 5-InsP7?
+  experts:
+  - Protein/inositol-pyrophosphate phosphatase biochemists
+  - PTP/dual-specificity-phosphatase structural biologists
+- question: &gt;-
+    What is the composition of the OCA complex, and does OCA6 function within it as a catalytic
+    subunit, a regulatory subunit, or a redundant paralog?
+  experts:
+  - Yeast signaling / stress-response biologists
+suggested_experiments:
+- experiment_type: In-vitro enzymology
+  description: &gt;-
+    Express and purify recombinant OCA6 and assay phosphatase activity against generic
+    phosphatase substrates, phosphotyrosine peptides, and an inositol-pyrophosphate panel
+    (including 5-InsP7), comparing wild type with active-site and P-loop-arginine-restored mutants
+    to test whether the degenerate CX5R loop can be catalytically rescued.
+- experiment_type: Affinity purification / mass spectrometry
+  description: &gt;-
+    Affinity-purify tagged OCA6 from yeast and identify interacting OCA-family members and other
+    partners to define the OCA complex and place OCA6 within it.
+- experiment_type: Phenotypic / genetic analysis
+  description: &gt;-
+    Characterize oca6 deletion phenotypes under oxidative stress, caffeine, and rapamycin, and in
+    the BMV-replication assay, with epistasis against SIW14/OCA3 and the other OCA genes to
+    determine OCA6&#39;s specific and redundant contributions.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/SRP40/SRP40-ai-review.html
+++ b/genes/yeast/SRP40/SRP40-ai-review.html
@@ -1,0 +1,2777 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SRP40 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SRP40</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P32583" target="_blank" class="term-link">
+                        P32583
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SRP40";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P32583" data-a="DESCRIPTION: SRP40 (YKR092C) is a small (406-residue, ~41 kDa),..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SRP40 (YKR092C) is a small (406-residue, ~41 kDa), highly acidic (pI ~3.9), serine-rich (~49% Ser) nucleolar protein of Saccharomyces cerevisiae, and is the budding-yeast homolog of the vertebrate nucleolar phosphoprotein Nopp140 (its C-terminal SRP40_C domain is ~59% identical to the Nopp140 C-terminus). The protein is almost entirely intrinsically disordered, built from serine-rich low-complexity tracts interspersed with acidic (Asp/Glu) and basic (Lys/Arg) charge clusters, plus the single conserved folded C-terminal module; it carries no recognizable catalytic motif. Like Nopp140, it is a casein kinase II phosphoprotein (though phosphorylated to a lesser extent than the vertebrate protein) and is additionally serine- pyrophosphorylated by the inositol pyrophosphate 5-IP7. Srp40p localizes to the nucleolus and is proposed to act as a chaperone of small nucleolar ribonucleoprotein particles (snoRNPs) that mediate rRNA maturation, with a particular genetic link to the stability of box H/ACA snoRNAs; rat Nopp140 can functionally substitute for it. The gene is nonessential but dosage-sensitive: both deletion and overexpression impair growth. Its name (&#34;Suppressor of RNA Polymerase&#34;) derives from its original isolation as a weak extragenic suppressor of a mutation in the AC40 subunit shared by RNA polymerases I and III, and does not denote a signal-recognition-particle function.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                    GO:0005730
+                                </a>
+                            </span>
+                            <span class="term-label">nucleolus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0005730" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) nucleolar localization, concordant with the direct yeast experimental evidence and with the Nopp140/SRP40 family being nucleolar. Accept as a core cellular-component annotation.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link">
+                                        PMID:8702624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SRP40 localizes to the yeast nucleolus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0005654" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred nucleoplasmic localization. Nopp140/Treacle-family members do distribute to the nucleoplasm and coiled/Cajal bodies in addition to the nucleolus, so this is plausible, but the direct yeast evidence is for the nucleolus. Keep as a secondary, non-core location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                    GO:0005730
+                                </a>
+                            </span>
+                            <span class="term-label">nucleolus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0005730" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) nucleolar localization; redundant with, and consistent with, the direct IDA and phylogenetic IBA nucleolus annotations. Accept.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link">
+                                        PMID:8702624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SRP40 localizes to the yeast nucleolus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function with ND (no data). This is an honest reflection of the state of knowledge: no specific molecular activity has been experimentally assigned to this disordered nucleolar protein, and none can be inferred from sequence (no catalytic motif; only the non-enzymatic C-terminal SRP40_C module). Accept rather than inventing an MF term; the genuine molecular-function gap is recorded in knowledge_gaps.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                    GO:0005730
+                                </a>
+                            </span>
+                            <span class="term-label">nucleolus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8702624
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comparison of the rat nucleolar protein nopp140 with its yea...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0005730" data-r="PMID:8702624" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) localization of Srp40p to the yeast nucleolus. This is the best-supported, core cellular-component annotation for the gene.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link">
+                                        PMID:8702624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SRP40 localizes to the yeast nucleolus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006913" target="_blank" class="term-link">
+                                    GO:0006913
+                                </a>
+                            </span>
+                            <span class="term-label">nucleocytoplasmic transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8702624
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comparison of the rat nucleolar protein nopp140 with its yea...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0006913" data-r="PMID:8702624" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation transferred from the rat ortholog Nopp140 (UniProtKB:P41777). Nopp140 shuttles between the nucleolus and cytoplasm and binds nuclear localization signals, and was proposed to chaperone ribosome biogenesis on that basis; the transport/shuttling activity, however, is a vertebrate-Nopp140 property and has NOT been directly demonstrated for yeast Srp40p, and the source paper itself notes yeast/vertebrate disparities in nucleolar dynamics. The better-supported functional role of yeast Srp40p is nucleolar snoRNP chaperoning within ribosome biogenesis (PMID:12700234), not transport per se. Retain as a non-core, ortholog-inferred process rather than removing an ISS annotation made by a curator from a selected ortholog.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link">
+                                        PMID:8702624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">its nuclear localization signal binding capacity, and its shuttling between the nucleolus and the cytoplasm, Nopp140 was proposed to function as a chaperone in ribosome biogenesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042254" target="_blank" class="term-link">
+                                    GO:0042254
+                                </a>
+                            </span>
+                            <span class="term-label">ribosome biogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12700234" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12700234
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic interaction between a chaperone of small nucleolar r...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P32583" data-a="GO:0042254" data-r="PMID:12700234" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation (not currently in GOA). Srp40p is a nucleolar protein proposed to chaperone the snoRNPs required for rRNA maturation, and its genetic depletion specifically destabilizes box H/ACA snoRNAs; rat Nopp140 restores box H/ACA snoRNA stability, confirming it as the functional Nopp140 homolog. This is the best-supported biological process for the gene and is captured as a core function. Evidence is genetic/homology-based (a proposal), so the underlying molecular activity remains a knowledge gap.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12700234" target="_blank" class="term-link">
+                                        PMID:12700234
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Srp40p is a nonessential yeast nucleolar protein proposed to function as a chaperone for over 100 small nucleolar ribonucleoprotein particles that are required for rRNA maturation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Nucleolar protein contributing to ribosome biogenesis, proposed to act as a chaperone of small nucleolar ribonucleoprotein particles (snoRNPs) — in particular the box H/ACA class involved in rRNA modification — with the underlying molecular activity undetermined.</h3>
+                <span class="vote-buttons" data-g="P32583" data-a="FUNCTION: Nucleolar protein contributing to ribosome biogene..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042254" target="_blank" class="term-link">
+                                ribosome biogenesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                nucleolus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12700234" target="_blank" class="term-link">
+                                PMID:12700234
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Srp40p is a nonessential yeast nucleolar protein proposed to function as a chaperone for over 100 small nucleolar ribonucleoprotein particles that are required for rRNA maturation.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link">
+                                PMID:8702624
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">SRP40 localizes to the yeast nucleolus</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" target="_blank" class="term-link">
+                            PMID:8702624
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comparison of the rat nucleolar protein nopp140 with its yeast homolog SRP40. Differential phosphorylation in vertebrates and yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SRP40 encodes an acidic, serine-rich 41 kDa protein whose C-terminus is 59% identical to that of rat Nopp140; it localizes to the yeast nucleolus, is phosphorylated by casein kinase II (to a lesser extent than Nopp140), and is required at a specific cellular concentration for optimal growth (both overexpression and deletion are deleterious).</div>
+
+                        <div class="finding-text">"SRP40 localizes to the yeast nucleolus and is required at a specific cellular concentration for optimal growth as indicated by the negative effect on cell growth of both overexpression and deletion of its gene."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12700234" target="_blank" class="term-link">
+                            PMID:12700234
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic interaction between a chaperone of small nucleolar ribonucleoprotein particles and cytosolic serine hydroxymethyltransferase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Srp40p is a nonessential nucleolar protein proposed to chaperone the &gt;100 snoRNPs required for rRNA maturation; its genetic depletion specifically depletes box H/ACA snoRNAs, and rat Nopp140 restores growth and box H/ACA snoRNA stability, confirming it as the functional yeast homolog of Nopp140.</div>
+
+                        <div class="finding-text">"Srp40p is a nonessential yeast nucleolar protein proposed to function as a chaperone for over 100 small nucleolar ribonucleoprotein particles that are required for rRNA maturation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8516295" target="_blank" class="term-link">
+                            PMID:8516295
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactions between three common subunits of yeast RNA polymerases I and III.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Srp40p bind snoRNAs (particularly box H/ACA snoRNAs) or snoRNP proteins directly, and does it possess measurable RNA-chaperone (annealing/remodeling) or RNP-assembly activity in vitro?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="Q: Does Srp40p bind snoRNAs (particularly box H/ACA s..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> At which step of ribosome biogenesis does Srp40p act, and does its loss primarily affect box H/ACA snoRNP assembly, stability, localization, or recycling?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="Q: At which step of ribosome biogenesis does Srp40p a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What accounts for the dual dosage sensitivity (both deletion and overexpression are deleterious), and which factors buffer srp40-delta to keep the gene nonessential?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="Q: What accounts for the dual dosage sensitivity (bot..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the CK2 phosphorylation and 5-IP7 serine pyrophosphorylation of Srp40p regulate its snoRNP-associated function, and can specific phospho-sites be linked to the growth or box H/ACA snoRNA phenotypes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="Q: Do the CK2 phosphorylation and 5-IP7 serine pyroph..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro RNA-binding and RNA-chaperone assays (EMSA, filter binding, FRET-based annealing/strand-displacement) using recombinant Srp40p and candidate box H/ACA snoRNAs and snoRNP components, with the disordered N-terminus and the SRP40_C domain tested separately.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="EXPERIMENT: In vitro RNA-binding and RNA-chaperone assays (EMS..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenous affinity purification / proximity labeling (e.g. BioID or AP-MS) plus CLIP-seq of tagged Srp40p to define its direct protein and RNA partners in the nucleolus and to test the snoRNP-chaperone model in vivo.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="EXPERIMENT: Endogenous affinity purification / proximity label..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Systematic genetic analysis (synthetic-lethal / dosage screens beyond the known shm2 ade3 interaction) and phospho-site mutant series (CK2 and 5-IP7 pyrophosphorylation sites) scored for growth, box H/ACA snoRNA levels, and rRNA processing, to connect Srp40p&#39;s PTMs and partners to its cellular role.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P32583" data-a="EXPERIMENT: Systematic genetic analysis (synthetic-lethal / do..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular activity of Srp40p and the precise step in ribosome biogenesis at which it acts are unknown. Whether it directly chaperones/assembles snoRNPs, stabilizes box H/ACA snoRNAs, or contributes indirectly (e.g. through its highly phosphorylated, acidic, disordered tracts) is undetermined, as is the reason the gene is simultaneously nonessential and dosage-sensitive (toxic when either deleted or overexpressed).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: Srp40p is the yeast Nopp140 homolog (SRP40_C domain ~59% identical to Nopp140&#39;s C-terminus); it is a ~41 kDa, acidic (pI ~3.9), ~49%-serine, almost fully intrinsically disordered nucleolar protein with no catalytic motif; it is CK2-phosphorylated and 5-IP7 serine-pyrophosphorylated; it localizes to the nucleolus (IDA); it is nonessential but its deletion and overexpression both impair growth; its genetic depletion specifically destabilizes box H/ACA snoRNAs; and rat Nopp140 functionally complements srp40-delta.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Defining the activity of this tractable, conserved nucleolar chaperone would illuminate how the Nopp140/Treacle family (implicated in human ribosomopathies) contributes to snoRNP function and rRNA maturation, and would provide an experimental anchor for a class of disordered nucleolar proteins that GO cannot currently describe at the molecular-function level.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical reconstitution of Srp40p RNA/snoRNP-chaperone activity; interactome/ CLIP mapping of its snoRNP (especially box H/ACA) partners in vivo; genetic dissection of the redundancy/buffering that renders it nonessential and of the basis of overexpression toxicity; phospho-site (CK2 / 5-IP7) separation-of-function alleles to connect its unusual PTMs to the growth and box H/ACA phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Srp40p is a nonessential yeast nucleolar protein proposed to function as a chaperone for over 100 small nucleolar ribonucleoprotein particles that are required for rRNA maturation."</em> — PMID:12700234</li>
+
+                <li><em>"required at a specific cellular concentration for optimal growth as indicated by the negative effect on cell growth of both overexpression and deletion of its gene"</em> — PMID:8702624</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SRP40-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P32583" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: SRP40 (YKR092C) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">24 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T03:33:14.914697</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="SRP40-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-srp40-ykr092c-in-saccharomyces-cerevisiae">Comprehensive Research Report: SRP40 (YKR092C) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-geneprotein-identity-and-verification">1. Gene/Protein Identity and Verification</h2>
+<p>SRP40 (Suppressor protein SRP40; UniProt P32583) is encoded by the gene <em>SRP40</em> (systematic name YKR092C) in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). It is the budding yeast ortholog of mammalian nucleolar phosphoprotein 140 (Nopp140, gene <em>NOLC1</em>), a conserved nucleolar chaperone protein involved in small nucleolar ribonucleoprotein (snoRNP) biogenesis and ribosome assembly (yang2000conservedcompositionof pages 2-3, he2011structureandfunction pages 1-4). The carboxy-terminal domain of yeast Srp40p shares 59% identity with the corresponding region of mammalian Nopp140, and this high conservation has been used as a criterion for identifying Nopp140 orthologs across eukaryotes (he2011structureandfunction pages 1-4). The key C-terminal domain corresponds to the Srp40_C domain annotated in Pfam (PF05022) and InterPro (IPR007718).</p>
+<p>The following table summarizes the key properties of SRP40:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>SRP40 / Srp40p summary</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>SRP40</strong></td>
+<td>(yang2000conservedcompositionof pages 2-3, yang2000conservedcompositionof pages 7-9)</td>
+</tr>
+<tr>
+<td>Systematic name</td>
+<td><strong>YKR092C</strong>; ORF name reported in UniProt context as <strong>YKR412A</strong></td>
+<td>(yang2000conservedcompositionof pages 2-3)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P32583</strong></td>
+<td>(yang2000conservedcompositionof pages 2-3)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Saccharomyces cerevisiae</strong> (strain S288c / baker’s yeast)</td>
+<td>(yang2000conservedcompositionof pages 2-3, yang2000conservedcompositionof pages 7-9)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>Nucleolar phosphoprotein and <strong>yeast homolog of mammalian Nopp140</strong>; functions as a <strong>snoRNP chaperone/assembly factor</strong>, with strongest evidence for a selective role in <strong>box H/ACA snoRNP biogenesis, stability, and trafficking</strong>, thereby supporting pre-rRNA processing and modification</td>
+<td>(nierhaus2004proteinsynthesisand pages 141-145, he2011structureandfunction pages 8-11, yang2000conservedcompositionof pages 2-3, yang2000conservedcompositionof pages 7-9)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td><strong>N-terminal LisH dimerization motif</strong>; <strong>central intrinsically disordered repeat domain</strong> with serine-rich acidic and lysine/proline-rich basic regions; <strong>conserved C-terminal domain</strong> corresponding to the <strong>Srp40_C / Nopp140 C-terminus</strong>. In yeast, the central region is simplified to <strong>two acidic clusters separated by one basic stretch</strong></td>
+<td>(he2011structureandfunction pages 4-6, he2011structureandfunction pages 1-4, he2011structureandfunction pages 6-8)</td>
+</tr>
+<tr>
+<td>Phosphorylation features</td>
+<td>Central serine-rich region is a major target of <strong>casein kinase 2 (CK2/CKII)</strong> phosphorylation; phosphorylation is required for efficient interaction with snoRNP components and is a core mechanistic feature of Nopp140-family proteins</td>
+<td>(he2011structureandfunction pages 4-6, meznad2026intrinsicallydisorderedregions pages 3-4, meznad2026intrinsicallydisorderedregions pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Localizes to the <strong>nucleolus</strong>, specifically to the <strong>nucleolar body (NB)</strong>, a subnucleolar compartment related to the vertebrate Cajal body; N-terminus and central domain are sufficient for nuclear localization, whereas the C-terminus alone is not</td>
+<td>(verheggen2001boxcdsmall pages 5-6, verheggen2001boxcdsmall pages 4-5, verheggen2001boxcdsmall pages 7-9, he2011structureandfunction pages 1-4)</td>
+</tr>
+<tr>
+<td>Key interactors / functional partners</td>
+<td>Interacts functionally with <strong>box H/ACA and box C/D snoRNPs</strong>, more strongly with <strong>box H/ACA snoRNPs</strong>; works with <strong>Nsr1p</strong> in snoRNA trafficking; phosphorylation-dependent interactions connect the family to <strong>CK2</strong>; Nopp140-family proteins also interact with <strong>RNA polymerase I</strong>, linking snoRNP metabolism to rDNA transcription</td>
+<td>(nierhaus2004proteinsynthesisand pages 141-145, he2011structureandfunction pages 8-11, verheggen2001boxcdsmall pages 4-5, verheggen2001boxcdsmall pages 5-6, he2011structureandfunction pages 4-6, meznad2026intrinsicallydisorderedregions pages 4-5)</td>
+</tr>
+<tr>
+<td>Role in pathways</td>
+<td>Functions in <strong>snoRNA maturation/trafficking</strong>, <strong>snoRNP assembly</strong>, <strong>pre-rRNA processing</strong>, <strong>rRNA modification</strong> (especially pseudouridylation-associated H/ACA pathways), and coordination of these events with <strong>Pol I transcription</strong></td>
+<td>(nierhaus2004proteinsynthesisand pages 141-145, he2011structureandfunction pages 8-11, verheggen2001boxcdsmall pages 9-9, he2011structureandfunction pages 18-21)</td>
+</tr>
+<tr>
+<td>Phenotype on deletion or depletion</td>
+<td><strong>Reduction of box H/ACA snoRNAs</strong> (e.g., snR3, snR10, snR11, snR42, snR30) with relative preservation of several box C/D snoRNAs; loss of SRP40 also disrupts <strong>NB accumulation/retention of box C/D snoRNAs</strong> and can impair NB formation or snoRNP association with the NB</td>
+<td>(he2011structureandfunction pages 8-11, yang2000conservedcompositionof pages 7-9, verheggen2001boxcdsmall pages 5-6, verheggen2001boxcdsmall pages 9-9)</td>
+</tr>
+<tr>
+<td>Mammalian ortholog</td>
+<td><strong>Nopp140 / NOLC1</strong>, a conserved nucleolar phosphoprotein chaperone involved in concentrating snoRNPs and supporting rRNA modification in the dense fibrillar component</td>
+<td>(yang2000conservedcompositionof pages 2-3, meznad2026intrinsicallydisorderedregions pages 1-2, baral2019thedrosophilaneuroblasts pages 43-48)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identity, structure, localization, interactions, and functional phenotypes of yeast SRP40/Srp40p, together with its relationship to mammalian Nopp140/NOLC1. It is useful as a compact reference for functional annotation and evidence tracking.</em></p>
+<h2 id="2-primary-function-snornp-chaperone">2. Primary Function: snoRNP Chaperone</h2>
+<p>SRP40/Srp40p functions primarily as a <strong>nucleolar phosphoprotein chaperone for small nucleolar ribonucleoproteins (snoRNPs)</strong>. It is not an enzyme per se, but rather a scaffolding/adapter protein that facilitates the biogenesis, assembly, trafficking, and stabilization of snoRNPs. These snoRNPs are essential for site-specific chemical modification of pre-ribosomal RNA (pre-rRNA) and for certain endonucleolytic pre-rRNA processing events required during ribosome biogenesis (nierhaus2004proteinsynthesisand pages 141-145, yang2000conservedcompositionof pages 2-3).</p>
+<p>Srp40p associates with both major classes of snoRNPs—box C/D snoRNPs (which guide 2′-O-methylation of rRNA) and box H/ACA snoRNPs (which guide pseudouridylation of rRNA)—but shows a stronger functional interaction with box H/ACA snoRNPs (he2011structureandfunction pages 8-11, yang2000conservedcompositionof pages 7-9). Genetic depletion of Srp40p leads to significant reductions in box H/ACA snoRNA levels (including snR3, snR10, snR11, snR42, and snR30), while box C/D snoRNAs (such as U3, U14, and U24) remain relatively unaffected (he2011structureandfunction pages 8-11). This phenotype closely resembles the effect of depleting integral box H/ACA snoRNP core proteins (Cbf5p, Nhp2p, and Nop10p), consistent with a model in which Srp40p acts as a biogenesis or stability factor for H/ACA-type snoRNPs (he2011structureandfunction pages 8-11, yang2000conservedcompositionof pages 7-9). The proposed chaperone function involves facilitating proper snoRNP assembly, localization, and transport—processes essential for snoRNP-mediated pre-rRNA processing and modification (yang2000conservedcompositionof pages 2-3).</p>
+<h2 id="3-domain-architecture-and-phosphorylation">3. Domain Architecture and Phosphorylation</h2>
+<h3 id="31-overall-structural-organization">3.1. Overall Structural Organization</h3>
+<p>Like its mammalian ortholog Nopp140, Srp40p has a tripartite domain architecture (he2011structureandfunction pages 4-6, he2011structureandfunction pages 1-4):</p>
+<ul>
+<li>
+<p><strong>N-terminal domain:</strong> Contains a LisH (Lis1-homology) dimerization motif consisting of two alpha helices that form a four-helix anti-parallel bundle upon dimerization (he2011structureandfunction pages 4-6).</p>
+</li>
+<li>
+<p><strong>Central repeat domain:</strong> In mammalian Nopp140, this consists of 10 repeating motifs of alternating serine-rich acidic segments and lysine/proline-rich basic segments (meznad2026intrinsicallydisorderedregions pages 3-4). In yeast Srp40p, this region is simplified to two acidic clusters separated by one basic stretch (he2011structureandfunction pages 1-4). The serine residues within the acidic motifs are extensively phosphorylated.</p>
+</li>
+<li>
+<p><strong>C-terminal domain (Srp40_C):</strong> This is the most conserved region among Nopp140 orthologs (he2011structureandfunction pages 6-8, he2011structureandfunction pages 1-4). In mammalian Nopp140, it consists of two subdomains (NoppCa and NoppCb) encoded by separate exons and contains a conserved protein kinase A (PKA) phosphorylation site (he2011structureandfunction pages 6-8). The C-terminal domain plays a critical role in nucleolar localization and Cajal body integrity; when overexpressed, it acts as a dominant negative, redistributing Nopp140, NAP57, and fibrillarin from nucleoli to nucleoplasmic granules and dispersing coilin from Cajal bodies (he2011structureandfunction pages 6-8). However, the C-terminal domain alone is not sufficient for nuclear localization—either the N-terminus or the central domain of Srp40p is required for this function (he2011structureandfunction pages 1-4).</p>
+</li>
+</ul>
+<h3 id="32-phosphorylation-by-casein-kinase-2">3.2. Phosphorylation by Casein Kinase 2</h3>
+<p>A defining biochemical feature of Srp40p/Nopp140 is its extensive phosphorylation by casein kinase 2 (CK2/CKII). In rat Nopp140, 82 serine residues in the acidic motifs of the central domain serve as potential phosphorylation substrates, with 45 being recognizable CK2 consensus sites (he2011structureandfunction pages 4-6). Once a serine is phosphorylated, it creates the critical acidic residue for another CK2 phosphorylation site, enabling a cascade phosphorylation mechanism (he2011structureandfunction pages 4-6). Nopp140 forms a stable complex with the β regulatory subunit of CK2 (he2011structureandfunction pages 4-6). Importantly, phosphorylation of the central domain is required for Nopp140's interaction with snoRNPs—dephosphorylation abolishes binding to snoRNP core proteins (meznad2026intrinsicallydisorderedregions pages 4-5, he2011structureandfunction pages 4-6, meznad2026intrinsicallydisorderedregions pages 3-4). This phosphorylation-dependent, electrostatic, and reversible mode of interaction is central to the protein's chaperone function.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>Srp40p localizes to the <strong>nucleolar body (NB)</strong>, a subnucleolar compartment that is contiguous with the dense fibrillar region of the nucleolus in yeast (verheggen2001boxcdsmall pages 5-6, verheggen2001boxcdsmall pages 4-5, verheggen2001boxcdsmall pages 7-9). This NB is functionally related to the <strong>Cajal body (CB)</strong> found in vertebrate cells (verheggen2001boxcdsmall pages 4-5). YFP-fusion experiments have demonstrated that Srp40p is detected in the NB, where it plays a direct role in concentrating snoRNAs during snoRNP assembly (verheggen2001boxcdsmall pages 4-5). In mammalian cells, the Nopp140 ortholog localizes to both the dense fibrillar component (DFC) of the nucleolus and Cajal bodies, where it shuttles between the two compartments to facilitate snoRNP trafficking and delivery (meznad2026intrinsicallydisorderedregions pages 1-2, he2011structureandfunction pages 18-21).</p>
+<p>Nuclear targeting of Srp40p requires either its N-terminal or central domain, while the carboxy-terminal domain alone is insufficient for establishing nuclear localization (he2011structureandfunction pages 1-4).</p>
+<h2 id="5-role-in-snorna-trafficking-and-nucleolar-body-formation">5. Role in snoRNA Trafficking and Nucleolar Body Formation</h2>
+<p>Srp40p is required for the accumulation of box C/D snoRNAs in the nucleolar body (NB) (verheggen2001boxcdsmall pages 5-6). In the NB, snoRNAs interact with Srp40p as part of the initial assembly process. Deletion of <em>SRP40</em> prevents the concentration of overexpressed box C/D snoRNAs in the NB, although at endogenous expression levels from a centromeric vector, nucleolar localization of snoRNAs is not dramatically impaired (verheggen2001boxcdsmall pages 4-5). This suggests that Srp40p functions primarily in an intermediate step of snoRNA trafficking, particularly under conditions of snoRNA abundance.</p>
+<p>The protein works in concert with Nsr1p (the yeast ortholog of mammalian nucleolin) in a regulated snoRNA trafficking pathway: Srp40p promotes snoRNP concentration in the NB, while the fully assembled snoRNP is subsequently transferred to Nsr1p for final delivery to rRNA precursors (verheggen2001boxcdsmall pages 9-9). The two factors work antagonistically in regulating snoRNA localization—accumulation of snoRNAs in the NB is decreased by deletion of <em>SRP40</em> and increased by mutation of <em>NSR1</em> (verheggen2001boxcdsmall pages 4-5).</p>
+<p>Depletion of Srp40p can also inhibit NB formation itself and/or prevent snoRNP association with the NB structure, indicating a role in the structural organization of this subnucleolar compartment (verheggen2001boxcdsmall pages 9-9).</p>
+<h2 id="6-pathway-context-ribosome-biogenesis-and-rrna-modification">6. Pathway Context: Ribosome Biogenesis and rRNA Modification</h2>
+<p>SRP40/Nopp140-family proteins occupy a central position in the ribosome biogenesis pathway by linking snoRNP-mediated rRNA modification to RNA polymerase I transcription. Srp40p associates with both snoRNP classes and interacts with RNA Pol I's largest subunit, thereby connecting snoRNP metabolism to rDNA transcription (nierhaus2004proteinsynthesisand pages 141-145). In the mammalian system, the Nopp140 central domain (residues 204–382 in the mammalian protein) interacts with RPA194, the largest subunit of RNA polymerase I, while the carboxy-terminal portion mediates additional protein-protein interactions relevant to transcriptional regulation (he2011structureandfunction pages 11-13, baral2019thedrosophilaneuroblasts pages 43-48).</p>
+<p>The genetic interaction between <em>SRP40</em> and <em>LES2</em> (a synthetically lethal gene) underscores its tight functional coupling to snoRNP-dependent pathways (yang2000conservedcompositionof pages 7-9). Additionally, <em>LSM5</em> shows genetic interactions with <em>SRP40</em>, pointing to broader functional links to snoRNA biogenesis factors (as noted in the context of Lsm2–Lsm7 complex studies with snoRNA snR5).</p>
+<h2 id="7-recent-advances-phase-separation-and-the-dense-fibrillar-component">7. Recent Advances: Phase Separation and the Dense Fibrillar Component</h2>
+<p>Recent work on the mammalian ortholog Nopp140/NOLC1 has provided mechanistic insight into how SRP40-family proteins organize the nucleolar environment. Meznad et al. demonstrated that Nopp140 concentrates snoRNPs and other ribosome biogenesis factors through multivalent, phosphorylation-dependent interactions between its charged repeat domain and intrinsically disordered, NLS-rich regions of snoRNP core proteins (NAP57/dyskerin, NOP56, NOP58) and RNA polymerase I subunit PAF49 (meznad2026intrinsicallydisorderedregions pages 9-10, meznad2026intrinsicallydisorderedregions pages 1-2, meznad2026intrinsicallydisorderedregions pages 4-5). These complementary electrostatic interactions create a liquid-liquid phase-separated biomolecular condensate that constitutes the dense fibrillar component (DFC) of the nucleolus (meznad2026intrinsicallydisorderedregions pages 9-10, meznad2026intrinsicallydisorderedregions pages 1-2). As few as three repeats of Nopp140 are sufficient for interaction with binding partners, and the interactions are abolished by dephosphorylation (meznad2026intrinsicallydisorderedregions pages 4-5).</p>
+<p>This concentration mechanism ensures that approximately 200 snoRNPs are kept in the local vicinity of elongating RNA polymerase I, permitting efficient scanning of the ~13 kb rRNA transcript and near-complete modification of the ~200 target nucleotides per rRNA molecule across the approximately 10 million rRNAs produced per cell (meznad2026intrinsicallydisorderedregions pages 9-10). The dynamic, weak, and transient nature of these interactions allows free mobility of snoRNPs within the condensate while maintaining their high local concentration near nascent pre-rRNA (meznad2026intrinsicallydisorderedregions pages 9-10).</p>
+<h2 id="8-essentiality-and-phenotypic-consequences">8. Essentiality and Phenotypic Consequences</h2>
+<p><em>SRP40</em> is a <strong>non-essential gene</strong> in yeast; its deletion does not result in lethality under standard growth conditions. However, loss of Srp40p has specific phenotypic consequences including the reduction of box H/ACA snoRNA steady-state levels and disruption of nucleolar body structure (he2011structureandfunction pages 8-11, yang2000conservedcompositionof pages 7-9, verheggen2001boxcdsmall pages 9-9). In synthetic lethal backgrounds (e.g., with <em>les2</em> mutations), <em>srp40</em> deletion leads to more severe loss of box H/ACA snoRNAs (nierhaus2004proteinsynthesisand pages 141-145, yang2000conservedcompositionof pages 7-9). Earlier work by Ikonomova et al. (1997) suggested a dose-sensitive role for Srp40p in preribosome assembly or transport that depends on its carboxy-terminal domain for proper localization to the yeast nucleoskeleton (noted in retrieved unobtainable papers).</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>Srp40p is a highly phosphorylated, intrinsically disordered nucleolar protein that functions as a chaperone for snoRNPs in <em>Saccharomyces cerevisiae</em>. Its primary role is to facilitate the biogenesis, stabilization, and trafficking of snoRNPs—particularly box H/ACA snoRNPs—within the nucleolus, thereby supporting rRNA pseudouridylation and pre-rRNA processing. Srp40p localizes to the nucleolar body and contributes to the structural organization of this subnucleolar compartment. Its phosphorylation by casein kinase 2 is essential for its interactions with snoRNP components. Through interactions with RNA Pol I, Srp40p connects snoRNP-mediated rRNA modification to rDNA transcription, coordinating key steps in ribosome biogenesis. Recent studies on its mammalian ortholog Nopp140 have revealed that this protein family drives the formation of the dense fibrillar component condensate through multivalent, charge-mediated interactions with intrinsically disordered regions of its binding partners.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(yang2000conservedcompositionof pages 2-3): Yunfeng Yang, Cynthia Isaac, Chen Wang, François Dragon, Vanda Pogac̆ić, and U. Thomas Meier. Conserved composition of mammalian box h/aca and box c/d small nucleolar ribonucleoprotein particles and their interaction with the common factor nopp140. Molecular biology of the cell, 11 2:567-77, Feb 2000. URL: https://doi.org/10.1091/mbc.11.2.567, doi:10.1091/mbc.11.2.567. This article has 163 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2011structureandfunction pages 1-4): Fang He and Patrick DiMario. Structure and function of nopp140 and treacle. ArXiv, pages 253-278, Jan 2011. URL: https://doi.org/10.1007/978-1-4614-0514-6_11, doi:10.1007/978-1-4614-0514-6_11. This article has 18 citations.</p>
+</li>
+<li>
+<p>(yang2000conservedcompositionof pages 7-9): Yunfeng Yang, Cynthia Isaac, Chen Wang, François Dragon, Vanda Pogac̆ić, and U. Thomas Meier. Conserved composition of mammalian box h/aca and box c/d small nucleolar ribonucleoprotein particles and their interaction with the common factor nopp140. Molecular biology of the cell, 11 2:567-77, Feb 2000. URL: https://doi.org/10.1091/mbc.11.2.567, doi:10.1091/mbc.11.2.567. This article has 163 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nierhaus2004proteinsynthesisand pages 141-145): K. Nierhaus and Daniel N. Wilson. Protein synthesis and ribosome structure : translating the genome. ArXiv, Aug 2004. URL: https://doi.org/10.1002/3527603433, doi:10.1002/3527603433. This article has 39 citations.</p>
+</li>
+<li>
+<p>(he2011structureandfunction pages 8-11): Fang He and Patrick DiMario. Structure and function of nopp140 and treacle. ArXiv, pages 253-278, Jan 2011. URL: https://doi.org/10.1007/978-1-4614-0514-6_11, doi:10.1007/978-1-4614-0514-6_11. This article has 18 citations.</p>
+</li>
+<li>
+<p>(he2011structureandfunction pages 4-6): Fang He and Patrick DiMario. Structure and function of nopp140 and treacle. ArXiv, pages 253-278, Jan 2011. URL: https://doi.org/10.1007/978-1-4614-0514-6_11, doi:10.1007/978-1-4614-0514-6_11. This article has 18 citations.</p>
+</li>
+<li>
+<p>(he2011structureandfunction pages 6-8): Fang He and Patrick DiMario. Structure and function of nopp140 and treacle. ArXiv, pages 253-278, Jan 2011. URL: https://doi.org/10.1007/978-1-4614-0514-6_11, doi:10.1007/978-1-4614-0514-6_11. This article has 18 citations.</p>
+</li>
+<li>
+<p>(meznad2026intrinsicallydisorderedregions pages 3-4): Koceila Meznad, Manisha Deogharia, Ludivine Wacheul, Christiane Zorbas, Denis L.J. Lafontaine, and U. Thomas Meier. Intrinsically disordered regions stimulate concentration of small nucleolar ribonucleoproteins and formation of cajal bodies and nucleoli. Genes &amp; Development, 40(5-6):351-365, Nov 2026. URL: https://doi.org/10.1101/gad.353180.125, doi:10.1101/gad.353180.125. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(meznad2026intrinsicallydisorderedregions pages 1-2): Koceila Meznad, Manisha Deogharia, Ludivine Wacheul, Christiane Zorbas, Denis L.J. Lafontaine, and U. Thomas Meier. Intrinsically disordered regions stimulate concentration of small nucleolar ribonucleoproteins and formation of cajal bodies and nucleoli. Genes &amp; Development, 40(5-6):351-365, Nov 2026. URL: https://doi.org/10.1101/gad.353180.125, doi:10.1101/gad.353180.125. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(verheggen2001boxcdsmall pages 5-6): C. Verheggen, J. Mouaikel, M. Thiry, J. Blanchard, D. Tollervey, Remi Bordonné, D. Lafontaine, and E. Bertrand. Box c/d small nucleolar rna trafficking involves small nucleolar rnp proteins, nucleolar factors and a novel nuclear domain. The EMBO Journal, 20:5480-5490, Oct 2001. URL: https://doi.org/10.1093/emboj/20.19.5480, doi:10.1093/emboj/20.19.5480. This article has 218 citations.</p>
+</li>
+<li>
+<p>(verheggen2001boxcdsmall pages 4-5): C. Verheggen, J. Mouaikel, M. Thiry, J. Blanchard, D. Tollervey, Remi Bordonné, D. Lafontaine, and E. Bertrand. Box c/d small nucleolar rna trafficking involves small nucleolar rnp proteins, nucleolar factors and a novel nuclear domain. The EMBO Journal, 20:5480-5490, Oct 2001. URL: https://doi.org/10.1093/emboj/20.19.5480, doi:10.1093/emboj/20.19.5480. This article has 218 citations.</p>
+</li>
+<li>
+<p>(verheggen2001boxcdsmall pages 7-9): C. Verheggen, J. Mouaikel, M. Thiry, J. Blanchard, D. Tollervey, Remi Bordonné, D. Lafontaine, and E. Bertrand. Box c/d small nucleolar rna trafficking involves small nucleolar rnp proteins, nucleolar factors and a novel nuclear domain. The EMBO Journal, 20:5480-5490, Oct 2001. URL: https://doi.org/10.1093/emboj/20.19.5480, doi:10.1093/emboj/20.19.5480. This article has 218 citations.</p>
+</li>
+<li>
+<p>(meznad2026intrinsicallydisorderedregions pages 4-5): Koceila Meznad, Manisha Deogharia, Ludivine Wacheul, Christiane Zorbas, Denis L.J. Lafontaine, and U. Thomas Meier. Intrinsically disordered regions stimulate concentration of small nucleolar ribonucleoproteins and formation of cajal bodies and nucleoli. Genes &amp; Development, 40(5-6):351-365, Nov 2026. URL: https://doi.org/10.1101/gad.353180.125, doi:10.1101/gad.353180.125. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(verheggen2001boxcdsmall pages 9-9): C. Verheggen, J. Mouaikel, M. Thiry, J. Blanchard, D. Tollervey, Remi Bordonné, D. Lafontaine, and E. Bertrand. Box c/d small nucleolar rna trafficking involves small nucleolar rnp proteins, nucleolar factors and a novel nuclear domain. The EMBO Journal, 20:5480-5490, Oct 2001. URL: https://doi.org/10.1093/emboj/20.19.5480, doi:10.1093/emboj/20.19.5480. This article has 218 citations.</p>
+</li>
+<li>
+<p>(he2011structureandfunction pages 18-21): Fang He and Patrick DiMario. Structure and function of nopp140 and treacle. ArXiv, pages 253-278, Jan 2011. URL: https://doi.org/10.1007/978-1-4614-0514-6_11, doi:10.1007/978-1-4614-0514-6_11. This article has 18 citations.</p>
+</li>
+<li>
+<p>(baral2019thedrosophilaneuroblasts pages 43-48): S. S. Baral. The drosophila neuroblasts: a model system for human ribosomopathies. ArXiv, 2019. URL: https://doi.org/10.31390/gradschool_dissertations.4859, doi:10.31390/gradschool_dissertations.4859. This article has 0 citations.</p>
+</li>
+<li>
+<p>(he2011structureandfunction pages 11-13): Fang He and Patrick DiMario. Structure and function of nopp140 and treacle. ArXiv, pages 253-278, Jan 2011. URL: https://doi.org/10.1007/978-1-4614-0514-6_11, doi:10.1007/978-1-4614-0514-6_11. This article has 18 citations.</p>
+</li>
+<li>
+<p>(meznad2026intrinsicallydisorderedregions pages 9-10): Koceila Meznad, Manisha Deogharia, Ludivine Wacheul, Christiane Zorbas, Denis L.J. Lafontaine, and U. Thomas Meier. Intrinsically disordered regions stimulate concentration of small nucleolar ribonucleoproteins and formation of cajal bodies and nucleoli. Genes &amp; Development, 40(5-6):351-365, Nov 2026. URL: https://doi.org/10.1101/gad.353180.125, doi:10.1101/gad.353180.125. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="SRP40-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>he2011structureandfunction pages 1-4</li>
+<li>yang2000conservedcompositionof pages 2-3</li>
+<li>he2011structureandfunction pages 8-11</li>
+<li>he2011structureandfunction pages 4-6</li>
+<li>meznad2026intrinsicallydisorderedregions pages 3-4</li>
+<li>he2011structureandfunction pages 6-8</li>
+<li>verheggen2001boxcdsmall pages 4-5</li>
+<li>verheggen2001boxcdsmall pages 5-6</li>
+<li>verheggen2001boxcdsmall pages 9-9</li>
+<li>nierhaus2004proteinsynthesisand pages 141-145</li>
+<li>yang2000conservedcompositionof pages 7-9</li>
+<li>meznad2026intrinsicallydisorderedregions pages 4-5</li>
+<li>meznad2026intrinsicallydisorderedregions pages 9-10</li>
+<li>meznad2026intrinsicallydisorderedregions pages 1-2</li>
+<li>verheggen2001boxcdsmall pages 7-9</li>
+<li>he2011structureandfunction pages 18-21</li>
+<li>baral2019thedrosophilaneuroblasts pages 43-48</li>
+<li>he2011structureandfunction pages 11-13</li>
+<li>https://doi.org/10.1091/mbc.11.2.567,</li>
+<li>https://doi.org/10.1007/978-1-4614-0514-6_11,</li>
+<li>https://doi.org/10.1002/3527603433,</li>
+<li>https://doi.org/10.1101/gad.353180.125,</li>
+<li>https://doi.org/10.1093/emboj/20.19.5480,</li>
+<li>https://doi.org/10.31390/gradschool_dissertations.4859,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SRP40-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P32583" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="srp40-ykr092c-p32583-curation-notes">SRP40 (YKR092C, P32583) — curation notes</h1>
+<p>Autonomous AI review journal. Provenance recorded inline as <code>[PMID:xxxx "verbatim quote"]</code><br />
+or <code>[file:...]</code>. SRP40 is an understudied ("dark") <em>S. cerevisiae</em> nucleolar protein.</p>
+<h2 id="identity-and-basic-facts">Identity and basic facts</h2>
+<ul>
+<li>UniProt P32583, <code>SRP40_YEAST</code>; SGD S000001800; systematic name YKR092C; ORF YKR412A.</li>
+<li>406 aa, 41 kDa, acidic pI ~3.9, ~49% serine.</li>
+<li>RecName in UniProt is a historical misnomer: "Suppressor protein SRP40" — named as a<br />
+<strong>weak suppressor of a mutant of the AC40 subunit shared by RNA polymerases I and III</strong><br />
+  (Lalo, Carles, Sentenac, Thuriaux 1993, PMID:8516295, the naming paper). UniProt FUNCTION<br />
+  line: "Not known; weak suppressor of a mutant of the subunit AC40 of DNA dependent RNA<br />
+  polymerase I and III." SRP40 here = "Suppressor of RNA Polymerase, 40 kDa", NOT signal<br />
+  recognition particle.</li>
+</ul>
+<h2 id="domain-sequence-architecture-inline-bioinformatic-reasoning-from-the-uniprot-record">Domain / sequence architecture (inline bioinformatic reasoning from the UniProt record)</h2>
+<ul>
+<li>The protein is <strong>almost entirely intrinsically disordered</strong>: UniProt annotates<br />
+<code>REGION 1..335 /note="Disordered" (MobiDB-lite)</code>, i.e. the N-terminal ~82% of the protein.</li>
+<li>The disordered region is dominated by <strong>serine-rich low-complexity tracts</strong> interspersed<br />
+  with <strong>acidic (Asp/Glu) and basic (Lys/Arg) charge clusters</strong> — multiple <code>COMPBIAS</code><br />
+  features "Low complexity" and "Basic and acidic residues". The raw sequence shows long<br />
+  runs of <code>SSSSSSSSS...</code> and <code>DSDSDSDS...</code> (serine/aspartate repeats). This is the classic<br />
+  Nopp140/Treacle-type acidic-serine-rich (poly-S / SR-like, CK2-substrate) architecture,<br />
+  not a folded catalytic domain.</li>
+<li>The <strong>only recognizable folded module is the C-terminal SRP40_C domain</strong><br />
+  (Pfam PF05022, InterPro IPR007718), roughly the last ~70 aa. This is the region that is<br />
+<strong>59% identical to the C-terminus of rat Nopp140</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" title="carboxyl terminus   exhibits 59% sequence identity to that of Nopp140">PMID:8702624</a>. No enzymatic motif is present; this<br />
+  domain family has no assigned catalytic activity.</li>
+<li><strong>Interpretation:</strong> the sequence is consistent with a scaffold / chaperone / RNP-assembly<br />
+  factor that works through disordered, highly-phosphorylatable acidic-serine tracts plus a<br />
+  conserved C-terminal interaction module — NOT with a specific enzymatic molecular function.<br />
+  A specific biochemical activity cannot be assigned from sequence.</li>
+</ul>
+<h2 id="post-translational-modification">Post-translational modification</h2>
+<ul>
+<li>Extensively phosphorylated by <strong>casein kinase II (CK2)</strong>, like Nopp140, but to a much<br />
+  lesser degree than the vertebrate protein <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" title="Like Nopp140, SRP40 is   phosphorylated by casein kinase II, but to a much lesser extent">PMID:8702624</a>.</li>
+<li>Multiple mapped phosphosites (large-scale MS): pSer133, pThr289, pSer293, pSer394<br />
+  (UniProt MOD_RES; PMID:17287358, 17330950, 18407956, 19779198). Cdk1 substrate<br />
+  (PMID:19779198).</li>
+<li>Unusual <strong>serine pyrophosphorylation</strong> by the inositol pyrophosphate 5-IP7<br />
+  (5-diphosphoinositol pentakisphosphate): a Mg2+-dependent, enzyme-independent transfer of<br />
+  a β-phosphate onto a pre-phosphorylated serine (UniProt PTM; PMID:15604408, PMID:17873058).<br />
+  This is a PTM of the protein, not a molecular function <em>of</em> the protein.</li>
+</ul>
+<h2 id="what-is-known-evidence-supported">What is KNOWN (evidence-supported)</h2>
+<ol>
+<li><strong>Nucleolar localization.</strong> SRP40 localizes to the yeast nucleolus<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8702624" title="SRP40 localizes to the yeast nucleolus">PMID:8702624</a>; GOA IDA C:nucleolus from<br />
+   PMID:8702624, assigned by SGD. Also nucleolus ISS/IBA. SGD C = nucleolus.</li>
+<li><strong>Yeast homolog of rat Nopp140.</strong> Immunologically and structurally related; C-terminus<br />
+   59% identical [PMID:8702624 "identifies the yeast SRP40 gene product as immunologically<br />
+   and structurally related to rat Nopp140"; "bona fide yeast Nopp140 homolog"]. Rat Nopp140<br />
+   functionally complements loss of SRP40 <a href="https://pubmed.ncbi.nlm.nih.gov/12700234" title="rat Nopp140 restored growth and    stability of box H/ACA snoRNAs after genetic depletion of SRP40 ... it is indeed the    functional homolog of yeast Srp40p">PMID:12700234</a>.</li>
+<li><strong>Proposed snoRNP chaperone / role in ribosome biogenesis.</strong> Srp40p is "proposed to<br />
+   function as a chaperone for over 100 small nucleolar ribonucleoprotein particles that are<br />
+   required for rRNA maturation" <a href="https://pubmed.ncbi.nlm.nih.gov/12700234">PMID:12700234</a>. Depletion of SRP40 (in the srp40Δ shm2 ade3<br />
+   synthetic-lethal background) specifically depletes <strong>box H/ACA snoRNAs</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12700234" title="the specific depletion of box H/ACA small nucleolar RNAs from the    srp40Delta shm2 ade3 strain">PMID:12700234</a>. This links SRP40 to box H/ACA snoRNP stability, i.e. the<br />
+   pseudouridylation snoRNP branch of ribosome biogenesis.</li>
+<li><strong>Dosage-sensitive, nonessential.</strong> Deletion is viable; SRP40 is "required at a specific<br />
+   cellular concentration for optimal growth as indicated by the negative effect on cell<br />
+   growth of both overexpression and deletion of its gene" <a href="https://pubmed.ncbi.nlm.nih.gov/8702624">PMID:8702624</a>. "Srp40p is a<br />
+   nonessential yeast nucleolar protein" <a href="https://pubmed.ncbi.nlm.nih.gov/12700234">PMID:12700234</a>. SGD: viable; overexpression<br />
+   decreases growth rate. Extensive genetic interaction network (SGD ~284 genes).</li>
+<li><strong>Historically a weak suppressor of the RNA Pol I/III AC40 (rpc40) mutant</strong> — the origin<br />
+   of the gene name <a href="https://pubmed.ncbi.nlm.nih.gov/8516295">PMID:8516295</a>; a genetic, not mechanistic, observation.</li>
+</ol>
+<p>The Nopp140 shuttling / NLS-binding "chaperone in ribosome biogenesis" model is a property<br />
+established for <strong>rat Nopp140</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/8702624" title="Based on its subcellular location, its nuclear localization signal binding capacity, and its shuttling between the nucleolus and the cytoplasm, Nopp140 was proposed to function as a chaperone in ribosome biogenesis">PMID:8702624</a>. It is<br />
+the basis of the SRP40 ISS annotation to nucleocytoplasmic transport (transferred from the<br />
+mammalian ortholog P41777), but the shuttling / NLS-binding activity has NOT been directly<br />
+demonstrated for yeast Srp40p itself — the 1996 paper notes yeast/vertebrate disparities in<br />
+nucleolar dynamics.</p>
+<h2 id="what-is-not-known-the-gap">What is NOT known (the gap)</h2>
+<ul>
+<li><strong>No specific molecular function has been experimentally assigned.</strong> UniProt FUNCTION =<br />
+  "Not known"; SGD MF = "molecular_function" (ND, GO:0003674); the protein is disordered with<br />
+  no catalytic motif. Whether Srp40p acts as an RNA chaperone, a snoRNP-assembly scaffold, a<br />
+  phosphoprotein hub, or a charge-based crowding/condensate component is undetermined.</li>
+<li><strong>The precise step in ribosome biogenesis is undefined.</strong> SRP40 is linked to box H/ACA<br />
+  snoRNP stability <em>genetically</em> (in a sensitized srp40Δ shm2 ade3 background), but its direct<br />
+  molecular role (which snoRNP components it binds, whether it acts on assembly, stability,<br />
+  transport, or recycling) is not established. The chaperone-of-snoRNPs role is stated as a<br />
+<em>proposal</em> <a href="https://pubmed.ncbi.nlm.nih.gov/12700234" title="proposed to function as a chaperone">PMID:12700234</a>.</li>
+<li><strong>Redundancy / dosage biology unexplained.</strong> Nonessential yet dosage-sensitive in both<br />
+  directions; the buffering partner(s) that make it dispensable, and the reason overexpression<br />
+  is toxic, are unknown.</li>
+<li><strong>Nucleocytoplasmic transport role not directly shown in yeast.</strong> The shuttling/NLS-binding<br />
+  activity is a Nopp140 (rat) property transferred by ISS; not directly demonstrated for<br />
+  yeast Srp40p.</li>
+</ul>
+<h2 id="annotation-by-annotation-plan-goa-6-rows">Annotation-by-annotation plan (GOA, 6 rows)</h2>
+<ol>
+<li><code>GO:0005730 nucleolus</code> IBA (is_active_in, GO_REF:0000033) — ACCEPT. Consistent with IDA;<br />
+   phylogenetically robust (Nopp140 family is nucleolar).</li>
+<li><code>GO:0005654 nucleoplasm</code> IBA (is_active_in, GO_REF:0000033) — KEEP_AS_NON_CORE. Plausible<br />
+   phylogenetic transfer (Nopp140/Treacle family members are nucleoplasmic/coiled-body too),<br />
+   but the direct yeast evidence is for nucleolus; keep, non-core, secondary location.</li>
+<li><code>GO:0005730 nucleolus</code> IEA (located_in, GO_REF:0000117 ARBA) — ACCEPT (redundant with IDA;<br />
+   electronic confirmation of the well-supported nucleolar localization).</li>
+<li><code>GO:0003674 molecular_function</code> ND (enables, GO_REF:0000015) — ACCEPT. Honest "no data"<br />
+   root MF annotation; correctly reflects that no specific MF is known. This is the honest<br />
+   dark-gene MF state; do not fabricate an MF term.</li>
+<li><code>GO:0005730 nucleolus</code> IDA (located_in, PMID:8702624) — ACCEPT. Core; primary experimental<br />
+   localization.</li>
+<li><code>GO:0006913 nucleocytoplasmic transport</code> ISS (involved_in, PMID:8702624, from<br />
+   UniProtKB:P41777 = rat Nopp140) — KEEP_AS_NON_CORE (lean) / consider MARK_AS_OVER_ANNOTATED.<br />
+   Rationale: the transport/shuttling role is a rat-Nopp140 property transferred by similarity;<br />
+   not directly demonstrated in yeast. It is not wrong on family grounds, but it is peripheral<br />
+   and unverified in <em>S. cerevisiae</em>. Keep as non-core with a clear caveat rather than REMOVE<br />
+   (ISS from a curator-selected ortholog; per guidelines do not REMOVE on paralog/ortholog<br />
+   grounds). The core supportable role is nucleolar snoRNP-chaperone/ribosome-biogenesis, not<br />
+   the transport aspect. NOTE: ribosome biogenesis (GO:0042254) is a better-supported BP for<br />
+   this gene but is not in GOA; capture it via core_functions + proposed reasoning, and note<br />
+   the snoRNP/box H/ACA link from PMID:12700234.</li>
+</ol>
+<h2 id="core_functions-plan">core_functions plan</h2>
+<ul>
+<li>Nucleolar localization (CC): GO:0005730 nucleolus — strongly supported (IDA).</li>
+<li>Ribosome-biogenesis / snoRNP-associated role (BP): the best-supported functional statement<br />
+  is participation in ribosome biogenesis via box H/ACA snoRNP chaperoning (GO:0042254<br />
+  ribosome biogenesis; PMID:12700234). No specific MF term is assignable — leave MF dark and<br />
+  document in knowledge_gaps. Avoid <code>protein binding</code>.</li>
+</ul>
+<h2 id="references-to-add">References to add</h2>
+<ul>
+<li>PMID:8702624 (Meier 1996) — HIGH, VERIFIED (abstract-only; primary yeast localization +<br />
+  homology).</li>
+<li>PMID:12700234 (Yang &amp; Meier 2003) — HIGH, VERIFIED (abstract-only; snoRNP-chaperone<br />
+  proposal, box H/ACA link, Nopp140 complementation).</li>
+<li>PMID:8516295 (Lalo et al. 1993) — MEDIUM, VERIFIED (gene-naming / AC40 suppressor origin).</li>
+<li>GO_REF:0000015, GO_REF:0000033, GO_REF:0000117 — annotation-method refs.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P32583
+gene_symbol: SRP40
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  SRP40 (YKR092C) is a small (406-residue, ~41 kDa), highly acidic (pI ~3.9),
+  serine-rich (~49% Ser) nucleolar protein of Saccharomyces cerevisiae, and is the
+  budding-yeast homolog of the vertebrate nucleolar phosphoprotein Nopp140 (its
+  C-terminal SRP40_C domain is ~59% identical to the Nopp140 C-terminus). The protein
+  is almost entirely intrinsically disordered, built from serine-rich low-complexity
+  tracts interspersed with acidic (Asp/Glu) and basic (Lys/Arg) charge clusters, plus
+  the single conserved folded C-terminal module; it carries no recognizable catalytic
+  motif. Like Nopp140, it is a casein kinase II phosphoprotein (though phosphorylated
+  to a lesser extent than the vertebrate protein) and is additionally serine-
+  pyrophosphorylated by the inositol pyrophosphate 5-IP7. Srp40p localizes to the
+  nucleolus and is proposed to act as a chaperone of small nucleolar ribonucleoprotein
+  particles (snoRNPs) that mediate rRNA maturation, with a particular genetic link to
+  the stability of box H/ACA snoRNAs; rat Nopp140 can functionally substitute for it.
+  The gene is nonessential but dosage-sensitive: both deletion and overexpression
+  impair growth. Its name (&#34;Suppressor of RNA Polymerase&#34;) derives from its original
+  isolation as a weak extragenic suppressor of a mutation in the AC40 subunit shared by
+  RNA polymerases I and III, and does not denote a signal-recognition-particle function.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:8702624
+  title: Comparison of the rat nucleolar protein nopp140 with its yeast homolog SRP40.
+    Differential phosphorylation in vertebrates and yeast.
+  findings:
+  - statement: &gt;-
+      SRP40 encodes an acidic, serine-rich 41 kDa protein whose C-terminus is 59%
+      identical to that of rat Nopp140; it localizes to the yeast nucleolus, is
+      phosphorylated by casein kinase II (to a lesser extent than Nopp140), and is
+      required at a specific cellular concentration for optimal growth (both
+      overexpression and deletion are deleterious).
+    supporting_text: &gt;-
+      SRP40 localizes to the yeast nucleolus and is required at a specific cellular
+      concentration for optimal growth as indicated by the negative effect on cell
+      growth of both overexpression and deletion of its gene.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Meier UT, J Biol Chem 1996; abstract-only). Establishes the
+      primary yeast experimental facts used here: nucleolar localization, Nopp140
+      homology (59% C-terminal identity), CK2 phosphorylation, and dosage sensitivity.
+      The shuttling / NLS-binding &#34;chaperone in ribosome biogenesis&#34; model in this
+      paper is stated for rat Nopp140, not directly demonstrated for yeast Srp40p.
+- id: PMID:12700234
+  title: Genetic interaction between a chaperone of small nucleolar ribonucleoprotein
+    particles and cytosolic serine hydroxymethyltransferase.
+  findings:
+  - statement: &gt;-
+      Srp40p is a nonessential nucleolar protein proposed to chaperone the &gt;100 snoRNPs
+      required for rRNA maturation; its genetic depletion specifically depletes box
+      H/ACA snoRNAs, and rat Nopp140 restores growth and box H/ACA snoRNA stability,
+      confirming it as the functional yeast homolog of Nopp140.
+    supporting_text: &gt;-
+      Srp40p is a nonessential yeast nucleolar protein proposed to function as a
+      chaperone for over 100 small nucleolar ribonucleoprotein particles that are
+      required for rRNA maturation.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Yang Y, Meier UT, J Biol Chem 2003; abstract-only). Strongest
+      functional evidence linking SRP40 to ribosome biogenesis via box H/ACA snoRNP
+      stability and confirming rat-Nopp140 functional complementation. The snoRNP-
+      chaperone role is explicitly described as a proposal, and the box H/ACA snoRNA
+      depletion is measured in a sensitized srp40-delta shm2 ade3 background.
+- id: PMID:8516295
+  title: Interactions between three common subunits of yeast RNA polymerases I and III.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Lalo et al., PNAS 1993). Cited by UniProt as the origin of the
+      SRP40 name (a weak extragenic suppressor of an rpc40/AC40 RNA-polymerase-I/III
+      mutant). The cached abstract concerns AC40/AC19/ABC10 polymerase-subunit
+      interactions and does NOT itself mention SRP40; retained only as background for
+      the name/origin, not as support for any SRP40 functional claim.
+existing_annotations:
+- term:
+    id: GO:0005730
+    label: nucleolus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) nucleolar localization, concordant with the direct yeast
+      experimental evidence and with the Nopp140/SRP40 family being nucleolar. Accept
+      as a core cellular-component annotation.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8702624
+      supporting_text: SRP40 localizes to the yeast nucleolus
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred nucleoplasmic localization. Nopp140/Treacle-family
+      members do distribute to the nucleoplasm and coiled/Cajal bodies in addition to
+      the nucleolus, so this is plausible, but the direct yeast evidence is for the
+      nucleolus. Keep as a secondary, non-core location.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0005730
+    label: nucleolus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) nucleolar localization; redundant with, and consistent with,
+      the direct IDA and phylogenetic IBA nucleolus annotations. Accept.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8702624
+      supporting_text: SRP40 localizes to the yeast nucleolus
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function with ND (no data). This is an honest reflection of the
+      state of knowledge: no specific molecular activity has been experimentally
+      assigned to this disordered nucleolar protein, and none can be inferred from
+      sequence (no catalytic motif; only the non-enzymatic C-terminal SRP40_C module).
+      Accept rather than inventing an MF term; the genuine molecular-function gap is
+      recorded in knowledge_gaps.
+    action: ACCEPT
+- term:
+    id: GO:0005730
+    label: nucleolus
+  evidence_type: IDA
+  original_reference_id: PMID:8702624
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) localization of Srp40p to the yeast nucleolus. This is
+      the best-supported, core cellular-component annotation for the gene.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8702624
+      supporting_text: SRP40 localizes to the yeast nucleolus
+- term:
+    id: GO:0006913
+    label: nucleocytoplasmic transport
+  evidence_type: ISS
+  original_reference_id: PMID:8702624
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS annotation transferred from the rat ortholog Nopp140 (UniProtKB:P41777).
+      Nopp140 shuttles between the nucleolus and cytoplasm and binds nuclear
+      localization signals, and was proposed to chaperone ribosome biogenesis on that
+      basis; the transport/shuttling activity, however, is a vertebrate-Nopp140
+      property and has NOT been directly demonstrated for yeast Srp40p, and the source
+      paper itself notes yeast/vertebrate disparities in nucleolar dynamics. The
+      better-supported functional role of yeast Srp40p is nucleolar snoRNP chaperoning
+      within ribosome biogenesis (PMID:12700234), not transport per se. Retain as a
+      non-core, ortholog-inferred process rather than removing an ISS annotation made
+      by a curator from a selected ortholog.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:8702624
+      supporting_text: &gt;-
+        its nuclear localization signal binding capacity, and its shuttling between the
+        nucleolus and the cytoplasm, Nopp140 was proposed to function as a chaperone in
+        ribosome biogenesis
+- term:
+    id: GO:0042254
+    label: ribosome biogenesis
+  evidence_type: IGI
+  original_reference_id: PMID:12700234
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation (not currently in GOA). Srp40p is a nucleolar protein
+      proposed to chaperone the snoRNPs required for rRNA maturation, and its genetic
+      depletion specifically destabilizes box H/ACA snoRNAs; rat Nopp140 restores box
+      H/ACA snoRNA stability, confirming it as the functional Nopp140 homolog. This is
+      the best-supported biological process for the gene and is captured as a core
+      function. Evidence is genetic/homology-based (a proposal), so the underlying
+      molecular activity remains a knowledge gap.
+    action: NEW
+    supported_by:
+    - reference_id: PMID:12700234
+      supporting_text: &gt;-
+        Srp40p is a nonessential yeast nucleolar protein proposed to function as a
+        chaperone for over 100 small nucleolar ribonucleoprotein particles that are
+        required for rRNA maturation.
+core_functions:
+- description: &gt;-
+    Nucleolar protein contributing to ribosome biogenesis, proposed to act as a
+    chaperone of small nucleolar ribonucleoprotein particles (snoRNPs) — in particular
+    the box H/ACA class involved in rRNA modification — with the underlying molecular
+    activity undetermined.
+  supported_by:
+  - reference_id: PMID:12700234
+    supporting_text: &gt;-
+      Srp40p is a nonessential yeast nucleolar protein proposed to function as a
+      chaperone for over 100 small nucleolar ribonucleoprotein particles that are
+      required for rRNA maturation.
+  - reference_id: PMID:8702624
+    supporting_text: SRP40 localizes to the yeast nucleolus
+  locations:
+  - id: GO:0005730
+    label: nucleolus
+  directly_involved_in:
+  - id: GO:0042254
+    label: ribosome biogenesis
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular activity that underlies this core function is undefined: whether
+      Srp40p&#39;s contribution to ribosome biogenesis is a bona fide RNA/snoRNP-chaperone
+      activity, an assembly/stabilization scaffold role, or an indirect phospho- and
+      charge-driven effect is not established. This entry scopes the MF gap to the core
+      function; the gene-level knowledge_gaps entry covers the broader unknowns
+      (precise biogenesis step, dosage sensitivity, redundancy).
+    gap_kind:
+    - BIOLOGY
+    - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    resolution: &gt;-
+      Direct in vitro RNA/snoRNP-binding and chaperone (RNA-annealing / RNP-assembly)
+      assays with recombinant Srp40p, paired with in vivo interactome/CLIP mapping of
+      its snoRNP partners.
+    provenance:
+    - reference_id: PMID:12700234
+      supporting_text: &gt;-
+        proposed to function as a chaperone for over 100 small nucleolar
+        ribonucleoprotein particles
+knowledge_gaps:
+- gap_statement: &gt;-
+    The specific molecular activity of Srp40p and the precise step in ribosome
+    biogenesis at which it acts are unknown. Whether it directly chaperones/assembles
+    snoRNPs, stabilizes box H/ACA snoRNAs, or contributes indirectly (e.g. through its
+    highly phosphorylated, acidic, disordered tracts) is undetermined, as is the reason
+    the gene is simultaneously nonessential and dosage-sensitive (toxic when either
+    deleted or overexpressed).
+  boundary: &gt;-
+    Firmly established: Srp40p is the yeast Nopp140 homolog (SRP40_C domain ~59%
+    identical to Nopp140&#39;s C-terminus); it is a ~41 kDa, acidic (pI ~3.9), ~49%-serine,
+    almost fully intrinsically disordered nucleolar protein with no catalytic motif; it
+    is CK2-phosphorylated and 5-IP7 serine-pyrophosphorylated; it localizes to the
+    nucleolus (IDA); it is nonessential but its deletion and overexpression both impair
+    growth; its genetic depletion specifically destabilizes box H/ACA snoRNAs; and rat
+    Nopp140 functionally complements srp40-delta.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Defining the activity of this tractable, conserved nucleolar chaperone would
+    illuminate how the Nopp140/Treacle family (implicated in human ribosomopathies)
+    contributes to snoRNP function and rRNA maturation, and would provide an
+    experimental anchor for a class of disordered nucleolar proteins that GO cannot
+    currently describe at the molecular-function level.
+  resolution: &gt;-
+    Biochemical reconstitution of Srp40p RNA/snoRNP-chaperone activity; interactome/
+    CLIP mapping of its snoRNP (especially box H/ACA) partners in vivo; genetic
+    dissection of the redundancy/buffering that renders it nonessential and of the
+    basis of overexpression toxicity; phospho-site (CK2 / 5-IP7) separation-of-function
+    alleles to connect its unusual PTMs to the growth and box H/ACA phenotypes.
+  provenance:
+  - reference_id: PMID:12700234
+    supporting_text: &gt;-
+      Srp40p is a nonessential yeast nucleolar protein proposed to function as a
+      chaperone for over 100 small nucleolar ribonucleoprotein particles that are
+      required for rRNA maturation.
+  - reference_id: PMID:8702624
+    supporting_text: &gt;-
+      required at a specific cellular concentration for optimal growth as indicated by
+      the negative effect on cell growth of both overexpression and deletion of its gene
+suggested_questions:
+- question: &gt;-
+    Does Srp40p bind snoRNAs (particularly box H/ACA snoRNAs) or snoRNP proteins
+    directly, and does it possess measurable RNA-chaperone (annealing/remodeling) or
+    RNP-assembly activity in vitro?
+- question: &gt;-
+    At which step of ribosome biogenesis does Srp40p act, and does its loss primarily
+    affect box H/ACA snoRNP assembly, stability, localization, or recycling?
+- question: &gt;-
+    What accounts for the dual dosage sensitivity (both deletion and overexpression are
+    deleterious), and which factors buffer srp40-delta to keep the gene nonessential?
+- question: &gt;-
+    Do the CK2 phosphorylation and 5-IP7 serine pyrophosphorylation of Srp40p regulate
+    its snoRNP-associated function, and can specific phospho-sites be linked to the
+    growth or box H/ACA snoRNA phenotypes?
+suggested_experiments:
+- description: &gt;-
+    In vitro RNA-binding and RNA-chaperone assays (EMSA, filter binding, FRET-based
+    annealing/strand-displacement) using recombinant Srp40p and candidate box H/ACA
+    snoRNAs and snoRNP components, with the disordered N-terminus and the SRP40_C
+    domain tested separately.
+- description: &gt;-
+    Endogenous affinity purification / proximity labeling (e.g. BioID or AP-MS) plus
+    CLIP-seq of tagged Srp40p to define its direct protein and RNA partners in the
+    nucleolus and to test the snoRNP-chaperone model in vivo.
+- description: &gt;-
+    Systematic genetic analysis (synthetic-lethal / dosage screens beyond the known
+    shm2 ade3 interaction) and phospho-site mutant series (CK2 and 5-IP7
+    pyrophosphorylation sites) scored for growth, box H/ACA snoRNA levels, and rRNA
+    processing, to connect Srp40p&#39;s PTMs and partners to its cellular role.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2929 |
| Gene review HTML pages | 2929 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
