### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/ECOLI/yegV/yegV-ai-review.html
+++ b/genes/ECOLI/yegV/yegV-ai-review.html
@@ -1488,14 +1488,8 @@
                     <span class="report-badge">Falcon</span>
 
 
-                    <span class="report-badge">Edison Scientific Literature</span>
 
 
-                    <span class="report-badge">17 citations</span>
-
-
-
-                    <span class="report-meta-text">2026-03-22T18:13:44.687197</span>
 
 
 

--- a/genes/yeast/COS9/COS9-ai-review.html
+++ b/genes/yeast/COS9/COS9-ai-review.html
@@ -1,0 +1,2150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>COS9 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>COS9</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P36034" target="_blank" class="term-link">
+                        P36034
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "COS9";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P36034" data-a="DESCRIPTION: COS9 (systematic name YKL219W) is a Saccharomyces ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>COS9 (systematic name YKL219W) is a Saccharomyces cerevisiae membrane protein of the subtelomeric DUP240/COS (COnserved Sequence) multigene family (COS1-COS10, COS12), which is largely uncharacterized at the molecular level. It is a multi-pass integral membrane protein of 407 residues containing tandem DUP domains (Pfam PF00674; InterPro IPR001142) and a very high lysine content (~8% of residues). Cos family members localize to endosomes and act in the multivesicular body (MVB) sorting pathway, where they cluster into ubiquitin-rich endosomal microdomains that concentrate and trap cargo — including ubiquitinated membrane proteins and GPI-anchored proteins — to promote their incorporation into intralumenal vesicles and delivery to the vacuole for degradation. The Cos proteins are themselves heavily ubiquitinated by the Rsp5 ubiquitin ligase system and are proposed to supply a ubiquitin sorting signal in trans to non-ubiquitinated cargo. Expression of COS genes is induced under nutrient (niacin/NAD+) stress through relief of Sir2-dependent subtelomeric silencing. No molecular (catalytic or binding) activity is known for the Cos family, which remains enzymatically uncharacterized.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36034" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> COS9 is a multi-pass integral membrane protein of the DUP/COS family, with three UniProt-predicted transmembrane helices (and a family model of four membrane-spanning segments). Membrane localization is well supported by domain architecture and is the most defensible COS9-specific cellular component. Accepted; the more specific endosomal membrane location is captured by the endosome annotation.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link">
+                                        PMID:25942624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cos proteins are comprised of ~380 residues, predicted to form 4 membrane spanning segments that bridge 2 small extracellular loops and larger cytosolic N and C-terminal tails</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    GO:0005768
+                                </a>
+                            </span>
+                            <span class="term-label">endosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25942624
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A family of tetraspans organizes cargo for sorting into mult...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36034" data-a="GO:0005768" data-r="PMID:25942624" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Endosome localization is annotated by ISS with WITH/FROM SGD:S000003922, which is the paralog COS5 (YJR161C) — the experimentally characterized Cos representative. In that study Cos proteins localize to peri-vacuolar/late endosomal (class E) compartments and form endosomal microdomains. This is a biologically plausible homology-based compartment assignment for Cos9; it has not been measured on Cos9 itself, so it is kept as a well-supported non-core (homology) annotation rather than removed on paralog grounds.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link">
+                                        PMID:25942624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A strong FRET signal between Cos5-GFP and Cos5-mCherry was only found at peri-vacuolar / late endosomal structures of wild-type cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043328" target="_blank" class="term-link">
+                                    GO:0043328
+                                </a>
+                            </span>
+                            <span class="term-label">protein transport to vacuole involved in ubiquitin-dependent protein catabolic process via the multivesicular body sorting pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25942624
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A family of tetraspans organizes cargo for sorting into mult...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P36034" data-a="GO:0043328" data-r="PMID:25942624" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This biological-process annotation captures the Cos family role — promoting MVB sorting of cargo for ubiquitin-dependent vacuolar degradation — and is transferred to Cos9 by ISS (WITH/FROM SGD:S000003922 = COS5). The experimental basis (whole-family cosΔ deletion plus Cos5 assays) establishes this role for the family; Cos9&#39;s individual contribution has not been directly tested, but the annotation is the best available statement of Cos9&#39;s probable function and is retained. Kept as non-core because it is homology-based and describes a process rather than a Cos9-specific molecular activity.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link">
+                                        PMID:25942624
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These data suggest Cos proteins mediate efficient sorting of a wide number of MVB cargoes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P36034" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> No molecular function has been assigned to COS9, and the DUP/COS family is enzymatically uncharacterized (InterPro IPR001142 describes it as membrane proteins &#34;of unknown function&#34;). The ND (no data) annotation accurately records this molecular- function gap. Accepted as an honest statement of the unknown; see knowledge_gaps.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>By homology to the experimentally characterized paralog Cos5, Cos9 is inferred to act at endosomes in the multivesicular body (MVB) sorting pathway, contributing to the family&#39;s role of clustering into ubiquitin-rich endosomal microdomains that trap ubiquitinated and GPI-anchored cargo and promote its sorting into intralumenal vesicles for ubiquitin-dependent vacuolar degradation. Its own molecular activity is unknown; no catalytic or specific binding function can be assigned to Cos9 or to the DUP/COS family, and Cos9&#39;s individual contribution has not been directly measured.</h3>
+                <span class="vote-buttons" data-g="P36034" data-a="FUNCTION: By homology to the experimentally characterized pa..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043328" target="_blank" class="term-link">
+                                protein transport to vacuole involved in ubiquitin-dependent protein catabolic process via the multivesicular body sorting pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link">
+                                PMID:25942624
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Here we show that a family of highly ubiquitinated tetraspan Cos proteins provides a Ub signal in trans, allowing sorting of nonubiquitinated MVB cargo into the canonical ESCRT- and Ub-dependent pathway.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" target="_blank" class="term-link">
+                            PMID:25942624
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A family of tetraspans organizes cargo for sorting into multivesicular bodies.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Cos proteins are a family of highly ubiquitinated tetraspan yeast membrane proteins that cluster into endosomal subdomains, concentrate ubiquitinated and GPI-anchored cargo, and are required for efficient sorting of that cargo into MVB intralumenal vesicles along the ESCRT- and ubiquitin-dependent pathway.</div>
+
+                        <div class="finding-text">"Here we show that a family of highly ubiquitinated tetraspan Cos proteins provides a Ub signal in trans, allowing sorting of nonubiquitinated MVB cargo into the canonical ESCRT- and Ub-dependent pathway."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">COS gene expression is induced by nutrient stress through an NAD+/Sir2-dependent mechanism (relief of subtelomeric silencing), accelerating downregulation of cell surface proteins.</div>
+
+                        <div class="finding-text">"Expression of these proteins increases during nutrient stress through an NAD(+)/Sir2-dependent mechanism that in turn accelerates the downregulation of a broad range of cell-surface proteins."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Cos9, like Cos5, localize to endosomal microdomains and become ubiquitinated, and is it required (individually or redundantly) for MVB sorting of ubiquitinated and GPI-anchored cargo? All current COS9 functional annotations are ISS transfers from Cos5.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36034" data-a="Q: Does Cos9, like Cos5, localize to endosomal microd..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the molecular activity of the DUP/COS family? Is &#34;supplying ubiquitin in trans&#34; and forming a cargo-trapping endosomal microdomain a distinct molecular function that warrants a dedicated GO term, or is it best captured as a set of biological-process and protein-clustering annotations?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36034" data-a="Q: What is the molecular activity of the DUP/COS fami..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Under what conditions is COS9 expressed relative to its paralogs, and does the NAD+/Sir2-dependent subtelomeric derepression that induces the COS family apply equally to COS9 given its chromosome XI location?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P36034" data-a="Q: Under what conditions is COS9 expressed relative t..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct a chromosomally tagged Cos9 (e.g. Cos9-GFP) strain and assay steady-state localization and vacuolar sorting, alongside ubiquitination-site mapping, to establish whether Cos9 behaves like the characterized Cos5.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Cos9 localizes to endosomes, is ubiquitinated by the Rsp5 system, and is itself sorted into the vacuole, matching the family behavior established for Cos5.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P36034" data-a="EXPERIMENT: Construct a chromosomally tagged Cos9 (e.g. Cos9-G..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Delete COS9 individually and in a COS-family-sensitized background (e.g. combined with single deletions of other COS genes and/or sna3Δ bsd2Δ) and quantify MVB sorting of reporter cargoes (Mup1-GFP, Ste3-GFP, GPI-anchored YFP fusions) to measure Cos9&#39;s individual contribution to cargo sorting.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: COS9 contributes redundantly to MVB cargo sorting; its loss produces a measurable defect only when other COS family members are also compromised.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P36034" data-a="EXPERIMENT: Delete COS9 individually and in a COS-family-sensi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether COS9 is functionally equivalent to the characterized paralog COS5 (i.e. an active, redundant MVB-sorting factor) or is instead specialized, expressed only under particular conditions, or effectively dispensable, is undetermined. All functional annotations of COS9 are homology-based (ISS from COS5); no COS9-specific loss-of-function or localization experiment has been reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> COS9 (YKL219W) is a subtelomeric DUP/COS-family multi-pass membrane protein. The COS family (COS1-COS10, COS12) is highly similar at protein and nucleotide level and shows strong functional redundancy — a phenotype required deletion of all COS genes together. The endosome and MVB-sorting annotations on COS9 are transferred by ISS from COS5, the experimentally studied representative; COS9 itself was not among the individually tested genes (COS1, COS2, COS4, COS5, COS6).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Subtelomeric multigene families such as COS are a common source of &#34;dark,&#34; redundant paralogs whose individual roles are rarely dissected. Establishing whether COS9 is an active member, a conditionally expressed variant, or a near-pseudogene would sharpen the annotation of the whole family and of yeast MVB sorting.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> COS9-specific expression profiling across growth/nutrient-stress conditions; a COS9-tagged strain to test endosomal localization directly; and single-gene deletion in a COS-family-sensitized background with cargo-sorting assays to measure COS9&#39;s individual contribution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The 11 COS genes, COS1 – COS10 and COS12, are remarkably similar at both the protein and nucleotide level"</em> — PMID:25942624</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(COS9-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P36034" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cos9-ykl219w-curation-notes">COS9 (YKL219W) — curation notes</h1>
+<p><em>S. cerevisiae</em> gene, SGD standard name <strong>COS9</strong>, systematic <strong>YKL219W</strong>, UniProt <strong>P36034</strong>,<br />
+SGD:S000001702. Member of the DUP240/<strong>COS</strong> (COnserved Sequence) subtelomeric multigene family.<br />
+This is an <strong>understudied ("dark") gene</strong>: there is essentially <strong>no COS9-specific experimental<br />
+characterization</strong>. What is "known" about COS9 is (a) sequence/domain-based, and (b) inferred by<br />
+homology (ISS) from the experimentally-studied paralog <strong>COS5</strong> (see below). These notes carefully<br />
+separate COS9-specific evidence from family-level evidence.</p>
+<h2 id="identity-genomic-context">Identity / genomic context</h2>
+<ul>
+<li>Subtelomeric location on chromosome XI (YKL219W). The COS family resides in subtelomeric regions<br />
+  of 9 of the 16 yeast chromosomes and comprises COS1–COS10 and COS12 (plus pseudogenes)<br />
+  [PMID:25942624 "found in subtelomeric regions within 9 of the 16 yeast chromosomes"; "The 11 COS<br />
+  genes, COS1 – COS10 and COS12, are remarkably similar at both the protein and nucleotide level"].</li>
+<li>407 aa protein, MW ~48.5 kDa (UniProt P36034).</li>
+</ul>
+<h2 id="domain-sequence-analysis-inline-from-uniprot-p36034-own-counts">Domain / sequence analysis (inline, from UniProt P36034 + own counts)</h2>
+<ul>
+<li><strong>Family:</strong> UniProt "Belongs to the DUP/COS family" {ECO:0000305}; InterPro <strong>IPR001142</strong> (Yeast<br />
+  membrane protein DUP/COS), Pfam <strong>PF00674 (DUP)</strong> ×2 copies. InterPro describes this family as<br />
+  "uncharacterized integral membrane proteins from yeast that contain internal duplications … of<br />
+  unknown function" (InterPro API for IPR001142, retrieved 2026-07). The 2× DUP Pfam hit reflects the<br />
+  internal duplication that gives the family its name (DUP = DUPlicated).</li>
+<li><strong>Topology:</strong> UniProt annotates 3 predicted TM helices (75–95, 98–118, 261–281) by sequence analysis<br />
+  (ECO:0000255). The literature model for the family is <strong>4 membrane-spanning segments</strong> bridging 2<br />
+  small extracellular loops with large cytosolic N- and C-terminal tails <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" title="predicted to   form 4 membrane spanning segments that bridge 2 small extracellular loops and larger cytosolic N and   C-terminal tails">PMID:25942624</a>. Multi-pass membrane protein is well supported; exact TM count (3 vs 4) is a<br />
+  prediction-dependent detail.</li>
+<li><strong>Lysine content (own count on P36034 sequence):</strong> 34 Lys / 407 = <strong>8.4%</strong>, consistent with the<br />
+  family observation that "Cos proteins also have a very high proportion of lysines (9% of all<br />
+  residues)" <a href="https://pubmed.ncbi.nlm.nih.gov/25942624">PMID:25942624</a>. Two lysines (K93, K102) fall within predicted TM segments; most are in<br />
+  the cytosolic tails. This abundance of lysines is the structural basis for the family's heavy<br />
+  ubiquitination and the proposed "supply Ub in trans" mechanism — but note this is a <strong>family-level<br />
+  mechanistic inference</strong>; COS9's own ubiquitination sites have not been mapped.</li>
+<li><strong>TMD composition:</strong> the family model invokes "atypical" polar/arginine residues in the TMDs as<br />
+  functionally important for cargo trapping <a href="https://pubmed.ncbi.nlm.nih.gov/25942624" title="Cos proteins have many residues within   their TMDs that are atypical for such hydrophobic stretches">PMID:25942624</a>. COS9's UniProt-predicted TM segments<br />
+  are largely hydrophobic with a couple of embedded lysines; a full TMD-polarity analysis was not the<br />
+  focus here.</li>
+<li>No catalytic domain, no signal peptide beyond the membrane-integration signals; molecular function<br />
+  is <strong>not</strong> assignable from domains (the family is enzymatically uncharacterized).</li>
+</ul>
+<h2 id="what-is-known-vs-not-known">What is KNOWN vs NOT-known</h2>
+<h3 id="known-well-supported-for-cos9-specifically">KNOWN (well-supported for COS9 specifically)</h3>
+<ul>
+<li><strong>Membrane / multi-pass membrane protein.</strong> Domain/topology-defensible (DUP/COS integral membrane<br />
+  family; 3 predicted TM helices). GOA GO:0016020 (membrane, IEA UniProtKB-SubCell). Higher-resolution<br />
+  location for COS9 itself is inferred, not measured.</li>
+</ul>
+<h3 id="known-by-homology-iss-from-cos5-biologically-plausible-but-not-cos9-measured">KNOWN-by-homology (ISS from COS5; biologically plausible but not COS9-measured)</h3>
+<ul>
+<li><strong>Endosome localization</strong> (GO:0005768) and <strong>MVB-sorting role</strong> (GO:0043328, protein transport to<br />
+  vacuole involved in ubiquitin-dependent protein catabolic process via the MVB pathway). Both are GOA<br />
+  ISS annotations with <code>WITH/FROM: SGD:S000003922</code>, which is <strong>COS5 (YJR161C)</strong> — the experimentally<br />
+  characterized paralog — citing PMID:25942624. SGD's own COS9 summary echoes this:<br />
+  the COS family "provides ubiquitin in trans for nonubiquitinated cargo proteins" in the MVB pathway<br />
+  (yeastgenome.org locus S000001702, retrieved 2026-07).</li>
+<li><strong>Family (not COS9-specific) experimental basis</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25942624">PMID:25942624</a>: Cos proteins are highly<br />
+  ubiquitinated (Rsp5-dependent, with Sna3/Bsd2), self-associate into endosomal microdomains<br />
+  ("Cos corral"), trap Ub-cargo and GPI-anchored proteins, and are themselves sorted into MVB<br />
+  intralumenal vesicles; COS expression is induced under nutrient (niacin/NAD+) stress via Sir2<br />
+  de-repression of subtelomeric loci. <strong>These experiments used the whole-family cosΔ deletion and<br />
+  Cos5 as representative; single-gene tests were done for COS1, COS2, COS4, COS5, COS6 — NOT COS9.</strong></li>
+</ul>
+<h3 id="not-known-genuine-cos9-gaps">NOT known (genuine COS9 gaps)</h3>
+<ul>
+<li><strong>Molecular function is unknown</strong> (GOA has ND for MF, GO:0003674). The DUP/COS family has no assigned<br />
+  catalytic/binding activity; the proposed role is a structural/adaptor "supply Ub in trans / cargo<br />
+  corral" activity that has not been given a specific validated MF term even at the family level.</li>
+<li><strong>Whether COS9 is functionally equivalent to COS5</strong> (vs specialized/pseudogene-like/redundant) is<br />
+  untested. Given the extreme sequence similarity across the family and the whole-family redundancy<br />
+  seen in cosΔ, COS9 most parsimoniously shares the family role, but its individual contribution,<br />
+  cargo preferences, expression pattern, and whether it is expressed at meaningful levels are open.</li>
+<li><strong>Phenotype:</strong> SGD notes overexpression of COS9 causes decreased vegetative growth rate<br />
+  (yeastgenome.org S000001702); no single-deletion loss-of-function phenotype specific to COS9 is<br />
+  documented (family redundancy). BioGRID-ORCS: 0 hits in 10 CRISPR screens (UniProt DR line),<br />
+  consistent with dispensability/redundancy.</li>
+</ul>
+<h2 id="paralog-disambiguation">Paralog disambiguation</h2>
+<ul>
+<li><strong>COS5 (YJR161C, SGD:S000003922)</strong> is the ISS source and the experimentally studied representative.</li>
+<li>Do NOT attribute Cos5-specific assay results (e.g. the 33-Lys→Arg Cos5KR mutant, GST-CTD Rsp5<br />
+  binding for Cos4/5/6, FRET self-association of Cos5) to COS9 as if measured on COS9. They inform the<br />
+  family model and justify homology-based (ISS) annotation, not experimental (IDA/IPI) annotation of<br />
+  COS9.</li>
+</ul>
+<h2 id="annotation-review-reasoning-summary">Annotation-review reasoning (summary)</h2>
+<ul>
+<li>GO:0016020 membrane (IEA) — ACCEPT; domain-defensible, core (it is a multi-pass membrane protein).</li>
+<li>GO:0005768 endosome (ISS from COS5) — KEEP_AS_NON_CORE / ACCEPT as homology-based; plausible steady-<br />
+  state compartment; not COS9-measured. Keep (do not REMOVE — never REMOVE a well-supported homology<br />
+  annotation on paralog grounds).</li>
+<li>GO:0043328 MVB protein transport to vacuole (ISS from COS5) — KEEP_AS_NON_CORE; represents the<br />
+  family role imputed to COS9 by homology. This is the best current statement of what COS9 probably<br />
+  does, but it is a process (not a molecular function) and is homology-based. Retain.</li>
+<li>GO:0003674 molecular_function ND — ACCEPT (accurately records that MF is unknown).</li>
+</ul>
+<h2 id="provenance">Provenance</h2>
+<ul>
+<li>PMID:25942624 (MacDonald et al., Dev Cell 2015) — primary family paper; full text cached.</li>
+<li>SGD locus pages S000001702 (COS9) and S000003922 (COS5), yeastgenome.org, retrieved 2026-07.</li>
+<li>InterPro IPR001142 API, retrieved 2026-07.</li>
+<li>UniProt P36034 (cached COS9-uniprot.txt).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P36034
+gene_symbol: COS9
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  COS9 (systematic name YKL219W) is a Saccharomyces cerevisiae membrane protein of the
+  subtelomeric DUP240/COS (COnserved Sequence) multigene family (COS1-COS10, COS12), which
+  is largely uncharacterized at the molecular level. It is a multi-pass integral membrane
+  protein of 407 residues containing tandem DUP domains (Pfam PF00674; InterPro IPR001142)
+  and a very high lysine content (~8% of residues). Cos family members localize
+  to endosomes and act in the multivesicular body (MVB) sorting pathway, where they cluster
+  into ubiquitin-rich endosomal microdomains that concentrate and trap cargo — including
+  ubiquitinated membrane proteins and GPI-anchored proteins — to promote their incorporation
+  into intralumenal vesicles and delivery to the vacuole for degradation. The Cos proteins are
+  themselves heavily ubiquitinated by the Rsp5 ubiquitin ligase system and are proposed to
+  supply a ubiquitin sorting signal in trans to non-ubiquitinated cargo. Expression of COS
+  genes is induced under nutrient (niacin/NAD+) stress through relief of Sir2-dependent
+  subtelomeric silencing. No molecular (catalytic or binding) activity is known for the Cos
+  family, which remains enzymatically uncharacterized.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:25942624
+  title: &#34;A family of tetraspans organizes cargo for sorting into multivesicular bodies.&#34;
+  findings:
+  - statement: &gt;-
+      The Cos proteins are a family of highly ubiquitinated tetraspan yeast membrane proteins
+      that cluster into endosomal subdomains, concentrate ubiquitinated and GPI-anchored
+      cargo, and are required for efficient sorting of that cargo into MVB intralumenal
+      vesicles along the ESCRT- and ubiquitin-dependent pathway.
+    supporting_text: &gt;-
+      Here we show that a family of highly ubiquitinated tetraspan Cos proteins provides a Ub
+      signal in trans, allowing sorting of nonubiquitinated MVB cargo into the canonical
+      ESCRT- and Ub-dependent pathway.
+    reference_section_type: ABSTRACT
+  - statement: &gt;-
+      COS gene expression is induced by nutrient stress through an NAD+/Sir2-dependent
+      mechanism (relief of subtelomeric silencing), accelerating downregulation of cell
+      surface proteins.
+    supporting_text: &gt;-
+      Expression of these proteins increases during nutrient stress through an
+      NAD(+)/Sir2-dependent mechanism that in turn accelerates the downregulation of a broad
+      range of cell-surface proteins.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified primary paper (MacDonald et al., Dev Cell 2015; PMC4421094). It is
+      the source of the COS9 endosome and MVB-sorting ISS annotations, propagated via
+      WITH/FROM SGD:S000003922 (COS5, the experimentally studied representative). The paper
+      characterizes the COS family (COS1-COS10 and COS12) collectively via a whole-family
+      cosΔ deletion and Cos5 as the representative; single-gene tests used COS1, COS2, COS4,
+      COS5, COS6. COS9 (YKL219W) is not individually assayed, so its annotations are
+      homology-based rather than direct experimental evidence for Cos9.
+existing_annotations:
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      COS9 is a multi-pass integral membrane protein of the DUP/COS family, with three
+      UniProt-predicted transmembrane helices (and a family model of four membrane-spanning
+      segments). Membrane localization is well supported by domain architecture and is the
+      most defensible COS9-specific cellular component. Accepted; the more specific endosomal
+      membrane location is captured by the endosome annotation.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:25942624
+      supporting_text: &gt;-
+        Cos proteins are comprised of ~380 residues, predicted to form 4 membrane spanning
+        segments that bridge 2 small extracellular loops and larger cytosolic N and
+        C-terminal tails
+      reference_section_type: RESULTS
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: ISS
+  original_reference_id: PMID:25942624
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Endosome localization is annotated by ISS with WITH/FROM SGD:S000003922, which is the
+      paralog COS5 (YJR161C) — the experimentally characterized Cos representative. In that
+      study Cos proteins localize to peri-vacuolar/late endosomal (class E) compartments and
+      form endosomal microdomains. This is a biologically plausible homology-based
+      compartment assignment for Cos9; it has not been measured on Cos9 itself, so it is kept
+      as a well-supported non-core (homology) annotation rather than removed on paralog
+      grounds.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:25942624
+      supporting_text: &gt;-
+        A strong FRET signal between Cos5-GFP and Cos5-mCherry was only found at
+        peri-vacuolar / late endosomal structures of wild-type cells
+      reference_section_type: RESULTS
+- term:
+    id: GO:0043328
+    label: protein transport to vacuole involved in ubiquitin-dependent protein catabolic
+      process via the multivesicular body sorting pathway
+  evidence_type: ISS
+  original_reference_id: PMID:25942624
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This biological-process annotation captures the Cos family role — promoting MVB sorting
+      of cargo for ubiquitin-dependent vacuolar degradation — and is transferred to Cos9 by
+      ISS (WITH/FROM SGD:S000003922 = COS5). The experimental basis (whole-family cosΔ
+      deletion plus Cos5 assays) establishes this role for the family; Cos9&#39;s individual
+      contribution has not been directly tested, but the annotation is the best available
+      statement of Cos9&#39;s probable function and is retained. Kept as non-core because it is
+      homology-based and describes a process rather than a Cos9-specific molecular activity.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:25942624
+      supporting_text: &gt;-
+        These data suggest Cos proteins mediate efficient sorting of a wide number of MVB
+        cargoes.
+      reference_section_type: RESULTS
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      No molecular function has been assigned to COS9, and the DUP/COS family is
+      enzymatically uncharacterized (InterPro IPR001142 describes it as membrane proteins &#34;of
+      unknown function&#34;). The ND (no data) annotation accurately records this molecular-
+      function gap. Accepted as an honest statement of the unknown; see knowledge_gaps.
+    action: ACCEPT
+core_functions:
+- description: &gt;-
+    By homology to the experimentally characterized paralog Cos5, Cos9 is inferred to act at
+    endosomes in the multivesicular body (MVB) sorting pathway, contributing to the family&#39;s
+    role of clustering into ubiquitin-rich endosomal microdomains that trap ubiquitinated and
+    GPI-anchored cargo and promote its sorting into intralumenal vesicles for
+    ubiquitin-dependent vacuolar degradation. Its own molecular activity is unknown; no
+    catalytic or specific binding function can be assigned to Cos9 or to the DUP/COS family,
+    and Cos9&#39;s individual contribution has not been directly measured.
+  directly_involved_in:
+  - id: GO:0043328
+    label: protein transport to vacuole involved in ubiquitin-dependent protein catabolic
+      process via the multivesicular body sorting pathway
+  locations:
+  - id: GO:0005768
+    label: endosome
+  - id: GO:0016020
+    label: membrane
+  supported_by:
+  - reference_id: PMID:25942624
+    supporting_text: &gt;-
+      Here we show that a family of highly ubiquitinated tetraspan Cos proteins provides a Ub
+      signal in trans, allowing sorting of nonubiquitinated MVB cargo into the canonical
+      ESCRT- and Ub-dependent pathway.
+    reference_section_type: ABSTRACT
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular function of Cos9 is unknown. No catalytic activity or specific binding
+      partner has been assigned to Cos9 or to any member of the DUP/COS family; even the
+      proposed family-level activity — supplying a ubiquitin sorting signal &#34;in trans&#34; and
+      forming a cargo-trapping endosomal microdomain — has no adequate GO molecular-function
+      term and has not been demonstrated for Cos9 individually.
+    boundary: &gt;-
+      Cos9 is a multi-pass DUP/COS-family integral membrane protein with a high lysine
+      content. By homology to the paralog Cos5, Cos proteins localize to endosomes, are
+      heavily ubiquitinated (Rsp5-dependent, via Sna3/Bsd2 and direct C-terminal binding),
+      self-associate into endosomal microdomains, and are required for efficient MVB sorting
+      of ubiquitinated and GPI-anchored cargo. The functional data derive from a whole-family
+      cosΔ deletion and from Cos5 as the representative; single-gene tests used COS1, COS2,
+      COS4, COS5, and COS6 — not COS9.
+    gap_kind:
+    - BIOLOGY
+    - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Cos proteins are proposed as functional analogs of mammalian tetraspanins in MVB
+      sorting and provide a route by which non-ubiquitinated (e.g. GPI-anchored) cargo enters
+      the ESCRT/ubiquitin-dependent pathway. Defining the Cos molecular activity would clarify
+      how cargo is corralled and given ubiquitin in trans, and whether individual paralogs
+      such as Cos9 are redundant with, or specialized relative to, the rest of the family.
+    resolution: &gt;-
+      Cos9-specific tagged localization and single-gene loss-of-function (in a
+      family-sensitized background) with cargo-sorting readouts; affinity/proximity
+      proteomics and ubiquitination-site mapping on Cos9; and, for the ontology gap, a GO
+      molecular-function term for the cargo-clustering / ubiquitin-supplied-in-trans MVB
+      sorting activity of Cos/tetraspan-like proteins.
+    provenance:
+    - reference_id: PMID:25942624
+      supporting_text: &gt;-
+        Future structure/function studies will determine the biophysical characteristics of
+        Cos proteins that allow them to operate.
+      reference_section_type: DISCUSSION
+    - reference_id: PMID:25942624
+      supporting_text: &gt;-
+        Yet, exactly how Cos proteins segregate cargo remains to be determined.
+      reference_section_type: DISCUSSION
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether COS9 is functionally equivalent to the characterized paralog COS5 (i.e. an active,
+    redundant MVB-sorting factor) or is instead specialized, expressed only under particular
+    conditions, or effectively dispensable, is undetermined. All functional annotations of
+    COS9 are homology-based (ISS from COS5); no COS9-specific loss-of-function or localization
+    experiment has been reported.
+  boundary: &gt;-
+    COS9 (YKL219W) is a subtelomeric DUP/COS-family multi-pass membrane protein. The COS
+    family (COS1-COS10, COS12) is highly similar at protein and nucleotide level and shows
+    strong functional redundancy — a phenotype required deletion of all COS genes together.
+    The endosome and MVB-sorting annotations on COS9 are transferred by ISS from COS5, the
+    experimentally studied representative; COS9 itself was not among the individually tested
+    genes (COS1, COS2, COS4, COS5, COS6).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Subtelomeric multigene families such as COS are a common source of &#34;dark,&#34; redundant
+    paralogs whose individual roles are rarely dissected. Establishing whether COS9 is an
+    active member, a conditionally expressed variant, or a near-pseudogene would sharpen the
+    annotation of the whole family and of yeast MVB sorting.
+  resolution: &gt;-
+    COS9-specific expression profiling across growth/nutrient-stress conditions; a
+    COS9-tagged strain to test endosomal localization directly; and single-gene deletion in a
+    COS-family-sensitized background with cargo-sorting assays to measure COS9&#39;s individual
+    contribution.
+  provenance:
+  - reference_id: PMID:25942624
+    supporting_text: &gt;-
+      The 11 COS genes, COS1 – COS10 and COS12, are remarkably similar at both the protein
+      and nucleotide level
+    reference_section_type: RESULTS
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does Cos9, like Cos5, localize to endosomal microdomains and become ubiquitinated, and is
+    it required (individually or redundantly) for MVB sorting of ubiquitinated and
+    GPI-anchored cargo? All current COS9 functional annotations are ISS transfers from Cos5.
+- question: &gt;-
+    What is the molecular activity of the DUP/COS family? Is &#34;supplying ubiquitin in trans&#34;
+    and forming a cargo-trapping endosomal microdomain a distinct molecular function that
+    warrants a dedicated GO term, or is it best captured as a set of biological-process and
+    protein-clustering annotations?
+- question: &gt;-
+    Under what conditions is COS9 expressed relative to its paralogs, and does the
+    NAD+/Sir2-dependent subtelomeric derepression that induces the COS family apply equally to
+    COS9 given its chromosome XI location?
+suggested_experiments:
+- description: &gt;-
+    Construct a chromosomally tagged Cos9 (e.g. Cos9-GFP) strain and assay steady-state
+    localization and vacuolar sorting, alongside ubiquitination-site mapping, to establish
+    whether Cos9 behaves like the characterized Cos5.
+  hypothesis: &gt;-
+    Cos9 localizes to endosomes, is ubiquitinated by the Rsp5 system, and is itself sorted
+    into the vacuole, matching the family behavior established for Cos5.
+- description: &gt;-
+    Delete COS9 individually and in a COS-family-sensitized background (e.g. combined with
+    single deletions of other COS genes and/or sna3Δ bsd2Δ) and quantify MVB sorting of
+    reporter cargoes (Mup1-GFP, Ste3-GFP, GPI-anchored YFP fusions) to measure Cos9&#39;s
+    individual contribution to cargo sorting.
+  hypothesis: &gt;-
+    COS9 contributes redundantly to MVB cargo sorting; its loss produces a measurable defect
+    only when other COS family members are also compromised.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/BIOREASON_COMPARISON/article/manuscript.tex
+++ b/pages/projects/BIOREASON_COMPARISON/article/manuscript.tex
@@ -119,9 +119,7 @@ TODO
 \hypertarget{introduction}{%
 \section{Introduction}\label{introduction}}
 
-Functional annotation of gene products --- determining, recording, and
-structuring what a protein does, where in the cell it does it, and in
-what biological process it participates --- is one of the central
+Functional annotation of gene products is one of the central
 tasks of modern molecular biology, underpinning high-throughput
 analyses of molecular data. The Gene Ontology (GO) project organizes
 these annotations, and coordinated both manual curation efforts and
@@ -129,32 +127,30 @@ the assessment and application of annotation
 pipelines\cite{goconsortium2023}.
 
 Annotations in GO can be classified in two categories: \textbf{(i)
-literature-based expert curation}, in which professional curators read
-papers on experimentally tractable model systems and encode the
-findings as structured, evidence-coded annotations; and \textbf{(ii)
-computational inference}, which propagates function across the long tail of
-uncharacterised proteins.
+literature-based expert curation}, in which expert curators and encode
+findings from papers as structured, evidence-coded annotations;
+and \textbf{(ii) computational inference}, which propagates function
+from literature-based knowledge across the tree of life.
 
