### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/ASL/ASL-ai-review.html
+++ b/genes/human/ASL/ASL-ai-review.html
@@ -1,0 +1,5281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ASL - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ASL</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P04424" target="_blank" class="term-link">
+                        P04424
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ASL";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P04424" data-a="DESCRIPTION: Argininosuccinate lyase (ASL; arginosuccinase; EC ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Argininosuccinate lyase (ASL; arginosuccinase; EC 4.3.2.1) is a cytosolic enzyme that catalyzes the reversible cleavage of L-argininosuccinate into L-arginine and fumarate. This reaction is the third and final step of L-arginine biosynthesis and a step of the urea cycle, in which ASL acts downstream of argininosuccinate synthase (ASS1) to regenerate arginine; in hepatocytes arginine is then hydrolyzed by arginase to release urea for nitrogen detoxification, while in non-hepatic tissues ASL provides arginine for other pathways. ASL is a homotetramer belonging to the lyase 1 family (argininosuccinate lyase subfamily) within the fumarase/aspartase (L-aspartase-like) superfamily; its four active sites are each built from residues contributed by more than one subunit, which is the structural basis for the extensive intragenic (interallelic) complementation seen among disease alleles. Beyond its catalytic role, ASL has a distinct, catalysis-independent structural function: it is required to assemble and maintain a tissue-specific multiprotein complex (with argininosuccinate synthase, the arginine transporter SLC7A1/CAT-1, HSP90 and a nitric oxide synthase NOS1/NOS2/NOS3) that channels intracellular and extracellular arginine to nitric oxide synthesis. Loss of ASL function causes argininosuccinic aciduria, an autosomal recessive urea cycle disorder featuring hyperammonemia together with ammonia-independent systemic features (systemic hypertension, chronic hepatic disease, neurocognitive impairment) attributable in part to cell-autonomous nitric oxide deficiency.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred core molecular function. ASL cleaves L-argininosuccinate to L-arginine and fumarate (EC 4.3.2.1), the reaction that defines this orthology group and is directly supported for the human enzyme by biochemical assay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the correct, well-supported core molecular function of ASL. The IBA is concordant with multiple human experimental annotations (EXP/IDA) and with the UniProt-curated catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0006526" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred involvement in L-arginine biosynthesis. ASL performs the final (argininosuccinate-cleaving) step of de novo arginine synthesis from ornithine and carbamoyl phosphate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process, concordant with human IDA annotations and the UniProt-curated arginine-biosynthesis pathway (step 3/3). ASL supplies arginine both for the urea cycle in liver and for other arginine-dependent pathways in non-hepatic tissues.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link">
+                                        PMID:11747432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reaction involved in the biosynthesis of arginine in all species and in the production of urea in ureotelic species</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred cytosolic localization. ASL is a soluble cytosolic enzyme; its urea-cycle and arginine-biosynthesis reactions occur in the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core cellular component, concordant with the human TAS cytosol/cytoplasm annotations and with the soluble, non-membrane biochemistry of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/282632" target="_blank" class="term-link">
+                                        PMID:282632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ASL activity was visualized on gels after electrophoresis by a new method, termed bioautography</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level catalytic activity assigned electronically from InterPro domain membership (fumarase/aspartase superfamily). This is the uninformative parent of the specific, correct term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ASL&#39;s molecular function is captured precisely and correctly by GO:0004056 argininosuccinate lyase activity (EC 4.3.2.1), which is annotated with strong experimental (EXP/IDA) and phylogenetic (IBA) support. GO:0003824 is the most general MF root and adds no information beyond &#34;is an enzyme&#34;; it should not be considered a core function statement.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of argininosuccinate lyase activity from InterPro signature IPR009049, RHEA:24020 and EC 4.3.2.1. This is the correct core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific molecular function, fully concordant with the human experimental and phylogenetic annotations to the same term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0006526" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of L-arginine biosynthetic process from UniPathway mapping and ortholog evidence. Correct core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with human IDA and IBA annotations to the same process; matches the UniProt-curated arginine biosynthesis pathway (step 3/3).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005515" data-r="PMID:25416956" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding recorded from a proteome-scale binary interactome (Y2H) screen (interactor NTAQ1, Q96HA8). The bare protein binding term is uninformative about ASL&#39;s molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare GO:0005515 protein binding is not an informative molecular-function statement and is not a core function. The biologically meaningful self-association of ASL is captured by GO:0042802 (identical protein binding); the physiologically important heteromeric interactions (ASS1, SLC7A1, NOS) underlie the nitric-oxide role captured by GO:0045429. The interaction evidence itself is retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26871637
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread Expansion of Protein Interaction Capabilities by ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005515" data-r="PMID:26871637" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding from a high-throughput interactome study of alternative-splicing isoforms (interactor MCMBP isoform, Q9BTE3-2). Uninformative MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is not an informative molecular function and is not core. The interaction detection is retained as non-core supporting data; the informative self-interaction is annotated separately as GO:0042802.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005515" data-r="PMID:31515488" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding from a large-scale study of interaction disruption by genetic variants (interactor NTAQ1, Q96HA8). Uninformative MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is not an informative molecular function and is not core; retained as non-core interaction evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005515" data-r="PMID:32296183" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding from the HuRI reference binary interactome (multiple interactors, e.g. TRIM3 O75382, NTAQ1 Q96HA8, MCMBP Q9BTE3-2). Uninformative MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is not an informative molecular function and is not core; retained as non-core interaction evidence. Physiologically relevant heteromeric partners (ASS1/SLC7A1/NOS) are not among these high-throughput hits.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21988832
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toward an understanding of the protein interaction network o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0042802" data-r="PMID:21988832" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ASL self-association (P04424-P04424) detected in a human liver protein interaction network study. This reflects the biologically real homotetramer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ASL is an obligate homotetramer whose subunits jointly form the shared active sites; self-association is intrinsic to its catalytic architecture and is directly supported by structural and biochemical work. This is an informative, correct molecular-function statement (unlike bare protein binding).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0042802" data-r="PMID:25416956" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ASL self-association (P04424-P04424) detected in a proteome-scale binary interactome, consistent with the homotetramer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates the biologically real ASL homotetramer; informative and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25502805
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A massively parallel pipeline to clone DNA variants and exam...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0042802" data-r="PMID:25502805" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ASL self-association (P04424-P04424) detected in a massively parallel clone/variant interaction pipeline, consistent with the homotetramer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates the homotetramer; informative and correct self-interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0042802" data-r="PMID:31515488" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ASL self-association (P04424-P04424) detected in a study of variant effects on protein interactions, consistent with the homotetramer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates the homotetramer; informative and correct self-interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0042802" data-r="PMID:32296183" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ASL self-association (P04424-P04424) detected in the HuRI reference binary interactome, consistent with the homotetramer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates the biologically real ASL homotetramer; informative and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045429" target="_blank" class="term-link">
+                                    GO:0045429
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of nitric oxide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0045429" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer of a mouse Asl (Q91YI0) experimental annotation for the role of ASL in promoting nitric oxide biosynthesis. This transfers the same biology established experimentally for both mouse and human ASL in PMID:22081021.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The underlying biology is genuine and experimentally supported in both species - ASL contributes, via a catalysis-independent structural role in the NOS multiprotein complex, to nitric oxide production. The orthology-transfer IEA is redundant with the human IMP annotation of the same term (PMID:22081021) but is not wrong. This is a secondary (moonlighting/structural) function rather than the enzyme&#39;s core catalytic function, hence non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link">
+                                        PMID:22081021
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mechanistic studies showed that ASL has a structural function in addition to its catalytic activity, by which it contributes to the formation of a multiprotein complex required for NO production.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0000050" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of urea cycle from UniPathway mapping. ASL performs the step that regenerates arginine (from argininosuccinate) within the urea cycle, providing for hepatic nitrogen detoxification into urea.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process. This is the canonical urea-cycle role of ASL and is central to the disease mechanism (hyperammonemia in argininosuccinic aciduria). Concordant with UniProt pathway curation (urea cycle, step 1/1 for this reaction).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link">
+                                        PMID:11747432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reaction involved in the biosynthesis of arginine in all species and in the production of urea in ureotelic species</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9956524
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005829" data-r="Reactome:R-HSA-9956524" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted cytosolic localization (from the ASL variant urea-cycle reaction pathway). ASL is a soluble cytosolic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core cellular component, concordant with the IBA and TAS cytosol/cytoplasm annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2263616" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2263616
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular analysis of human argininosuccinate lyase: mutant ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="PMID:2263616" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration of argininosuccinate lyase activity via characterization of human ASL and its ASA disease variants (e.g. R95C), including expression of mutant cDNA in COS cells showing loss of ASL activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for the core molecular function in the human enzyme. R95C produces little protein and less than 1% ASL activity, establishing that the assayed activity is that of the ASL gene product.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2263616" target="_blank" class="term-link">
+                                        PMID:2263616
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Expression in COS cells demonstrated that the R95C mutation produces normal amounts of ASAL mRNA but little protein and less than 1% ASAL activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9045711" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9045711
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Intragenic complementation at the human argininosuccinate ly...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="PMID:9045711" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay of ASL activity in COS-cell expression / intragenic complementation experiments, where the Q286R and D87G alleles each conferred loss of ASL activity and cotransfection partially restored it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong direct experimental support for the core catalytic function of human ASL.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9045711" target="_blank" class="term-link">
+                                        PMID:9045711
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">each conferred loss of ASL activity in COS cell transfection assays</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006525" target="_blank" class="term-link">
+                                    GO:0006525
+                                </a>
+                            </span>
+                            <span class="term-label">arginine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9045711" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9045711
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Intragenic complementation at the human argininosuccinate ly...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0006525" data-r="PMID:9045711" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Involvement in arginine metabolism inferred from direct assay of ASL activity and the resulting arginine production/loss in the complementation experiments.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general. GO:0006525 arginine metabolic process is a broad parent; ASL&#39;s specific role is captured more precisely by GO:0006526 L-arginine biosynthetic process (the direction ASL contributes to). Retained as an accurate but non-core parent annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9045711" target="_blank" class="term-link">
+                                        PMID:9045711
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">each conferred loss of ASL activity in COS cell transfection assays</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045429" target="_blank" class="term-link">
+                                    GO:0045429
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of nitric oxide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22081021
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Requirement of argininosuccinate lyase for systemic nitric o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0045429" data-r="PMID:22081021" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally demonstrated requirement of ASL for nitric oxide production. Human ASA (ASL-null) subjects and cells, a hypomorphic Asl mouse, and ASL-knockdown cells all show reduced NOS-dependent NO. Crucially, catalytically dead but structurally intact human ASL mutants (R236W, R113Q) still support NOS complex formation and restore arginine-stimulated NO, showing this is a catalysis-independent structural role in assembling the NOS multiprotein complex (ASS1, SLC7A1, NOS).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a genuine, well-supported second function of ASL (a moonlighting/structural role distinct from its catalytic activity) and explains the ammonia-independent systemic features (hypertension, hepatic/neurologic disease) of argininosuccinic aciduria. It is captured as a core function in core_functions as the NOS scaffold role, but relative to the enzyme&#39;s canonical urea-cycle/arginine-biosynthesis catalysis it is treated as non-core at the annotation level.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link">
+                                        PMID:22081021
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mechanistic studies showed that ASL has a structural function in addition to its catalytic activity, by which it contributes to the formation of a multiprotein complex required for NO production.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link">
+                                        PMID:22081021
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Loss of Asl in both humans and mice leads to reduced NO synthesis, owing to both decreased endogenous arginine synthesis and an impaired ability to use extracellular arginine for NO production.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11747433
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanisms for intragenic complementation at the human argin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="PMID:11747433" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct biochemical characterization of recombinant human ASL and its active-site (Q286R, D87G) and stability (M360T, A398D) mutants, confirming argininosuccinate lyase activity and its dependence on the homotetrameric shared-active-site architecture.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong direct experimental support for the core catalytic function; the paper reconstructs the reaction in vivo and in vitro with recombinant protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11747432
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Three-dimensional structure of the argininosuccinate lyase f...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0006526" data-r="PMID:11747432" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The 2.65 A structure of the human ASL Q286R allele together with catalytic characterization supports ASL&#39;s role in the arginine-producing reaction of arginine biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process, supported by direct structural/biochemical study of the human enzyme. The reaction is explicitly stated to be part of arginine biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link">
+                                        PMID:11747432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reaction involved in the biosynthesis of arginine in all species and in the production of urea in ureotelic species</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11747433
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mechanisms for intragenic complementation at the human argin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0006526" data-r="PMID:11747433" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biochemical reconstitution of the ASL reaction (argininosuccinate to arginine + fumarate) with recombinant human protein supports involvement in arginine biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process, supported by direct assay of the arginine-producing reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                        PMID:11747433
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11747432
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Three-dimensional structure of the argininosuccinate lyase f...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="PMID:11747432" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Catalytic characterization and high-resolution structure of human ASL (Q286R allele) directly demonstrate argininosuccinate lyase activity and its kinetics (KM 0.12 mM for argininosuccinate).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong direct experimental support for the core molecular function in the human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link">
+                                        PMID:11747432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate lyase (ASL) catalyzes the reversible breakdown of argininosuccinate to arginine and fumarate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0070062" data-r="PMID:19056867" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ASL peptides detected in urinary exosomes by large-scale proteomics/phosphoproteomics. This is a mass-spectrometry catalog location, not a site where ASL performs its known function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput proteomic detection in exosomes is common for abundant cytosolic enzymes and does not reflect a functional extracellular localization. ASL is a soluble cytosolic urea-cycle enzyme; the exosome finding is retained as non-core observational data. Cytosol (GO:0005829) is the functionally relevant compartment.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70573
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005829" data-r="Reactome:R-HSA-70573" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted cytosolic localization (from the argininosuccinate to fumarate + arginine urea-cycle reaction). Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core cellular component, concordant with the IBA and other TAS cytosol/cytoplasm annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                                    GO:0004056
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate lyase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/282632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:282632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Argininosuccinic aciduria: assignment of the argininosuccina...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0004056" data-r="PMID:282632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion of ASL enzymatic activity (EC 4.3.2.1) from an early study that assayed human ASL by bioautography and mapped the ASL gene to chromosome 7.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the enzyme activity (EC 4.3.2.1) was directly detected and used to map the human gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/282632" target="_blank" class="term-link">
+                                        PMID:282632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">associated with a deficiency of argininosuccinate lyase (ASL; L-argininosuccinate arginine-lyase, EC 4.3.2.1)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/282632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:282632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Argininosuccinic aciduria: assignment of the argininosuccina...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0005737" data-r="PMID:282632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion of cytoplasmic localization for ASL. The more specific and functionally accurate term is cytosol (GO:0005829).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general. Cytoplasm is accurate; the more specific cytosol term (annotated separately by IBA/TAS) is preferred as the core localization. Retained as an accurate broader-term annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140378" target="_blank" class="term-link">
+                                    GO:0140378
+                                </a>
+                            </span>
+                            <span class="term-label">protein complex scaffold activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22081021
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Requirement of argininosuccinate lyase for systemic nitric o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P04424" data-a="GO:0140378" data-r="PMID:22081021" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed molecular-function statement for ASL&#39;s catalysis-independent structural role: it scaffolds a tissue-specific nitric oxide synthase multiprotein complex (with ASS1, SLC7A1 and NOS1/NOS2/NOS3). Catalytically dead but structurally intact human ASL (R236W, R113Q) still supports NOS complex formation, while loss of ASL disrupts the complex, defining a scaffold rather than catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GOA captures the downstream process (GO:0045429 positive regulation of nitric oxide biosynthetic process, IMP) but not the underlying molecular function. GO:0140378 protein complex scaffold activity best represents ASL&#39;s demonstrated role in holding the NOS complex together independently of its lyase catalysis, and grounds the corresponding core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link">
+                                        PMID:22081021
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mechanistic studies showed that ASL has a structural function in addition to its catalytic activity, by which it contributes to the formation of a multiprotein complex required for NO production.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ASL/ASL-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">forming a metabolon that channels arginine directly to NOS for nitric oxide (NO) production</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyzes the reversible cleavage of L-argininosuccinate to L-arginine and fumarate (EC 4.3.2.1), a step of the cytosolic urea cycle, as an obligate homotetramer with shared active sites.</h3>
+                <span class="vote-buttons" data-g="P04424" data-a="FUNCTION: Catalyzes the reversible cleavage of L-argininosuc..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                            argininosuccinate lyase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                                PMID:11747433
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Argininosuccinate lyase (ASL) is a homotetrameric enzyme that catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/282632" target="_blank" class="term-link">
+                                PMID:282632
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">associated with a deficiency of argininosuccinate lyase (ASL; L-argininosuccinate arginine-lyase, EC 4.3.2.1)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Regenerates L-arginine from argininosuccinate as the final step of de novo arginine biosynthesis, supplying arginine for downstream pathways in hepatic and non-hepatic tissues.</h3>
+                <span class="vote-buttons" data-g="P04424" data-a="FUNCTION: Regenerates L-arginine from argininosuccinate as t..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004056" target="_blank" class="term-link">
+                            argininosuccinate lyase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                L-arginine biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link">
+                                PMID:11747432
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a reaction involved in the biosynthesis of arginine in all species and in the production of urea in ureotelic species</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Provides a catalysis-independent scaffold function that holds together a tissue-specific nitric oxide synthase multiprotein complex (with ASS1, SLC7A1 and NOS1/NOS2/NOS3), channelling arginine to nitric oxide production and thereby positively regulating nitric oxide biosynthesis.</h3>
+                <span class="vote-buttons" data-g="P04424" data-a="FUNCTION: Provides a catalysis-independent scaffold function..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140378" target="_blank" class="term-link">
+                            protein complex scaffold activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045429" target="_blank" class="term-link">
+                                positive regulation of nitric oxide biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link">
+                                PMID:22081021
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Mechanistic studies showed that ASL has a structural function in addition to its catalytic activity, by which it contributes to the formation of a multiprotein complex required for NO production.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" target="_blank" class="term-link">
+                            PMID:11747432
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Three-dimensional structure of the argininosuccinate lyase frequently complementing allele Q286R.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" target="_blank" class="term-link">
+                            PMID:11747433
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mechanisms for intragenic complementation at the human argininosuccinate lyase locus.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
+                            PMID:21988832
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22081021" target="_blank" class="term-link">
+                            PMID:22081021
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Requirement of argininosuccinate lyase for systemic nitric oxide production.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2263616" target="_blank" class="term-link">
+                            PMID:2263616
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular analysis of human argininosuccinate lyase: mutant characterization and alternative splicing of the coding region.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link">
+                            PMID:25502805
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A massively parallel pipeline to clone DNA variants and examine molecular phenotypes of human disease mutations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link">
+                            PMID:26871637
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread Expansion of Protein Interaction Capabilities by Alternative Splicing.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/282632" target="_blank" class="term-link">
+                            PMID:282632
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Argininosuccinic aciduria: assignment of the argininosuccinate lyase gene to the pter to q22 region of human chromosome 7 by bioautography.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                            PMID:31515488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9045711" target="_blank" class="term-link">
+                            PMID:9045711
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Intragenic complementation at the human argininosuccinate lyase locus. Identification of the major complementing alleles.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70573
+
+                    </span>
+                </div>
+
+                <div class="reference-title">argininosuccinate &lt;=&gt; fumarate + arginine</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9956524
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ASL variants don&#39;t synthesize fumarate and arginine</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ASL/ASL-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report (falcon) for human ASL</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ASL-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P04424" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Functional Annotation of Human ASL (Argininosuccinate Lyase)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">40 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:25:20.571681</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ASL-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-functional-annotation-of-human-asl-argininosuccinate-lyase">Comprehensive Functional Annotation of Human ASL (Argininosuccinate Lyase)</h1>
+<h2 id="gene-and-protein-identity">Gene and Protein Identity</h2>
+<p>The human <em>ASL</em> gene (UniProt: P04424) encodes argininosuccinate lyase (ASAL; EC 4.3.2.1), also known as arginosuccinase. The gene is located on chromosome 7 (7q11.21), spanning approximately 17,554 base pairs organized into 16 coding exons plus an exon 0 that encodes only the 5′ untranslated region (baruteau2019argininosuccinicaciduriarecent pages 1-6, erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5, baruteau2019argininosuccinicaciduriarecent pages 6-9). The encoded protein consists of 464 amino acids with a monomer molecular weight of approximately 52 kDa (nagamani2012argininosuccinatelyasedeficiency pages 2-3). ASL belongs to the lyase 1 family and is a member of the β-elimination/fumarate lyase superfamily, sharing structural homology with fumarase, aspartase, and adenylosuccinate lyase (chakraborty1999mutationalanalysisof pages 48-53, toth2000thestructureof pages 1-2).</p>
+<p>The following table summarizes the key molecular and functional properties of human ASL:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>ASL</strong> (argininosuccinate lyase; argininosuccinase) in <strong>Homo sapiens</strong> (human) (baruteau2019argininosuccinicaciduriarecent pages 1-6, erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>P04424</strong></td>
+</tr>
+<tr>
+<td>Chromosome location</td>
+<td><strong>Chromosome 7</strong>; reported as <strong>7q11.21 / cen-q11.2</strong>, with gene structure including exon 0 for 5' UTR and 16 coding exons (baruteau2019argininosuccinicaciduriarecent pages 1-6, erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5, baruteau2019argininosuccinicaciduriarecent pages 6-9)</td>
+</tr>
+<tr>
+<td>Protein size</td>
+<td><strong>464 aa</strong>, about <strong>52 kDa per monomer</strong> (tetramer ~208 kDa) (nagamani2012argininosuccinatelyasedeficiency pages 2-3)</td>
+</tr>
+<tr>
+<td>Quaternary structure</td>
+<td><strong>Homotetramer</strong> with <strong>4 active sites</strong>; each active site is formed at the interface of <strong>three subunits</strong> (chakraborty1999mutationalanalysisof pages 48-53, baruteau2019argininosuccinicaciduriarecent pages 1-6, nagamani2012argininosuccinatelyasedeficiency pages 2-3)</td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 4.3.2.1</strong> (argininosuccinate lyase) (baruteau2019argininosuccinicaciduriarecent pages 1-6)</td>
+</tr>
+<tr>
+<td>Reaction catalyzed</td>
+<td>Reversible cleavage of <strong>argininosuccinate → L-arginine + fumarate</strong>; this is the 4th step of the urea cycle and also supplies arginine in the citrulline-NO cycle (chakraborty1999mutationalanalysisof pages 36-42, baruteau2019argininosuccinicaciduriarecent pages 1-6, wu1998argininemetabolismnitric pages 2-3)</td>
+</tr>
+<tr>
+<td>Substrate specificity</td>
+<td>Physiologic substrate is <strong>argininosuccinic acid (argininosuccinate)</strong>; ASL is the only enzyme capable of generating endogenous arginine in mammalian cells (nagamani2012argininosuccinatelyasedeficiency pages 2-3, keshet2018arginineandthe pages 2-2)</td>
+</tr>
+<tr>
+<td>Catalytic mechanism</td>
+<td><strong>β-elimination (ElcB)</strong> mechanism with a <strong>carbanion intermediate</strong>; elimination proceeds with <strong>trans stereochemistry</strong>, and C–N bond cleavage is likely rate-limiting (chakraborty1999mutationalanalysisof pages 36-42, chakraborty1999mutationalanalysisof pages 42-48)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Cytosolic</strong> enzyme; also functions in a compartmentalized <strong>CAT1-ASS1-ASL-NOS</strong> complex for arginine channeling to NOS (baruteau2019argininosuccinicaciduriarecent pages 1-6, baruteau2019argininosuccinicaciduriarecent pages 6-9, mori2004argininemetabolicenzymes pages 2-3)</td>
+</tr>
+<tr>
+<td>Primary tissue expression</td>
+<td>Expressed predominantly in <strong>liver</strong>; also present in <strong>kidney (proximal tubules)</strong>, brain, heart, muscle, skin, hematopoietic tissues, small intestine, pancreas, fibroblasts, and erythrocytes. Kidney is a major site of endogenous arginine synthesis (~60% net synthesis in adults) (baruteau2019argininosuccinicaciduriarecent pages 1-6, nagamani2012argininosuccinatelyasedeficiency pages 2-3, chakraborty1999mutationalanalysisof pages 36-42)</td>
+</tr>
+<tr>
+<td>Pathway involvement</td>
+<td><strong>Urea cycle:</strong> supports ammonia detoxification/ureagenesis. <strong>Citrulline-NO cycle:</strong> regenerates arginine from citrulline to support nitric oxide synthesis by NOS (baruteau2019argininosuccinicaciduriarecent pages 1-6, mori2004argininemetabolicenzymes pages 1-2)</td>
+</tr>
+<tr>
+<td>Superfamily / family membership</td>
+<td>Member of the <strong>β-elimination / fumarate-lyase-related superfamily</strong>, related to <strong>δ-crystallin</strong>, fumarase, aspartase, and adenylosuccinate lyase; highly conserved across bacteria to mammals (chakraborty1999mutationalanalysisof pages 48-53, erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5, toth2000thestructureof pages 1-2)</td>
+</tr>
+<tr>
+<td>Key catalytic residues</td>
+<td>Frequently implicated catalytic residues include <strong>H91, H162, K289, E296</strong>; H162/K289/E296 are central to proton abstraction and charge-relay chemistry (chakraborty1999mutationalanalysisof pages 42-48, chakraborty1999mutationalanalysisof pages 48-53)</td>
+</tr>
+<tr>
+<td>Disease association</td>
+<td>Biallelic pathogenic variants cause <strong>ASL deficiency (ASLD)</strong>, also called <strong>argininosuccinic aciduria (ASA)</strong>, a urea-cycle disorder with hyperammonemia and broader systemic disease including neurocognitive and liver manifestations (baruteau2019argininosuccinicaciduriarecent pages 1-6, gurung2024mrnatherapycorrects pages 11-12, kho2023argininosuccinatelyasedeficiency pages 4-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core molecular, structural, biochemical, and disease-related properties of human argininosuccinate lyase (ASL). It is useful as a compact reference for functional annotation and for connecting ASL’s enzymatic role to its pathway context and disease relevance.</em></p>
+<h2 id="1-enzymatic-function-reaction-and-substrate-specificity">1. Enzymatic Function: Reaction and Substrate Specificity</h2>
+<p>ASL catalyzes the reversible cleavage of L-argininosuccinate into L-arginine and fumarate (chakraborty1999mutationalanalysisof pages 36-42, baruteau2019argininosuccinicaciduriarecent pages 1-6, wu1998argininemetabolismnitric pages 2-3). This reaction represents the fourth step of the urea cycle and is the sole enzymatic means of generating endogenous arginine in mammalian cells (nagamani2012argininosuccinatelyasedeficiency pages 2-3, keshet2018arginineandthe pages 2-2). The physiological substrate is argininosuccinic acid (argininosuccinate), and the products are L-arginine and fumarate (nagamani2012argininosuccinatelyasedeficiency pages 2-3). Kinetic studies using the homologous duck δ II crystallin (which retains ASL activity) have reported a V_max of 3.47 μmol/min/mg protein and a K_m of 0.35 mM (chakraborty1999mutationalanalysisof pages 32-36). In bovine and human ASL, non-linear kinetics with negative cooperativity at high substrate concentrations have been observed, with potential allosteric regulation by GTP (chakraborty1999mutationalanalysisof pages 42-48).</p>
+<p>The reaction proceeds via an E1cB (elimination, unimolecular, conjugate base) mechanism involving a carbanion intermediate (chakraborty1999mutationalanalysisof pages 36-42, chakraborty1999mutationalanalysisof pages 42-48). Catalysis is initiated by proton abstraction at the Cβ position of argininosuccinate, generating a carbanion intermediate, followed by proton donation at the guanidinium nitrogen concurrent with cleavage of the Cα–N bond. The elimination proceeds with trans stereochemistry, requiring five atoms (catalytic base, H, Cβ, Cα, and N) to be coplanar. C–N bond cleavage is the likely rate-limiting step, and fumarate release exceeds arginine release by an order of magnitude (chakraborty1999mutationalanalysisof pages 36-42, chakraborty1999mutationalanalysisof pages 42-48).</p>
+<h2 id="2-protein-structure-and-catalytic-architecture">2. Protein Structure and Catalytic Architecture</h2>
+<p>ASL functions as a cytosolic homotetramer with a total molecular weight of approximately 208 kDa, containing four catalytically active sites (chakraborty1999mutationalanalysisof pages 48-53, baruteau2019argininosuccinicaciduriarecent pages 1-6, nagamani2012argininosuccinatelyasedeficiency pages 2-3). Each monomer adopts a predominantly α-helical fold organized into three domains. The active sites are formed at the interfaces of three different subunits within the tetramer, meaning that proper quaternary assembly is essential for enzymatic activity (chakraborty1999mutationalanalysisof pages 48-53, nagamani2012argininosuccinatelyasedeficiency pages 2-3). This multi-subunit active site architecture also underpins the phenomenon of intragenic complementation, whereby heterotetramers formed from two individually inactive mutant monomers can regain partial enzymatic function (baruteau2019argininosuccinicaciduriarecent pages 6-9, engel2012bacterialexpressionof pages 7-8).</p>
+<p>Key catalytic residues include His162, which acts as the general base for proton abstraction; Lys289, which is absolutely conserved and stabilizes the carbanion intermediate; Glu296, which participates in a charge-relay network with His162 to enhance its basicity; and His91, which plays a role in substrate binding and catalysis (chakraborty1999mutationalanalysisof pages 42-48, chakraborty1999mutationalanalysisof pages 48-53). These residues are spatially distributed across different monomers but cluster together at the active site upon tetramer formation. Despite low overall sequence identity (approximately 15%) among superfamily members, three highly conserved regions that contribute these catalytic residues are maintained across all members of the fumarate lyase superfamily (chakraborty1999mutationalanalysisof pages 48-53).</p>
+<h2 id="3-subcellular-localization-and-tissue-distribution">3. Subcellular Localization and Tissue Distribution</h2>
+<p>ASL is a cytosolic enzyme (baruteau2019argininosuccinicaciduriarecent pages 1-6, chakraborty1999mutationalanalysisof pages 36-42, wu1998argininemetabolismnitric pages 2-3). It is predominantly expressed in the liver, where it functions as part of the hepatic urea cycle localized in periportal hepatocytes (baruteau2019argininosuccinicaciduriarecent pages 1-6, wu1998argininemetabolismnitric pages 5-6). However, ASL expression is ubiquitous and is also found at significant levels in the kidney (specifically in proximal tubules, where approximately 60% of net endogenous arginine synthesis occurs in adult mammals), brain, heart, skeletal muscle, skin, hematopoietic tissues, small intestine, pancreas, fibroblasts, and erythrocytes (baruteau2019argininosuccinicaciduriarecent pages 1-6, nagamani2012argininosuccinatelyasedeficiency pages 2-3, erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 3-4, chakraborty1999mutationalanalysisof pages 36-42).</p>
+<p>Importantly, ASL is not only a soluble cytoplasmic enzyme but also participates in a multiprotein complex at specific subcellular locations. In endothelial cells, ASL has been shown to colocalize with the cationic amino acid transporter CAT1, argininosuccinate synthase (ASS1), and endothelial nitric oxide synthase (eNOS) in caveolae, forming a metabolon that channels arginine directly to NOS for nitric oxide (NO) production (baruteau2019argininosuccinicaciduriarecent pages 6-9, mori2004argininemetabolicenzymes pages 2-3). This compartmentalized complex is critical for efficient NO biosynthesis and has functional significance beyond what bulk arginine availability alone would predict.</p>
+<h2 id="4-biochemical-and-signaling-pathways">4. Biochemical and Signaling Pathways</h2>
+<h3 id="41-the-urea-cycle">4.1 The Urea Cycle</h3>
+<p>ASL catalyzes the fourth of five enzymatic steps in the urea cycle, which is the primary pathway for detoxification of ammonia in mammals (baruteau2019argininosuccinicaciduriarecent pages 1-6). In this pathway, ammonia derived from amino acid catabolism is converted to urea through the sequential actions of carbamoyl phosphate synthetase I (CPS1), ornithine transcarbamylase (OTC), argininosuccinate synthase (ASS1), ASL, and arginase 1 (ARG1). The first two steps occur in the mitochondrial matrix, while ASS1, ASL, and ARG1 operate in the cytosol. ASL cleaves argininosuccinate to produce arginine, which is then hydrolyzed by arginase to yield urea and ornithine, completing the cycle. The fumarate released by ASL can enter the TCA cycle as an anaplerotic substrate (wu1998argininemetabolismnitric pages 2-3).</p>
+<h3 id="42-the-citrulline-no-cycle">4.2 The Citrulline-NO Cycle</h3>
+<p>Beyond its role in ureagenesis, ASL functions as a critical component of the citrulline-NO cycle (also called the arginine-citrulline cycle), which supports nitric oxide synthesis (baruteau2019argininosuccinicaciduriarecent pages 1-6, mori2004argininemetabolicenzymes pages 1-2, mori2004argininemetabolicenzymes pages 2-3, keshet2018arginineandthe pages 2-2). In this pathway, ASS1 condenses citrulline (a byproduct of NOS activity) with aspartate to form argininosuccinate, which ASL then cleaves to regenerate arginine. Arginine is subsequently used by NOS to produce NO and citrulline, completing the cycle. This recycling mechanism is essential for sustained NO production in cells expressing all three NOS isoforms (neuronal nNOS, endothelial eNOS, and inducible iNOS) (mori2004argininemetabolicenzymes pages 1-2).</p>
+<p>The citrulline-NO cycle has been demonstrated to be functional in multiple cell types, including activated macrophages, microglia, glial cells, neuronal PC12 cells, retinal pigment epithelial cells, and vascular endothelial cells (mori2004argininemetabolicenzymes pages 1-2). ASL and ASS are coinduced with iNOS during inflammatory stimulation in macrophages, and colocalize with both nNOS and eNOS in neurons and endothelial cells, respectively (mori2004argininemetabolicenzymes pages 2-3). The colocalization of ASL with eNOS in endothelial caveolae, as part of a multiprotein complex including CAT1 and ASS1, facilitates efficient arginine channeling that is essential for regulated NO production (baruteau2019argininosuccinicaciduriarecent pages 6-9, mori2004argininemetabolicenzymes pages 2-3).</p>
+<h3 id="43-arginine-as-a-metabolic-nexus">4.3 Arginine as a Metabolic Nexus</h3>
+<p>Because ASL is the only enzyme in mammalian cells capable of generating endogenous arginine de novo, its product serves as a precursor for multiple biologically important pathways, including the synthesis of urea, NO, polyamines, proline, glutamate, creatine, and agmatine (nagamani2012argininosuccinatelyasedeficiency pages 2-3, erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 3-4, keshet2018arginineandthe pages 2-2). This positions ASL at a critical metabolic nexus linking nitrogen disposal, signaling, protein synthesis, and energy metabolism.</p>
+<h2 id="5-evolutionary-conservation-and-relationship-to-crystallin">5. Evolutionary Conservation and Relationship to δ-Crystallin</h2>
+<p>ASL is highly evolutionarily conserved across species ranging from bacteria and yeast to plants and mammals (erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5, baruteau2019argininosuccinicaciduriarecent pages 6-9). Human and yeast ASL sequences share approximately 50% nucleotide identity and 54% amino acid identity (chakraborty1999mutationalanalysisof pages 36-42). Notably, ASL shares a common ancestral origin with avian δ-crystallins, which were recruited from an ancestral ASL gene to serve structural roles in the lens of birds and reptiles (erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5, chakraborty1999mutationalanalysisof pages 32-36). Of the two avian δ-crystallin isoforms (δI and δII), which share approximately 89% amino acid sequence identity, only δII retains catalytic ASL activity with kinetic parameters comparable to mammalian ASL, while δI has been specialized for a purely structural role (chakraborty1999mutationalanalysisof pages 32-36). This represents a classic example of gene sharing, where a single gene serves both enzymatic and structural functions. The conservation of ASL in birds, which lack a functional urea cycle, further demonstrates that ASL's role in arginine generation for protein synthesis and NO production is evolutionarily fundamental, independent of ureagenesis (erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5). Fifteen of the intron/exon boundaries are in identical positions between the rat ASL gene and chicken δ-crystallin genes, providing strong structural evidence for their shared origin (chakraborty1999mutationalanalysisof pages 32-36).</p>
+<h2 id="6-asl-deficiency-and-disease">6. ASL Deficiency and Disease</h2>
+<h3 id="61-argininosuccinic-aciduria-asa">6.1 Argininosuccinic Aciduria (ASA)</h3>
+<p>Biallelic pathogenic variants in <em>ASL</em> cause argininosuccinate lyase deficiency (ASLD; OMIM 207900), also known as argininosuccinic aciduria (ASA), an autosomal recessive urea cycle disorder (baruteau2019argininosuccinicaciduriarecent pages 1-6, kho2023argininosuccinatelyasedeficiency pages 1-2). ASLD presents as a spectrum of disease ranging from severe neonatal-onset hyperammonemia to late-onset and even asymptomatic forms. Approximately 140 pathogenic variants have been documented in the <em>ASL</em> gene, including missense, nonsense, insertion, deletion, and splicing mutations, with exons 4, 5, and 7 identified as mutational hotspots (erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5, baruteau2019argininosuccinicaciduriarecent pages 6-9). Three founder mutations have been identified in Saudi Arabian and Finnish populations (baruteau2019argininosuccinicaciduriarecent pages 6-9). A notable feature of ASLD is the phenomenon of intragenic complementation, whereby compound heterozygous patients may have milder phenotypes than expected from individual allelic effects, owing to the multi-subunit active site architecture (baruteau2019argininosuccinicaciduriarecent pages 6-9, engel2012bacterialexpressionof pages 7-8).</p>
+<h3 id="62-beyond-hyperammonemia-no-deficiency-and-systemic-disease">6.2 Beyond Hyperammonemia: NO Deficiency and Systemic Disease</h3>
+<p>A critical insight from recent research is that ASLD is not merely a disorder of ammonia detoxification but a systemic disease with neurocognitive, hepatic, and vascular manifestations that can occur independently of hyperammonemia (baruteau2019argininosuccinicaciduriarecent pages 1-6, kho2023argininosuccinatelyasedeficiency pages 1-2). This is attributable to ASL's role in the citrulline-NO cycle: loss of ASL leads to cell-autonomous NO deficiency because arginine cannot be regenerated intracellularly for NOS, even when extracellular arginine is available (kho2023argininosuccinatelyasedeficiency pages 4-6, kho2023argininosuccinatelyasedeficiency pages 6-7, kho2023argininosuccinatelyasedeficiency pages 2-4). A landmark study by Kho et al. (2023) demonstrated that ASL deficiency disrupts blood-brain barrier (BBB) integrity through NO-mediated dysregulation of tight junction claudin proteins, specifically causing upregulation of claudin-1 and downregulation of claudin-5 in brain microvascular endothelial cells (kho2023argininosuccinatelyasedeficiency pages 4-6, kho2023argininosuccinatelyasedeficiency pages 2-4, kho2023argininosuccinatelyasedeficiency pages 7-9). In vivo, hypomorphic ASL-deficient mice showed BBB leakage that was partially rescued by NO supplementation with sodium nitrite, establishing a direct mechanistic link between ASL-dependent NO production and BBB maintenance (kho2023argininosuccinatelyasedeficiency pages 6-7, kho2023argininosuccinatelyasedeficiency pages 9-10).</p>
+<p>Additionally, Gurung et al. (2024) identified dysregulation of glutathione biosynthesis and oxidative stress as a novel pathophysiological mechanism in ASLD, with upregulated cysteine metabolism contrasting with glutathione depletion and downregulated antioxidant pathways in both patients and animal models (gurung2024mrnatherapycorrects pages 11-12, gurung2024mrnatherapycorrects pages 1-3).</p>
+<h3 id="63-emerging-therapeutic-approaches">6.3 Emerging Therapeutic Approaches</h3>
+<p>Several novel therapeutic strategies for ASLD are under active development:</p>
+<p><strong>mRNA Therapy:</strong> Gurung et al. (2024) demonstrated that human ASL mRNA encapsulated in lipid nanoparticles (LNP) corrected glutathione metabolism, improved chronic liver disease, and restored ureagenesis in ASL-deficient mouse models. Treatment from birth normalized plasma metabolites and liver ASL expression. The study also introduced [18F]FSPG PET as a noninvasive tool to monitor disease and therapeutic response (gurung2024mrnatherapycorrects pages 11-12, gurung2024mrnatherapycorrects pages 1-3). Independently, Daly et al. (2023) showed that nucleoside-modified ASL mRNA-LNP provided complete survival protection in ASL-deficient mice at 3 mg/kg administered twice weekly, with a favorable safety and immunogenicity profile (daly2023aslmrnalnptherapeutic pages 1-2, daly2023aslmrnalnptherapeutic pages 11-13).</p>
+<p><strong>CRISPR Base Editing:</strong> Jalil et al. (2024) demonstrated that CRISPR adenine base editors (ABE8e) delivered via lipid nanoparticles could correct the common c.1153C&gt;T pathogenic variant in patient-derived primary fibroblasts, restoring ASL enzyme activity to approximately 59% of healthy donor levels and significantly reducing argininosuccinic acid accumulation (jalil2024geneticandfunctional pages 11-12).</p>
+<p>These therapeutic advances underscore the dual enzymatic and structural roles of ASL—liver-directed therapies can address ureagenesis and hepatic disease, but the systemic NO-related manifestations, particularly neurological complications, remain a challenge that may require complementary approaches (daly2023aslmrnalnptherapeutic pages 13-15).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>Human ASL (P04424) is a cytosolic homotetrameric enzyme that catalyzes the reversible β-elimination of argininosuccinate to yield arginine and fumarate via an E1cB mechanism with a carbanion intermediate. It operates at the intersection of two critical metabolic pathways—the urea cycle for ammonia detoxification and the citrulline-NO cycle for nitric oxide synthesis—and is the sole enzyme capable of endogenous arginine generation. ASL is expressed broadly across tissues, with highest levels in liver and kidney. Its participation in a multiprotein complex with ASS1 and NOS enables arginine channeling for regulated NO production in endothelial and other cell types. ASL is highly conserved from bacteria to mammals and shares evolutionary and structural origins with avian δ-crystallins. Loss-of-function mutations cause argininosuccinic aciduria, a systemic disorder with hyperammonemia, NO deficiency, glutathione dysregulation, and neurovascular complications including blood-brain barrier disruption. Recent therapeutic advances including mRNA-LNP and CRISPR base editing approaches show significant preclinical promise for correcting ASL deficiency.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(baruteau2019argininosuccinicaciduriarecent pages 1-6): Julien Baruteau, Carmen Diez‐Fernandez, Shaul Lerner, Giusy Ranucci, Paul Gissen, Carlo Dionisi‐Vici, Sandesh Nagamani, Ayelet Erez, and Johannes Häberle. Argininosuccinic aciduria: recent pathophysiological insights and therapeutic prospects. Journal of Inherited Metabolic Disease, 42:1147-1161, Nov 2019. URL: https://doi.org/10.1002/jimd.12047, doi:10.1002/jimd.12047. This article has 58 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 4-5): Ayelet Erez, Sandesh C. Sreenath Nagamani, and Brendan Lee. Argininosuccinate lyase deficiency—argininosuccinic aciduria and beyond. American Journal of Medical Genetics Part C: Seminars in Medical Genetics, 157:45-53, Feb 2011. URL: https://doi.org/10.1002/ajmg.c.30289, doi:10.1002/ajmg.c.30289. This article has 132 citations.</p>
+</li>
+<li>
+<p>(baruteau2019argininosuccinicaciduriarecent pages 6-9): Julien Baruteau, Carmen Diez‐Fernandez, Shaul Lerner, Giusy Ranucci, Paul Gissen, Carlo Dionisi‐Vici, Sandesh Nagamani, Ayelet Erez, and Johannes Häberle. Argininosuccinic aciduria: recent pathophysiological insights and therapeutic prospects. Journal of Inherited Metabolic Disease, 42:1147-1161, Nov 2019. URL: https://doi.org/10.1002/jimd.12047, doi:10.1002/jimd.12047. This article has 58 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nagamani2012argininosuccinatelyasedeficiency pages 2-3): Sandesh C.S. Nagamani, Ayelet Erez, and Brendan Lee. Argininosuccinate lyase deficiency. May 2012. URL: https://doi.org/10.1038/gim.2011.1, doi:10.1038/gim.2011.1. This article has 174 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chakraborty1999mutationalanalysisof pages 48-53): Anita R. Chakraborty, Alan Davidson, and P. Lynne Howell. Mutational analysis of amino acid residues involved in argininosuccinate lyase activity in duck delta ii crystallin. Biochemistry, 38 8:2435-43, Feb 1999. URL: https://doi.org/10.1021/bi982150g, doi:10.1021/bi982150g. This article has 36 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(toth2000thestructureof pages 1-2): Eric A Toth and Todd O Yeates. The structure of adenylosuccinate lyase, an enzyme with dual activity in the de novo purine biosynthetic pathway. Structure, 8 2:163-74, Feb 2000. URL: https://doi.org/10.1016/s0969-2126(00)00092-7, doi:10.1016/s0969-2126(00)00092-7. This article has 129 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chakraborty1999mutationalanalysisof pages 36-42): Anita R. Chakraborty, Alan Davidson, and P. Lynne Howell. Mutational analysis of amino acid residues involved in argininosuccinate lyase activity in duck delta ii crystallin. Biochemistry, 38 8:2435-43, Feb 1999. URL: https://doi.org/10.1021/bi982150g, doi:10.1021/bi982150g. This article has 36 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu1998argininemetabolismnitric pages 2-3): Guoyao WU and Sidney M. MORRIS. Arginine metabolism: nitric oxide and beyond. The Biochemical journal, 336 ( Pt 1):1-17, Nov 1998. URL: https://doi.org/10.1042/bj3360001, doi:10.1042/bj3360001. This article has 3857 citations.</p>
+</li>
+<li>
+<p>(keshet2018arginineandthe pages 2-2): Rom Keshet and Ayelet Erez. Arginine and the metabolic regulation of nitric oxide synthesis in cancer. Disease Models &amp; Mechanisms, Aug 2018. URL: https://doi.org/10.1242/dmm.033332, doi:10.1242/dmm.033332. This article has 197 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chakraborty1999mutationalanalysisof pages 42-48): Anita R. Chakraborty, Alan Davidson, and P. Lynne Howell. Mutational analysis of amino acid residues involved in argininosuccinate lyase activity in duck delta ii crystallin. Biochemistry, 38 8:2435-43, Feb 1999. URL: https://doi.org/10.1021/bi982150g, doi:10.1021/bi982150g. This article has 36 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mori2004argininemetabolicenzymes pages 2-3): Masataka Mori and Tomomi Gotoh. Arginine metabolic enzymes, nitric oxide and infection. The Journal of nutrition, 134 10 Suppl:2820S-2825S;discussion2853S, Oct 2004. URL: https://doi.org/10.1093/jn/134.10.2820s, doi:10.1093/jn/134.10.2820s. This article has 215 citations.</p>
+</li>
+<li>
+<p>(mori2004argininemetabolicenzymes pages 1-2): Masataka Mori and Tomomi Gotoh. Arginine metabolic enzymes, nitric oxide and infection. The Journal of nutrition, 134 10 Suppl:2820S-2825S;discussion2853S, Oct 2004. URL: https://doi.org/10.1093/jn/134.10.2820s, doi:10.1093/jn/134.10.2820s. This article has 215 citations.</p>
+</li>
+<li>
+<p>(gurung2024mrnatherapycorrects pages 11-12): Sonam Gurung, Oskar Vilhelmsson Timmermand, Dany Perocheau, Ana Luisa Gil-Martinez, Magdalena Minnion, Loukia Touramanidou, Sherry Fang, Martina Messina, Youssef Khalil, Justyna Spiewak, Abigail R. Barber, Richard S. Edwards, Patricia Lipari Pinto, Patrick F. Finn, Alex Cavedon, Summar Siddiqui, Lisa Rice, Paolo G. V. Martini, Deborah Ridout, Wendy Heywood, Ian Hargreaves, Simon Heales, Philippa B. Mills, Simon N. Waddington, Paul Gissen, Simon Eaton, Mina Ryten, Martin Feelisch, Andrea Frassetto, Timothy H. Witney, and Julien Baruteau. Mrna therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria. Science translational medicine, 16:eadh1334-eadh1334, Jan 2024. URL: https://doi.org/10.1126/scitranslmed.adh1334, doi:10.1126/scitranslmed.adh1334. This article has 37 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kho2023argininosuccinatelyasedeficiency pages 4-6): Jordan Kho, Urszula Polak, Ming-Ming Jiang, John D. Odom, Jill V. Hunter, Saima M. Ali, Lindsay C. Burrage, Sandesh C.S. Nagamani, Robia G. Pautler, Hannah P. Thompson, Akihiko Urayama, Zixue Jin, and Brendan Lee. Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide–mediated dysregulation of claudin expression. JCI Insight, Sep 2023. URL: https://doi.org/10.1172/jci.insight.168475, doi:10.1172/jci.insight.168475. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chakraborty1999mutationalanalysisof pages 32-36): Anita R. Chakraborty, Alan Davidson, and P. Lynne Howell. Mutational analysis of amino acid residues involved in argininosuccinate lyase activity in duck delta ii crystallin. Biochemistry, 38 8:2435-43, Feb 1999. URL: https://doi.org/10.1021/bi982150g, doi:10.1021/bi982150g. This article has 36 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(engel2012bacterialexpressionof pages 7-8): Katharina Engel, Jean‐Marc Vuissoz, Sandra Eggimann, Murielle Groux, Christoph Berning, Liyan Hu, Vera Klaus, Dorothea Moeslinger, Saadet Mercimek‐Mahmutoglu, Sylvia Stöckler, Bendicht Wermuth, Johannes Häberle, and Jean‐Marc Nuoffer. Bacterial expression of mutant argininosuccinate lyase reveals imperfect correlation of in-vitro enzyme activity with clinical phenotype in argininosuccinic aciduria. Journal of Inherited Metabolic Disease, 35:133-140, Jan 2012. URL: https://doi.org/10.1007/s10545-011-9357-x, doi:10.1007/s10545-011-9357-x. This article has 21 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu1998argininemetabolismnitric pages 5-6): Guoyao WU and Sidney M. MORRIS. Arginine metabolism: nitric oxide and beyond. The Biochemical journal, 336 ( Pt 1):1-17, Nov 1998. URL: https://doi.org/10.1042/bj3360001, doi:10.1042/bj3360001. This article has 3857 citations.</p>
+</li>
+<li>
+<p>(erez2011argininosuccinatelyasedeficiency—argininosuccinic pages 3-4): Ayelet Erez, Sandesh C. Sreenath Nagamani, and Brendan Lee. Argininosuccinate lyase deficiency—argininosuccinic aciduria and beyond. American Journal of Medical Genetics Part C: Seminars in Medical Genetics, 157:45-53, Feb 2011. URL: https://doi.org/10.1002/ajmg.c.30289, doi:10.1002/ajmg.c.30289. This article has 132 citations.</p>
+</li>
+<li>
+<p>(kho2023argininosuccinatelyasedeficiency pages 1-2): Jordan Kho, Urszula Polak, Ming-Ming Jiang, John D. Odom, Jill V. Hunter, Saima M. Ali, Lindsay C. Burrage, Sandesh C.S. Nagamani, Robia G. Pautler, Hannah P. Thompson, Akihiko Urayama, Zixue Jin, and Brendan Lee. Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide–mediated dysregulation of claudin expression. JCI Insight, Sep 2023. URL: https://doi.org/10.1172/jci.insight.168475, doi:10.1172/jci.insight.168475. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kho2023argininosuccinatelyasedeficiency pages 6-7): Jordan Kho, Urszula Polak, Ming-Ming Jiang, John D. Odom, Jill V. Hunter, Saima M. Ali, Lindsay C. Burrage, Sandesh C.S. Nagamani, Robia G. Pautler, Hannah P. Thompson, Akihiko Urayama, Zixue Jin, and Brendan Lee. Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide–mediated dysregulation of claudin expression. JCI Insight, Sep 2023. URL: https://doi.org/10.1172/jci.insight.168475, doi:10.1172/jci.insight.168475. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kho2023argininosuccinatelyasedeficiency pages 2-4): Jordan Kho, Urszula Polak, Ming-Ming Jiang, John D. Odom, Jill V. Hunter, Saima M. Ali, Lindsay C. Burrage, Sandesh C.S. Nagamani, Robia G. Pautler, Hannah P. Thompson, Akihiko Urayama, Zixue Jin, and Brendan Lee. Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide–mediated dysregulation of claudin expression. JCI Insight, Sep 2023. URL: https://doi.org/10.1172/jci.insight.168475, doi:10.1172/jci.insight.168475. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kho2023argininosuccinatelyasedeficiency pages 7-9): Jordan Kho, Urszula Polak, Ming-Ming Jiang, John D. Odom, Jill V. Hunter, Saima M. Ali, Lindsay C. Burrage, Sandesh C.S. Nagamani, Robia G. Pautler, Hannah P. Thompson, Akihiko Urayama, Zixue Jin, and Brendan Lee. Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide–mediated dysregulation of claudin expression. JCI Insight, Sep 2023. URL: https://doi.org/10.1172/jci.insight.168475, doi:10.1172/jci.insight.168475. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kho2023argininosuccinatelyasedeficiency pages 9-10): Jordan Kho, Urszula Polak, Ming-Ming Jiang, John D. Odom, Jill V. Hunter, Saima M. Ali, Lindsay C. Burrage, Sandesh C.S. Nagamani, Robia G. Pautler, Hannah P. Thompson, Akihiko Urayama, Zixue Jin, and Brendan Lee. Argininosuccinate lyase deficiency causes blood-brain barrier disruption via nitric oxide–mediated dysregulation of claudin expression. JCI Insight, Sep 2023. URL: https://doi.org/10.1172/jci.insight.168475, doi:10.1172/jci.insight.168475. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gurung2024mrnatherapycorrects pages 1-3): Sonam Gurung, Oskar Vilhelmsson Timmermand, Dany Perocheau, Ana Luisa Gil-Martinez, Magdalena Minnion, Loukia Touramanidou, Sherry Fang, Martina Messina, Youssef Khalil, Justyna Spiewak, Abigail R. Barber, Richard S. Edwards, Patricia Lipari Pinto, Patrick F. Finn, Alex Cavedon, Summar Siddiqui, Lisa Rice, Paolo G. V. Martini, Deborah Ridout, Wendy Heywood, Ian Hargreaves, Simon Heales, Philippa B. Mills, Simon N. Waddington, Paul Gissen, Simon Eaton, Mina Ryten, Martin Feelisch, Andrea Frassetto, Timothy H. Witney, and Julien Baruteau. Mrna therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria. Science translational medicine, 16:eadh1334-eadh1334, Jan 2024. URL: https://doi.org/10.1126/scitranslmed.adh1334, doi:10.1126/scitranslmed.adh1334. This article has 37 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(daly2023aslmrnalnptherapeutic pages 1-2): Owen Daly, Azita Josefine Mahiny, Sara Majeski, Kevin McClintock, Julia Reichert, Gábor Boros, Gábor Tamás Szabó, Jonas Reinholz, Petra Schreiner, Steve Reid, Kieu Lam, Marlen Lepper, Melanie Adler, Tracy Meffen, James Heyes, Katalin Karikó, Pete Lutwyche, and Irena Vlatkovic. Asl mrna-lnp therapeutic for the treatment of argininosuccinic aciduria enables survival benefit in a mouse model. Biomedicines, 11:1735, Jun 2023. URL: https://doi.org/10.3390/biomedicines11061735, doi:10.3390/biomedicines11061735. This article has 4 citations.</p>
+</li>
+<li>
+<p>(daly2023aslmrnalnptherapeutic pages 11-13): Owen Daly, Azita Josefine Mahiny, Sara Majeski, Kevin McClintock, Julia Reichert, Gábor Boros, Gábor Tamás Szabó, Jonas Reinholz, Petra Schreiner, Steve Reid, Kieu Lam, Marlen Lepper, Melanie Adler, Tracy Meffen, James Heyes, Katalin Karikó, Pete Lutwyche, and Irena Vlatkovic. Asl mrna-lnp therapeutic for the treatment of argininosuccinic aciduria enables survival benefit in a mouse model. Biomedicines, 11:1735, Jun 2023. URL: https://doi.org/10.3390/biomedicines11061735, doi:10.3390/biomedicines11061735. This article has 4 citations.</p>
+</li>
+<li>
+<p>(jalil2024geneticandfunctional pages 11-12): Sami Jalil, Timo Keskinen, Juhana Juutila, Rocio Sartori Maldonado, Liliya Euro, Anu Suomalainen, Risto Lapatto, Emilia Kuuluvainen, Ville Hietakangas, Timo Otonkoski, Mervi E. Hyvönen, and Kirmo Wartiovaara. Genetic and functional correction of argininosuccinate lyase deficiency using crispr adenine base editors. American Journal of Human Genetics, 111:714-728, Apr 2024. URL: https://doi.org/10.1016/j.ajhg.2024.03.004, doi:10.1016/j.ajhg.2024.03.004. This article has 21 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(daly2023aslmrnalnptherapeutic pages 13-15): Owen Daly, Azita Josefine Mahiny, Sara Majeski, Kevin McClintock, Julia Reichert, Gábor Boros, Gábor Tamás Szabó, Jonas Reinholz, Petra Schreiner, Steve Reid, Kieu Lam, Marlen Lepper, Melanie Adler, Tracy Meffen, James Heyes, Katalin Karikó, Pete Lutwyche, and Irena Vlatkovic. Asl mrna-lnp therapeutic for the treatment of argininosuccinic aciduria enables survival benefit in a mouse model. Biomedicines, 11:1735, Jun 2023. URL: https://doi.org/10.3390/biomedicines11061735, doi:10.3390/biomedicines11061735. This article has 4 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ASL-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>nagamani2012argininosuccinatelyasedeficiency pages 2-3</li>
+<li>baruteau2019argininosuccinicaciduriarecent pages 1-6</li>
+<li>chakraborty1999mutationalanalysisof pages 32-36</li>
+<li>chakraborty1999mutationalanalysisof pages 42-48</li>
+<li>chakraborty1999mutationalanalysisof pages 48-53</li>
+<li>wu1998argininemetabolismnitric pages 2-3</li>
+<li>mori2004argininemetabolicenzymes pages 1-2</li>
+<li>mori2004argininemetabolicenzymes pages 2-3</li>
+<li>chakraborty1999mutationalanalysisof pages 36-42</li>
+<li>baruteau2019argininosuccinicaciduriarecent pages 6-9</li>
+<li>jalil2024geneticandfunctional pages 11-12</li>
+<li>daly2023aslmrnalnptherapeutic pages 13-15</li>
+<li>toth2000thestructureof pages 1-2</li>
+<li>keshet2018arginineandthe pages 2-2</li>
+<li>gurung2024mrnatherapycorrects pages 11-12</li>
+<li>kho2023argininosuccinatelyasedeficiency pages 4-6</li>
+<li>engel2012bacterialexpressionof pages 7-8</li>
+<li>wu1998argininemetabolismnitric pages 5-6</li>
+<li>kho2023argininosuccinatelyasedeficiency pages 1-2</li>
+<li>kho2023argininosuccinatelyasedeficiency pages 6-7</li>
+<li>kho2023argininosuccinatelyasedeficiency pages 2-4</li>
+<li>kho2023argininosuccinatelyasedeficiency pages 7-9</li>
+<li>kho2023argininosuccinatelyasedeficiency pages 9-10</li>
+<li>gurung2024mrnatherapycorrects pages 1-3</li>
+<li>daly2023aslmrnalnptherapeutic pages 1-2</li>
+<li>daly2023aslmrnalnptherapeutic pages 11-13</li>
+<li>18F</li>
+<li>https://doi.org/10.1002/jimd.12047,</li>
+<li>https://doi.org/10.1002/ajmg.c.30289,</li>
+<li>https://doi.org/10.1038/gim.2011.1,</li>
+<li>https://doi.org/10.1021/bi982150g,</li>
+<li>https://doi.org/10.1016/s0969-2126(00</li>
+<li>https://doi.org/10.1042/bj3360001,</li>
+<li>https://doi.org/10.1242/dmm.033332,</li>
+<li>https://doi.org/10.1093/jn/134.10.2820s,</li>
+<li>https://doi.org/10.1126/scitranslmed.adh1334,</li>
+<li>https://doi.org/10.1172/jci.insight.168475,</li>
+<li>https://doi.org/10.1007/s10545-011-9357-x,</li>
+<li>https://doi.org/10.3390/biomedicines11061735,</li>
+<li>https://doi.org/10.1016/j.ajhg.2024.03.004,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ASL-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P04424" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="asl-argininosuccinate-lyase-p04424-review-notes">ASL (argininosuccinate lyase, P04424) — review notes</h1>
+<h2 id="core-enzyme-function">Core enzyme function</h2>
+<p>ASL catalyzes the reversible cleavage of L-argininosuccinate to L-arginine + fumarate (EC 4.3.2.1;<br />
+RHEA:24020). It is the third/final step of the L-arginine biosynthesis branch and the second-to-last<br />
+step of the urea cycle (cytosolic).</p>
+<ul>
+<li>UniProt P04424 FUNCTION: "Catalyzes the reversible cleavage of L-argininosuccinate to fumarate and<br />
+  L-arginine, an intermediate step reaction in the urea cycle mostly providing for hepatic nitrogen<br />
+  detoxification into excretable urea as well as de novo L-arginine synthesis in nonhepatic tissues"<br />
+  (ECO:0000269 from PubMed:11747432, 11747433, 22081021, 2263616, 9045711).</li>
+<li>EC 4.3.2.1 established by direct enzyme assay in humans, e.g. <a href="https://pubmed.ncbi.nlm.nih.gov/282632" title="associated with a   deficiency of argininosuccinate lyase (ASL; L-argininosuccinate arginine-lyase, EC 4.3.2.1)">PMID:282632</a>.</li>
+<li>Homotetramer: <a href="https://pubmed.ncbi.nlm.nih.gov/11747433" title="Argininosuccinate lyase (ASL) is a homotetrameric enzyme that   catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.">PMID:11747433</a>; first<br />
+  high-resolution human structure is the Q286R allele <a href="https://pubmed.ncbi.nlm.nih.gov/11747432" title="This is the first   high-resolution structure of human ASL.">PMID:11747432</a>. Active sites are shared between tetramer subunits,<br />
+  the basis of the well-documented intragenic complementation in ASA patients.</li>
+<li>Lyase 1 family, argininosuccinate lyase subfamily; fumarase/aspartase (L-aspartase-like) superfamily<br />
+  (UniProt SIMILARITY + InterPro IPR008948 L-Aspartase-like, IPR000362 Fumarate_lyase_fam).</li>
+</ul>
+<h2 id="second-non-catalytic-structural-role-nitric-oxide-production">Second, non-catalytic (structural) role: nitric oxide production</h2>
+<p>ASL has a well-documented structural role in assembling a NOS-containing multiprotein complex that<br />
+channels arginine to nitric oxide synthase; this is independent of catalytic activity.</p>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/22081021" title="Mechanistic studies showed that ASL has a structural function in addition to its   catalytic activity, by which it contributes to the formation of a multiprotein complex required for   NO production.">PMID:22081021</a></li>
+<li>Human catalytic-dead mutants retain the structural function: R236W "abolishes the enzymatic<br />
+  activity ... but does not abolish its tertiary structure"; overexpressing R113Q (catalytically dead)<br />
+  in ASA fibroblasts restored arginine-stimulated nitrite (NO) production. Loss of ASL, not loss of<br />
+  its catalysis, disrupts the NOS complex.</li>
+<li>Human ASA subjects show loss of NOS-dependent (flow-mediated) vascular relaxation but normal<br />
+  response to a NOS-independent NO donor (nitroglycerin), and reduced plasma RSNO/nitrite despite<br />
+  high plasma arginine — a systemic NO deficiency phenotype distinct from hyperammonemia.</li>
+<li>UniProt SUBUNIT: "Forms tissue-specific complexes with ASS1, SLC7A1, HSP90AA1 and nitric oxide<br />
+  synthase NOS1, NOS2 or NOS3; the complex maintenance is independent of ASL catalytic function"<br />
+  (partly By similarity to mouse Q91YI0).</li>
+<li>GOA term used is GO:0045429 "positive regulation of nitric oxide biosynthetic process" (IMP,<br />
+  PMID:22081021, human ASL) and an Ensembl-Compara ortholog-transfer IEA (GO_REF:0000107) of the<br />
+  same term from mouse Asl (Q91YI0). Both point to the same real biology.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Argininosuccinic aciduria (ASA / ASLD; MIM 207900; MONDO:0008815), autosomal recessive, second most<br />
+common urea cycle disorder (~1 in 70,000; dismech kb/disorders/Argininosuccinic_Aciduria.yaml). Beyond<br />
+hyperammonemia, chronic ammonia-independent complications (neurocognitive, hepatic fibrosis, systemic<br />
+hypertension) are attributed in part to cell-autonomous NO deficiency (PMID:22081021).</p>
+<h2 id="localization">Localization</h2>
+<p>Cytosolic enzyme (GO:0005829). UniProt DR: cytosol IBA (GO_Central), cytoplasm TAS (ProtInc,<br />
+PMID:282632). Also detected in urinary exosomes by large-scale proteomics <a href="https://pubmed.ncbi.nlm.nih.gov/19056867">PMID:19056867</a> — a<br />
+mass-spec location catalog finding, not a curated site of action.</p>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>Core: GO:0004056 (MF, EXP/IDA/IBA), GO:0000050 urea cycle (BP), GO:0006526 L-arginine biosynthetic<br />
+  process (BP), GO:0005829 cytosol (CC), GO:0042802 identical protein binding (homotetramer).</li>
+<li>Second core / non-core: GO:0045429 positive regulation of NO biosynthetic process (structural NOS<br />
+  role, PMID:22081021).</li>
+<li>MARK_AS_OVER_ANNOTATED: GO:0003824 catalytic activity (root MF, InterPro IEA) — too general; a<br />
+  specific EC 4.3.2.1 term (GO:0004056) is annotated.</li>
+<li>Bare GO:0005515 protein binding IPI (from high-throughput interactome/Y2H/AP-MS screens): not<br />
+  informative MF; the biologically meaningful self-association is captured by GO:0042802. Keep as<br />
+  non-core (evidence exists) but not core.</li>
+<li>GO:0070062 extracellular exosome (HDA, urinary exosome proteomics) — mass-spec catalog location,<br />
+  keep as non-core.</li>
+<li>GO:0006525 arginine metabolic process (IDA) — correct but general parent of the more specific<br />
+  GO:0006526; keep as non-core.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P04424
+gene_symbol: ASL
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  Argininosuccinate lyase (ASL; arginosuccinase; EC 4.3.2.1) is a cytosolic enzyme
+  that catalyzes the reversible cleavage of L-argininosuccinate into L-arginine and
+  fumarate. This reaction is the third and final step of L-arginine biosynthesis and
+  a step of the urea cycle, in which ASL acts downstream of argininosuccinate synthase
+  (ASS1) to regenerate arginine; in hepatocytes arginine is then hydrolyzed by arginase
+  to release urea for nitrogen detoxification, while in non-hepatic tissues ASL provides
+  arginine for other pathways. ASL is a homotetramer belonging to the lyase 1 family
+  (argininosuccinate lyase subfamily) within the fumarase/aspartase (L-aspartase-like)
+  superfamily; its four active sites are each built from residues contributed by more
+  than one subunit, which is the structural basis for the extensive intragenic (interallelic)
+  complementation seen among disease alleles. Beyond its catalytic role, ASL has a
+  distinct, catalysis-independent structural function: it is required to assemble and
+  maintain a tissue-specific multiprotein complex (with argininosuccinate synthase,
+  the arginine transporter SLC7A1/CAT-1, HSP90 and a nitric oxide synthase NOS1/NOS2/NOS3)
+  that channels intracellular and extracellular arginine to nitric oxide synthesis.
+  Loss of ASL function causes argininosuccinic aciduria, an autosomal recessive urea
+  cycle disorder featuring hyperammonemia together with ammonia-independent systemic
+  features (systemic hypertension, chronic hepatic disease, neurocognitive impairment)
+  attributable in part to cell-autonomous nitric oxide deficiency.
+alternative_products:
+- name: &#39;1&#39;
+  id: P04424-1
+- name: &#39;2&#39;
+  id: P04424-2
+  sequence_note: VSP_047256
+- name: &#39;3&#39;
+  id: P04424-3
+  sequence_note: VSP_047255
+existing_annotations:
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred core molecular function. ASL cleaves L-argininosuccinate
+      to L-arginine and fumarate (EC 4.3.2.1), the reaction that defines this orthology
+      group and is directly supported for the human enzyme by biochemical assay.
+    action: ACCEPT
+    reason: &gt;-
+      This is the correct, well-supported core molecular function of ASL. The IBA
+      is concordant with multiple human experimental annotations (EXP/IDA) and with
+      the UniProt-curated catalytic activity.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred involvement in L-arginine biosynthesis. ASL performs
+      the final (argininosuccinate-cleaving) step of de novo arginine synthesis from
+      ornithine and carbamoyl phosphate.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process, concordant with human IDA annotations and the
+      UniProt-curated arginine-biosynthesis pathway (step 3/3). ASL supplies arginine
+      both for the urea cycle in liver and for other arginine-dependent pathways in
+      non-hepatic tissues.
+    supported_by:
+    - reference_id: PMID:11747432
+      supporting_text: a reaction involved in the biosynthesis of arginine in all
+        species and in the production of urea in ureotelic species
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred cytosolic localization. ASL is a soluble cytosolic
+      enzyme; its urea-cycle and arginine-biosynthesis reactions occur in the cytosol.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core cellular component, concordant with the human TAS cytosol/cytoplasm
+      annotations and with the soluble, non-membrane biochemistry of the enzyme.
+    supported_by:
+    - reference_id: PMID:282632
+      supporting_text: ASL activity was visualized on gels after electrophoresis by
+        a new method, termed bioautography
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root-level catalytic activity assigned electronically from InterPro domain membership
+      (fumarase/aspartase superfamily). This is the uninformative parent of the specific,
+      correct term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      ASL&#39;s molecular function is captured precisely and correctly by GO:0004056 argininosuccinate
+      lyase activity (EC 4.3.2.1), which is annotated with strong experimental (EXP/IDA)
+      and phylogenetic (IBA) support. GO:0003824 is the most general MF root and adds
+      no information beyond &#34;is an enzyme&#34;; it should not be considered a core function
+      statement.
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic assignment of argininosuccinate lyase activity from InterPro signature
+      IPR009049, RHEA:24020 and EC 4.3.2.1. This is the correct core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and specific molecular function, fully concordant with the human experimental
+      and phylogenetic annotations to the same term.
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment of L-arginine biosynthetic process from UniPathway mapping
+      and ortholog evidence. Correct core process.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with human IDA and IBA annotations to the same process; matches the
+      UniProt-curated arginine biosynthesis pathway (step 3/3).
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic protein binding recorded from a proteome-scale binary interactome (Y2H)
+      screen (interactor NTAQ1, Q96HA8). The bare protein binding term is uninformative
+      about ASL&#39;s molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Per curation guidelines, bare GO:0005515 protein binding is not an informative
+      molecular-function statement and is not a core function. The biologically meaningful
+      self-association of ASL is captured by GO:0042802 (identical protein binding);
+      the physiologically important heteromeric interactions (ASS1, SLC7A1, NOS) underlie
+      the nitric-oxide role captured by GO:0045429. The interaction evidence itself
+      is retained as non-core.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26871637
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic protein binding from a high-throughput interactome study of alternative-splicing
+      isoforms (interactor MCMBP isoform, Q9BTE3-2). Uninformative MF term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Bare protein binding is not an informative molecular function and is not core.
+      The interaction detection is retained as non-core supporting data; the informative
+      self-interaction is annotated separately as GO:0042802.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic protein binding from a large-scale study of interaction disruption by
+      genetic variants (interactor NTAQ1, Q96HA8). Uninformative MF term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Bare protein binding is not an informative molecular function and is not core;
+      retained as non-core interaction evidence.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic protein binding from the HuRI reference binary interactome (multiple
+      interactors, e.g. TRIM3 O75382, NTAQ1 Q96HA8, MCMBP Q9BTE3-2). Uninformative
+      MF term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Bare protein binding is not an informative molecular function and is not core;
+      retained as non-core interaction evidence. Physiologically relevant heteromeric
+      partners (ASS1/SLC7A1/NOS) are not among these high-throughput hits.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ASL self-association (P04424-P04424) detected in a human liver protein interaction
+      network study. This reflects the biologically real homotetramer.
+    action: ACCEPT
+    reason: &gt;-
+      ASL is an obligate homotetramer whose subunits jointly form the shared active
+      sites; self-association is intrinsic to its catalytic architecture and is directly
+      supported by structural and biochemical work. This is an informative, correct
+      molecular-function statement (unlike bare protein binding).
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ASL self-association (P04424-P04424) detected in a proteome-scale binary interactome,
+      consistent with the homotetramer.
+    action: ACCEPT
+    reason: Corroborates the biologically real ASL homotetramer; informative and correct.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25502805
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ASL self-association (P04424-P04424) detected in a massively parallel clone/variant
+      interaction pipeline, consistent with the homotetramer.
+    action: ACCEPT
+    reason: Corroborates the homotetramer; informative and correct self-interaction
+      annotation.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ASL self-association (P04424-P04424) detected in a study of variant effects
+      on protein interactions, consistent with the homotetramer.
+    action: ACCEPT
+    reason: Corroborates the homotetramer; informative and correct self-interaction
+      annotation.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ASL self-association (P04424-P04424) detected in the HuRI reference binary interactome,
+      consistent with the homotetramer.
+    action: ACCEPT
+    reason: Corroborates the biologically real ASL homotetramer; informative and correct.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0045429
+    label: positive regulation of nitric oxide biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer of a mouse Asl (Q91YI0) experimental annotation
+      for the role of ASL in promoting nitric oxide biosynthesis. This transfers the
+      same biology established experimentally for both mouse and human ASL in PMID:22081021.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The underlying biology is genuine and experimentally supported in both species
+      - ASL contributes, via a catalysis-independent structural role in the NOS multiprotein
+      complex, to nitric oxide production. The orthology-transfer IEA is redundant
+      with the human IMP annotation of the same term (PMID:22081021) but is not wrong.
+      This is a secondary (moonlighting/structural) function rather than the enzyme&#39;s
+      core catalytic function, hence non-core.
+    supported_by:
+    - reference_id: PMID:22081021
+      supporting_text: Mechanistic studies showed that ASL has a structural function
+        in addition to its catalytic activity, by which it contributes to the formation
+        of a multiprotein complex required for NO production.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment of urea cycle from UniPathway mapping. ASL performs the
+      step that regenerates arginine (from argininosuccinate) within the urea cycle,
+      providing for hepatic nitrogen detoxification into urea.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process. This is the canonical urea-cycle role of ASL
+      and is central to the disease mechanism (hyperammonemia in argininosuccinic
+      aciduria). Concordant with UniProt pathway curation (urea cycle, step 1/1 for
+      this reaction).
+    supported_by:
+    - reference_id: PMID:11747432
+      supporting_text: a reaction involved in the biosynthesis of arginine in all
+        species and in the production of urea in ureotelic species
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9956524
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-asserted cytosolic localization (from the ASL variant urea-cycle reaction
+      pathway). ASL is a soluble cytosolic enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core cellular component, concordant with the IBA and TAS cytosol/cytoplasm
+      annotations.
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: EXP
+  original_reference_id: PMID:2263616
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental demonstration of argininosuccinate lyase activity via characterization
+      of human ASL and its ASA disease variants (e.g. R95C), including expression
+      of mutant cDNA in COS cells showing loss of ASL activity.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental support for the core molecular function in the human enzyme.
+      R95C produces little protein and less than 1% ASL activity, establishing that
+      the assayed activity is that of the ASL gene product.
+    supported_by:
+    - reference_id: PMID:2263616
+      supporting_text: Expression in COS cells demonstrated that the R95C mutation
+        produces normal amounts of ASAL mRNA but little protein and less than 1% ASAL
+        activity.
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: IDA
+  original_reference_id: PMID:9045711
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay of ASL activity in COS-cell expression / intragenic complementation
+      experiments, where the Q286R and D87G alleles each conferred loss of ASL activity
+      and cotransfection partially restored it.
+    action: ACCEPT
+    reason: Strong direct experimental support for the core catalytic function of
+      human ASL.
+    supported_by:
+    - reference_id: PMID:9045711
+      supporting_text: each conferred loss of ASL activity in COS cell transfection
+        assays
+- term:
+    id: GO:0006525
+    label: arginine metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:9045711
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Involvement in arginine metabolism inferred from direct assay of ASL activity
+      and the resulting arginine production/loss in the complementation experiments.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but general. GO:0006525 arginine metabolic process is a broad parent;
+      ASL&#39;s specific role is captured more precisely by GO:0006526 L-arginine biosynthetic
+      process (the direction ASL contributes to). Retained as an accurate but non-core
+      parent annotation.
+    supported_by:
+    - reference_id: PMID:9045711
+      supporting_text: each conferred loss of ASL activity in COS cell transfection
+        assays
+- term:
+    id: GO:0045429
+    label: positive regulation of nitric oxide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:22081021
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimentally demonstrated requirement of ASL for nitric oxide production.
+      Human ASA (ASL-null) subjects and cells, a hypomorphic Asl mouse, and ASL-knockdown
+      cells all show reduced NOS-dependent NO. Crucially, catalytically dead but structurally
+      intact human ASL mutants (R236W, R113Q) still support NOS complex formation
+      and restore arginine-stimulated NO, showing this is a catalysis-independent structural
+      role in assembling the NOS multiprotein complex (ASS1, SLC7A1, NOS).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a genuine, well-supported second function of ASL (a moonlighting/structural
+      role distinct from its catalytic activity) and explains the ammonia-independent
+      systemic features (hypertension, hepatic/neurologic disease) of argininosuccinic
+      aciduria. It is captured as a core function in core_functions as the NOS scaffold
+      role, but relative to the enzyme&#39;s canonical urea-cycle/arginine-biosynthesis
+      catalysis it is treated as non-core at the annotation level.
+    supported_by:
+    - reference_id: PMID:22081021
+      supporting_text: Mechanistic studies showed that ASL has a structural function
+        in addition to its catalytic activity, by which it contributes to the formation
+        of a multiprotein complex required for NO production.
+    - reference_id: PMID:22081021
+      supporting_text: Loss of Asl in both humans and mice leads to reduced NO synthesis,
+        owing to both decreased endogenous arginine synthesis and an impaired ability
+        to use extracellular arginine for NO production.
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: IDA
+  original_reference_id: PMID:11747433
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct biochemical characterization of recombinant human ASL and its active-site
+      (Q286R, D87G) and stability (M360T, A398D) mutants, confirming argininosuccinate
+      lyase activity and its dependence on the homotetrameric shared-active-site architecture.
+    action: ACCEPT
+    reason: &gt;-
+      Strong direct experimental support for the core catalytic function; the paper
+      reconstructs the reaction in vivo and in vitro with recombinant protein.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:11747432
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The 2.65 A structure of the human ASL Q286R allele together with catalytic characterization
+      supports ASL&#39;s role in the arginine-producing reaction of arginine biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process, supported by direct structural/biochemical
+      study of the human enzyme. The reaction is explicitly stated to be part of arginine
+      biosynthesis.
+    supported_by:
+    - reference_id: PMID:11747432
+      supporting_text: a reaction involved in the biosynthesis of arginine in all
+        species and in the production of urea in ureotelic species
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:11747433
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Biochemical reconstitution of the ASL reaction (argininosuccinate to arginine
+      + fumarate) with recombinant human protein supports involvement in arginine
+      biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process, supported by direct assay of the arginine-producing
+      reaction.
+    supported_by:
+    - reference_id: PMID:11747433
+      supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+        catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: IDA
+  original_reference_id: PMID:11747432
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Catalytic characterization and high-resolution structure of human ASL (Q286R
+      allele) directly demonstrate argininosuccinate lyase activity and its kinetics
+      (KM 0.12 mM for argininosuccinate).
+    action: ACCEPT
+    reason: Strong direct experimental support for the core molecular function in
+      the human enzyme.
+    supported_by:
+    - reference_id: PMID:11747432
+      supporting_text: Argininosuccinate lyase (ASL) catalyzes the reversible breakdown
+        of argininosuccinate to arginine and fumarate
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ASL peptides detected in urinary exosomes by large-scale proteomics/phosphoproteomics.
+      This is a mass-spectrometry catalog location, not a site where ASL performs
+      its known function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      High-throughput proteomic detection in exosomes is common for abundant cytosolic
+      enzymes and does not reflect a functional extracellular localization. ASL is
+      a soluble cytosolic urea-cycle enzyme; the exosome finding is retained as non-core
+      observational data. Cytosol (GO:0005829) is the functionally relevant compartment.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70573
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-asserted cytosolic localization (from the argininosuccinate to fumarate
+      + arginine urea-cycle reaction). Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core cellular component, concordant with the IBA and other TAS cytosol/cytoplasm
+      annotations.
+- term:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  evidence_type: TAS
+  original_reference_id: PMID:282632
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Traceable assertion of ASL enzymatic activity (EC 4.3.2.1) from an early study
+      that assayed human ASL by bioautography and mapped the ASL gene to chromosome
+      7.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function; the enzyme activity (EC 4.3.2.1) was directly
+      detected and used to map the human gene.
+    supported_by:
+    - reference_id: PMID:282632
+      supporting_text: associated with a deficiency of argininosuccinate lyase (ASL;
+        L-argininosuccinate arginine-lyase, EC 4.3.2.1)
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: TAS
+  original_reference_id: PMID:282632
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable assertion of cytoplasmic localization for ASL. The more specific and
+      functionally accurate term is cytosol (GO:0005829).
+    action: ACCEPT
+    reason: &gt;-
+      Correct but general. Cytoplasm is accurate; the more specific cytosol term (annotated
+      separately by IBA/TAS) is preferred as the core localization. Retained as an
+      accurate broader-term annotation.
+- term:
+    id: GO:0140378
+    label: protein complex scaffold activity
+  evidence_type: IMP
+  original_reference_id: PMID:22081021
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed molecular-function statement for ASL&#39;s catalysis-independent structural
+      role: it scaffolds a tissue-specific nitric oxide synthase multiprotein complex
+      (with ASS1, SLC7A1 and NOS1/NOS2/NOS3). Catalytically dead but structurally intact
+      human ASL (R236W, R113Q) still supports NOS complex formation, while loss of
+      ASL disrupts the complex, defining a scaffold rather than catalytic function.
+    action: NEW
+    reason: &gt;-
+      GOA captures the downstream process (GO:0045429 positive regulation of nitric
+      oxide biosynthetic process, IMP) but not the underlying molecular function.
+      GO:0140378 protein complex scaffold activity best represents ASL&#39;s demonstrated
+      role in holding the NOS complex together independently of its lyase catalysis,
+      and grounds the corresponding core function.
+    additional_reference_ids:
+    - file:human/ASL/ASL-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:22081021
+      supporting_text: Mechanistic studies showed that ASL has a structural function
+        in addition to its catalytic activity, by which it contributes to the formation
+        of a multiprotein complex required for NO production.
+    - reference_id: file:human/ASL/ASL-deep-research-falcon.md
+      supporting_text: forming a metabolon that channels arginine directly to NOS
+        for nitric oxide (NO) production
+core_functions:
+- description: &gt;-
+    Catalyzes the reversible cleavage of L-argininosuccinate to L-arginine and fumarate
+    (EC 4.3.2.1), a step of the cytosolic urea cycle, as an obligate homotetramer
+    with shared active sites.
+  molecular_function:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  directly_involved_in:
+  - id: GO:0000050
+    label: urea cycle
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:11747433
+    supporting_text: Argininosuccinate lyase (ASL) is a homotetrameric enzyme that
+      catalyzes the reversible cleavage of argininosuccinate to arginine and fumarate.
+  - reference_id: PMID:282632
+    supporting_text: associated with a deficiency of argininosuccinate lyase (ASL;
+      L-argininosuccinate arginine-lyase, EC 4.3.2.1)
+- description: &gt;-
+    Regenerates L-arginine from argininosuccinate as the final step of de novo arginine
+    biosynthesis, supplying arginine for downstream pathways in hepatic and non-hepatic
+    tissues.
+  molecular_function:
+    id: GO:0004056
+    label: argininosuccinate lyase activity
+  directly_involved_in:
+  - id: GO:0006526
+    label: L-arginine biosynthetic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:11747432
+    supporting_text: a reaction involved in the biosynthesis of arginine in all species
+      and in the production of urea in ureotelic species
+- description: &gt;-
+    Provides a catalysis-independent scaffold function that holds together a tissue-specific
+    nitric oxide synthase multiprotein complex (with ASS1, SLC7A1 and NOS1/NOS2/NOS3),
+    channelling arginine to nitric oxide production and thereby positively regulating
+    nitric oxide biosynthesis.
+  molecular_function:
+    id: GO:0140378
+    label: protein complex scaffold activity
+  directly_involved_in:
+  - id: GO:0045429
+    label: positive regulation of nitric oxide biosynthetic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:22081021
+    supporting_text: Mechanistic studies showed that ASL has a structural function
+      in addition to its catalytic activity, by which it contributes to the formation
+      of a multiprotein complex required for NO production.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:11747432
+  title: Three-dimensional structure of the argininosuccinate lyase frequently complementing
+    allele Q286R.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. First high-resolution (2.65 A) structure of human ASL (Q286R
+      allele); establishes catalytic activity, kinetics, and homotetrameric architecture.
+      Abstract-only in cache but concordant with UniProt curation.
+- id: PMID:11747433
+  title: Mechanisms for intragenic complementation at the human argininosuccinate
+    lyase locus.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Defines ASL as a homotetramer catalyzing reversible cleavage
+      of argininosuccinate to arginine and fumarate; reconstructs intragenic complementation
+      in vitro and in vivo. Abstract-only in cache.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput proteomic detection of ASL in urinary exosomes; a catalog location,
+      not evidence of functional extracellular localization.
+- id: PMID:21988832
+  title: Toward an understanding of the protein interaction network of the human liver.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Detects ASL self-interaction (P04424-P04424), consistent with the known homotetramer.
+- id: PMID:22081021
+  title: Requirement of argininosuccinate lyase for systemic nitric oxide production.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text in cache (PMC3348956). Demonstrates a catalysis-independent structural
+      role of ASL in NOS multiprotein complex assembly and NO production in both mouse
+      and human (including human ASA subjects and catalytically dead R236W/R113Q human
+      ASL). Basis for the GO:0045429 IMP and the Ensembl-Compara IEA.
+- id: PMID:2263616
+  title: &#39;Molecular analysis of human argininosuccinate lyase: mutant characterization
+    and alternative splicing of the coding region.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Establishes that ASA deficiency maps to the ASL structural
+      gene; R95C expressed in COS cells gives less than 1% ASL activity. Supports
+      core catalytic function. Abstract-only in cache.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale binary interactome; source of an ASL self-interaction (GO:0042802)
+      and a generic protein-binding (GO:0005515) annotation.
+- id: PMID:25502805
+  title: A massively parallel pipeline to clone DNA variants and examine molecular
+    phenotypes of human disease mutations.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput clone/variant interaction pipeline; source of an ASL self-interaction
+      (GO:0042802) annotation.
+- id: PMID:26871637
+  title: Widespread Expansion of Protein Interaction Capabilities by Alternative Splicing.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput isoform interactome; source of a generic protein-binding (GO:0005515)
+      annotation with an MCMBP isoform.
+- id: PMID:282632
+  title: &#39;Argininosuccinic aciduria: assignment of the argininosuccinate lyase gene
+    to the pter to q22 region of human chromosome 7 by bioautography.&#39;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Detects human ASL activity (EC 4.3.2.1) by bioautography and
+      maps the ASL gene to chromosome 7. Supports catalytic activity and cytoplasmic
+      localization (TAS). Abstract-only in cache.
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale variant interaction study; source of ASL self-interaction (GO:0042802)
+      and generic protein-binding (GO:0005515) annotations.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI reference interactome; source of an ASL self-interaction (GO:0042802) and
+      generic protein-binding (GO:0005515) annotations.
+- id: PMID:9045711
+  title: Intragenic complementation at the human argininosuccinate lyase locus. Identification
+    of the major complementing alleles.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Direct COS-cell assay of human ASL activity; Q286R and D87G
+      alleles confer loss of activity and cotransfection partially restores it (proof
+      of intragenic complementation). Supports core catalytic function and arginine
+      metabolism. Abstract-only in cache.
+- id: Reactome:R-HSA-70573
+  title: argininosuccinate &lt;=&gt; fumarate + arginine
+  findings: []
+- id: Reactome:R-HSA-9956524
+  title: ASL variants don&#39;t synthesize fumarate and arginine
+  findings: []
+- id: file:human/ASL/ASL-deep-research-falcon.md
+  title: Deep research report (falcon) for human ASL
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      LLM-generated deep-research synthesis. Corroborates the cytosolic homotetramer,
+      the argininosuccinate to arginine + fumarate reaction, urea-cycle and citrulline-NO-cycle
+      roles, and the CAT1-ASS1-ASL-NOS metabolon. Only used here for the well-established
+      NOS-metabolon claim, which is independently confirmed by PMID:22081021.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ASS1/ASS1-ai-review.html
+++ b/genes/human/ASS1/ASS1-ai-review.html
@@ -1,0 +1,8776 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ASS1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ASS1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P00966" target="_blank" class="term-link">
+                        P00966
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ASS1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P00966" data-a="DESCRIPTION: ASS1 encodes argininosuccinate synthase (EC 6.3.4...." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ASS1 encodes argininosuccinate synthase (EC 6.3.4.5), a cytosolic homotetrameric ligase that catalyzes the ATP-dependent condensation of L-citrulline and L-aspartate to form argininosuccinate, AMP and diphosphate. This is the rate-limiting and committed step of de novo L-arginine biosynthesis and the third step of the hepatic urea cycle, where aspartate serves as the second nitrogen donor and the reaction feeds argininosuccinate to argininosuccinate lyase (ASL) for cleavage to arginine and fumarate. In the liver the enzyme is central to the disposal of ammonia as urea; in most extrahepatic tissues, ASS1 acting together with ASL regenerates arginine from citrulline (the citrulline-arginine cycle) and supplies arginine as substrate for nitric oxide synthases (the citrulline-NO cycle), notably in vascular endothelium and immune cells. Enzyme activity is modulated post-translationally, including inhibitory acetylation of Lys165/Lys176 that imposes a circadian rhythm on ureagenesis. Loss-of-function ASS1 variants cause citrullinemia type I (CTLN1), an autosomal recessive urea cycle disorder with hyperammonemia, elevated plasma citrulline and low arginine.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred core molecular function. This is the correct and well-supported catalytic activity for ASS1 (EC 6.3.4.5), the enzyme name itself, and is confirmed by direct enzymology of the human recombinant protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA at exactly the right level of specificity for the family and directly corroborated by human experimental data. This is a defining core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred cytosolic localization. ASS1 is a soluble cytosolic enzyme; the substrate citrulline is exported from mitochondria and converted in the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with UniProt subcellular location (Cytoplasm, cytosol) and with direct immunofluorescence/experimental evidence. Correct compartment for a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006526" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred role in L-arginine biosynthesis. ASS1 with ASL performs the two steps that convert citrulline to arginine, making arginine available in most tissues.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, matching UniProt PATHWAY annotation (L-arginine biosynthesis, step 2/3) and experimental patient/expression data. IBA at appropriate specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0000050" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred participation in the urea cycle, the metabolic step condensing citrulline and aspartate to argininosuccinate. This is a core biological process for the hepatic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by human enzymology and disease genetics; ASS1 deficiency is the cause of citrullinemia type I, a urea cycle disorder. IBA correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (multiple IEA methods) assignment of the core catalytic activity, backed by InterPro signatures, RHEA:10932 and EC 6.3.4.5. Fully consistent with the experimental activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA/IMP argininosuccinate synthase activity annotations but correct; the EC/RHEA/InterPro mapping is accurate for this enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link">
+                                        PMID:18473344
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">caused by deficiency of the urea cycle enzyme argininosuccinate synthetase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping of ATP binding. ASS1 uses ATP as a co-substrate (activating citrulline via a citrullyl-AMP intermediate), and UniProt documents an ATP-binding SSGGxDS motif and ATP-binding feature/keyword.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct molecular function supported by the catalyzed reaction (ATP -&gt; AMP + PPi) and by UniProt nucleotide-binding features; a genuine ligand-binding activity underpinning catalysis.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005829" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Subcellular-location keyword mapping to cytosol from UniProt SL-0091.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally supported cytosolic localization; redundant but correct.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006526" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated assignment of the L-arginine biosynthetic process, matching UniPathway UPA00068.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process, redundant with the IBA/IMP annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12620389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel raf kinase protein-protein interactions found by an ex...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005515" data-r="PMID:12620389" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with ARAF (Raf kinase) found in an exhaustive yeast two-hybrid screen. &#34;protein binding&#34; is uninformative and this is a high-throughput two-hybrid hit with no established biological consequence for ASS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare &#34;protein binding&#34; (GO:0005515) is uninformative and should be avoided. The interaction is a screen-derived putative binary interaction (A-Raf/C-Raf Y2H atlas) not connected to ASS1 function; it adds no functional information to the review.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link">
+                                        PMID:12620389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have performed an exhaustive unbiased yeast two-hybrid analysis to identify</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17496144" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17496144
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Restructuring of the dinucleotide-binding fold in an NADP(H)...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005515" data-r="PMID:17496144" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with NMRAL1 (HSCARG, an NADP(H)-sensing redox protein). UniProt records this interaction, and NMRAL1 has been reported to regulate ASS1 activity. However the GO term captured is only the uninformative &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative and discouraged. The underlying NMRAL1 interaction is real and biologically noted (redox regulation of ASS1), but the informative content belongs in a specific term or in the description, not in GO:0005515. The interaction itself is retained conceptually via UniProt SUBUNIT and is not lost.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17496144" target="_blank" class="term-link">
+                                        PMID:17496144
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">may be argininosuccinate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28587924" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28587924
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PRMT7 Interacts with ASS1 and Citrullinemia Mutations Disrup...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005515" data-r="PMID:28587924" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with PRMT7 (protein arginine methyltransferase 7), a direct interactor identified by Y2H and confirmed by pull-down; citrullinemia mutations disrupt the interaction. Captured only as uninformative &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is discouraged. The PRMT7-ASS1 interaction is a genuine and interesting finding, but the GO term is uninformative; the biology is retained in the description and could be captured by a specific term if warranted. No functional information is lost by removing GO:0005515.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28587924" target="_blank" class="term-link">
+                                        PMID:28587924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">interacts with ASS1 using pull-down studies.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16189514
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Towards a proteome-scale map of the human protein-protein in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0042802" data-r="PMID:16189514" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction (ASS1-ASS1) consistent with the well-established homotetrameric quaternary structure of the enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;identical protein binding&#34; is informative here: ASS1 is a homotetramer composed of identical subunits, so self-association is a bona fide, functionally meaningful property (the active enzyme is the tetramer). Multiple independent interactome studies report the self-interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21988832
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toward an understanding of the protein interaction network o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0042802" data-r="PMID:21988832" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction detected in a human liver protein-interaction network study, consistent with the homotetrameric architecture of ASS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates the homotetramer; &#34;identical protein binding&#34; is a meaningful function for this obligate oligomer.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0042802" data-r="PMID:25416956" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction from a proteome-scale human interactome map, again consistent with the homotetramer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reinforces the biologically meaningful homo-oligomerization of ASS1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0000050" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated urea cycle assignment, matching UniPathway UPA00158.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process, redundant with IBA and multiple experimental IMP annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001822" target="_blank" class="term-link">
+                                    GO:0001822
+                                </a>
+                            </span>
+                            <span class="term-label">kidney development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0001822" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. ASS1 is expressed in fetal kidney and is part of the intestinal-renal citrulline-arginine axis, but a direct role in kidney developmental morphogenesis is not established for the human enzyme; this reads as an expression/context annotation rather than a developmental function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer IEA reflecting a tissue in which ASS1 is expressed and active rather than a core molecular role in organ development. Not a core function; retain as non-core pending direct evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001889" target="_blank" class="term-link">
+                                    GO:0001889
+                                </a>
+                            </span>
+                            <span class="term-label">liver development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0001889" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. ASS1 is the principal hepatic urea-cycle enzyme and is developmentally regulated in fetal liver, but &#34;liver development&#34; (organ morphogenesis) overstates its role; its liver function is metabolic (ureagenesis).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer IEA describing the tissue context (liver) of ASS1 expression rather than a causal role in liver organogenesis. Retain as non-core; the metabolic role is captured by the urea cycle / arginine biosynthesis annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005739" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer (from mouse) placing ASS1 in the mitochondrion. This contradicts the well-established cytosolic localization of ASS1; the enzyme acts in the cytosol on citrulline exported from mitochondria.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ASS1 is a soluble cytosolic enzyme (UniProt: Cytoplasm, cytosol; direct IDA cytosol annotations). Mitochondrial localization is an over-propagated ortholog-transfer IEA inconsistent with the human protein and with urea-cycle compartmentalization (only the upstream steps CPS1/OTC are mitochondrial).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005741" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer (from rat) placing ASS1 at the mitochondrial outer membrane. Inconsistent with the established cytosolic localization of the enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated ortholog-transfer IEA. ASS1 is cytosolic; there is no reliable evidence for the human enzyme residing at the mitochondrial outer membrane.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006953" target="_blank" class="term-link">
+                                    GO:0006953
+                                </a>
+                            </span>
+                            <span class="term-label">acute-phase response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006953" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. Reflects transcriptional induction of ASS1 under inflammatory/cytokine stimulation rather than a direct molecular role in the acute-phase response.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Regulation-of-expression / stimulus-response context transferred from ortholog, not a core catalytic role. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007494" target="_blank" class="term-link">
+                                    GO:0007494
+                                </a>
+                            </span>
+                            <span class="term-label">midgut development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0007494" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. Likely reflects intestinal ASS1 expression (enterocytes contribute to systemic citrulline/arginine metabolism) rather than a role in gut morphogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer IEA describing an expression context, not a core developmental function of the human enzyme. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007584" target="_blank" class="term-link">
+                                    GO:0007584
+                                </a>
+                            </span>
+                            <span class="term-label">response to nutrient</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0007584" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. ASS1 expression/activity responds to dietary protein and amino acid availability, but this is a stimulus-response context, not a core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Physiologically plausible (urea-cycle flux tracks nitrogen load) but an ortholog-transfer response annotation rather than core function. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007623" target="_blank" class="term-link">
+                                    GO:0007623
+                                </a>
+                            </span>
+                            <span class="term-label">circadian rhythm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0007623" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from mouse. This is corroborated by direct human/mouse evidence: CLOCK acetylates ASS1 (K165/K176) to inactivate it in a circadian manner, imposing a circadian rhythm on ureagenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by experiment (see the IDA circadian rhythm annotation, PMID:28985504), but this is a regulated-behavior/output context rather than ASS1&#39;s core catalytic function. Retain as non-core; redundant with the experimental annotation below.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link">
+                                        PMID:28985504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ASS1 acetylation by CLOCK exhibits circadian oscillation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009410" target="_blank" class="term-link">
+                                    GO:0009410
+                                </a>
+                            </span>
+                            <span class="term-label">response to xenobiotic stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0009410" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat, reflecting altered ASS1 expression on xenobiotic exposure. Stimulus-response context, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009636" target="_blank" class="term-link">
+                                    GO:0009636
+                                </a>
+                            </span>
+                            <span class="term-label">response to toxic substance</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0009636" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. A broad stimulus-response term reflecting expression changes; not a core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation with no direct human evidence for a core role; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010043" target="_blank" class="term-link">
+                                    GO:0010043
+                                </a>
+                            </span>
+                            <span class="term-label">response to zinc ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0010043" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; a specific stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010046" target="_blank" class="term-link">
+                                    GO:0010046
+                                </a>
+                            </span>
+                            <span class="term-label">response to mycotoxin</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0010046" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; narrow stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014075" target="_blank" class="term-link">
+                                    GO:0014075
+                                </a>
+                            </span>
+                            <span class="term-label">response to amine</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0014075" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015643" target="_blank" class="term-link">
+                                    GO:0015643
+                                </a>
+                            </span>
+                            <span class="term-label">toxic substance binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0015643" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat asserting ASS1 &#34;binds a toxic substance&#34;. There is no credible biochemical basis for treating ASS1 as a toxin-binding protein; ASS1 is a metabolic ligase. This is an anomalous, likely spuriously propagated molecular-function IEA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically implausible for a cytosolic urea-cycle ligase; unsupported by any human evidence or by the enzyme&#39;s mechanism. The term definition (&#34;Binding to a toxic substance, a poisonous substance that causes damage to biological systems&#34;) does not fit ASS1. Over-propagated ortholog-transfer IEA.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032355" target="_blank" class="term-link">
+                                    GO:0032355
+                                </a>
+                            </span>
+                            <span class="term-label">response to estradiol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0032355" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032496" target="_blank" class="term-link">
+                                    GO:0032496
+                                </a>
+                            </span>
+                            <span class="term-label">response to lipopolysaccharide</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0032496" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. ASS1 is induced with iNOS in inflammatory (LPS/cytokine) settings to supply arginine for NO production, so this context is plausible, but it is not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation consistent with the citrulline-NO cycle role in immune/inflammatory cells; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043025" target="_blank" class="term-link">
+                                    GO:0043025
+                                </a>
+                            </span>
+                            <span class="term-label">neuronal cell body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0043025" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat placing ASS1 in the neuronal cell body. ASS1 is expressed in specific neurons (citrulline-NO cycle), and within a neuron it would be cytosolic; the specific location is an ortholog-transferred expression context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cell-type-specific localization transferred from ortholog; plausible for the tissue context but not the canonical/core cytosolic annotation. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043200" target="_blank" class="term-link">
+                                    GO:0043200
+                                </a>
+                            </span>
+                            <span class="term-label">response to amino acid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0043200" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; amino-acid stimulus-response context (ASS1 expression/activity responds to substrate and amino acid availability).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
+                                    GO:0043204
+                                </a>
+                            </span>
+                            <span class="term-label">perikaryon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0043204" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat placing ASS1 in the perikaryon (neuronal cell body cytoplasm). A cell-type-specific location transferred from ortholog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer localization tied to a specific tissue context; not the canonical/core cytosol annotation. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043434" target="_blank" class="term-link">
+                                    GO:0043434
+                                </a>
+                            </span>
+                            <span class="term-label">response to peptide hormone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0043434" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048545" target="_blank" class="term-link">
+                                    GO:0048545
+                                </a>
+                            </span>
+                            <span class="term-label">response to steroid hormone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0048545" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; steroid-hormone stimulus-response context (ASS1 is known to be glucocorticoid-inducible).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051384" target="_blank" class="term-link">
+                                    GO:0051384
+                                </a>
+                            </span>
+                            <span class="term-label">response to glucocorticoid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0051384" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. ASS1 transcription is induced by glucocorticoids (hepatic urea-cycle regulation), so this context is plausible.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation reflecting hormonal regulation of expression, not core catalytic function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060416" target="_blank" class="term-link">
+                                    GO:0060416
+                                </a>
+                            </span>
+                            <span class="term-label">response to growth hormone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0060416" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060539" target="_blank" class="term-link">
+                                    GO:0060539
+                                </a>
+                            </span>
+                            <span class="term-label">diaphragm development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0060539" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat. There is no established human evidence linking ASS1 to diaphragm morphogenesis; this reads as a weakly supported ortholog-transferred developmental annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer developmental annotation lacking direct human support; not a core function. Retain as non-core rather than removing, deferring to the experimental source in the orthologous species.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070542" target="_blank" class="term-link">
+                                    GO:0070542
+                                </a>
+                            </span>
+                            <span class="term-label">response to fatty acid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0070542" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070852" target="_blank" class="term-link">
+                                    GO:0070852
+                                </a>
+                            </span>
+                            <span class="term-label">cell body fiber</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0070852" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; a neuronal cell-type-specific location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer localization for a specific tissue context; not the canonical/core cytosol annotation. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071222" target="_blank" class="term-link">
+                                    GO:0071222
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to lipopolysaccharide</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071222" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; cellular stimulus-response context (inflammatory induction of ASS1 for arginine/NO supply).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation consistent with the citrulline-NO cycle in immune cells; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071230" target="_blank" class="term-link">
+                                    GO:0071230
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to amino acid stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071230" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; amino-acid stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071242" target="_blank" class="term-link">
+                                    GO:0071242
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to ammonium ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071242" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; stimulus-response context (ureagenesis responds to nitrogen/ammonia load).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071320" target="_blank" class="term-link">
+                                    GO:0071320
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to cAMP</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071320" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; second-messenger stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071346" target="_blank" class="term-link">
+                                    GO:0071346
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to type II interferon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071346" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; cytokine (IFN-gamma) stimulus-response context, consistent with immune induction of ASS1 for arginine/NO supply.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071356" target="_blank" class="term-link">
+                                    GO:0071356
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to tumor necrosis factor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071356" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; cytokine (TNF) stimulus-response context. Related human work shows ASS1/NOS3 counteract TNF-alpha-stimulated monocyte adhesion in endothelium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071377" target="_blank" class="term-link">
+                                    GO:0071377
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to glucagon stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071377" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context (glucagon induces hepatic urea-cycle enzymes).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071400" target="_blank" class="term-link">
+                                    GO:0071400
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to oleic acid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071400" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; a narrow fatty-acid stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071418" target="_blank" class="term-link">
+                                    GO:0071418
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to amine stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071418" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; amine stimulus-response context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071549" target="_blank" class="term-link">
+                                    GO:0071549
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to dexamethasone stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071549" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer from rat; glucocorticoid (dexamethasone) stimulus-response context, consistent with glucocorticoid induction of ASS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transfer response annotation, not core function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7977368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in argininosuccinate synthetase mRNA of Japanese p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0000050" data-r="PMID:7977368" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) urea cycle annotation based on characterization of citrullinemia-causing ASS1 mutations in patients. Loss of ASS1 function blocks the urea cycle, causing classic citrullinemia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by patient mutation genetics; a core biological process. Defer to the curator&#39;s full-text reading of the disease-gene relationship.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link">
+                                        PMID:7977368
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Citrullinemia is an autosomal recessive disease caused by a genetic deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006533" target="_blank" class="term-link">
+                                    GO:0006533
+                                </a>
+                            </span>
+                            <span class="term-label">L-aspartate catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7977368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in argininosuccinate synthetase mRNA of Japanese p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006533" data-r="PMID:7977368" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) annotation reflecting that ASS1 consumes L-aspartate (the second nitrogen donor) in the argininosuccinate synthase reaction. This is a curator reframing of the same catalytic step as an aspartate catabolic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect (ASS1 does consume aspartate as a co-substrate), but it is a redundant, substrate-centric restatement of the core argininosuccinate synthase activity / urea cycle role rather than an independent biological process. Retain as non-core; defer to the experimental curator who read the full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link">
+                                        PMID:7977368
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Citrullinemia is an autosomal recessive disease caused by a genetic deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019241" target="_blank" class="term-link">
+                                    GO:0019241
+                                </a>
+                            </span>
+                            <span class="term-label">L-citrulline catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7977368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in argininosuccinate synthetase mRNA of Japanese p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0019241" data-r="PMID:7977368" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) annotation reflecting that ASS1 consumes L-citrulline in the argininosuccinate synthase reaction; ASS1 deficiency causes citrulline accumulation. This is a substrate-centric reframing of the same catalytic step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect (citrulline is the substrate whose accumulation defines citrullinemia), but it is a redundant restatement of the core enzyme activity / arginine-biosynthesis and urea-cycle roles. Retain as non-core; defer to the experimental curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link">
+                                        PMID:7977368
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Citrullinemia is an autosomal recessive disease caused by a genetic deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct immunofluorescence (Human Protein Atlas) localization to the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental confirmation of the core cytosolic localization of ASS1.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9956517
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005829" data-r="Reactome:R-HSA-9956517" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing ASS1 (in the context of disease variants failing to synthesize argininosuccinate) in the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established cytosolic localization; redundant but correct.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28985504
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLOCK Acetylates ASS1 to Drive Circadian Rhythm of Ureagenes...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="PMID:28985504" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for ASS1 catalytic activity from the CLOCK-acetylation study, which manipulated ASS1 and measured its activity (acetylation of K165/K176 inactivates the enzyme).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function directly assayed in the study; ASS1 &#34;catalyzes the rate-limiting step of arginine biosynthesis&#34;.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link">
+                                        PMID:28985504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">synthase (ASS1) to inactivate ASS1, which catalyzes the rate-limiting step of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28985504
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLOCK Acetylates ASS1 to Drive Circadian Rhythm of Ureagenes...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005515" data-r="PMID:28985504" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/UniProt interaction with CLOCK (O15516) demonstrated in the circadian-ureagenesis study. Captured only as uninformative &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is discouraged. The ASS1-CLOCK interaction is genuine and functionally important (CLOCK acetylates ASS1), but this content is retained in the description and in the circadian-rhythm annotation; the uninformative GO:0005515 term itself adds nothing.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link">
+                                        PMID:28985504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CLOCK directly acetylates K165 and K176 of argininosuccinate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28985504
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLOCK Acetylates ASS1 to Drive Circadian Rhythm of Ureagenes...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005829" data-r="PMID:28985504" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) cytosolic localization from the CLOCK-acetylation study; UniProt cites this paper for the Cytoplasm, cytosol subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental confirmation of the core cytosolic localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007623" target="_blank" class="term-link">
+                                    GO:0007623
+                                </a>
+                            </span>
+                            <span class="term-label">circadian rhythm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28985504
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CLOCK Acetylates ASS1 to Drive Circadian Rhythm of Ureagenes...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0007623" data-r="PMID:28985504" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) evidence that ASS1 activity is under circadian control: CLOCK acetylates ASS1 in a circadian manner, producing an oscillation in ASS1 activity and ureagenesis in human cells and mouse liver.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported experimentally, but this describes a regulated output/behavior in which ASS1 participates rather than ASS1&#39;s intrinsic core function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link">
+                                        PMID:28985504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ASS1 acetylation by CLOCK exhibits circadian oscillation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8792870
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of human wild-type and mutant argininosucci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0000050" data-r="PMID:8792870" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) urea cycle annotation from characterization of wild-type and mutant human ASS proteins; the paper explicitly frames ASS as a urea cycle enzyme and links mutations to citrullinemia.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, directly supported by recombinant enzymology of the human protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8792870
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of human wild-type and mutant argininosucci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="PMID:8792870" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) measurement of ASS catalytic activity: purified recombinant wild-type human ASS matched native liver enzyme, and mutants showed reduced/abolished activity and abnormal kinetics (elevated Km for citrulline).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct biochemical characterization of the core molecular function of the human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">G280R mutant was extracted with an amount of ASS protein similar to wild-type</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8792870
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of human wild-type and mutant argininosucci...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006526" data-r="PMID:8792870" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for ASS1&#39;s role in arginine biosynthesis via the biochemical characterization of the enzyme that carries out the committed step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by the human enzymology; defer to the experimental curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                        PMID:8792870
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18473344
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Investigation of citrullinemia type I variants by in vitro e...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0000050" data-r="PMID:18473344" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) urea cycle annotation from in vitro expression/enzymology of CTLN1 variants; the paper describes ASS as &#34;the urea cycle enzyme argininosuccinate synthetase&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by disease-variant enzymology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link">
+                                        PMID:18473344
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">caused by deficiency of the urea cycle enzyme argininosuccinate synthetase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18473344
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Investigation of citrullinemia type I variants by in vitro e...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="PMID:18473344" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) enzymatic analysis of purified wild-type and mutant ASS proteins, with measured kinetic parameters (KM 112 uM citrulline, 68 uM aspartate) and reduced activity for pathogenic variants.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct measurement of the core catalytic activity; underpins the UniProt EC 6.3.4.5 and kinetic parameters.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link">
+                                        PMID:18473344
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">enzymatic analysis of purified wild-type and the mutant ASS proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18473344
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Investigation of citrullinemia type I variants by in vitro e...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006526" data-r="PMID:18473344" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for the arginine-biosynthesis role via enzymology of the ASS reaction, which produces argininosuccinate en route to arginine.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by the human enzyme characterization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link">
+                                        PMID:18473344
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">caused by deficiency of the urea cycle enzyme argininosuccinate synthetase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27287393
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Kinetic mutations in argininosuccinate synthetase deficiency...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0000050" data-r="PMID:27287393" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) urea cycle annotation from characterization of 21 kinetic CTLN1 mutations; the paper frames citrullinemia type 1 as &#34;an autosomal-recessive urea cycle disorder&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by disease-mutation enzymology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link">
+                                        PMID:27287393
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BACKGROUND: Citrullinemia type 1 is an autosomal-recessive urea cycle disorder</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27287393
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Kinetic mutations in argininosuccinate synthetase deficiency...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="PMID:27287393" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) measurement of ASS catalytic activity and kinetics for 21 mutants by tandem mass spectrometry; 13 were inactive and 8 had decreased substrate affinity, rescuable by aspartate supplementation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct quantitative measurement of the core molecular function of the human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link">
+                                        PMID:27287393
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">activity and kinetic parameters were measured using tandem mass spectrometry and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27287393
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Kinetic mutations in argininosuccinate synthetase deficiency...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0006526" data-r="PMID:27287393" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for the arginine-biosynthesis role via kinetic characterization of the ASS reaction (citrulline + aspartate + ATP -&gt; argininosuccinate).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by the human enzyme kinetics.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link">
+                                        PMID:27287393
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">map near the substrate (aspartate or citrulline)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0070062" data-r="PMID:23533145" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput detection of ASS1 peptides in urinary/prostatic exosome proteomes. This is a mass-spectrometry proteomic inventory, not evidence of a functional extracellular-vesicle localization for a cytosolic metabolic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Abundant cytosolic enzymes are common background hits in exosome/secretome proteomics; the finding is real as a detection event but does not reflect a core functional localization. Retain as non-core rather than removing, since the peptide detection is genuine.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">expressed prostatic secretions in urine (EPS-urine), exosome preparations were</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                                    GO:0004055
+                                </a>
+                            </span>
+                            <span class="term-label">argininosuccinate synthase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7977368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in argininosuccinate synthetase mRNA of Japanese p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0004055" data-r="PMID:7977368" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for the catalytic activity via mutation analysis in citrullinemia patients; the deficiency of ASS activity underlies the disease.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function supported by patient genetics; defer to the experimental curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link">
+                                        PMID:7977368
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Citrullinemia is an autosomal recessive disease caused by a genetic deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016597" target="_blank" class="term-link">
+                                    GO:0016597
+                                </a>
+                            </span>
+                            <span class="term-label">amino acid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7977368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in argininosuccinate synthetase mRNA of Japanese p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0016597" data-r="PMID:7977368" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) annotation of amino acid binding, reflecting that ASS1 binds its amino acid substrates L-citrulline and L-aspartate; several CTLN1 mutations map to the substrate (aspartate/citrulline) binding site and impair substrate affinity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative molecular function distinct from the catalytic term: ASS1 has bona fide amino acid (citrulline/aspartate) binding sites (documented in UniProt BINDING features), and kinetic mutants show altered Km. Supported by the experimental mutation studies.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link">
+                                        PMID:27287393
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">map near the substrate (aspartate or citrulline)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045429" target="_blank" class="term-link">
+                                    GO:0045429
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of nitric oxide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21106532
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endothelial argininosuccinate synthetase 1 regulates nitric ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0045429" data-r="PMID:21106532" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence in endothelial cells that ASS1, by regenerating arginine (the NOS3 substrate) from citrulline, increases NO production; overexpression of ASS1 raised NO and ASS1/NOS3 siRNAs attenuated shear-stress-induced NO. This is the citrulline-NO cycle role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine, physiologically important extrahepatic function of ASS1 (supplying arginine for NO synthesis) but it is a downstream regulatory consequence of the core arginine-biosynthesis activity in a specific cell type, not the enzyme&#39;s intrinsic core function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link">
+                                        PMID:21106532
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">increased NO production and decreased monocyte adhesion stimulated by tumor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071499" target="_blank" class="term-link">
+                                    GO:0071499
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to laminar fluid shear stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21106532
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endothelial argininosuccinate synthetase 1 regulates nitric ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0071499" data-r="PMID:21106532" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence that laminar shear stress induces ASS1 in endothelial cells and that ASS1 (with NOS3) is required for the shear-stress-stimulated increase in NO production.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A cell-type-specific stimulus-response/physiological role, downstream of ASS1&#39;s core arginine supply function; not the enzyme&#39;s intrinsic core function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link">
+                                        PMID:21106532
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SiRNAs of NOS3 and ASS1 attenuated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903038" target="_blank" class="term-link">
+                                    GO:1903038
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of leukocyte cell-cell adhesion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21106532
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endothelial argininosuccinate synthetase 1 regulates nitric ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:1903038" data-r="PMID:21106532" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence that ASS1 (via NO production) reduces TNF-alpha-stimulated monocyte adhesion to endothelial cells, an anti-inflammatory endothelial effect downstream of arginine/NO supply.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A downstream physiological consequence of the endothelial citrulline-NO cycle role, mediated by NO rather than a direct ASS1 activity on adhesion; not a core function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link">
+                                        PMID:21106532
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">increased NO production and decreased monocyte adhesion stimulated by tumor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
+                                    GO:0003723
+                                </a>
+                            </span>
+                            <span class="term-label">RNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22658674
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insights into RNA biology from an atlas of mammalian mRNA-bi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0003723" data-r="PMID:22658674" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput &#34;interactome capture&#34; detection of ASS1 among mRNA-binding proteins in proliferating HeLa cells (mRNA interactome atlas). Many metabolic enzymes were unexpectedly captured; no dedicated RNA-binding function has been demonstrated for ASS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This derives from a single high-throughput RNA-interactome screen that recovered numerous &#34;moonlighting&#34; metabolic enzymes. There is no orthogonal validation of a functional RNA-binding role for ASS1, so it is very likely an over-annotation rather than a core or established secondary function. Flag as over-annotated rather than accepting.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link">
+                                        PMID:22658674
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">RNA-binding enzymes of intermediary</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0070062" data-r="PMID:19056867" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput detection of ASS1 in a large-scale urinary-exosome proteome. As above, an MS inventory hit for a cytosolic enzyme rather than evidence of a functional extracellular localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine peptide detection in an exosome proteomics dataset, but not a core functional localization for this cytosolic urea-cycle enzyme. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                                        PMID:19056867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Normal human urine contains large numbers of exosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70577
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005829" data-r="Reactome:R-HSA-70577" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement localizing the ASS1 tetramer (in complex with NMRAL1 dimer and NADPH) to the cytosol, in the argininosuccinate-forming reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established cytosolic localization of ASS1; correct.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6194510" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6194510
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sequence for human argininosuccinate synthetase cDNA.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P00966" data-a="GO:0005737" data-r="PMID:6194510" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (from the human ASS cDNA sequencing paper) localizing ASS1 to the cytoplasm. This is the general parent of the more specific cytosol annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than warranted: ASS1 is specifically cytosolic (GO:0005829), which is directly supported by immunofluorescence (IDA) and multiple sources. Replace the general &#34;cytoplasm&#34; with the more informative &#34;cytosol&#34;.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    cytosol
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Argininosuccinate synthase: ATP-dependent condensation of L-citrulline and L-aspartate to form argininosuccinate (plus AMP and diphosphate) in the cytosol. This is the rate-limiting, committed step of de novo L-arginine biosynthesis and the argininosuccinate-forming step of the urea cycle, in which aspartate is the second nitrogen donor. The enzyme functions as a homotetramer of identical subunits, uses ATP as co-substrate (with defined ATP- and amino acid-binding sites), and its product is handed to argininosuccinate lyase (ASL) to yield arginine and fumarate.</h3>
+                <span class="vote-buttons" data-g="P00966" data-a="FUNCTION: Argininosuccinate synthase: ATP-dependent condensa..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004055" target="_blank" class="term-link">
+                            argininosuccinate synthase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                L-arginine biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Substrates:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:57743" target="_blank" class="term-link">
+                                L-citrulline
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:29991" target="_blank" class="term-link">
+                                L-aspartate
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:30616" target="_blank" class="term-link">
+                                ATP
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                                PMID:8792870
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link">
+                                PMID:27287393
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">map near the substrate (aspartate or citrulline)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link">
+                                PMID:28985504
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">synthase (ASS1) to inactivate ASS1, which catalyzes the rate-limiting step of</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link">
+                            PMID:12620389
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
+                            PMID:16189514
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Towards a proteome-scale map of the human protein-protein interaction network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17496144" target="_blank" class="term-link">
+                            PMID:17496144
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Restructuring of the dinucleotide-binding fold in an NADP(H) sensor protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18473344" target="_blank" class="term-link">
+                            PMID:18473344
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Investigation of citrullinemia type I variants by in vitro expression studies.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21106532" target="_blank" class="term-link">
+                            PMID:21106532
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endothelial argininosuccinate synthetase 1 regulates nitric oxide production and monocyte adhesion under static and laminar shear stress conditions.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
+                            PMID:21988832
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link">
+                            PMID:22658674
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Insights into RNA biology from an atlas of mammalian mRNA-binding proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27287393" target="_blank" class="term-link">
+                            PMID:27287393
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Kinetic mutations in argininosuccinate synthetase deficiency: characterisation and in vitro correction by substrate supplementation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28587924" target="_blank" class="term-link">
+                            PMID:28587924
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PRMT7 Interacts with ASS1 and Citrullinemia Mutations Disrupt the Interaction.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28985504" target="_blank" class="term-link">
+                            PMID:28985504
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLOCK Acetylates ASS1 to Drive Circadian Rhythm of Ureagenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/6194510" target="_blank" class="term-link">
+                            PMID:6194510
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sequence for human argininosuccinate synthetase cDNA.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7977368" target="_blank" class="term-link">
+                            PMID:7977368
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in argininosuccinate synthetase mRNA of Japanese patients, causing classical citrullinemia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8792870" target="_blank" class="term-link">
+                            PMID:8792870
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of human wild-type and mutant argininosuccinate synthetase proteins expressed in bacterial cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70577
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ASS1 tetramer:NMRAL1 dimer:NADPH transforms L-Asp and L-Cit to ARSUA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9956517
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ASS1 variants don&#39;t synthesize arginosuccinate</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ASS1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P00966" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: Human ASS1 (Argininosuccinate Synthase 1)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">32 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:33:02.628505</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ASS1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="ASS1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-human-ass1-argininosuccinate-synthase-1">Comprehensive Research Report: Human ASS1 (Argininosuccinate Synthase 1)</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>ASS1 (also known as ASS; HGNC:758) encodes argininosuccinate synthase 1 (UniProt: P00966), a 412-residue (~46 kDa) cytosolic enzyme classified under EC 6.3.4.5 (diezfernandez2017mutationsinthe pages 1-6, karlberg2008structureofhuman pages 1-2). The protein belongs to the argininosuccinate synthase family, type 1 subfamily, and is one of the most extensively studied urea cycle enzymes in humans.</p>
+<p>The following table summarizes the key properties of ASS1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>ASS1</strong>; synonym: <strong>ASS</strong> (human argininosuccinate synthase 1) (karlberg2008structureofhuman pages 1-2, diezfernandez2017mutationsinthe pages 1-6)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>Argininosuccinate synthase 1</strong>; catalyzes argininosuccinate formation in arginine biosynthesis/urea cycle (karlberg2008structureofhuman pages 1-2, fung2025arginineatthe pages 2-3)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P00966</strong></td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 6.3.4.5</strong> (argininosuccinate synthase) (karlberg2008structureofhuman pages 1-2)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Homo sapiens (Human)</strong></td>
+</tr>
+<tr>
+<td>Molecular weight</td>
+<td>Monomer is approximately <strong>46 kDa</strong> (diezfernandez2017mutationsinthe pages 1-6)</td>
+</tr>
+<tr>
+<td>Oligomeric state</td>
+<td><strong>Homotetramer</strong>; tetrameric state is conserved and required for activity (diezfernandez2017mutationsinthe pages 1-6, karlberg2008structureofhuman pages 3-5)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Primarily <strong>cytosolic</strong>; in liver associated with periportal hepatocyte urea-cycle function; can accumulate in the <strong>nucleus</strong> during DNA damage responses; reported association with <strong>caveolae</strong> in endothelial cells (lim2024ass1metabolicallycontributes pages 6-6, finnie2020investigatingass1and pages 100-105)</td>
+</tr>
+<tr>
+<td>Primary substrates</td>
+<td><strong>Citrulline</strong>, <strong>L-aspartate</strong>, and <strong>ATP</strong> (karlberg2008structureofhuman pages 1-2, karlberg2008structureofhuman pages 5-6)</td>
+</tr>
+<tr>
+<td>Primary products</td>
+<td><strong>Argininosuccinate</strong>, <strong>AMP</strong>, and <strong>pyrophosphate (PPi)</strong> (karlberg2008structureofhuman pages 1-2)</td>
+</tr>
+<tr>
+<td>Catalyzed reaction</td>
+<td>ATP-dependent condensation of citrulline with aspartate to form argininosuccinate; rate-limiting step of de novo arginine synthesis and a key urea-cycle step (karlberg2008structureofhuman pages 1-2, delage2010argininedeprivationand pages 2-3)</td>
+</tr>
+<tr>
+<td>Key active-site residues</td>
+<td>Residues implicated in substrate binding/catalysis include <strong>Glu270, Tyr282, Arg127, Asn123, Tyr87, Ser189, Thr119, Gln40</strong>; Arg127 and Asn123 help bind substrates, and domain movement helps position citrulline for attack on ATP (karlberg2008structureofhuman pages 5-6, karlberg2008structureofhuman pages 6-7)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>Three-part architecture: <strong>nucleotide-binding domain</strong>, <strong>synthetase domain</strong>, and <strong>C-terminal oligomerization helix</strong> (diezfernandez2017mutationsinthe pages 1-6, karlberg2008structureofhuman pages 3-5)</td>
+</tr>
+<tr>
+<td>Key regulatory modifications</td>
+<td><strong>CLOCK-mediated acetylation</strong> at <strong>K165/K176</strong> rhythmically inhibits ASS1 activity and drives circadian ureagenesis; <strong>Cys132 nitrosylation</strong> has been reported as an inactivating mammalian regulatory modification (lin2017clockacetylatesass1 pages 8-9, lin2017clockacetylatesass1 pages 3-4, lin2017clockacetylatesass1 pages 6-7, karlberg2008structureofhuman pages 5-6)</td>
+</tr>
+<tr>
+<td>Major pathway roles</td>
+<td>Functions in the <strong>urea cycle</strong>, <strong>de novo arginine biosynthesis</strong>, and <strong>citrulline–NO cycle</strong>; also influences nucleotide synthesis by competing for aspartate and can link ureagenesis to hepatic <strong>AMPK/lipid metabolism</strong> (fung2025arginineatthe pages 2-3, delage2010argininedeprivationand pages 2-3, sun2022argininosuccinatesynthase1 pages 2-4, madiraju2016argininosuccinatesynthetaseregulates pages 5-5)</td>
+</tr>
+<tr>
+<td>Recent non-canonical functions</td>
+<td>In 2024, ASS1 was shown to have a <strong>nuclear DNA-damage-response role</strong>: after DNA damage it accumulates in the nucleus, generates fumarate with ASL, promotes <strong>SMARCC1 succination</strong>, and modulates p53-regulated chromatin accessibility/transcription (lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 4-5)</td>
+</tr>
+<tr>
+<td>Associated diseases/contexts</td>
+<td><strong>Citrullinemia type I (CTLN1)</strong> from biallelic ASS1 deficiency causes hyperammonemia and elevated citrulline; in cancer, <strong>ASS1 silencing</strong> creates <strong>arginine auxotrophy</strong> and therapeutic vulnerability to arginine deprivation (diezfernandez2017mutationsinthe pages 10-14, diezfernandez2017mutationsinthe pages 14-18, ribas2022hyperammonemiaininherited pages 4-5, rogers2022canonicalandnoncanonical pages 13-17, delage2010argininedeprivationand pages 3-5)</td>
+</tr>
+<tr>
+<td>PDB structure ID</td>
+<td><strong>2NZ2</strong> (human ASS1 crystal structure) (diezfernandez2017mutationsinthe pages 22-27)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>Argininosuccinate synthase family</strong>, type 1 subfamily; structurally conserved tetrameric enzyme family (diezfernandez2017mutationsinthe pages 1-6, karlberg2008structureofhuman pages 3-5)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core biochemical, structural, localization, regulatory, and disease-associated properties of human ASS1. It is useful as a compact reference for functional annotation and interpretation of recent ASS1 literature.</em></p>
+<h2 id="2-enzymatic-function-reaction-substrates-and-mechanism">2. Enzymatic Function: Reaction, Substrates, and Mechanism</h2>
+<h3 id="21-catalyzed-reaction">2.1 Catalyzed Reaction</h3>
+<p>ASS1 catalyzes the ATP-dependent condensation of L-citrulline and L-aspartate to form argininosuccinate, with concomitant production of AMP and pyrophosphate (PPi) (karlberg2008structureofhuman pages 1-2). This reaction constitutes the rate-limiting step in both the urea cycle and de novo arginine biosynthesis (delage2010argininedeprivationand pages 2-3). The overall reaction is:</p>
+<p><strong>L-Citrulline + L-Aspartate + ATP → Argininosuccinate + AMP + PPi</strong></p>
+<h3 id="22-catalytic-mechanism">2.2 Catalytic Mechanism</h3>
+<p>The crystal structure of human ASS1 (PDB: 2NZ2), solved at 2.4 Å resolution, reveals the structural basis for catalysis (karlberg2008structureofhuman pages 2-3, karlberg2008structureofhuman pages 5-6). The mechanism proceeds through an ATP-dependent, two-step process. ATP binds to the nucleotide-binding domain, triggering a conformational change in which this domain approaches the synthetase domain in a hinge-like movement (lakhalnaouar2012leishmaniadonovaniargininosuccinate pages 2-3). In the human enzyme, the nucleophilic oxygen atom of citrulline is positioned approximately 4.8 Å from the ATP α-phosphate, considerably shorter than the 7.9 Å distance observed in bacterial ASS, suggesting that smaller conformational changes are required for catalysis in the human enzyme (karlberg2008structureofhuman pages 5-6). During catalysis, citrulline undergoes nucleophilic attack on the α-phosphate of ATP, forming a citrullyl-AMP intermediate, which is subsequently attacked by the amino group of aspartate to yield argininosuccinate.</p>
+<p>Key active-site residues involved in substrate binding and catalysis include Glu270, Tyr282, Arg127, Asn123, Tyr87, and Ser189, which coordinate citrulline through salt bridges and hydrogen bonds (karlberg2008structureofhuman pages 5-6). Aspartate is coordinated by Asn123 and Thr119, while Gln40 forms a hydrogen bond with the adenine moiety of ATP (karlberg2008structureofhuman pages 5-6, karlberg2008structureofhuman pages 6-7). A conserved mammalian residue, Cys132, positioned approximately 10.1 Å from ATP, can undergo S-nitrosylation, providing a mechanism for feedback inhibition by nitric oxide (karlberg2008structureofhuman pages 5-6, diezfernandez2017mutationsinthe pages 22-27).</p>
+<h2 id="3-structural-biology">3. Structural Biology</h2>
+<h3 id="31-domain-architecture">3.1 Domain Architecture</h3>
+<p>Each ASS1 monomer comprises three distinct structural domains: (i) an N-terminal nucleotide-binding domain containing an ATP pyrophosphatase consensus sequence, (ii) a central synthetase domain that harbors the substrate-binding cavity for citrulline and aspartate, and (iii) a C-terminal α-helical oligomerization domain that mediates tetramerization (diezfernandez2017mutationsinthe pages 1-6, karlberg2008structureofhuman pages 3-5, lakhalnaouar2012leishmaniadonovaniargininosuccinate pages 2-3). The two catalytic domains are tightly integrated, with helices from the nucleotide-binding domain traversing through the synthetase domain core (karlberg2008structureofhuman pages 3-5).</p>
+<h3 id="32-quaternary-structure">3.2 Quaternary Structure</h3>
+<p>ASS1 functions as a homotetramer composed of two identical dimers (karlberg2008structureofhuman pages 3-5). The dimer interface is formed exclusively between synthetase domains and involves helices 10 and 11, strands 11 and 14, a β-hairpin (residues 84–87), and an extended loop (residues 198–202), stabilized by two sets of five salt bridges and numerous polar interactions (karlberg2008structureofhuman pages 3-5). The tetramer interface is primarily hydrophobic, formed by helices 11 and 12 from the synthetase domains and helix 14 from the C-terminal oligomerization tail, surrounding a solvent-filled central cavity (karlberg2008structureofhuman pages 3-5). Mutations affecting the oligomerization helix, such as p.Gly390Arg, abolish enzymatic activity, demonstrating the essential nature of the tetrameric assembly (diezfernandez2017mutationsinthe pages 1-6, diezfernandez2017mutationsinthe pages 10-14).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<h3 id="41-cytosolic-localization">4.1 Cytosolic Localization</h3>
+<p>ASS1 is primarily a cytosolic enzyme in most tissues (finnie2020investigatingass1and pages 100-105, lim2024ass1metabolicallycontributes pages 6-6). In the liver, it functions within the cytosol of periportal hepatocytes as part of the urea cycle, where it is highly expressed (finnie2020investigatingass1and pages 100-105, diezfernandez2017mutationsinthe pages 10-14). In the kidney, ASS1 is predominantly cytosolic and confined to proximal tubular epithelial cells across all three segments of the proximal tubule, with very low expression in the rest of the nephron (finnie2020investigatingass1and pages 100-105). In endothelial cells, ASS1 associates with caveolae at relatively low expression levels, where it supports nitric oxide synthesis by coupling with NOS isoforms (finnie2020investigatingass1and pages 100-105).</p>
+<h3 id="42-nuclear-localization">4.2 Nuclear Localization</h3>
+<p>A landmark 2024 study by Lim et al. in <em>Nature Metabolism</em> revealed that ASS1 also functions in the nucleus following DNA damage (lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 4-5). Upon DNA damage induction (e.g., by doxorubicin), ASS1 is translocated to the nucleus via the importin IPO7 in a partially p53-dependent manner (lim2024ass1metabolicallycontributes pages 4-5, lim2024ass1metabolicallycontributes pages 2-3). In the nucleus, ASS1 is chromatin-bound and its binding intensifies upon DNA damage (lim2024ass1metabolicallycontributes pages 6-6).</p>
+<h2 id="5-biological-pathways-and-functions">5. Biological Pathways and Functions</h2>
+<p>The following table provides a comprehensive summary of the metabolic pathways and biological processes involving ASS1:</p>
+<table>
+<thead>
+<tr>
+<th>Pathway/Process</th>
+<th>Role of ASS1</th>
+<th>Tissue Context</th>
+<th>Key Interacting Enzymes/Proteins</th>
+<th>References</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Urea cycle (ammonia detoxification)</td>
+<td>Catalyzes the ATP-dependent condensation of citrulline and aspartate to form argininosuccinate, a rate-limiting cytosolic step of the urea cycle that supports ammonia disposal as urea.</td>
+<td>Highest functional importance in liver, especially periportal hepatocytes; also relevant in inherited urea-cycle disease.</td>
+<td>ASL, CPS1, OTC, ARG1</td>
+<td>(karlberg2008structureofhuman pages 1-2, delage2010argininedeprivationand pages 2-3, diezfernandez2017mutationsinthe pages 10-14, diezfernandez2017mutationsinthe pages 14-18)</td>
+</tr>
+<tr>
+<td>De novo arginine biosynthesis</td>
+<td>Produces argininosuccinate for subsequent conversion to arginine, supporting endogenous arginine synthesis from citrulline and aspartate.</td>
+<td>Broadly expressed across tissues; especially important in kidney for systemic arginine production and in liver for integrated nitrogen metabolism.</td>
+<td>ASL, citrulline supply pathways</td>
+<td>(fung2025arginineatthe pages 2-3, finnie2020investigatingass1and pages 100-105, sun2022argininosuccinatesynthase1 pages 1-2)</td>
+</tr>
+<tr>
+<td>Citrulline-NO recycling cycle</td>
+<td>Regenerates arginine from citrulline to sustain nitric oxide production; acts as a key control point in the citrulline-NO cycle.</td>
+<td>Endothelial and other NO-producing cells; also relevant in liver injury contexts with NOS2 induction.</td>
+<td>NOS isoforms, ASL, caveolae-associated partners</td>
+<td>(delage2010argininedeprivationand pages 2-3, leung2012argininosuccinatesynthaseconditions pages 3-5, finnie2020investigatingass1and pages 100-105)</td>
+</tr>
+<tr>
+<td>Aspartate competition/pyrimidine synthesis</td>
+<td>Consumes aspartate for argininosuccinate synthesis; when ASS1 is lost or silenced, aspartate is redirected toward pyrimidine/nucleotide biosynthesis, promoting proliferation.</td>
+<td>Especially prominent in ASS1-low or ASS1-silenced cancers.</td>
+<td>Pyrimidine synthesis network, p53-linked metabolic regulators</td>
+<td>(sun2022argininosuccinatesynthase1 pages 2-4, fung2025arginineatthe pages 9-10, rogers2022canonicalandnoncanonical pages 17-21, lim2024ass1metabolicallycontributes pages 6-6)</td>
+</tr>
+<tr>
+<td>AMPK/lipid metabolism linkage</td>
+<td>Couples ureagenesis and amino-acid catabolism to hepatic AMPK activation and lipid oxidation; ASS1 knockdown suppresses ureagenesis and AMPK signaling.</td>
+<td>Liver, particularly fasting/protein catabolism metabolic states.</td>
+<td>AMPK and downstream hepatic lipid metabolism effectors</td>
+<td>(madiraju2016argininosuccinatesynthetaseregulates pages 5-5)</td>
+</tr>
+<tr>
+<td>Nuclear DNA damage response (p53/SMARCC1)</td>
+<td>After DNA damage, ASS1 accumulates in nucleus and cytosol; in nucleus it works with ASL to generate fumarate, promotes SMARCC1 succination, alters SWI/SNF complex behavior, and modulates p53-regulated cell-cycle transcription.</td>
+<td>Demonstrated in cultured human cancer cells and supported by liver nuclear studies; relevant to tumor suppression and genome maintenance.</td>
+<td>p53, IPO7, ASL, SMARCC1, SNF5, SWI/SNF chromatin-remodeling complex</td>
+<td>(lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 4-5, lim2024ass1metabolicallycontributes pages 1-2, lim2024ass1metabolicallycontributes pages 2-3, lim2024ass1metabolicallycontributes pages 7-8)</td>
+</tr>
+<tr>
+<td>Circadian regulation of ureagenesis (CLOCK acetylation)</td>
+<td>Undergoes rhythmic CLOCK/BMAL1-dependent acetylation at K165/K176, which inhibits ASS1 activity and drives circadian oscillation of ureagenesis and arginine-cycle metabolites.</td>
+<td>Hepatocytes and mouse liver.</td>
+<td>CLOCK, BMAL1, HDACs</td>
+<td>(lin2017clockacetylatesass1 pages 8-9, lin2017clockacetylatesass1 pages 10-11, lin2017clockacetylatesass1 pages 3-4, lin2017clockacetylatesass1 pages 6-7, lin2017clockacetylatesass1 pages 4-5, lin2017clockacetylatesass1 pages 9-10)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the major metabolic pathways and biological processes involving human ASS1, including canonical urea-cycle functions and newer non-canonical roles in nuclear DNA-damage signaling and circadian regulation. It is useful for functional annotation because it links ASS1 biochemistry to tissue context and interacting partners.</em></p>
+<h3 id="51-urea-cycle">5.1 Urea Cycle</h3>
+<p>In the hepatic urea cycle, ASS1 catalyzes the cytosolic condensation of citrulline (produced from carbamoyl phosphate and ornithine in the mitochondria by OTC) with aspartate to generate argininosuccinate (karlberg2008structureofhuman pages 1-2, fung2025arginineatthe pages 2-3). This is the rate-limiting step of ureagenesis, which detoxifies neurotoxic ammonia by converting it to urea for renal excretion (delage2010argininedeprivationand pages 2-3, diezfernandez2017mutationsinthe pages 10-14). ASS1 expression is highest in periportal hepatocytes, consistent with the zonation pattern of urea cycle enzymes (diezfernandez2017mutationsinthe pages 10-14).</p>
+<h3 id="52-de-novo-arginine-biosynthesis">5.2 De Novo Arginine Biosynthesis</h3>
+<p>Beyond the liver, ASS1 operates together with argininosuccinate lyase (ASL) to convert citrulline and aspartate into arginine (fung2025arginineatthe pages 2-3, finnie2020investigatingass1and pages 100-105). The kidney is the primary site of systemic arginine production in the body, where proximal tubular cells express high levels of ASS1 to convert circulating citrulline (derived from intestinal metabolism of dietary glutamine) into arginine (finnie2020investigatingass1and pages 100-105, fung2025arginineatthe pages 2-3). ASS1 is widely expressed across healthy tissues and supports de novo arginine synthesis in most cell types (fung2025arginineatthe pages 2-3).</p>
+<h3 id="53-citrulline-no-recycling-cycle">5.3 Citrulline-NO Recycling Cycle</h3>
+<p>In nitric oxide (NO)-producing cells, ASS1 participates in the citrulline-NO recycling cycle: nitric oxide synthases (NOS) convert arginine to NO and citrulline, and ASS1 regenerates arginine from citrulline, completing the cycle and sustaining NO production (fung2025arginineatthe pages 2-3, delage2010argininedeprivationand pages 2-3, leung2012argininosuccinatesynthaseconditions pages 3-5). ASS1 functions as a potential enzymatic "switch" that provides substrate for NOS-induced NO synthesis and may have a rate-limiting role in high-output NO generation (leung2012argininosuccinatesynthaseconditions pages 3-5). However, at the whole-body level, citrulline availability—rather than ASS1 activity per se—is the ultimate limiting factor for endogenous arginine and NO synthesis (delage2010argininedeprivationand pages 2-3).</p>
+<h3 id="54-aspartate-partitioning-and-pyrimidine-metabolism">5.4 Aspartate Partitioning and Pyrimidine Metabolism</h3>
+<p>ASS1 competes with pyrimidine/nucleotide biosynthesis pathways for cytosolic aspartate (sun2022argininosuccinatesynthase1 pages 2-4, fung2025arginineatthe pages 9-10, lim2024ass1metabolicallycontributes pages 6-6). When ASS1 is present and active, it diverts aspartate toward argininosuccinate synthesis; when ASS1 is silenced or lost, aspartate is redirected toward pyrimidine nucleotide synthesis, supporting increased cell proliferation and potentially contributing to nucleotide imbalance and mutagenesis (lim2024ass1metabolicallycontributes pages 6-6, rogers2022canonicalandnoncanonical pages 17-21).</p>
+<h3 id="55-ampk-and-hepatic-lipid-metabolism">5.5 AMPK and Hepatic Lipid Metabolism</h3>
+<p>Madiraju et al. (2016) demonstrated that ASS1 regulates hepatic AMPK, linking protein catabolism and ureagenesis to hepatic lipid metabolism (madiraju2016argininosuccinatesynthetaseregulates pages 5-5). ASS1 knockdown inhibits both ureagenesis and AMPK activity in the liver, suggesting that ASS1 contributes to a protein-sparing metabolic switch during fasting or caloric restriction by connecting amino acid flux to fatty acid oxidation (madiraju2016argininosuccinatesynthetaseregulates pages 5-5).</p>
+<h3 id="56-nuclear-dna-damage-response">5.6 Nuclear DNA Damage Response</h3>
+<p>In 2024, Lim et al. discovered a non-canonical nuclear function for ASS1 in the p53-mediated DNA damage response (lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 1-2). Following DNA damage, ASS1 expression is elevated in both the cytosol and nucleus with at least partial dependency on p53 (lim2024ass1metabolicallycontributes pages 1-2, lim2024ass1metabolicallycontributes pages 2-3). In the cytosol, ASS1 metabolically restrains cell cycle progression by restricting nucleotide synthesis through aspartate consumption (lim2024ass1metabolicallycontributes pages 6-6). In the nucleus, ASS1 cooperates with ASL to generate fumarate, which promotes succination of SMARCC1, a subunit of the SWI/SNF chromatin-remodeling complex (lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 5-6). This succination destabilizes the SMARCC1–SNF5 interaction, reducing chromatin accessibility at a subset of p53-regulated cell cycle gene promoters and thereby decreasing their transcription (lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 1-2). Loss of ASS1 results in decreased SMARCC1 succination, enhanced chromatin accessibility, increased DNA damage, and accelerated cell cycle progression, likely contributing to cancer mutagenesis (lim2024ass1metabolicallycontributes pages 6-6, lim2024ass1metabolicallycontributes pages 1-2).</p>
+<h3 id="57-circadian-regulation-of-ureagenesis">5.7 Circadian Regulation of Ureagenesis</h3>
+<p>Lin et al. (2017) demonstrated that the circadian clock protein CLOCK, facilitated by BMAL1, directly acetylates ASS1 at lysine residues K165 and K176, inhibiting ASS1 enzymatic activity by up to 50% (lin2017clockacetylatesass1 pages 3-4, lin2017clockacetylatesass1 pages 6-7). This acetylation exhibits circadian oscillation in both human cells and mouse liver, driven by rhythmic CLOCK–ASS1 interaction, and is reversed by HDACs (lin2017clockacetylatesass1 pages 8-9, lin2017clockacetylatesass1 pages 4-5). This post-translational modification mechanism drives the circadian rhythm of ureagenesis without altering ASS1 mRNA or protein levels (lin2017clockacetylatesass1 pages 3-4, lin2017clockacetylatesass1 pages 9-10). Acetylation-defective mutants (K165R/K176R) maintain elevated enzymatic activity regardless of CLOCK status, confirming these residues as the critical regulatory sites (lin2017clockacetylatesass1 pages 7-8, lin2017clockacetylatesass1 pages 6-7).</p>
+<h2 id="6-post-translational-regulation">6. Post-Translational Regulation</h2>
+<p>In addition to CLOCK-mediated acetylation at K165/K176, ASS1 is regulated by several other post-translational modifications. Cys132, a conserved mammalian residue, undergoes S-nitrosylation, which inactivates the enzyme and provides a feedback inhibition mechanism linking NO production to arginine biosynthesis (karlberg2008structureofhuman pages 5-6, diezfernandez2017mutationsinthe pages 22-27). Phosphorylation at Ser328 has also been identified as a post-translational modification site (diezfernandez2017mutationsinthe pages 22-27). The p53 tumor suppressor directly transactivates ASS1 expression in response to genotoxic stress, revealing transcriptional regulation linked to cellular stress responses (lim2024ass1metabolicallycontributes pages 2-3).</p>
+<h2 id="7-disease-associations">7. Disease Associations</h2>
+<h3 id="71-citrullinemia-type-i-ctln1">7.1 Citrullinemia Type I (CTLN1)</h3>
+<p>Biallelic loss-of-function mutations in ASS1 cause citrullinemia type I (CTLN1), an autosomal recessive urea cycle disorder with an incidence of approximately 1 in 250,000 live births (ribas2022hyperammonemiaininherited pages 4-5). The clinical spectrum ranges from severe neonatal-onset disease with life-threatening hyperammonemia (lethargy, somnolence, feeding refusal, vomiting, cerebral edema, convulsions, and coma) to milder late-onset forms presenting with recurrent neurological symptoms or even asymptomatic biochemical abnormalities (diezfernandez2017mutationsinthe pages 10-14, diezfernandez2017mutationsinthe pages 14-18). Biochemically, CTLN1 is characterized by markedly elevated plasma citrulline (often &gt;2000 μmol/L), elevated ammonia and glutamine, low plasma arginine, and urinary orotic aciduria (diezfernandez2017mutationsinthe pages 14-18, ribas2022hyperammonemiaininherited pages 4-5). Mutations affecting the oligomerization interface (e.g., p.Gly324Ser, p.Arg363 mutations) tend to cause neonatal-onset disease, while some missense mutations in less critical regions may permit residual activity and milder presentations (diezfernandez2017mutationsinthe pages 10-14).</p>
+<h3 id="72-cancer-and-arginine-auxotrophy">7.2 Cancer and Arginine Auxotrophy</h3>
+<p>Many aggressive tumors silence ASS1 expression, rendering them arginine-auxotrophic—dependent on extracellular arginine for survival (rogers2022canonicalandnoncanonical pages 13-17, delage2010argininedeprivationand pages 3-5, sun2022argininosuccinatesynthase1 pages 1-2). ASS1 silencing occurs predominantly through epigenetic mechanisms, including CpG island hypermethylation of the ASS1 promoter, HIF-1α-mediated transcriptional repression under hypoxic conditions, METTL14-mediated N6-methyladenosine modification, and miRNA-mediated suppression (sun2022argininosuccinatesynthase1 pages 1-2, sun2022argininosuccinatesynthase1 pages 2-4, rogers2022canonicalandnoncanonical pages 21-25). Tumors with frequent ASS1 loss include melanoma, hepatocellular carcinoma, mesothelioma, sarcomas (up to 88%), renal cell carcinoma, pancreatic cancer, and prostate cancer (delage2010argininedeprivationand pages 3-5, rogers2022canonicalandnoncanonical pages 13-17). The loss of ASS1 redirects aspartate toward pyrimidine synthesis to support proliferation and simultaneously impairs NO-dependent tumor suppressive signaling (sun2022argininosuccinatesynthase1 pages 2-4).</p>
+<p>This vulnerability is exploited therapeutically by arginine deprivation therapy using ADI-PEG20 (pegylated arginine deiminase from <em>Mycoplasma</em>), which degrades extracellular arginine and selectively kills ASS1-deficient cancer cells (delage2010argininedeprivationand pages 3-5, rogers2022canonicalandnoncanonical pages 17-21, sun2022argininosuccinatesynthase1 pages 4-5). ADI-PEG20 has been evaluated in clinical trials for malignant pleural mesothelioma, pancreatic adenocarcinoma, non-small cell lung cancer, and other ASS1-low tumor types (sun2022argininosuccinatesynthase1 pages 7-7, sun2022argininosuccinatesynthase1 pages 4-5). Resistance mechanisms include ASS1 re-expression via promoter demethylation, autophagy-mediated intracellular arginine recycling, and extracellular vesicle-mediated arginine provision from stromal fibroblasts (rogers2022canonicalandnoncanonical pages 21-25, rogers2022canonicalandnoncanonical pages 13-17).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>ASS1 is a multifunctional metabolic enzyme whose primary role—the ATP-dependent condensation of citrulline and aspartate to form argininosuccinate—positions it at the nexus of nitrogen metabolism in humans. Operating principally in the cytosol, ASS1 is rate-limiting for the urea cycle, de novo arginine biosynthesis, and the citrulline-NO recycling pathway (fung2025arginineatthe pages 2-3, delage2010argininedeprivationand pages 2-3). Recent research has expanded the functional repertoire of ASS1 to include nuclear roles in the p53-mediated DNA damage response via fumarate-dependent chromatin remodeling (lim2024ass1metabolicallycontributes pages 6-6), circadian regulation of ureagenesis through CLOCK-mediated acetylation (lin2017clockacetylatesass1 pages 3-4), and coupling of ureagenesis to hepatic lipid metabolism through AMPK (madiraju2016argininosuccinatesynthetaseregulates pages 5-5). Loss of ASS1 function underlies the inherited metabolic disorder citrullinemia type I and creates a metabolic vulnerability in numerous cancers that has been therapeutically targeted through arginine deprivation strategies (ribas2022hyperammonemiaininherited pages 4-5, delage2010argininedeprivationand pages 3-5).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(diezfernandez2017mutationsinthe pages 1-6): Carmen Diez-Fernandez, Véronique Rüfenacht, and Johannes Häberle. Mutations in the human argininosuccinate synthetase (ass1) gene, impact on patients, common changes, and structural considerations. Human Mutation, 38:471-484, May 2017. URL: https://doi.org/10.1002/humu.23184, doi:10.1002/humu.23184. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(karlberg2008structureofhuman pages 1-2): Tobias Karlberg, Ruairi Collins, Susanne van den Berg, Alex Flores, Martin Hammarström, Martin Högbom, Lovisa Holmberg Schiavone, and Jonas Uppenberg. Structure of human argininosuccinate synthetase. Acta crystallographica. Section D, Biological crystallography, 64 Pt 3:279-86, Mar 2008. URL: https://doi.org/10.1107/s0907444907067455, doi:10.1107/s0907444907067455. This article has 56 citations.</p>
+</li>
+<li>
+<p>(fung2025arginineatthe pages 2-3): Tak Shun Fung, Keun Woo Ryu, and Craig B Thompson. Arginine: at the crossroads of nitrogen metabolism. The EMBO Journal, 44:1275-1293, Feb 2025. URL: https://doi.org/10.1038/s44318-025-00379-3, doi:10.1038/s44318-025-00379-3. This article has 94 citations.</p>
+</li>
+<li>
+<p>(karlberg2008structureofhuman pages 3-5): Tobias Karlberg, Ruairi Collins, Susanne van den Berg, Alex Flores, Martin Hammarström, Martin Högbom, Lovisa Holmberg Schiavone, and Jonas Uppenberg. Structure of human argininosuccinate synthetase. Acta crystallographica. Section D, Biological crystallography, 64 Pt 3:279-86, Mar 2008. URL: https://doi.org/10.1107/s0907444907067455, doi:10.1107/s0907444907067455. This article has 56 citations.</p>
+</li>
+<li>
+<p>(lim2024ass1metabolicallycontributes pages 6-6): Lisha Qiu Jin Lim, Lital Adler, Emma Hajaj, Leandro R. Soria, Rotem Ben-Tov Perry, Naama Darzi, Ruchama Brody, Noa Furth, Michal Lichtenstein, Elizabeta Bab-Dinitz, Ziv Porat, Tevie Melman, Alexander Brandis, Sergey Malitsky, Maxim Itkin, Yael Aylon, Shifra Ben-Dor, Irit Orr, Amir Pri-Or, Rony Seger, Yoav Shaul, Eytan Ruppin, Moshe Oren, Minervo Perez, Jordan Meier, Nicola Brunetti-Pierri, Efrat Shema, Igor Ulitsky, and Ayelet Erez. Ass1 metabolically contributes to the nuclear and cytosolic p53-mediated dna damage response. Nature Metabolism, 6:1294-1309, Jun 2024. URL: https://doi.org/10.1038/s42255-024-01060-5, doi:10.1038/s42255-024-01060-5. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(finnie2020investigatingass1and pages 100-105): Sarah Louise Finnie. Investigating ass1 and its role in renal fibrosis. ArXiv, Jun 2020. URL: https://doi.org/10.7488/era/258, doi:10.7488/era/258. This article has 0 citations.</p>
+</li>
+<li>
+<p>(karlberg2008structureofhuman pages 5-6): Tobias Karlberg, Ruairi Collins, Susanne van den Berg, Alex Flores, Martin Hammarström, Martin Högbom, Lovisa Holmberg Schiavone, and Jonas Uppenberg. Structure of human argininosuccinate synthetase. Acta crystallographica. Section D, Biological crystallography, 64 Pt 3:279-86, Mar 2008. URL: https://doi.org/10.1107/s0907444907067455, doi:10.1107/s0907444907067455. This article has 56 citations.</p>
+</li>
+<li>
+<p>(delage2010argininedeprivationand pages 2-3): Barbara Delage, Dean A. Fennell, Linda Nicholson, Iain McNeish, Nicholas R. Lemoine, Tim Crook, and Peter W. Szlosarek. Arginine deprivation and argininosuccinate synthetase expression in the treatment of cancer. International Journal of Cancer, 126:2762-2772, Jun 2010. URL: https://doi.org/10.1002/ijc.25202, doi:10.1002/ijc.25202. This article has 524 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(karlberg2008structureofhuman pages 6-7): Tobias Karlberg, Ruairi Collins, Susanne van den Berg, Alex Flores, Martin Hammarström, Martin Högbom, Lovisa Holmberg Schiavone, and Jonas Uppenberg. Structure of human argininosuccinate synthetase. Acta crystallographica. Section D, Biological crystallography, 64 Pt 3:279-86, Mar 2008. URL: https://doi.org/10.1107/s0907444907067455, doi:10.1107/s0907444907067455. This article has 56 citations.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 8-9): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 3-4): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 6-7): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sun2022argininosuccinatesynthase1 pages 2-4): Naihui Sun and Xing Zhao. Argininosuccinate synthase 1, arginine deprivation therapy and cancer management. Frontiers in Pharmacology, Jul 2022. URL: https://doi.org/10.3389/fphar.2022.935553, doi:10.3389/fphar.2022.935553. This article has 47 citations.</p>
+</li>
+<li>
+<p>(madiraju2016argininosuccinatesynthetaseregulates pages 5-5): Anila K. Madiraju, Tiago Alves, Xiaojian Zhao, Gary W. Cline, Dongyan Zhang, Sanjay Bhanot, Varman T. Samuel, Richard G. Kibbey, and Gerald I. Shulman. Argininosuccinate synthetase regulates hepatic ampk linking protein catabolism and ureagenesis to hepatic lipid metabolism. Proceedings of the National Academy of Sciences, 113:E3423-E3430, May 2016. URL: https://doi.org/10.1073/pnas.1606022113, doi:10.1073/pnas.1606022113. This article has 77 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lim2024ass1metabolicallycontributes pages 4-5): Lisha Qiu Jin Lim, Lital Adler, Emma Hajaj, Leandro R. Soria, Rotem Ben-Tov Perry, Naama Darzi, Ruchama Brody, Noa Furth, Michal Lichtenstein, Elizabeta Bab-Dinitz, Ziv Porat, Tevie Melman, Alexander Brandis, Sergey Malitsky, Maxim Itkin, Yael Aylon, Shifra Ben-Dor, Irit Orr, Amir Pri-Or, Rony Seger, Yoav Shaul, Eytan Ruppin, Moshe Oren, Minervo Perez, Jordan Meier, Nicola Brunetti-Pierri, Efrat Shema, Igor Ulitsky, and Ayelet Erez. Ass1 metabolically contributes to the nuclear and cytosolic p53-mediated dna damage response. Nature Metabolism, 6:1294-1309, Jun 2024. URL: https://doi.org/10.1038/s42255-024-01060-5, doi:10.1038/s42255-024-01060-5. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diezfernandez2017mutationsinthe pages 10-14): Carmen Diez-Fernandez, Véronique Rüfenacht, and Johannes Häberle. Mutations in the human argininosuccinate synthetase (ass1) gene, impact on patients, common changes, and structural considerations. Human Mutation, 38:471-484, May 2017. URL: https://doi.org/10.1002/humu.23184, doi:10.1002/humu.23184. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diezfernandez2017mutationsinthe pages 14-18): Carmen Diez-Fernandez, Véronique Rüfenacht, and Johannes Häberle. Mutations in the human argininosuccinate synthetase (ass1) gene, impact on patients, common changes, and structural considerations. Human Mutation, 38:471-484, May 2017. URL: https://doi.org/10.1002/humu.23184, doi:10.1002/humu.23184. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ribas2022hyperammonemiaininherited pages 4-5): Graziela Schmitt Ribas, Franciele Fátima Lopes, Marion Deon, and Carmen Regla Vargas. Hyperammonemia in inherited metabolic diseases. Cellular and Molecular Neurobiology, 42:2593-2610, Oct 2022. URL: https://doi.org/10.1007/s10571-021-01156-6, doi:10.1007/s10571-021-01156-6. This article has 92 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rogers2022canonicalandnoncanonical pages 13-17): Canonical and Noncanonical Mechanisms of Resistance to Arginine Starvation in Cancer This article has 0 citations.</p>
+</li>
+<li>
+<p>(delage2010argininedeprivationand pages 3-5): Barbara Delage, Dean A. Fennell, Linda Nicholson, Iain McNeish, Nicholas R. Lemoine, Tim Crook, and Peter W. Szlosarek. Arginine deprivation and argininosuccinate synthetase expression in the treatment of cancer. International Journal of Cancer, 126:2762-2772, Jun 2010. URL: https://doi.org/10.1002/ijc.25202, doi:10.1002/ijc.25202. This article has 524 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diezfernandez2017mutationsinthe pages 22-27): Carmen Diez-Fernandez, Véronique Rüfenacht, and Johannes Häberle. Mutations in the human argininosuccinate synthetase (ass1) gene, impact on patients, common changes, and structural considerations. Human Mutation, 38:471-484, May 2017. URL: https://doi.org/10.1002/humu.23184, doi:10.1002/humu.23184. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(karlberg2008structureofhuman pages 2-3): Tobias Karlberg, Ruairi Collins, Susanne van den Berg, Alex Flores, Martin Hammarström, Martin Högbom, Lovisa Holmberg Schiavone, and Jonas Uppenberg. Structure of human argininosuccinate synthetase. Acta crystallographica. Section D, Biological crystallography, 64 Pt 3:279-86, Mar 2008. URL: https://doi.org/10.1107/s0907444907067455, doi:10.1107/s0907444907067455. This article has 56 citations.</p>
+</li>
+<li>
+<p>(lakhalnaouar2012leishmaniadonovaniargininosuccinate pages 2-3): Ines Lakhal-Naouar, Armando Jardim, Rona Strasser, Shen Luo, Yukiko Kozakai, Hira L. Nakhasi, and Robert C. Duncan. Leishmania donovani argininosuccinate synthase is an active enzyme associated with parasite pathogenesis. PLoS Neglected Tropical Diseases, 6:e1849, Oct 2012. URL: https://doi.org/10.1371/journal.pntd.0001849, doi:10.1371/journal.pntd.0001849. This article has 25 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lim2024ass1metabolicallycontributes pages 2-3): Lisha Qiu Jin Lim, Lital Adler, Emma Hajaj, Leandro R. Soria, Rotem Ben-Tov Perry, Naama Darzi, Ruchama Brody, Noa Furth, Michal Lichtenstein, Elizabeta Bab-Dinitz, Ziv Porat, Tevie Melman, Alexander Brandis, Sergey Malitsky, Maxim Itkin, Yael Aylon, Shifra Ben-Dor, Irit Orr, Amir Pri-Or, Rony Seger, Yoav Shaul, Eytan Ruppin, Moshe Oren, Minervo Perez, Jordan Meier, Nicola Brunetti-Pierri, Efrat Shema, Igor Ulitsky, and Ayelet Erez. Ass1 metabolically contributes to the nuclear and cytosolic p53-mediated dna damage response. Nature Metabolism, 6:1294-1309, Jun 2024. URL: https://doi.org/10.1038/s42255-024-01060-5, doi:10.1038/s42255-024-01060-5. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sun2022argininosuccinatesynthase1 pages 1-2): Naihui Sun and Xing Zhao. Argininosuccinate synthase 1, arginine deprivation therapy and cancer management. Frontiers in Pharmacology, Jul 2022. URL: https://doi.org/10.3389/fphar.2022.935553, doi:10.3389/fphar.2022.935553. This article has 47 citations.</p>
+</li>
+<li>
+<p>(leung2012argininosuccinatesynthaseconditions pages 3-5): Tung Ming Leung, Yongke Lu, Wei Yan, José A. Morón-Concepción, Stephen C. Ward, Xiaodong Ge, Laura Conde de la Rosa, and Natalia Nieto. Argininosuccinate synthase conditions the response to acute and chronic ethanol‐induced liver injury in mice. Hepatology, 55:1596-1609, May 2012. URL: https://doi.org/10.1002/hep.25543, doi:10.1002/hep.25543. This article has 75 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fung2025arginineatthe pages 9-10): Tak Shun Fung, Keun Woo Ryu, and Craig B Thompson. Arginine: at the crossroads of nitrogen metabolism. The EMBO Journal, 44:1275-1293, Feb 2025. URL: https://doi.org/10.1038/s44318-025-00379-3, doi:10.1038/s44318-025-00379-3. This article has 94 citations.</p>
+</li>
+<li>
+<p>(rogers2022canonicalandnoncanonical pages 17-21): Canonical and Noncanonical Mechanisms of Resistance to Arginine Starvation in Cancer This article has 0 citations.</p>
+</li>
+<li>
+<p>(lim2024ass1metabolicallycontributes pages 1-2): Lisha Qiu Jin Lim, Lital Adler, Emma Hajaj, Leandro R. Soria, Rotem Ben-Tov Perry, Naama Darzi, Ruchama Brody, Noa Furth, Michal Lichtenstein, Elizabeta Bab-Dinitz, Ziv Porat, Tevie Melman, Alexander Brandis, Sergey Malitsky, Maxim Itkin, Yael Aylon, Shifra Ben-Dor, Irit Orr, Amir Pri-Or, Rony Seger, Yoav Shaul, Eytan Ruppin, Moshe Oren, Minervo Perez, Jordan Meier, Nicola Brunetti-Pierri, Efrat Shema, Igor Ulitsky, and Ayelet Erez. Ass1 metabolically contributes to the nuclear and cytosolic p53-mediated dna damage response. Nature Metabolism, 6:1294-1309, Jun 2024. URL: https://doi.org/10.1038/s42255-024-01060-5, doi:10.1038/s42255-024-01060-5. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lim2024ass1metabolicallycontributes pages 7-8): Lisha Qiu Jin Lim, Lital Adler, Emma Hajaj, Leandro R. Soria, Rotem Ben-Tov Perry, Naama Darzi, Ruchama Brody, Noa Furth, Michal Lichtenstein, Elizabeta Bab-Dinitz, Ziv Porat, Tevie Melman, Alexander Brandis, Sergey Malitsky, Maxim Itkin, Yael Aylon, Shifra Ben-Dor, Irit Orr, Amir Pri-Or, Rony Seger, Yoav Shaul, Eytan Ruppin, Moshe Oren, Minervo Perez, Jordan Meier, Nicola Brunetti-Pierri, Efrat Shema, Igor Ulitsky, and Ayelet Erez. Ass1 metabolically contributes to the nuclear and cytosolic p53-mediated dna damage response. Nature Metabolism, 6:1294-1309, Jun 2024. URL: https://doi.org/10.1038/s42255-024-01060-5, doi:10.1038/s42255-024-01060-5. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 10-11): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 4-5): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 9-10): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lim2024ass1metabolicallycontributes pages 5-6): Lisha Qiu Jin Lim, Lital Adler, Emma Hajaj, Leandro R. Soria, Rotem Ben-Tov Perry, Naama Darzi, Ruchama Brody, Noa Furth, Michal Lichtenstein, Elizabeta Bab-Dinitz, Ziv Porat, Tevie Melman, Alexander Brandis, Sergey Malitsky, Maxim Itkin, Yael Aylon, Shifra Ben-Dor, Irit Orr, Amir Pri-Or, Rony Seger, Yoav Shaul, Eytan Ruppin, Moshe Oren, Minervo Perez, Jordan Meier, Nicola Brunetti-Pierri, Efrat Shema, Igor Ulitsky, and Ayelet Erez. Ass1 metabolically contributes to the nuclear and cytosolic p53-mediated dna damage response. Nature Metabolism, 6:1294-1309, Jun 2024. URL: https://doi.org/10.1038/s42255-024-01060-5, doi:10.1038/s42255-024-01060-5. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2017clockacetylatesass1 pages 7-8): Ran Lin, Yan Mo, Haihong Zha, Zhipeng Qu, Pancheng Xie, Zheng-Jiang Zhu, Ying Xu, Yue Xiong, and Kun-Liang Guan. Clock acetylates ass1 to drive circadian rhythm of ureagenesis. Molecular cell, 68 1:198-209.e6, Oct 2017. URL: https://doi.org/10.1016/j.molcel.2017.09.008, doi:10.1016/j.molcel.2017.09.008. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rogers2022canonicalandnoncanonical pages 21-25): Canonical and Noncanonical Mechanisms of Resistance to Arginine Starvation in Cancer This article has 0 citations.</p>
+</li>
+<li>
+<p>(sun2022argininosuccinatesynthase1 pages 4-5): Naihui Sun and Xing Zhao. Argininosuccinate synthase 1, arginine deprivation therapy and cancer management. Frontiers in Pharmacology, Jul 2022. URL: https://doi.org/10.3389/fphar.2022.935553, doi:10.3389/fphar.2022.935553. This article has 47 citations.</p>
+</li>
+<li>
+<p>(sun2022argininosuccinatesynthase1 pages 7-7): Naihui Sun and Xing Zhao. Argininosuccinate synthase 1, arginine deprivation therapy and cancer management. Frontiers in Pharmacology, Jul 2022. URL: https://doi.org/10.3389/fphar.2022.935553, doi:10.3389/fphar.2022.935553. This article has 47 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ASS1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="ASS1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>karlberg2008structureofhuman pages 1-2</li>
+<li>diezfernandez2017mutationsinthe pages 1-6</li>
+<li>diezfernandez2017mutationsinthe pages 22-27</li>
+<li>delage2010argininedeprivationand pages 2-3</li>
+<li>lakhalnaouar2012leishmaniadonovaniargininosuccinate pages 2-3</li>
+<li>karlberg2008structureofhuman pages 5-6</li>
+<li>karlberg2008structureofhuman pages 3-5</li>
+<li>madiraju2016argininosuccinatesynthetaseregulates pages 5-5</li>
+<li>diezfernandez2017mutationsinthe pages 10-14</li>
+<li>fung2025arginineatthe pages 2-3</li>
+<li>leung2012argininosuccinatesynthaseconditions pages 3-5</li>
+<li>ribas2022hyperammonemiaininherited pages 4-5</li>
+<li>karlberg2008structureofhuman pages 6-7</li>
+<li>diezfernandez2017mutationsinthe pages 14-18</li>
+<li>rogers2022canonicalandnoncanonical pages 13-17</li>
+<li>delage2010argininedeprivationand pages 3-5</li>
+<li>karlberg2008structureofhuman pages 2-3</li>
+<li>fung2025arginineatthe pages 9-10</li>
+<li>rogers2022canonicalandnoncanonical pages 17-21</li>
+<li>rogers2022canonicalandnoncanonical pages 21-25</li>
+<li>https://doi.org/10.1002/humu.23184,</li>
+<li>https://doi.org/10.1107/s0907444907067455,</li>
+<li>https://doi.org/10.1038/s44318-025-00379-3,</li>
+<li>https://doi.org/10.1038/s42255-024-01060-5,</li>
+<li>https://doi.org/10.7488/era/258,</li>
+<li>https://doi.org/10.1002/ijc.25202,</li>
+<li>https://doi.org/10.1016/j.molcel.2017.09.008,</li>
+<li>https://doi.org/10.3389/fphar.2022.935553,</li>
+<li>https://doi.org/10.1073/pnas.1606022113,</li>
+<li>https://doi.org/10.1007/s10571-021-01156-6,</li>
+<li>https://doi.org/10.1371/journal.pntd.0001849,</li>
+<li>https://doi.org/10.1002/hep.25543,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P00966
+gene_symbol: ASS1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ASS1 encodes argininosuccinate synthase (EC 6.3.4.5), a cytosolic homotetrameric
+  ligase that catalyzes the ATP-dependent condensation of L-citrulline and L-aspartate
+  to form argininosuccinate, AMP and diphosphate. This is the rate-limiting and committed
+  step of de novo L-arginine biosynthesis and the third step of the hepatic urea cycle,
+  where aspartate serves as the second nitrogen donor and the reaction feeds argininosuccinate
+  to argininosuccinate lyase (ASL) for cleavage to arginine and fumarate. In the liver
+  the enzyme is central to the disposal of ammonia as urea; in most extrahepatic tissues,
+  ASS1 acting together with ASL regenerates arginine from citrulline (the citrulline-arginine
+  cycle) and supplies arginine as substrate for nitric oxide synthases (the citrulline-NO
+  cycle), notably in vascular endothelium and immune cells. Enzyme activity is modulated
+  post-translationally, including inhibitory acetylation of Lys165/Lys176 that imposes a
+  circadian rhythm on ureagenesis. Loss-of-function ASS1 variants cause citrullinemia type I
+  (CTLN1), an autosomal recessive urea cycle disorder with hyperammonemia, elevated plasma
+  citrulline and low arginine.
+existing_annotations:
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred core molecular function. This is the correct and well-supported
+      catalytic activity for ASS1 (EC 6.3.4.5), the enzyme name itself, and is confirmed by
+      direct enzymology of the human recombinant protein.
+    action: ACCEPT
+    reason: &gt;-
+      IBA at exactly the right level of specificity for the family and directly corroborated by
+      human experimental data. This is a defining core function.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred cytosolic localization. ASS1 is a soluble cytosolic enzyme; the
+      substrate citrulline is exported from mitochondria and converted in the cytosol.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with UniProt subcellular location (Cytoplasm, cytosol) and with direct
+      immunofluorescence/experimental evidence. Correct compartment for a core function.
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred role in L-arginine biosynthesis. ASS1 with ASL performs the two
+      steps that convert citrulline to arginine, making arginine available in most tissues.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, matching UniProt PATHWAY annotation (L-arginine biosynthesis, step
+      2/3) and experimental patient/expression data. IBA at appropriate specificity.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred participation in the urea cycle, the metabolic step condensing
+      citrulline and aspartate to argininosuccinate. This is a core biological process for the
+      hepatic enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by human enzymology and disease genetics; ASS1 deficiency is the cause of
+      citrullinemia type I, a urea cycle disorder. IBA correct.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Automated (multiple IEA methods) assignment of the core catalytic activity, backed by
+      InterPro signatures, RHEA:10932 and EC 6.3.4.5. Fully consistent with the experimental
+      activity.
+    action: ACCEPT
+    reason: &gt;-
+      Redundant with the IBA/IMP argininosuccinate synthase activity annotations but correct; the
+      EC/RHEA/InterPro mapping is accurate for this enzyme.
+    supported_by:
+      - reference_id: PMID:18473344
+        supporting_text: &#34;caused by deficiency of the urea cycle enzyme argininosuccinate synthetase&#34;
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping of ATP binding. ASS1 uses ATP as a co-substrate (activating citrulline
+      via a citrullyl-AMP intermediate), and UniProt documents an ATP-binding SSGGxDS motif and
+      ATP-binding feature/keyword.
+    action: ACCEPT
+    reason: &gt;-
+      Correct molecular function supported by the catalyzed reaction (ATP -&gt; AMP + PPi) and by
+      UniProt nucleotide-binding features; a genuine ligand-binding activity underpinning catalysis.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Subcellular-location keyword mapping to cytosol from UniProt SL-0091.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimentally supported cytosolic localization; redundant but correct.
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Automated assignment of the L-arginine biosynthetic process, matching UniPathway UPA00068.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core process, redundant with the IBA/IMP annotations.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12620389
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with ARAF (Raf kinase) found in an exhaustive yeast two-hybrid
+      screen. &#34;protein binding&#34; is uninformative and this is a high-throughput two-hybrid hit with
+      no established biological consequence for ASS1.
+    action: REMOVE
+    reason: &gt;-
+      Per curation guidelines, bare &#34;protein binding&#34; (GO:0005515) is uninformative and should be
+      avoided. The interaction is a screen-derived putative binary interaction (A-Raf/C-Raf Y2H
+      atlas) not connected to ASS1 function; it adds no functional information to the review.
+    supported_by:
+      - reference_id: PMID:12620389
+        supporting_text: &#34;We have performed an exhaustive unbiased yeast two-hybrid analysis to identify&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17496144
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with NMRAL1 (HSCARG, an NADP(H)-sensing redox protein). UniProt
+      records this interaction, and NMRAL1 has been reported to regulate ASS1 activity. However
+      the GO term captured is only the uninformative &#34;protein binding&#34;.
+    action: REMOVE
+    reason: &gt;-
+      Bare &#34;protein binding&#34; is uninformative and discouraged. The underlying NMRAL1 interaction is
+      real and biologically noted (redox regulation of ASS1), but the informative content belongs
+      in a specific term or in the description, not in GO:0005515. The interaction itself is
+      retained conceptually via UniProt SUBUNIT and is not lost.
+    supported_by:
+      - reference_id: PMID:17496144
+        supporting_text: &#34;may be argininosuccinate&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28587924
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with PRMT7 (protein arginine methyltransferase 7), a direct
+      interactor identified by Y2H and confirmed by pull-down; citrullinemia mutations disrupt the
+      interaction. Captured only as uninformative &#34;protein binding&#34;.
+    action: REMOVE
+    reason: &gt;-
+      Bare &#34;protein binding&#34; is discouraged. The PRMT7-ASS1 interaction is a genuine and
+      interesting finding, but the GO term is uninformative; the biology is retained in the
+      description and could be captured by a specific term if warranted. No functional information
+      is lost by removing GO:0005515.
+    supported_by:
+      - reference_id: PMID:28587924
+        supporting_text: &#34;interacts with ASS1 using pull-down studies.&#34;
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16189514
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Self-interaction (ASS1-ASS1) consistent with the well-established homotetrameric quaternary
+      structure of the enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      &#34;identical protein binding&#34; is informative here: ASS1 is a homotetramer composed of identical
+      subunits, so self-association is a bona fide, functionally meaningful property (the active
+      enzyme is the tetramer). Multiple independent interactome studies report the self-interaction.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Self-interaction detected in a human liver protein-interaction network study, consistent with
+      the homotetrameric architecture of ASS1.
+    action: ACCEPT
+    reason: &gt;-
+      Corroborates the homotetramer; &#34;identical protein binding&#34; is a meaningful function for this
+      obligate oligomer.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Self-interaction from a proteome-scale human interactome map, again consistent with the
+      homotetramer.
+    action: ACCEPT
+    reason: &gt;-
+      Reinforces the biologically meaningful homo-oligomerization of ASS1.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Automated urea cycle assignment, matching UniPathway UPA00158.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core process, redundant with IBA and multiple experimental IMP annotations.
+- term:
+    id: GO:0001822
+    label: kidney development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. ASS1 is expressed in fetal kidney and is part of
+      the intestinal-renal citrulline-arginine axis, but a direct role in kidney developmental
+      morphogenesis is not established for the human enzyme; this reads as an expression/context
+      annotation rather than a developmental function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer IEA reflecting a tissue in which ASS1 is expressed and active rather than a
+      core molecular role in organ development. Not a core function; retain as non-core pending
+      direct evidence.
+- term:
+    id: GO:0001889
+    label: liver development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. ASS1 is the principal hepatic urea-cycle enzyme
+      and is developmentally regulated in fetal liver, but &#34;liver development&#34; (organ
+      morphogenesis) overstates its role; its liver function is metabolic (ureagenesis).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer IEA describing the tissue context (liver) of ASS1 expression rather than a
+      causal role in liver organogenesis. Retain as non-core; the metabolic role is captured by the
+      urea cycle / arginine biosynthesis annotations.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer (from mouse) placing ASS1 in the mitochondrion. This
+      contradicts the well-established cytosolic localization of ASS1; the enzyme acts in the
+      cytosol on citrulline exported from mitochondria.
+    action: REMOVE
+    reason: &gt;-
+      ASS1 is a soluble cytosolic enzyme (UniProt: Cytoplasm, cytosol; direct IDA cytosol
+      annotations). Mitochondrial localization is an over-propagated ortholog-transfer IEA
+      inconsistent with the human protein and with urea-cycle compartmentalization (only the
+      upstream steps CPS1/OTC are mitochondrial).
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer (from rat) placing ASS1 at the mitochondrial outer
+      membrane. Inconsistent with the established cytosolic localization of the enzyme.
+    action: REMOVE
+    reason: &gt;-
+      Over-propagated ortholog-transfer IEA. ASS1 is cytosolic; there is no reliable evidence for
+      the human enzyme residing at the mitochondrial outer membrane.
+- term:
+    id: GO:0006953
+    label: acute-phase response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. Reflects transcriptional induction of ASS1 under
+      inflammatory/cytokine stimulation rather than a direct molecular role in the acute-phase
+      response.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Regulation-of-expression / stimulus-response context transferred from ortholog, not a core
+      catalytic role. Retain as non-core.
+- term:
+    id: GO:0007494
+    label: midgut development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. Likely reflects intestinal ASS1 expression
+      (enterocytes contribute to systemic citrulline/arginine metabolism) rather than a role in gut
+      morphogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer IEA describing an expression context, not a core developmental function of
+      the human enzyme. Retain as non-core.
+- term:
+    id: GO:0007584
+    label: response to nutrient
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. ASS1 expression/activity responds to dietary
+      protein and amino acid availability, but this is a stimulus-response context, not a core
+      molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Physiologically plausible (urea-cycle flux tracks nitrogen load) but an ortholog-transfer
+      response annotation rather than core function. Retain as non-core.
+- term:
+    id: GO:0007623
+    label: circadian rhythm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from mouse. This is corroborated by direct human/mouse
+      evidence: CLOCK acetylates ASS1 (K165/K176) to inactivate it in a circadian manner, imposing
+      a circadian rhythm on ureagenesis.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supported by experiment (see the IDA circadian rhythm annotation, PMID:28985504), but this is
+      a regulated-behavior/output context rather than ASS1&#39;s core catalytic function. Retain as
+      non-core; redundant with the experimental annotation below.
+    supported_by:
+      - reference_id: PMID:28985504
+        supporting_text: &#34;ASS1 acetylation by CLOCK exhibits circadian oscillation&#34;
+- term:
+    id: GO:0009410
+    label: response to xenobiotic stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat, reflecting altered ASS1 expression on xenobiotic
+      exposure. Stimulus-response context, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation; retain as non-core.
+- term:
+    id: GO:0009636
+    label: response to toxic substance
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. A broad stimulus-response term reflecting
+      expression changes; not a core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation with no direct human evidence for a core role; retain
+      as non-core.
+- term:
+    id: GO:0010043
+    label: response to zinc ion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; a specific stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0010046
+    label: response to mycotoxin
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; narrow stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0014075
+    label: response to amine
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0015643
+    label: toxic substance binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat asserting ASS1 &#34;binds a toxic substance&#34;. There is
+      no credible biochemical basis for treating ASS1 as a toxin-binding protein; ASS1 is a
+      metabolic ligase. This is an anomalous, likely spuriously propagated molecular-function IEA.
+    action: REMOVE
+    reason: &gt;-
+      Biologically implausible for a cytosolic urea-cycle ligase; unsupported by any human evidence
+      or by the enzyme&#39;s mechanism. The term definition (&#34;Binding to a toxic substance, a poisonous
+      substance that causes damage to biological systems&#34;) does not fit ASS1. Over-propagated
+      ortholog-transfer IEA.
+- term:
+    id: GO:0032355
+    label: response to estradiol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0032496
+    label: response to lipopolysaccharide
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. ASS1 is induced with iNOS in inflammatory
+      (LPS/cytokine) settings to supply arginine for NO production, so this context is plausible,
+      but it is not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation consistent with the citrulline-NO cycle role in
+      immune/inflammatory cells; retain as non-core.
+- term:
+    id: GO:0043025
+    label: neuronal cell body
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat placing ASS1 in the neuronal cell body. ASS1 is
+      expressed in specific neurons (citrulline-NO cycle), and within a neuron it would be
+      cytosolic; the specific location is an ortholog-transferred expression context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cell-type-specific localization transferred from ortholog; plausible for the tissue context
+      but not the canonical/core cytosolic annotation. Retain as non-core.
+- term:
+    id: GO:0043200
+    label: response to amino acid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; amino-acid stimulus-response context (ASS1
+      expression/activity responds to substrate and amino acid availability).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0043204
+    label: perikaryon
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat placing ASS1 in the perikaryon (neuronal cell
+      body cytoplasm). A cell-type-specific location transferred from ortholog.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer localization tied to a specific tissue context; not the canonical/core
+      cytosol annotation. Retain as non-core.
+- term:
+    id: GO:0043434
+    label: response to peptide hormone
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0048545
+    label: response to steroid hormone
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; steroid-hormone stimulus-response context (ASS1 is
+      known to be glucocorticoid-inducible).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0051384
+    label: response to glucocorticoid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. ASS1 transcription is induced by glucocorticoids
+      (hepatic urea-cycle regulation), so this context is plausible.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation reflecting hormonal regulation of expression, not core
+      catalytic function; retain as non-core.
+- term:
+    id: GO:0060416
+    label: response to growth hormone
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0060539
+    label: diaphragm development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat. There is no established human evidence linking
+      ASS1 to diaphragm morphogenesis; this reads as a weakly supported ortholog-transferred
+      developmental annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer developmental annotation lacking direct human support; not a core function.
+      Retain as non-core rather than removing, deferring to the experimental source in the
+      orthologous species.
+- term:
+    id: GO:0070542
+    label: response to fatty acid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0070852
+    label: cell body fiber
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; a neuronal cell-type-specific location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer localization for a specific tissue context; not the canonical/core cytosol
+      annotation. Retain as non-core.
+- term:
+    id: GO:0071222
+    label: cellular response to lipopolysaccharide
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; cellular stimulus-response context (inflammatory
+      induction of ASS1 for arginine/NO supply).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation consistent with the citrulline-NO cycle in immune
+      cells; retain as non-core.
+- term:
+    id: GO:0071230
+    label: cellular response to amino acid stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; amino-acid stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071242
+    label: cellular response to ammonium ion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; stimulus-response context (ureagenesis responds
+      to nitrogen/ammonia load).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071320
+    label: cellular response to cAMP
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; second-messenger stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071346
+    label: cellular response to type II interferon
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; cytokine (IFN-gamma) stimulus-response context,
+      consistent with immune induction of ASS1 for arginine/NO supply.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071356
+    label: cellular response to tumor necrosis factor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; cytokine (TNF) stimulus-response context. Related
+      human work shows ASS1/NOS3 counteract TNF-alpha-stimulated monocyte adhesion in endothelium.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071377
+    label: cellular response to glucagon stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; hormone stimulus-response context (glucagon
+      induces hepatic urea-cycle enzymes).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071400
+    label: cellular response to oleic acid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; a narrow fatty-acid stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071418
+    label: cellular response to amine stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; amine stimulus-response context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0071549
+    label: cellular response to dexamethasone stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer from rat; glucocorticoid (dexamethasone) stimulus-response
+      context, consistent with glucocorticoid induction of ASS1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Ortholog-transfer response annotation, not core function; retain as non-core.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IMP
+  original_reference_id: PMID:7977368
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) urea cycle annotation based on characterization of citrullinemia-causing
+      ASS1 mutations in patients. Loss of ASS1 function blocks the urea cycle, causing classic
+      citrullinemia.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by patient mutation genetics; a core biological process. Defer to the
+      curator&#39;s full-text reading of the disease-gene relationship.
+    supported_by:
+      - reference_id: PMID:7977368
+        supporting_text: &#34;Citrullinemia is an autosomal recessive disease caused by a genetic deficiency&#34;
+- term:
+    id: GO:0006533
+    label: L-aspartate catabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:7977368
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) annotation reflecting that ASS1 consumes L-aspartate (the second nitrogen
+      donor) in the argininosuccinate synthase reaction. This is a curator reframing of the same
+      catalytic step as an aspartate catabolic process.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Not incorrect (ASS1 does consume aspartate as a co-substrate), but it is a redundant,
+      substrate-centric restatement of the core argininosuccinate synthase activity / urea cycle
+      role rather than an independent biological process. Retain as non-core; defer to the
+      experimental curator who read the full text.
+    supported_by:
+      - reference_id: PMID:7977368
+        supporting_text: &#34;Citrullinemia is an autosomal recessive disease caused by a genetic deficiency&#34;
+- term:
+    id: GO:0019241
+    label: L-citrulline catabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:7977368
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) annotation reflecting that ASS1 consumes L-citrulline in the
+      argininosuccinate synthase reaction; ASS1 deficiency causes citrulline accumulation. This is a
+      substrate-centric reframing of the same catalytic step.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Not incorrect (citrulline is the substrate whose accumulation defines citrullinemia), but it
+      is a redundant restatement of the core enzyme activity / arginine-biosynthesis and urea-cycle
+      roles. Retain as non-core; defer to the experimental curator.
+    supported_by:
+      - reference_id: PMID:7977368
+        supporting_text: &#34;Citrullinemia is an autosomal recessive disease caused by a genetic deficiency&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct immunofluorescence (Human Protein Atlas) localization to the cytosol.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental confirmation of the core cytosolic localization of ASS1.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9956517
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement placing ASS1 (in the context of disease variants failing
+      to synthesize argininosuccinate) in the cytosol.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the established cytosolic localization; redundant but correct.
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IMP
+  original_reference_id: PMID:28985504
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for ASS1 catalytic activity from the CLOCK-acetylation study,
+      which manipulated ASS1 and measured its activity (acetylation of K165/K176 inactivates the
+      enzyme).
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function directly assayed in the study; ASS1 &#34;catalyzes the rate-limiting step
+      of arginine biosynthesis&#34;.
+    supported_by:
+      - reference_id: PMID:28985504
+        supporting_text: &#34;synthase (ASS1) to inactivate ASS1, which catalyzes the rate-limiting step of&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28985504
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct/UniProt interaction with CLOCK (O15516) demonstrated in the circadian-ureagenesis
+      study. Captured only as uninformative &#34;protein binding&#34;.
+    action: REMOVE
+    reason: &gt;-
+      Bare &#34;protein binding&#34; is discouraged. The ASS1-CLOCK interaction is genuine and functionally
+      important (CLOCK acetylates ASS1), but this content is retained in the description and in the
+      circadian-rhythm annotation; the uninformative GO:0005515 term itself adds nothing.
+    supported_by:
+      - reference_id: PMID:28985504
+        supporting_text: &#34;CLOCK directly acetylates K165 and K176 of argininosuccinate&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:28985504
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) cytosolic localization from the CLOCK-acetylation study; UniProt
+      cites this paper for the Cytoplasm, cytosol subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental confirmation of the core cytosolic localization.
+- term:
+    id: GO:0007623
+    label: circadian rhythm
+  evidence_type: IDA
+  original_reference_id: PMID:28985504
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) evidence that ASS1 activity is under circadian control: CLOCK
+      acetylates ASS1 in a circadian manner, producing an oscillation in ASS1 activity and
+      ureagenesis in human cells and mouse liver.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Well supported experimentally, but this describes a regulated output/behavior in which ASS1
+      participates rather than ASS1&#39;s intrinsic core function. Retain as non-core.
+    supported_by:
+      - reference_id: PMID:28985504
+        supporting_text: &#34;ASS1 acetylation by CLOCK exhibits circadian oscillation&#34;
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IMP
+  original_reference_id: PMID:8792870
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) urea cycle annotation from characterization of wild-type and mutant human
+      ASS proteins; the paper explicitly frames ASS as a urea cycle enzyme and links mutations to
+      citrullinemia.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, directly supported by recombinant enzymology of the human protein.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IMP
+  original_reference_id: PMID:8792870
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) measurement of ASS catalytic activity: purified recombinant wild-type
+      human ASS matched native liver enzyme, and mutants showed reduced/abolished activity and
+      abnormal kinetics (elevated Km for citrulline).
+    action: ACCEPT
+    reason: &gt;-
+      Direct biochemical characterization of the core molecular function of the human enzyme.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;G280R mutant was extracted with an amount of ASS protein similar to wild-type&#34;
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:8792870
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for ASS1&#39;s role in arginine biosynthesis via the biochemical
+      characterization of the enzyme that carries out the committed step.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process supported by the human enzymology; defer to the experimental curator.
+    supported_by:
+      - reference_id: PMID:8792870
+        supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IMP
+  original_reference_id: PMID:18473344
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) urea cycle annotation from in vitro expression/enzymology of CTLN1
+      variants; the paper describes ASS as &#34;the urea cycle enzyme argininosuccinate synthetase&#34;.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process supported by disease-variant enzymology.
+    supported_by:
+      - reference_id: PMID:18473344
+        supporting_text: &#34;caused by deficiency of the urea cycle enzyme argininosuccinate synthetase&#34;
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IMP
+  original_reference_id: PMID:18473344
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) enzymatic analysis of purified wild-type and mutant ASS proteins, with
+      measured kinetic parameters (KM 112 uM citrulline, 68 uM aspartate) and reduced activity for
+      pathogenic variants.
+    action: ACCEPT
+    reason: &gt;-
+      Direct measurement of the core catalytic activity; underpins the UniProt EC 6.3.4.5 and
+      kinetic parameters.
+    supported_by:
+      - reference_id: PMID:18473344
+        supporting_text: &#34;enzymatic analysis of purified wild-type and the mutant ASS proteins&#34;
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:18473344
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for the arginine-biosynthesis role via enzymology of the ASS
+      reaction, which produces argininosuccinate en route to arginine.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process supported by the human enzyme characterization.
+    supported_by:
+      - reference_id: PMID:18473344
+        supporting_text: &#34;caused by deficiency of the urea cycle enzyme argininosuccinate synthetase&#34;
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IMP
+  original_reference_id: PMID:27287393
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) urea cycle annotation from characterization of 21 kinetic CTLN1 mutations;
+      the paper frames citrullinemia type 1 as &#34;an autosomal-recessive urea cycle disorder&#34;.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process supported by disease-mutation enzymology.
+    supported_by:
+      - reference_id: PMID:27287393
+        supporting_text: &#34;BACKGROUND: Citrullinemia type 1 is an autosomal-recessive urea cycle disorder&#34;
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IMP
+  original_reference_id: PMID:27287393
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) measurement of ASS catalytic activity and kinetics for 21 mutants by
+      tandem mass spectrometry; 13 were inactive and 8 had decreased substrate affinity, rescuable
+      by aspartate supplementation.
+    action: ACCEPT
+    reason: &gt;-
+      Direct quantitative measurement of the core molecular function of the human enzyme.
+    supported_by:
+      - reference_id: PMID:27287393
+        supporting_text: &#34;activity and kinetic parameters were measured using tandem mass spectrometry and&#34;
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:27287393
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for the arginine-biosynthesis role via kinetic characterization of
+      the ASS reaction (citrulline + aspartate + ATP -&gt; argininosuccinate).
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process supported by the human enzyme kinetics.
+    supported_by:
+      - reference_id: PMID:27287393
+        supporting_text: &#34;map near the substrate (aspartate or citrulline)&#34;
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput detection of ASS1 peptides in urinary/prostatic exosome proteomes. This is a
+      mass-spectrometry proteomic inventory, not evidence of a functional extracellular-vesicle
+      localization for a cytosolic metabolic enzyme.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Abundant cytosolic enzymes are common background hits in exosome/secretome proteomics; the
+      finding is real as a detection event but does not reflect a core functional localization.
+      Retain as non-core rather than removing, since the peptide detection is genuine.
+    supported_by:
+      - reference_id: PMID:23533145
+        supporting_text: &#34;expressed prostatic secretions in urine (EPS-urine), exosome preparations were&#34;
+- term:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  evidence_type: IMP
+  original_reference_id: PMID:7977368
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for the catalytic activity via mutation analysis in citrullinemia
+      patients; the deficiency of ASS activity underlies the disease.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function supported by patient genetics; defer to the experimental curator.
+    supported_by:
+      - reference_id: PMID:7977368
+        supporting_text: &#34;Citrullinemia is an autosomal recessive disease caused by a genetic deficiency&#34;
+- term:
+    id: GO:0016597
+    label: amino acid binding
+  evidence_type: IMP
+  original_reference_id: PMID:7977368
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) annotation of amino acid binding, reflecting that ASS1 binds its amino
+      acid substrates L-citrulline and L-aspartate; several CTLN1 mutations map to the substrate
+      (aspartate/citrulline) binding site and impair substrate affinity.
+    action: ACCEPT
+    reason: &gt;-
+      Informative molecular function distinct from the catalytic term: ASS1 has bona fide amino
+      acid (citrulline/aspartate) binding sites (documented in UniProt BINDING features), and
+      kinetic mutants show altered Km. Supported by the experimental mutation studies.
+    supported_by:
+      - reference_id: PMID:27287393
+        supporting_text: &#34;map near the substrate (aspartate or citrulline)&#34;
+- term:
+    id: GO:0045429
+    label: positive regulation of nitric oxide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:21106532
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence in endothelial cells that ASS1, by regenerating arginine (the
+      NOS3 substrate) from citrulline, increases NO production; overexpression of ASS1 raised NO and
+      ASS1/NOS3 siRNAs attenuated shear-stress-induced NO. This is the citrulline-NO cycle role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Genuine, physiologically important extrahepatic function of ASS1 (supplying arginine for NO
+      synthesis) but it is a downstream regulatory consequence of the core arginine-biosynthesis
+      activity in a specific cell type, not the enzyme&#39;s intrinsic core function. Retain as
+      non-core.
+    supported_by:
+      - reference_id: PMID:21106532
+        supporting_text: &#34;increased NO production and decreased monocyte adhesion stimulated by tumor&#34;
+- term:
+    id: GO:0071499
+    label: cellular response to laminar fluid shear stress
+  evidence_type: IMP
+  original_reference_id: PMID:21106532
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence that laminar shear stress induces ASS1 in endothelial cells and
+      that ASS1 (with NOS3) is required for the shear-stress-stimulated increase in NO production.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A cell-type-specific stimulus-response/physiological role, downstream of ASS1&#39;s core arginine
+      supply function; not the enzyme&#39;s intrinsic core function. Retain as non-core.
+    supported_by:
+      - reference_id: PMID:21106532
+        supporting_text: &#34;SiRNAs of NOS3 and ASS1 attenuated&#34;
+- term:
+    id: GO:1903038
+    label: negative regulation of leukocyte cell-cell adhesion
+  evidence_type: IMP
+  original_reference_id: PMID:21106532
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence that ASS1 (via NO production) reduces TNF-alpha-stimulated
+      monocyte adhesion to endothelial cells, an anti-inflammatory endothelial effect downstream of
+      arginine/NO supply.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A downstream physiological consequence of the endothelial citrulline-NO cycle role, mediated
+      by NO rather than a direct ASS1 activity on adhesion; not a core function. Retain as
+      non-core.
+    supported_by:
+      - reference_id: PMID:21106532
+        supporting_text: &#34;increased NO production and decreased monocyte adhesion stimulated by tumor&#34;
+- term:
+    id: GO:0003723
+    label: RNA binding
+  evidence_type: HDA
+  original_reference_id: PMID:22658674
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput &#34;interactome capture&#34; detection of ASS1 among mRNA-binding proteins in
+      proliferating HeLa cells (mRNA interactome atlas). Many metabolic enzymes were unexpectedly
+      captured; no dedicated RNA-binding function has been demonstrated for ASS1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This derives from a single high-throughput RNA-interactome screen that recovered numerous
+      &#34;moonlighting&#34; metabolic enzymes. There is no orthogonal validation of a functional
+      RNA-binding role for ASS1, so it is very likely an over-annotation rather than a core or
+      established secondary function. Flag as over-annotated rather than accepting.
+    supported_by:
+      - reference_id: PMID:22658674
+        supporting_text: &#34;RNA-binding enzymes of intermediary&#34;
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput detection of ASS1 in a large-scale urinary-exosome proteome. As above, an MS
+      inventory hit for a cytosolic enzyme rather than evidence of a functional extracellular
+      localization.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Genuine peptide detection in an exosome proteomics dataset, but not a core functional
+      localization for this cytosolic urea-cycle enzyme. Retain as non-core.
+    supported_by:
+      - reference_id: PMID:19056867
+        supporting_text: &#34;Normal human urine contains large numbers of exosomes&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70577
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement localizing the ASS1 tetramer (in complex with NMRAL1
+      dimer and NADPH) to the cytosol, in the argininosuccinate-forming reaction.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the established cytosolic localization of ASS1; correct.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: TAS
+  original_reference_id: PMID:6194510
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable author statement (from the human ASS cDNA sequencing paper) localizing ASS1 to the
+      cytoplasm. This is the general parent of the more specific cytosol annotations.
+    action: MODIFY
+    reason: &gt;-
+      Correct but less specific than warranted: ASS1 is specifically cytosolic (GO:0005829), which
+      is directly supported by immunofluorescence (IDA) and multiple sources. Replace the general
+      &#34;cytoplasm&#34; with the more informative &#34;cytosol&#34;.
+    proposed_replacement_terms:
+      - id: GO:0005829
+        label: cytosol
+core_functions:
+- description: &gt;-
+    Argininosuccinate synthase: ATP-dependent condensation of L-citrulline and L-aspartate to form
+    argininosuccinate (plus AMP and diphosphate) in the cytosol. This is the rate-limiting,
+    committed step of de novo L-arginine biosynthesis and the argininosuccinate-forming step of the
+    urea cycle, in which aspartate is the second nitrogen donor. The enzyme functions as a
+    homotetramer of identical subunits, uses ATP as co-substrate (with defined ATP- and amino
+    acid-binding sites), and its product is handed to argininosuccinate lyase (ASL) to yield
+    arginine and fumarate.
+  molecular_function:
+    id: GO:0004055
+    label: argininosuccinate synthase activity
+  directly_involved_in:
+    - id: GO:0000050
+      label: urea cycle
+    - id: GO:0006526
+      label: L-arginine biosynthetic process
+  locations:
+    - id: GO:0005829
+      label: cytosol
+  substrates:
+    - id: CHEBI:57743
+      label: L-citrulline
+    - id: CHEBI:29991
+      label: L-aspartate
+    - id: CHEBI:30616
+      label: ATP
+  supported_by:
+    - reference_id: PMID:8792870
+      supporting_text: &#34;Argininosuccinate synthetase (ASS) is a urea cycle enzyme with a tetrameric&#34;
+    - reference_id: PMID:27287393
+      supporting_text: &#34;map near the substrate (aspartate or citrulline)&#34;
+    - reference_id: PMID:28985504
+      supporting_text: &#34;synthase (ASS1) to inactivate ASS1, which catalyzes the rate-limiting step of&#34;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12620389
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast
+    two-hybrid analysis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput Y2H atlas of Raf-kinase interactors; ASS1/ARAF interaction is a screen hit
+      with no established functional relevance to ASS1. Correctly cited for a binary interaction but
+      only supports the uninformative &#34;protein binding&#34; term.
+- id: PMID:16189514
+  title: Towards a proteome-scale map of the human protein-protein interaction network.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Interactome map reporting the ASS1 self-interaction, consistent with the known homotetramer.
+- id: PMID:17496144
+  title: Restructuring of the dinucleotide-binding fold in an NADP(H) sensor protein.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Describes NMRAL1 (HSCARG) and notes it may regulate argininosuccinate synthetase; source of
+      the ASS1-NMRAL1 interaction. Supports only the uninformative &#34;protein binding&#34; term.
+- id: PMID:18473344
+  title: Investigation of citrullinemia type I variants by in vitro expression studies.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Bacterial expression/enzymology of wild-type and CTLN1 mutant ASS with measured KM and Vmax;
+      directly supports argininosuccinate synthase activity, arginine biosynthesis, urea cycle, and
+      the disease link. Basis for UniProt EC 6.3.4.5 and kinetic parameters.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Urinary exosome proteomics; ASS1 detected as an MS inventory hit, not evidence of functional
+      exosomal localization for this cytosolic enzyme.
+- id: PMID:21106532
+  title: Endothelial argininosuccinate synthetase 1 regulates nitric oxide production
+    and monocyte adhesion under static and laminar shear stress conditions.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Endothelial cell study establishing the citrulline-NO cycle role of ASS1 (arginine supply for
+      NOS3, effects on NO production and monocyte adhesion under shear stress). Supports the NO /
+      shear-stress / adhesion BP annotations as non-core extrahepatic functions.
+- id: PMID:21988832
+  title: Toward an understanding of the protein interaction network of the human liver.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Human liver interactome study reporting the ASS1 self-interaction, consistent with the
+      homotetramer.
+- id: PMID:22658674
+  title: Insights into RNA biology from an atlas of mammalian mRNA-binding proteins.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      Single high-throughput mRNA-interactome-capture screen that recovered many metabolic enzymes,
+      including ASS1, as putative RBPs. No orthogonal validation of an RNA-binding function for
+      ASS1; basis for flagging the RNA binding annotation as over-annotated.
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Prostatic-secretion/urinary exosome proteomics; ASS1 detected as an MS inventory hit, not a
+      functional localization.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale interactome map reporting the ASS1 self-interaction, consistent with the
+      homotetramer.
+- id: PMID:27287393
+  title: &#39;Kinetic mutations in argininosuccinate synthetase deficiency: characterisation
+    and in vitro correction by substrate supplementation.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Characterized 21 kinetic CTLN1 mutations by MS-based activity assays; 13 inactive, 8 with
+      decreased aspartate/citrulline affinity rescuable by aspartate supplementation. Strong support
+      for argininosuccinate synthase activity, substrate (amino acid) binding, and the urea
+      cycle/arginine biosynthesis roles.
+- id: PMID:28587924
+  title: PRMT7 Interacts with ASS1 and Citrullinemia Mutations Disrupt the Interaction.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Identifies and confirms (Y2H + pull-down) a direct PRMT7-ASS1 interaction disrupted by
+      citrullinemia mutations. Genuine interaction but captured only as uninformative &#34;protein
+      binding&#34;.
+- id: PMID:28985504
+  title: CLOCK Acetylates ASS1 to Drive Circadian Rhythm of Ureagenesis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows CLOCK acetylates ASS1 K165/K176 to inactivate it in a circadian manner, driving a
+      circadian rhythm of ureagenesis; also source of the direct cytosol localization and the
+      ASS1-CLOCK interaction. Confirms ASS1 as the rate-limiting arginine-biosynthesis enzyme.
+- id: PMID:6194510
+  title: Sequence for human argininosuccinate synthetase cDNA.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Early human ASS cDNA sequencing paper; cited (TAS) for cytoplasmic localization, generalized
+      here to the more specific cytosol.
+- id: PMID:7977368
+  title: Mutations in argininosuccinate synthetase mRNA of Japanese patients, causing
+    classical citrullinemia.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Identifies ASS1 mutations causing classical citrullinemia; basis for the experimental urea
+      cycle, argininosuccinate synthase activity, amino acid binding, and substrate
+      (aspartate/citrulline) catabolic-process annotations.
+- id: PMID:8792870
+  title: Characterization of human wild-type and mutant argininosuccinate synthetase
+    proteins expressed in bacterial cells.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Recombinant human ASS enzymology; wild-type matched native liver enzyme, mutants showed
+      reduced/abolished activity and abnormal kinetics. Explicitly describes ASS as a urea cycle
+      enzyme with a tetrameric structure of identical subunits; supports catalytic activity, urea
+      cycle, arginine biosynthesis, and the homotetramer.
+- id: Reactome:R-HSA-70577
+  title: ASS1 tetramer:NMRAL1 dimer:NADPH transforms L-Asp and L-Cit to ARSUA
+  findings: []
+- id: Reactome:R-HSA-9956517
+  title: ASS1 variants don&#39;t synthesize arginosuccinate
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -1781,8 +1781,8 @@ Design intent for complexes (the central modelling question): each respiratory c
                     <td class="num">8</td>
                     <td class="num">0</td>
                     <td class="num">0</td>
