### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/yeast/PRM5/PRM5-ai-review.html
+++ b/genes/yeast/PRM5/PRM5-ai-review.html
@@ -1,0 +1,2289 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PRM5 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PRM5</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P40476" target="_blank" class="term-link">
+                        P40476
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PRM5";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P40476" data-a="DESCRIPTION: PRM5 (YIL117C) is a 318-residue integral membrane ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PRM5 (YIL117C) is a 318-residue integral membrane protein of budding yeast with a single predicted transmembrane helix and a large, disordered, low-complexity C-terminal region. Its molecular function and biological role are not established. It was identified as one of a set of &#34;pheromone-regulated membrane&#34; (PRM) genes whose transcription is strongly induced by mating pheromone, and its expression is also induced by the cell wall integrity (Mpk1/Slt2–Rlm1) signalling pathway. It belongs to a fungal protein family (PANTHER PTHR36089; Pfam PF28230) that also contains its whole-genome-duplication paralog YNL058C and the chitin synthase III complex protein CSI2; family members are experimentally localized to fungal-type vacuole and bud-neck membranes, but the family carries no recognizable catalytic or binding motif and its shared molecular activity is unknown. PRM5 is phosphorylated on several serines in pheromone-arrested cells and is ubiquitinated, indicating it is expressed and post-translationally regulated, but no phenotype from large-scale deletion surveys (mild fitness, stress, and sporulation defects) has been mechanistically connected to a defined function.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000324" target="_blank" class="term-link">
+                                    GO:0000324
+                                </a>
+                            </span>
+                            <span class="term-label">fungal-type vacuole</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40476" data-a="GO:0000324" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically propagated cellular-component annotation. Per QuickGO, this IBA is propagated (with/from PANTHER:PTN002188658 | SGD:S000005367) from CSI2 (YOL007C), which has experimental (IDA/HDA) fungal-type-vacuole localization; the WGD paralog YNL058C also has experimental vacuole localization. Vacuolar-membrane localization is a reasonable inference for this membrane-protein family, but PRM5&#39;s own localization has not been directly determined, and this is a location, not a function. Keep as non-core, and note that the &#34;is_active_in&#34; qualifier overstates certainty for an uncharacterized protein (located_in would be more appropriate).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Defensible family-level localization inference from experimentally localized paralogs (CSI2, YNL058C), but not directly verified for PRM5 and not a functional claim; retain as supporting localization context rather than a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005935" target="_blank" class="term-link">
+                                    GO:0005935
+                                </a>
+                            </span>
+                            <span class="term-label">cellular bud neck</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40476" data-a="GO:0005935" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically propagated cellular-component annotation (with/from PANTHER:PTN002188659 | SGD:S000005367 = CSI2/YOL007C, which has experimental IDA bud-neck localization as a chitin synthase III complex protein). Because PRM5 is a WGD-era paralog whose molecular function has diverged and is unknown (ND), propagation of CSI2&#39;s bud-neck localization to PRM5 is a weaker inference than the vacuole call. Retain as non-core localization context; the &#34;is_active_in&#34; qualifier again overstates certainty for a dark protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Weakly supported localization inference propagated from the bud-neck-localized paralog CSI2; not directly verified for PRM5 and not a functional claim. Keep as non-core context, flagged as lower confidence than the vacuole annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40476" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Directly supported by sequence: UniProt annotates a single predicted transmembrane helix (FT TRANSMEM 75..98, ECO:0000255) and the subcellular location &#34;Membrane; Single-pass membrane protein&#34; (ECO:0000305), mapped to GO:0016020 via UniProtKB-SubCell SL-0162. This is the single most defensible annotation for this gene and is consistent with the entire PRM/PTHR36089 family being membrane proteins. Accept as-is.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane localization is directly grounded in the predicted transmembrane helix and UniProt subcellular-location curation; this is the best-supported annotation for PRM5.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40476" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function with ND (&#34;no biological data&#34;) is the correct, honest placeholder: PRM5 has no experimentally or computationally supportable molecular function. There is no catalytic or ligand-binding motif in the sequence, the PANTHER family (including the better-studied members CSI2 and YNL058C) also carries ND for molecular_function, and Heiman &amp; Walter note PRM-family members have no recognizable motifs hinting at function. Retain the ND annotation to accurately record that molecular function is unknown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Molecular function is genuinely unknown; the ND root annotation correctly documents the absence of data and should be retained (do not invent an MF term or use protein binding).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40476" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with ND is the correct honest placeholder. PRM5 transcription is induced by mating pheromone and by cell wall integrity signalling, but induction is not evidence of participation, and no mating, cell-wall, or other biological-process phenotype has been demonstrated for a prm5 deletion beyond mild large-scale-survey effects. Retain the ND annotation; a specific BP term would be over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biological process is unknown; being transcriptionally induced by pheromone/CWI signalling does not establish involvement in mating or cell-wall processes. The ND annotation correctly records the absence of data.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Integral (single-pass) membrane protein. This is the only molecular/cellular attribute of PRM5 that is directly supported by evidence: a single predicted transmembrane helix (UniProt FT TRANSMEM 75..98) and the UniProt subcellular location &#34;Membrane; Single-pass membrane protein&#34;. No molecular function can be responsibly assigned — the sequence carries no catalytic or binding motif, and the protein family (PANTHER PTHR36089) is functionally dark, so this entry deliberately asserts only localization and leaves molecular function open.</h3>
+                <span class="vote-buttons" data-g="P40476" data-a="FUNCTION: Integral (single-pass) membrane protein. This is t..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11062271" target="_blank" class="term-link">
+                                PMID:11062271
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">which we henceforth refer to as PRM genes (pheromone-regulated membrane proteins)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10594829" target="_blank" class="term-link">
+                            PMID:10594829
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide analysis of gene expression regulated by the yeast cell wall integrity signalling pathway.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The cell wall integrity (Mpk1/Slt2 MAP kinase) pathway, acting through the Rlm1 transcription factor, controls a set of cell-wall-related genes; PRM5 is annotated by UniProt as one of the transcripts induced by this pathway.</div>
+
+                        <div class="finding-text">"All of the regulation detected was mediated by the Rlm1 transcription factor"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11062271" target="_blank" class="term-link">
+                            PMID:11062271
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Prm1p, a pheromone-regulated multispanning membrane protein, facilitates plasma membrane fusion during yeast mating.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Defines the &#34;PRM&#34; (pheromone-regulated membrane protein) gene set — 20 genes induced &gt;3-fold by mating pheromone and predicted to encode membrane proteins — of which PRM5 is a member; the paper characterizes PRM1, not PRM5, and notes the family members carry no motifs indicating function.</div>
+
+                        <div class="finding-text">"which we henceforth refer to as PRM genes (pheromone-regulated membrane proteins)"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17330950" target="_blank" class="term-link">
+                            PMID:17330950
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale phosphorylation analysis of alpha-factor-arrested Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22106047" target="_blank" class="term-link">
+                            PMID:22106047
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sites of ubiquitin attachment in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does PRM5 have any molecular activity beyond being a membrane component, and what is the ancestral activity shared across the PTHR36089 / PRM5-like family (PRM5, YNL058C, CSI2)?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Heiman MG, Walter P</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40476" data-a="Q: Does PRM5 have any molecular activity beyond being..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is PRM5 functionally involved in the mating/cell-fusion program or in cell-wall integrity responses, or is its dual induction by pheromone and Mpk1–Rlm1 signalling incidental regulon membership without a corresponding functional role?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Levin DE</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40476" data-a="Q: Is PRM5 functionally involved in the mating/cell-f..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the subcellular localization of endogenously tagged PRM5 (C-terminal GFP under its native promoter) by fluorescence microscopy with organelle co-markers (FM4-64/vacuole, Cdc10/septin bud-neck, plasma-membrane markers), under basal, pheromone-induced, and CWI-induced conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PRM5 localizes to a specific membrane compartment (vacuolar membrane, bud neck, or plasma membrane) that constrains its function.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: fluorescence microscopy / subcellular localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40476" data-a="EXPERIMENT: Determine the subcellular localization of endogeno..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Identify PRM5 physical partners by affinity purification–mass spectrometry and/or proximity labeling (e.g. TurboID) of tagged PRM5 expressed under inducing conditions, and test whether partners overlap with those of the paralog YNL058C or of CSI2 / the chitin synthase III complex.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PRM5 acts within a physical module that reveals its molecular function.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction proteomics (AP-MS / proximity labeling)</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40476" data-a="EXPERIMENT: Identify PRM5 physical partners by affinity purifi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct single (prm5 delta) and double (prm5 delta ynl058c delta) deletions and assay quantitative mating/cell-fusion efficiency and cell-wall-stress sensitivity (Calcofluor White, Congo Red, caspofungin, elevated temperature) to test for a redundant role masked by the paralog.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PRM5 contributes to mating or cell-wall integrity, redundantly with its paralog YNL058C.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis / phenotypic assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40476" data-a="EXPERIMENT: Construct single (prm5 delta) and double (prm5 del..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of PRM5 is entirely unknown. No catalytic activity, ligand/partner binding, transport, or scaffolding role has been demonstrated or can be inferred from sequence, and no informative GO molecular-function term is supportable (the annotation is the ND root, not &#34;protein binding&#34;).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> PRM5 is a 318-aa single-pass membrane protein with one predicted transmembrane helix and a large disordered/low-complexity C-terminal region. It belongs to fungal family PTHR36089 / Pfam PF28230, whose members (including the paralog YNL058C and CSI2) are membrane proteins but also carry ND for molecular function; the family founding paper noted such PRM proteins have no recognizable motifs hinting at function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> PRM5 is a conserved-in-fungi, whole-genome-duplication-retained membrane protein induced by two major signalling pathways (mating and cell wall integrity); a defined molecular activity would convert a recurrently-cited &#34;pheromone-regulated membrane protein&#34; from a name into a mechanism and would likely illuminate the shared activity of the whole PRM5/PTHR36089 family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of the purified protein and its membrane topology; affinity/ proximity proteomics to identify partners; and structure prediction/experimental structure to test for a cryptic domain. Comparison with the paralog YNL058C and with CSI2 may reveal the ancestral family activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"no recognizable motifs to hint at its function"</em> — PMID:11062271</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process PRM5 participates in is unknown. It is transcriptionally induced by mating pheromone and by the cell wall integrity (Mpk1–Rlm1) pathway, but it has not been shown to function in mating, cell fusion, cell-wall biogenesis, or any other process; a prm5-null mutant is viable with only mild, mechanistically unexplained phenotypes.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Induction by pheromone (PRM gene set) and by cell wall integrity signalling is experimentally established (UniProt INDUCTION, ECO:0000269|PubMed:10594829 and PubMed:11062271). Large-scale deletion surveys report decreased competitive fitness, oxidative-stress resistance, sporulation efficiency, and starvation resistance, but none is tied to a defined role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing whether PRM5 acts in the mating/cell-fusion program (like its namesake PRM1), in cell-wall remodelling (consistent with CWI induction), or elsewhere would resolve why the gene is co-regulated with these pathways and whether its co-regulation reflects a genuine functional role or incidental regulon membership.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"All of the regulation detected was mediated by the Rlm1 transcription factor"</em> — PMID:10594829</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> PRM5&#39;s own subcellular localization has not been directly determined. Its current fungal-type-vacuole and bud-neck component annotations are phylogenetic (IBA) propagations from experimentally localized paralogs (CSI2, YNL058C), not direct observations of PRM5.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Membrane localization is well supported by the predicted transmembrane helix and UniProt subcellular-location curation. Whether PRM5 resides in the vacuolar membrane, at the bud neck, at the plasma membrane, or in another compartment is not experimentally established for PRM5 itself.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A definitive localization would sharpen functional hypotheses (vacuolar vs. bud-neck/cell- surface roles) and test whether PRM5 tracks the localization of its paralogs or has diverged after the whole-genome duplication.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct localization of tagged PRM5 (e.g. GFP fusion under native regulation, or under pheromone/CWI induction) with organelle co-markers.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PRM5-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40476" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="prm5-yil117c-curation-notes">PRM5 (YIL117C) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> PRM5 (UniProt P40476,<br />
+SGD:S000001379, systematic name YIL117C). PRM5 is an <strong>understudied ("dark") gene</strong>: a<br />
+pheromone- and cell-wall-integrity-regulated single-pass membrane protein of <strong>unknown<br />
+molecular function and unknown biological role</strong>. The deliverable is an honest<br />
+<code>knowledge_gaps</code> section plus conservative, domain/orthology-grounded <code>description</code> and<br />
+<code>core_functions</code> — never invented function.</p>
+<h2 id="identity-provenance">Identity / provenance</h2>
+<ul>
+<li>Standard name PRM5 ("Pheromone-Regulated Membrane protein 5"); systematic YIL117C; verified ORF.</li>
+<li>318 aa, ~34.7 kDa (UniProt P40476).</li>
+<li>Paralog <strong>YNL058C</strong> (arose from the whole-genome duplication) [SGD locus page, "Paralog: YNL058C (arose from whole genome duplication)"].</li>
+<li>UniProt: <code>PE 1: Evidence at protein level</code> (protein identified in MS studies), but this is<br />
+  identification-level evidence only; no direct functional assay exists.</li>
+</ul>
+<h2 id="domain-topology-reasoning-from-prm5-uniprottxt-read-inline">Domain / topology reasoning (from PRM5-uniprot.txt, read inline)</h2>
+<ul>
+<li><code>FT TRANSMEM 75..98 /note="Helical" /evidence=ECO:0000255</code> — one predicted TM helix ⇒<br />
+  consistent with the UniProt subcellular-location statement <code>Membrane; Single-pass membrane protein {ECO:0000305}</code>.</li>
+<li>Large C-terminal (238–318) <strong>disordered / low-complexity</strong> region (MobiDB-lite), with basic-and-acidic<br />
+  and polar low-complexity stretches. No catalytic motif, no recognizable enzymatic domain.</li>
+<li>N-terminus (1–60) is Ser/Thr-rich (<code>...TTSTSS TTTASSSSTI TSVASSSSSL...</code>), consistent with a<br />
+  potential O-glycosylation-prone / membrane-anchored surface region, but this is inference only.</li>
+<li>Pfam <code>PF28230 (SCY_4732)</code>; InterPro <code>IPR051009 (PRM5-like)</code>; PANTHER <code>PTHR36089</code> ("Pheromone-regulated<br />
+  membrane protein" / short "PRM"). <strong>The InterPro/PANTHER free-text description for PTHR36089 is<br />
+  machine-generated (<code>is_llm: true</code>, <code>is_reviewed_llm: false</code>) and must NOT be used as evidence of<br />
+  function</strong> — it merely restates the family name and the vacuolar-membrane localization of some members.</li>
+<li>Conclusion from domains: <strong>localization (membrane) is defensible; molecular function is NOT<br />
+  inferable from sequence.</strong> Single TM + long disordered cytosolic tail is compatible with many roles<br />
+  (scaffold, regulatory membrane anchor) but specifies none.</li>
+</ul>
+<h2 id="panther-family-pthr36089-context-interpropantherpthr36089">PANTHER family PTHR36089 context (interpro/panther/PTHR36089/)</h2>
+<p>The family bundles several <em>S. cerevisiae</em> members that share the PRM/vacuolar-membrane fold but<br />
+have divergent/unknown functions:<br />
+- <strong>PRM5</strong> = P40476 (this gene)<br />
+- <strong>YNL058C</strong> = P53947 ("Vacuolar membrane protein YNL058C") — WGD paralog of PRM5<br />
+- <strong>CSI2</strong> = Q08054 ("Chitin synthase 3 complex protein CSI2", YOL007C)</p>
+<p>Even the better-studied family members carry <strong>ND</strong> (no data) for molecular_function and<br />
+biological_process — i.e. the whole family is functionally dark at the MF level.</p>
+<h2 id="source-of-the-iba-phylogenetic-localization-annotations-verified">Source of the IBA (phylogenetic) localization annotations — verified</h2>
+<p>PRM5's two IBA annotations propagate from experimentally-localized <em>S. cerevisiae</em> paralogs via<br />
+the PANTHER tree (QuickGO with/from fields, verified 2026-07-05):</p>
+<ul>
+<li><code>GO:0000324 fungal-type vacuole</code> — IBA (GO_REF:0000033), with/from PANTHER:PTN002188658 | <strong>SGD:S000005367</strong></li>
+<li><code>GO:0005935 cellular bud neck</code>  — IBA (GO_REF:0000033), with/from PANTHER:PTN002188659 | <strong>SGD:S000005367</strong></li>
+</ul>
+<p><strong>SGD:S000005367 = CSI2 (YOL007C)</strong> (resolved via SGD backend). QuickGO confirms CSI2 (Q08054) has<br />
+<strong>experimental</strong> annotations to both terms: <code>GO:0000324</code> (IDA + HDA) and <code>GO:0005935</code> (IDA); the<br />
+WGD paralog YNL058C (P53947) also has experimental <code>GO:0000324</code> (HDA). So the IBA localization<br />
+calls on PRM5 are grounded in real experimental localization of close relatives — reasonable<br />
+<strong>localization</strong> propagations for a conserved membrane-protein family, though they do not establish<br />
+PRM5's own localization directly and do NOT imply any molecular function.</p>
+<h2 id="what-is-known-about-prm5">What is KNOWN about PRM5</h2>
+<ol>
+<li><strong>Membrane protein.</strong> Single predicted TM helix (UniProt FT TRANSMEM 75..98) → UniProt annotates<br />
+<code>Membrane; Single-pass membrane protein</code> (ECO:0000305). Supports <code>GO:0016020 membrane</code><br />
+   (IEA, UniProtKB-SubCell SL-0162).</li>
+<li><strong>Regulated by two stimuli (INDUCTION, experimental).</strong> UniProt: "Expression is regulated by the<br />
+   cell integrity signaling pathway and by pheromone." (ECO:0000269|PubMed:10594829,<br />
+   ECO:0000269|PubMed:11062271).</li>
+<li>CWI/Mpk1–Rlm1 induction: <a href="https://pubmed.ncbi.nlm.nih.gov/10594829" title="The cell integrity pathway of Saccharomyces cerevisiae      monitors cell wall remodelling during growth and differentiation... We identified 25 genes whose      regulation was altered by Mpk1 activity... All of the regulation detected was mediated by the      Rlm1 transcription factor">PMID:10594829</a>. (Abstract does not enumerate PRM5 by name — it is one of the Mpk1/Rlm1<br />
+     targets in the full dataset; regulation attribution follows UniProt's ECO:0000269 curation.)</li>
+<li>Pheromone induction: the "PRM" designation comes from Heiman &amp; Walter, who defined 20<br />
+     pheromone-regulated membrane-protein (PRM) genes induced &gt;3-fold by α-factor and encoding ≥1<br />
+     hydrophobic domain <a href="https://pubmed.ncbi.nlm.nih.gov/11062271" title="This parameter narrowed our pool of 54 candidates to 20 genes,      which we henceforth refer to as PRM genes (pheromone-regulated membrane proteins).">PMID:11062271</a>. That paper<br />
+     characterized PRM1 in depth; PRM5 is one of the co-identified PRM set (listed in its Fig. 1 table),<br />
+     not individually characterized there.</li>
+<li><strong>Post-translational modifications (large-scale MS, experimental identification).</strong></li>
+<li>Phosphoserines S129, S279, S282, S288 [PMID:17330950, alpha-factor-arrested phosphoproteome].</li>
+<li>Ubiquitination at K314 [PMID:22106047, sites of ubiquitin attachment].</li>
+<li>These establish the protein is expressed and is a substrate of the phospho/ubiquitin machinery<br />
+     under mating arrest, but do not define its function.</li>
+<li><strong>Deletion phenotype: viable, only subtle large-scale-survey phenotypes</strong> (SGD): decreased<br />
+   competitive fitness, decreased oxidative-stress resistance, decreased sporulation efficiency,<br />
+   decreased starvation resistance, altered toxin resistance. All from high-throughput surveys; no<br />
+   dedicated mechanistic study.</li>
+</ol>
+<h2 id="what-is-not-known-the-primary-deliverable-knowledge-gaps">What is NOT known (the primary deliverable: knowledge gaps)</h2>
+<ul>
+<li><strong>Molecular function: entirely unknown</strong> (SGD/GO = ND; no enzyme motif; family-wide MF is ND).<br />
+  Not a <code>protein binding</code> situation — there is simply no informative MF term supportable.</li>
+<li><strong>Biological process: unknown</strong> (GO = ND). It is <em>induced by</em> pheromone and CWI signaling, but<br />
+  induction ≠ participation; no mating or cell-wall phenotype has been demonstrated for a prm5Δ.</li>
+<li><strong>Own subcellular localization not directly determined.</strong> Membrane is supported by topology; the<br />
+  vacuole/bud-neck IBA calls are paralog-propagations, not direct PRM5 data.</li>
+<li><strong>No physical partners establishing a pathway.</strong> BioGRID lists interactions but none define function.</li>
+</ul>
+<h2 id="annotation-by-annotation-plan">Annotation-by-annotation plan</h2>
+<ol>
+<li><code>GO:0000324 fungal-type vacuole</code> (IBA, is_active_in) — localization propagated from CSI2 (experimental).<br />
+   Plausible localization for the family but PRM5's own localization is unverified and this is a<br />
+<em>component</em> not function. Keep but mark <strong>non-core</strong> (KEEP_AS_NON_CORE): defensible, not a core<br />
+   functional claim, and <code>is_active_in</code> overstates certainty for a dark protein.</li>
+<li><code>GO:0005935 cellular bud neck</code> (IBA, is_active_in) — same provenance (CSI2). CSI2 is a chitin<br />
+   synthase-3 complex bud-neck protein; propagation of <em>its</em> localization to PRM5 is weaker (function<br />
+   diverged; PRM5 is a WGD-era paralog with ND function). Keep as <strong>non-core</strong> (KEEP_AS_NON_CORE),<br />
+   noting reduced confidence; do not treat as core.</li>
+<li><code>GO:0016020 membrane</code> (IEA, located_in) — directly supported by TM prediction/UniProt SubCell.<br />
+   The single defensible, sequence-grounded annotation. <strong>ACCEPT.</strong></li>
+<li><code>GO:0003674 molecular_function</code> (ND) — correct honest placeholder; MF genuinely unknown. <strong>ACCEPT</strong><br />
+   (the ND root annotation accurately records "no data").</li>
+<li><code>GO:0008150 biological_process</code> (ND) — likewise the honest placeholder; BP unknown. <strong>ACCEPT.</strong></li>
+</ol>
+<p><code>core_functions</code>: at most a minimal localization statement (integral membrane component); no MF can<br />
+be responsibly asserted. <code>knowledge_gaps</code> carries the substance.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P40476
+gene_symbol: PRM5
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  PRM5 (YIL117C) is a 318-residue integral membrane protein of budding yeast with a single
+  predicted transmembrane helix and a large, disordered, low-complexity C-terminal region. Its
+  molecular function and biological role are not established. It was identified as one of a set
+  of &#34;pheromone-regulated membrane&#34; (PRM) genes whose transcription is strongly induced by
+  mating pheromone, and its expression is also induced by the cell wall integrity (Mpk1/Slt2–Rlm1)
+  signalling pathway. It belongs to a fungal protein family (PANTHER PTHR36089; Pfam PF28230)
+  that also contains its whole-genome-duplication paralog YNL058C and the chitin synthase III
+  complex protein CSI2; family members are experimentally localized to fungal-type vacuole and
+  bud-neck membranes, but the family carries no recognizable catalytic or binding motif and its
+  shared molecular activity is unknown. PRM5 is phosphorylated on several serines in
+  pheromone-arrested cells and is ubiquitinated, indicating it is expressed and post-translationally
+  regulated, but no phenotype from large-scale deletion surveys (mild fitness, stress, and
+  sporulation defects) has been mechanistically connected to a defined function.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:10594829
+  title: Genome-wide analysis of gene expression regulated by the yeast cell wall integrity
+    signalling pathway.
+  findings:
+  - statement: &gt;-
+      The cell wall integrity (Mpk1/Slt2 MAP kinase) pathway, acting through the Rlm1
+      transcription factor, controls a set of cell-wall-related genes; PRM5 is annotated by
+      UniProt as one of the transcripts induced by this pathway.
+    supporting_text: &#34;All of the regulation detected was mediated by the Rlm1 transcription factor&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper on the Mpk1/Rlm1 cell-integrity regulon. It defines the
+      CWI regulon (Rlm1-mediated) that includes PRM5 per UniProt&#39;s INDUCTION annotation
+      (ECO:0000269|PubMed:10594829). The cached record is abstract-only and does not enumerate
+      PRM5 by name; the specific attribution rests on UniProt curation of the full dataset.
+      Supports induction/regulation, not molecular function.
+- id: PMID:11062271
+  title: Prm1p, a pheromone-regulated multispanning membrane protein, facilitates plasma
+    membrane fusion during yeast mating.
+  findings:
+  - statement: &gt;-
+      Defines the &#34;PRM&#34; (pheromone-regulated membrane protein) gene set — 20 genes induced
+      &gt;3-fold by mating pheromone and predicted to encode membrane proteins — of which PRM5 is
+      a member; the paper characterizes PRM1, not PRM5, and notes the family members carry no
+      motifs indicating function.
+    supporting_text: &#34;which we henceforth refer to as PRM genes (pheromone-regulated membrane proteins)&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text verified. Source of the PRM5 name / pheromone-regulated designation.
+      PRM5 appears in the paper&#39;s Fig. 1 list of 20 PRM genes but is not individually
+      characterized (the paper functionally studies PRM1). Establishes pheromone induction
+      and membrane-protein prediction, not PRM5&#39;s molecular function.
+- id: PMID:17330950
+  title: Large-scale phosphorylation analysis of alpha-factor-arrested Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cached record; the primary source (via UniProt FT MOD_RES,
+      ECO:0007744|PubMed:17330950) for PRM5 phosphoserines S129, S279, S282, S288 detected in
+      alpha-factor-arrested cells. Establishes expression and PTM under mating arrest, not function.
+- id: PMID:22106047
+  title: Sites of ubiquitin attachment in Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text verified; large-scale ubiquitylation-site dataset and the source (via UniProt
+      FT CROSSLNK, ECO:0007744|PubMed:22106047) for PRM5 ubiquitination at K314. Establishes PTM
+      only, not function.
+existing_annotations:
+- term:
+    id: GO:0000324
+    label: fungal-type vacuole
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically propagated cellular-component annotation. Per QuickGO, this IBA is
+      propagated (with/from PANTHER:PTN002188658 | SGD:S000005367) from CSI2 (YOL007C), which
+      has experimental (IDA/HDA) fungal-type-vacuole localization; the WGD paralog YNL058C also
+      has experimental vacuole localization. Vacuolar-membrane localization is a reasonable
+      inference for this membrane-protein family, but PRM5&#39;s own localization has not been
+      directly determined, and this is a location, not a function. Keep as non-core, and note
+      that the &#34;is_active_in&#34; qualifier overstates certainty for an uncharacterized protein
+      (located_in would be more appropriate).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Defensible family-level localization inference from experimentally localized paralogs
+      (CSI2, YNL058C), but not directly verified for PRM5 and not a functional claim; retain as
+      supporting localization context rather than a core function.
+- term:
+    id: GO:0005935
+    label: cellular bud neck
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically propagated cellular-component annotation (with/from
+      PANTHER:PTN002188659 | SGD:S000005367 = CSI2/YOL007C, which has experimental IDA
+      bud-neck localization as a chitin synthase III complex protein). Because PRM5 is a
+      WGD-era paralog whose molecular function has diverged and is unknown (ND), propagation
+      of CSI2&#39;s bud-neck localization to PRM5 is a weaker inference than the vacuole call.
+      Retain as non-core localization context; the &#34;is_active_in&#34; qualifier again overstates
+      certainty for a dark protein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Weakly supported localization inference propagated from the bud-neck-localized paralog
+      CSI2; not directly verified for PRM5 and not a functional claim. Keep as non-core context,
+      flagged as lower confidence than the vacuole annotation.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Directly supported by sequence: UniProt annotates a single predicted transmembrane helix
+      (FT TRANSMEM 75..98, ECO:0000255) and the subcellular location &#34;Membrane; Single-pass
+      membrane protein&#34; (ECO:0000305), mapped to GO:0016020 via UniProtKB-SubCell SL-0162. This
+      is the single most defensible annotation for this gene and is consistent with the entire
+      PRM/PTHR36089 family being membrane proteins. Accept as-is.
+    action: ACCEPT
+    reason: &gt;-
+      Membrane localization is directly grounded in the predicted transmembrane helix and
+      UniProt subcellular-location curation; this is the best-supported annotation for PRM5.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function with ND (&#34;no biological data&#34;) is the correct, honest placeholder:
+      PRM5 has no experimentally or computationally supportable molecular function. There is no
+      catalytic or ligand-binding motif in the sequence, the PANTHER family (including the
+      better-studied members CSI2 and YNL058C) also carries ND for molecular_function, and
+      Heiman &amp; Walter note PRM-family members have no recognizable motifs hinting at function.
+      Retain the ND annotation to accurately record that molecular function is unknown.
+    action: ACCEPT
+    reason: &gt;-
+      Molecular function is genuinely unknown; the ND root annotation correctly documents the
+      absence of data and should be retained (do not invent an MF term or use protein binding).
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process with ND is the correct honest placeholder. PRM5 transcription is
+      induced by mating pheromone and by cell wall integrity signalling, but induction is not
+      evidence of participation, and no mating, cell-wall, or other biological-process phenotype
+      has been demonstrated for a prm5 deletion beyond mild large-scale-survey effects. Retain
+      the ND annotation; a specific BP term would be over-annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Biological process is unknown; being transcriptionally induced by pheromone/CWI signalling
+      does not establish involvement in mating or cell-wall processes. The ND annotation
+      correctly records the absence of data.
+core_functions:
+- description: &gt;-
+    Integral (single-pass) membrane protein. This is the only molecular/cellular attribute of
+    PRM5 that is directly supported by evidence: a single predicted transmembrane helix
+    (UniProt FT TRANSMEM 75..98) and the UniProt subcellular location &#34;Membrane; Single-pass
+    membrane protein&#34;. No molecular function can be responsibly assigned — the sequence carries
+    no catalytic or binding motif, and the protein family (PANTHER PTHR36089) is functionally
+    dark, so this entry deliberately asserts only localization and leaves molecular function open.
+  locations:
+  - id: GO:0016020
+    label: membrane
+  supported_by:
+  - reference_id: PMID:11062271
+    supporting_text: &#34;which we henceforth refer to as PRM genes (pheromone-regulated membrane proteins)&#34;
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of PRM5 is entirely unknown. No catalytic activity, ligand/partner
+    binding, transport, or scaffolding role has been demonstrated or can be inferred from
+    sequence, and no informative GO molecular-function term is supportable (the annotation is
+    the ND root, not &#34;protein binding&#34;).
+  boundary: &gt;-
+    PRM5 is a 318-aa single-pass membrane protein with one predicted transmembrane helix and a
+    large disordered/low-complexity C-terminal region. It belongs to fungal family PTHR36089 /
+    Pfam PF28230, whose members (including the paralog YNL058C and CSI2) are membrane proteins
+    but also carry ND for molecular function; the family founding paper noted such PRM proteins
+    have no recognizable motifs hinting at function.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    PRM5 is a conserved-in-fungi, whole-genome-duplication-retained membrane protein induced by
+    two major signalling pathways (mating and cell wall integrity); a defined molecular activity
+    would convert a recurrently-cited &#34;pheromone-regulated membrane protein&#34; from a name into a
+    mechanism and would likely illuminate the shared activity of the whole PRM5/PTHR36089 family.
+  resolution: &gt;-
+    Biochemical characterization of the purified protein and its membrane topology; affinity/
+    proximity proteomics to identify partners; and structure prediction/experimental structure to
+    test for a cryptic domain. Comparison with the paralog YNL058C and with CSI2 may reveal the
+    ancestral family activity.
+  provenance:
+  - reference_id: PMID:11062271
+    supporting_text: &#34;no recognizable motifs to hint at its function&#34;
+    reference_section_type: RESULTS
+- gap_statement: &gt;-
+    The biological process PRM5 participates in is unknown. It is transcriptionally induced by
+    mating pheromone and by the cell wall integrity (Mpk1–Rlm1) pathway, but it has not been
+    shown to function in mating, cell fusion, cell-wall biogenesis, or any other process; a
+    prm5-null mutant is viable with only mild, mechanistically unexplained phenotypes.
+  boundary: &gt;-
+    Induction by pheromone (PRM gene set) and by cell wall integrity signalling is experimentally
+    established (UniProt INDUCTION, ECO:0000269|PubMed:10594829 and PubMed:11062271). Large-scale
+    deletion surveys report decreased competitive fitness, oxidative-stress resistance,
+    sporulation efficiency, and starvation resistance, but none is tied to a defined role.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing whether PRM5 acts in the mating/cell-fusion program (like its namesake PRM1),
+    in cell-wall remodelling (consistent with CWI induction), or elsewhere would resolve why the
+    gene is co-regulated with these pathways and whether its co-regulation reflects a genuine
+    functional role or incidental regulon membership.
+  provenance:
+  - reference_id: PMID:10594829
+    supporting_text: &#34;All of the regulation detected was mediated by the Rlm1 transcription factor&#34;
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    PRM5&#39;s own subcellular localization has not been directly determined. Its current
+    fungal-type-vacuole and bud-neck component annotations are phylogenetic (IBA) propagations
+    from experimentally localized paralogs (CSI2, YNL058C), not direct observations of PRM5.
+  boundary: &gt;-
+    Membrane localization is well supported by the predicted transmembrane helix and UniProt
+    subcellular-location curation. Whether PRM5 resides in the vacuolar membrane, at the bud
+    neck, at the plasma membrane, or in another compartment is not experimentally established
+    for PRM5 itself.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    A definitive localization would sharpen functional hypotheses (vacuolar vs. bud-neck/cell-
+    surface roles) and test whether PRM5 tracks the localization of its paralogs or has diverged
+    after the whole-genome duplication.
+  resolution: &gt;-
+    Direct localization of tagged PRM5 (e.g. GFP fusion under native regulation, or under
+    pheromone/CWI induction) with organelle co-markers.
+suggested_questions:
+- question: &gt;-
+    Does PRM5 have any molecular activity beyond being a membrane component, and what is the
+    ancestral activity shared across the PTHR36089 / PRM5-like family (PRM5, YNL058C, CSI2)?
+  experts:
+  - Heiman MG
+  - Walter P
+- question: &gt;-
+    Is PRM5 functionally involved in the mating/cell-fusion program or in cell-wall integrity
+    responses, or is its dual induction by pheromone and Mpk1–Rlm1 signalling incidental
+    regulon membership without a corresponding functional role?
+  experts:
+  - Levin DE
+suggested_experiments:
+- hypothesis: &gt;-
+    PRM5 localizes to a specific membrane compartment (vacuolar membrane, bud neck, or plasma
+    membrane) that constrains its function.
+  description: &gt;-
+    Determine the subcellular localization of endogenously tagged PRM5 (C-terminal GFP under its
+    native promoter) by fluorescence microscopy with organelle co-markers (FM4-64/vacuole,
+    Cdc10/septin bud-neck, plasma-membrane markers), under basal, pheromone-induced, and
+    CWI-induced conditions.
+  experiment_type: fluorescence microscopy / subcellular localization
+- hypothesis: &gt;-
+    PRM5 acts within a physical module that reveals its molecular function.
+  description: &gt;-
+    Identify PRM5 physical partners by affinity purification–mass spectrometry and/or proximity
+    labeling (e.g. TurboID) of tagged PRM5 expressed under inducing conditions, and test whether
+    partners overlap with those of the paralog YNL058C or of CSI2 / the chitin synthase III
+    complex.
+  experiment_type: interaction proteomics (AP-MS / proximity labeling)
+- hypothesis: &gt;-
+    PRM5 contributes to mating or cell-wall integrity, redundantly with its paralog YNL058C.
+  description: &gt;-
+    Construct single (prm5 delta) and double (prm5 delta ynl058c delta) deletions and assay
+    quantitative mating/cell-fusion efficiency and cell-wall-stress sensitivity (Calcofluor
+    White, Congo Red, caspofungin, elevated temperature) to test for a redundant role masked by
+    the paralog.
+  experiment_type: genetic epistasis / phenotypic assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2931 |
| Gene review HTML pages | 2931 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
