### PR TITLE
urea_cycle module: cross-link all 8 gene reviews

### DIFF
--- a/modules/urea_cycle.yaml
+++ b/modules/urea_cycle.yaml
@@ -46,12 +46,56 @@ evidence:
       the human Reactome "Urea cycle" pathway (R-HSA-70635) and its member
       reactions (R-HSA-70542, R-HSA-70555, R-HSA-70560, R-HSA-70634,
       R-HSA-70577, R-HSA-70573, R-HSA-70569, R-HSA-372448).
+  - source_id: file:human/NAGS/NAGS-ai-review.yaml
+    title: NAGS gene review (human)
+    statement: >-
+      The NAGS regulatory-step grounding (UniProtKB:Q8N159, GO:0004042, EC
+      2.3.1.1, mitochondrial matrix) matches the completed human NAGS review.
+  - source_id: file:human/CPS1/CPS1-ai-review.yaml
+    title: CPS1 gene review (human)
+    statement: >-
+      The CPS1 step grounding (UniProtKB:P31327, GO:0004087 carbamoyl-phosphate
+      synthase (ammonia) activity, GO:0000050 urea cycle, mitochondrial matrix)
+      matches the completed human CPS1 review, which established the
+      ammonia-dependent (not glutamine-hydrolyzing) chemistry.
   - source_id: file:human/OTC/OTC-ai-review.yaml
     title: OTC gene review (human)
     statement: >-
       The OTC step grounding (UniProtKB:P00480, GO:0004585 ornithine
       carbamoyltransferase activity, GO:0000050 urea cycle, mitochondrial
       matrix) matches the completed human OTC review.
+  - source_id: file:human/SLC25A15/SLC25A15-ai-review.yaml
+    title: SLC25A15 gene review (human)
+    statement: >-
+      The ornithine/citrulline transport step (UniProtKB:Q9Y619, GO:0000064
+      L-ornithine transmembrane transporter activity, mitochondrial inner
+      membrane) matches the completed human SLC25A15/ORNT1 review.
+  - source_id: file:human/ASS1/ASS1-ai-review.yaml
+    title: ASS1 gene review (human)
+    statement: >-
+      The ASS1 step grounding (UniProtKB:P00966, GO:0004055 argininosuccinate
+      synthase activity, GO:0000050 urea cycle, cytosol) matches the completed
+      human ASS1 review.
+  - source_id: file:human/ASL/ASL-ai-review.yaml
+    title: ASL gene review (human)
+    statement: >-
+      The ASL step grounding (UniProtKB:P04424, GO:0004056 argininosuccinate
+      lyase activity, GO:0000050 urea cycle, cytosol) matches the completed
+      human ASL review, which also captures ASL's catalysis-independent NOS
+      scaffold role.
+  - source_id: file:human/ARG1/ARG1-ai-review.yaml
+    title: ARG1 gene review (human)
+    statement: >-
+      The ARG1 terminal-step grounding (UniProtKB:P05089, GO:0004053 arginase
+      activity, GO:0000050 urea cycle, cytosol) matches the completed human ARG1
+      review.
+  - source_id: file:human/SLC25A13/SLC25A13-ai-review.yaml
+    title: SLC25A13 gene review (human)
+    statement: >-
+      The citrin aspartate-supply step (UniProtKB:Q9UJS0, GO:0000515
+      aspartate:glutamate proton antiporter activity, mitochondrial inner
+      membrane) matches the completed human SLC25A13 review, which added the
+      urea-cycle (GO:0000050) involvement.
 module:
   id: urea_cycle
   label: Urea cycle


### PR DESCRIPTION
## Summary
Follow-up to the urea cycle cluster (all 8 gene reviews now merged: NAGS #1846, CPS1 #1840, OTC #1833, SLC25A15 #1847, ASS1 #1842, ASL #1843, ARG1 #1845, SLC25A13 #1848).

Enriches `modules/urea_cycle.yaml` evidence so every step is cross-linked to its completed human gene review via a `file:human/GENE/GENE-ai-review.yaml` reference (previously only OTC's review was linked, since it was the only one merged when the module was created). No grounding/structure changes.

## Validation
- `linkml-validate -C ModuleReview` → No issues found
- `module_validator` (term labels) → OK, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)