-Traditional production pipelines such as InterPro2GO, PANTHER/PAINT,
-and orthology transfer are attractive because their inferences are
-transparent: annotations can be traced back to a family, domain
-signature, phylogenetic node, or orthology assertion. Over-prediction
-can usually be easily corrected, for example by weaking a mapping
-between a domain/family and a GO term. Newer
-machine-learning predictors and protein language-model systems are
-less rule-like. They may consume sequence, structure, organism
-context, or model-derived embeddings directly, and some now emit
-free-text rationales or functional summaries alongside term
+Traditional computational pipelines such as InterPro2GO,
+PANTHER/PAINT, and orthology transfer are attractive because their
+inferences are transparent: annotations can be traced back to a
+family, domain signature, phylogenetic node, or orthology
+assertion. Over-prediction can usually be easily corrected, for
+example by weaking a mapping between a domain/family and a GO
+term. Newer machine-learning predictors and protein language-model
+systems are less rule-like. They may consume sequence, structure,
+organism context, or model-derived embeddings directly, and some now
+emit free-text rationales or functional summaries alongside term
 lists. This makes evaluation harder: the prediction is no longer only
 a set of GO terms, and the provenance chain is often less explicit.
 
 This presents a challenge for assessing whether predictions should be
 included alongside trusted methods in the main annotation corpus. The
-community's standard yardstick for answering this question has been
-the Critical Assessment of Functional Annotation (CAFA)
-series \cite{radivojac2013,jiang2016,zhou2019}, which applies temporal
-holdout against GOA snapshots and reports aggregate GOA-agreement
-scores.
+Critical Assessment of Functional Annotation (CAFA)
+project \cite{radivojac2013,jiang2016,zhou2019} evaluates function
+annotation pipelines,using temporal holdout against GO database
+snapshots and reports aggregate agreement scores.
 
 CAFA has been indispensable for tracking aggregate progress of the
 field, but two challenges limit its use as a deployment decision-support


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2930 |
| Gene review HTML pages | 2930 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