-                    <td class="num">8</td>                    <td class="num" data-sort-value="1">
-                        1/11
+                    <td class="num">8</td>                    <td class="num" data-sort-value="3">
+                        3/11
                     </td>
                     <td class="num" data-sort-value="0">
                         0

--- a/pages/modules/urea_cycle.html
+++ b/pages/modules/urea_cycle.html
@@ -578,11 +578,11 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(1/11 grounded genes reviewed)</span>
+                    <span class="muted small">(3/11 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        1 complete review(s) &middot;
-                        1 with deep research &middot;
-                        10 missing review &middot;
+                        3 complete review(s) &middot;
+                        3 with deep research &middot;
+                        8 missing review &middot;
                         0 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
@@ -595,6 +595,18 @@
                             </tr>
                         </thead>
                         <tbody>                                <tr>
+                                    <td>ASL
+                                        <span class="muted term-id">P04424</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>ASS1
+                                        <span class="muted term-id">P00966</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
                                     <td>SLC25A12 / aralar (human paralog)
                                         <span class="muted term-id">O75746</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
@@ -606,18 +618,6 @@
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
-                                </tr>                                <tr>
-                                    <td>ASS1 (human)
-                                        <span class="muted term-id">P00966</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>ASL (human)
-                                        <span class="muted term-id">P04424</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
                                     <td>ARG1 (human, cytosolic, hepatic)
                                         <span class="muted term-id">P05089</span></td>

--- a/pages/projects/UNIPROT_CAUTION_NOTE/uniprot_wide_queries.html
+++ b/pages/projects/UNIPROT_CAUTION_NOTE/uniprot_wide_queries.html
@@ -1655,7 +1655,7 @@
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0004177">GO:0004177</a> aminopeptidase activity(EXP)</td>
 </tr>
 <tr>
-<td>ASL</td>
+<td><a href="../../../genes/human/ASL/ASL-ai-review.html">ASL</a></td>
 <td>Schistosoma mansoni (Blood f</td>
 <td>G4VQX9</td>
 <td>PMID:28347672</td>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2934 |
| Gene review HTML pages | 2934 |
| Project pages | 1098 |
| Module pages | 88 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
