### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/ARG1/ARG1-ai-review.html
+++ b/genes/human/ARG1/ARG1-ai-review.html
@@ -1,0 +1,6268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ARG1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ARG1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P05089" target="_blank" class="term-link">
+                        P05089
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ARG1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P05089" data-a="DESCRIPTION: Arginase-1 (liver-type/type I arginase) is the cyt..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Arginase-1 (liver-type/type I arginase) is the cytosolic, manganese-dependent ureohydrolase that catalyzes the terminal step of the urea cycle, hydrolyzing L-arginine and water to L-ornithine and urea (EC 3.5.3.1). It is a homotrimer, each subunit containing a binuclear manganese cluster required for catalysis. In the liver, where it is most abundantly expressed, arginase-1 regenerates ornithine to sustain the urea cycle and produces the urea that is excreted, making it central to nitrogen disposal; the distinct mitochondrial paralog arginase-2 (ARG2) operates in extrahepatic tissues. Arginase-1 is also constitutively expressed in the granules of human neutrophils and other myeloid cells, where it acts as an immunoregulatory enzyme: released into the extracellular space or phagolysosome, it depletes local L-arginine, suppressing T-cell and NK-cell proliferation and cytokine production and contributing to antimicrobial defense. Loss-of-function variants cause argininemia (arginase deficiency), a urea cycle disorder characterized by progressive spastic diplegia/paraparesis, seizures, and intellectual disability, with hyperammonemia occurring less frequently than in proximal urea cycle disorders.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    GO:0004053
+                                </a>
+                            </span>
+                            <span class="term-label">arginase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0004053" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (PAN-GO) inference of arginase activity, the defining and core molecular function of ARG1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the correct, specific molecular function. Arginase activity (EC 3.5.3.1, L-arginine + H2O = L-ornithine + urea) is directly demonstrated for human ARG1 by crystallographic and enzymatic studies, so the IBA inference is strongly supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link">
+                                        PMID:17562323
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that ARG1 acts in the cytoplasm; consistent with its established cytosolic localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but non-specific. ARG1 is a cytosolic enzyme; the more precise term GO:0005829 (cytosol), also annotated, better captures the localization. Retained as it is not wrong, but subordinate to the cytosol annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006525" target="_blank" class="term-link">
+                                    GO:0006525
+                                </a>
+                            </span>
+                            <span class="term-label">arginine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0006525" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that ARG1 participates in arginine metabolism; correct but general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate at a general level. ARG1 catabolizes L-arginine, so involvement in arginine metabolism is correct; the more specific L-arginine catabolic process (GO:0006527) and urea cycle (GO:0000050) annotations capture the precise role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link">
+                                        PMID:17562323
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042130" target="_blank" class="term-link">
+                                    GO:0042130
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of T cell proliferation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0042130" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference of an immunoregulatory role in suppressing T-cell proliferation, corroborated by direct experimental evidence in human granulocyte arginase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported secondary (myeloid/immune) function. Extracellular arginase released from human granulocytes depletes arginine and suppresses T-cell proliferation. This is a genuine role but distinct from the core hepatic urea-cycle function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human granulocyte arginase induces a profound suppression of T-cell proliferation and cytokine synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0000050" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that ARG1 participates in the urea cycle; this is a core biological process for the enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ARG1 catalyzes the terminal step of the urea cycle, regenerating ornithine and releasing urea. This is a core biological process and the IBA inference is strongly supported by direct evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link">
+                                        PMID:3540966
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle in the liver of ureotelic animals.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030145" target="_blank" class="term-link">
+                                    GO:0030145
+                                </a>
+                            </span>
+                            <span class="term-label">manganese ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0030145" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference of manganese ion binding; ARG1 requires a binuclear Mn(2+) cluster for catalysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by high-resolution crystal structures showing two manganese ions per subunit forming the catalytic binuclear cluster. Core molecular function cofactor requirement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                                        PMID:16141327
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The ultrahigh-resolution structure of the human arginase I-ABH complex yields an unprecedented view of the binuclear manganese cluster</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that ARG1 acts in the cytosol; this is the established subcellular location of type I arginase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Arginase I is a cytosolic enzyme (in contrast to mitochondrial ARG2). This is the core localization where ureagenic arginine hydrolysis occurs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    GO:0004053
+                                </a>
+                            </span>
+                            <span class="term-label">arginase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0004053" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (multiple-method) inference of arginase activity, mapped from RHEA:20569/EC:3.5.3.1 and orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific molecular function, consistent with the RHEA reaction L-arginine + H2O = L-ornithine + urea and the experimental annotations. Duplicate of the IBA/EXP arginase-activity annotations, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                                        PMID:16141327
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we demonstrate the inhibition of arginase activity by ABH in human and murine myeloid cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated mapping from the UniProt Cytoplasm subcellular-location keyword.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general; cytosol (GO:0005829) is the more precise term for this cytosolic enzyme. Retained as a valid broader localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                                        PMID:16141327
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exploration of inhibition in the immune response</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006525" target="_blank" class="term-link">
+                                    GO:0006525
+                                </a>
+                            </span>
+                            <span class="term-label">arginine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0006525" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping (arginase domain) to arginine metabolic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general. The specific catabolic role (L-arginine catabolic process, GO:0006527) and urea cycle (GO:0000050) better capture ARG1&#39;s function; this broad parent is acceptable as an IEA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link">
+                                        PMID:17562323
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016813" target="_blank" class="term-link">
+                                    GO:0016813
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds, in linear amidines</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0016813" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping (ureohydrolase Mn-binding site) to a broad hydrolase-on-C-N-linear-amidines term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the parent term of the specific and experimentally established arginase activity (GO:0004053). Arginase hydrolyzes the C-N bond of the linear amidine L-arginine, so the term is not wrong, but it is over-general given the precise activity is known. Replace with the specific molecular function.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    arginase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase is a binuclear manganese metalloenzyme that hydrolyzes L-arginine to form L-ornithine and urea</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042127" target="_blank" class="term-link">
+                                    GO:0042127
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of cell population proliferation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0042127" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning inference of a general role in regulating cell population proliferation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Overly general electronic annotation. ARG1&#39;s proliferation-related effects are specifically on immune cells via arginine depletion (captured by the more specific negative regulation of T-cell proliferation terms). This broad, direction-less parent adds no functional specificity and is likely an over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human granulocyte arginase induces a profound suppression of T-cell proliferation and cytokine synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping to a generic metal ion binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The specific metal bound is known to be manganese (a binuclear Mn(2+) cluster, two ions per subunit), captured by GO:0030145 (manganese ion binding), which is also annotated. The generic parent should be specialized.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030145" target="_blank" class="term-link">
+                                    manganese ion binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                                        PMID:16141327
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The ultrahigh-resolution structure of the human arginase I-ABH complex yields an unprecedented view of the binuclear manganese cluster</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042832" target="_blank" class="term-link">
+                                    GO:0042832
+                                </a>
+                            </span>
+                            <span class="term-label">defense response to protozoan</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0042832" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology transfer from mouse Arg1 (Q61176) of a role in antiprotozoal defense.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an orthology-transferred (GO_REF:0000107, from mouse) immune role consistent with ARG1&#39;s known myeloid arginine-depletion function in antimicrobial defense, but it is a peripheral/species-informed role rather than the core hepatic function. Retained as non-core; the underlying human evidence is indirect.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link">
+                                        PMID:15546957
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">arginase I is localized in azurophil granules of neutrophils and constitutes a novel antimicrobial effector pathway, likely through arginine depletion in the phagolysosome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046007" target="_blank" class="term-link">
+                                    GO:0046007
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of activated T cell proliferation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0046007" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology transfer from mouse Arg1 of negative regulation of activated T-cell proliferation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the well-documented human function whereby extracellular/granulocyte arginase depletes arginine and suppresses T-cell proliferation. A genuine secondary immunoregulatory role; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human granulocyte arginase induces a profound suppression of T-cell proliferation and cytokine synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000552" target="_blank" class="term-link">
+                                    GO:2000552
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of T-helper 2 cell cytokine production</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:2000552" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology transfer from mouse Arg1 of a role in limiting Th2 cytokine production.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Orthology-transferred (from mouse) immunoregulatory role. ARG1&#39;s arginine depletion suppresses T-cell cytokine synthesis; this specific Th2 term reflects the mouse ILC2/type-2 inflammation context. Retained as a plausible non-core immune role; the direct human evidence is limited.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human granulocyte arginase induces a profound suppression of T-cell proliferation and cytokine synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0000050" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniPathway mapping (UPA00158) to the urea cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process. ARG1 performs the terminal step of the urea cycle. Duplicate of the IBA urea-cycle annotation, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link">
+                                        PMID:3540966
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle in the liver of ureotelic animals.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070947" target="_blank" class="term-link">
+                                    GO:0070947
+                                </a>
+                            </span>
+                            <span class="term-label">neutrophil-mediated killing of fungus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15546957
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arginase I is constitutively expressed in human granulocytes...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0070947" data-r="PMID:15546957" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) annotation from the study showing arginase I in azurophil granules participates in fungicidal activity of human neutrophils.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by the cited experimental study demonstrating a granulocyte antimicrobial effector role via arginine depletion. This is a genuine, well-evidenced secondary function in myeloid cells, distinct from the core hepatic urea-cycle role. Note UniProt now uses the closely related term GO:0070965 (positive regulation of neutrophil mediated killing of fungus) for the same evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link">
+                                        PMID:15546957
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">arginase I is localized in azurophil granules of neutrophils and constitutes a novel antimicrobial effector pathway, likely through arginine depletion in the phagolysosome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006527" target="_blank" class="term-link">
+                                    GO:0006527
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22959135" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22959135
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of novel ARG1 mutations causing hyperargininemia an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0006527" data-r="PMID:22959135" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) annotation from analysis of ARG1 mutations causing hyperargininemia, correlating loss of arginase activity with impaired L-arginine catabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. ARG1 catalyzes the breakdown of L-arginine; loss-of-function mutations cause hyperargininemia (accumulation of arginine), directly demonstrating its role in L-arginine catabolism. The curator assessed erythrocyte enzyme activity across a patient mutation series.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22959135" target="_blank" class="term-link">
+                                        PMID:22959135
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is caused by the deficient activity of the enzyme arginase I, encoded by the gene ARG1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9956512
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005829" data-r="Reactome:R-HSA-9956512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author annotation (ARG1 variant reaction) placing ARG1 in the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization for the cytosolic type I arginase. Consistent with the IBA cytosol annotation and biochemical evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    GO:0004053
+                                </a>
+                            </span>
+                            <span class="term-label">arginase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16141327
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of human arginase I at 1.29-A resolution a...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0004053" data-r="PMID:16141327" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence of arginase activity from the 1.29-A crystal structure and inhibition study of human arginase I.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function established by direct enzymatic assay and structural characterization of catalysis, including inhibition of arginase activity in human myeloid cells.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                                        PMID:16141327
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we demonstrate the inhibition of arginase activity by ABH in human and murine myeloid cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    GO:0004053
+                                </a>
+                            </span>
+                            <span class="term-label">arginase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17562323
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression, purification, assay, and crystal structure of pe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0004053" data-r="PMID:17562323" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that (perdeuterated) human arginase I catalyzes hydrolysis of L-arginine to L-ornithine and urea with wild-type activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, directly assayed. The enzyme is explicitly characterized as a manganese metalloenzyme catalyzing L-arginine hydrolysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link">
+                                        PMID:17562323
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    GO:0004053
+                                </a>
+                            </span>
+                            <span class="term-label">arginase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21728378
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Binding of alpha,alpha-disubstituted amino acids to arginase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0004053" data-r="PMID:21728378" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (kinetic assay plus crystal structures) of human arginase I catalytic activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, directly measured. The enzyme is characterized as a binuclear manganese metalloenzyme hydrolyzing L-arginine to L-ornithine and urea.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase is a binuclear manganese metalloenzyme that hydrolyzes L-arginine to form L-ornithine and urea</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16141327
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of human arginase I at 1.29-A resolution a...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005737" data-r="PMID:16141327" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental subcellular localization of ARG1 to the cytoplasm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general. The more precise cytosol term (GO:0005829) better captures the localization of this cytosolic enzyme. Retained as a valid broader annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28813417" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28813417
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CMTM6 maintains the expression of PD-L1 and regulates anti-t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005515" data-r="PMID:28813417" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation recording an ARG1-CMTM6 interaction detected by mass spectrometry in a study focused on CMTM6-mediated regulation of PD-L1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative and does not describe a molecular function. The supporting paper is a CRISPR/proteomics study of CMTM6 as a regulator of PD-L1; ARG1 appears only as one mass-spectrometry co-precipitant of CMTM6, with no evidence that this interaction is functionally relevant to ARG1. Per curation guidelines, avoid uninformative protein binding terms; this should not be treated as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28813417" target="_blank" class="term-link">
+                                        PMID:28813417
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CMTM6 is a ubiquitously expressed protein that binds PD-L1 and maintains its cell surface expression.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16709924
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Suppression of T-cell functions by human granulocyte arginas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005576" data-r="PMID:16709924" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that arginase I is liberated from human granulocytes and accumulates extracellularly during inflammation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine, experimentally demonstrated secondary localization. Neutrophil arginase is released into the extracellular space, where it depletes arginine. This is real but peripheral to the core intracellular (cytosolic) hepatic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">arginase I is liberated from human granulocytes, and very high activities accumulate extracellularly during purulent inflammatory reactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042130" target="_blank" class="term-link">
+                                    GO:0042130
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of T cell proliferation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16709924
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Suppression of T-cell functions by human granulocyte arginas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0042130" data-r="PMID:16709924" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that human granulocyte arginase suppresses T-cell proliferation via arginine depletion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported secondary immunoregulatory function. Extracellular arginase depletes arginine, downregulating CD3-zeta and suppressing T-cell proliferation. Genuine but distinct from the core urea-cycle role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This T-cell phenotype is due to arginase-mediated depletion of arginine in the T-cell environment, which leads to CD3zeta chain down-regulation but does not alter T-cell viability</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060336" target="_blank" class="term-link">
+                                    GO:0060336
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of type II interferon-mediated signaling pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16709924
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Suppression of T-cell functions by human granulocyte arginas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0060336" data-r="PMID:16709924" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation of a downstream effect on IFN-gamma signaling, linked to arginase-mediated suppression of T-cell cytokine synthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A downstream immunoregulatory consequence of arginine depletion (suppressed T-cell cytokine synthesis, including IFN-gamma responses) rather than a direct biochemical function of ARG1. Retained as non-core; the curator (UniProt) made this annotation from the full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human granulocyte arginase induces a profound suppression of T-cell proliferation and cytokine synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798749
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005576" data-r="Reactome:R-HSA-6798749" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome annotation (exocytosis of specific granule lumen proteins) placing ARG1 in the extracellular region upon neutrophil degranulation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally demonstrated release of neutrophil arginase into the extracellular space during degranulation. A genuine secondary localization, non-core relative to the cytosolic hepatic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                                        PMID:16709924
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">arginase I is liberated from human granulocytes, and very high activities accumulate extracellularly during purulent inflammatory reactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798751
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005576" data-r="Reactome:R-HSA-6798751" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome annotation (exocytosis of azurophil granule lumen proteins) placing ARG1 in the extracellular region upon neutrophil degranulation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same as the other extracellular-region annotations - reflects release of granule-stored neutrophil arginase. Genuine secondary localization; non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link">
+                                        PMID:15546957
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">arginase I is localized in azurophil granules of neutrophils and constitutes a novel antimicrobial effector pathway, likely through arginine depletion in the phagolysosome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035578" target="_blank" class="term-link">
+                                    GO:0035578
+                                </a>
+                            </span>
+                            <span class="term-label">azurophil granule lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798751
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0035578" data-r="Reactome:R-HSA-6798751" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome annotation placing ARG1 in the azurophil granule lumen of neutrophils.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by experimental localization of arginase I to azurophil granules of neutrophils. A genuine myeloid-cell localization, non-core relative to the core cytosolic hepatic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link">
+                                        PMID:15546957
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">arginase I is localized in azurophil granules of neutrophils and constitutes a novel antimicrobial effector pathway, likely through arginine depletion in the phagolysosome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035580" target="_blank" class="term-link">
+                                    GO:0035580
+                                </a>
+                            </span>
+                            <span class="term-label">specific granule lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798749
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0035580" data-r="Reactome:R-HSA-6798749" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome annotation placing ARG1 in the specific granule lumen of neutrophils.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects the granule storage of arginase I in neutrophils (the primary experimental report emphasizes azurophil granules; Reactome models both granule compartments). Genuine myeloid localization, non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link">
+                                        PMID:15546957
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in human leukocytes arginase I is constitutively expressed only in granulocytes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21630459
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic characterization of the human sperm nucleus.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005634" data-r="PMID:21630459" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics detection of ARG1 in an isolated human sperm nucleus fraction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This annotation derives from a large-scale catalog of 403 proteins detected in isolated sperm nuclei, not from a targeted study of nuclear ARG1 function. ARG1 is a well-established cytosolic enzyme with no known nuclear function; the detection likely reflects abundant cytoplasmic protein carryover in a bulk proteomic fraction. Marked as over-annotated rather than removed, as a mass-spec detection.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                                        PMID:21630459
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">403 different proteins have been identified from the isolated sperm nuclei</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70569
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005829" data-r="Reactome:R-HSA-70569" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome annotation (arginine + H2O =&gt; ornithine + urea reaction) placing ARG1 in the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization. This Reactome reaction is precisely the arginase reaction, correctly localized to the cytosol where the cytosolic type I arginase acts.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9959871
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005829" data-r="Reactome:R-HSA-9959871" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome annotation (ARG1 gene expression) associated with cytosolic localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization for the cytosolic type I arginase; duplicate of the other cytosol annotations, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                                    GO:0004053
+                                </a>
+                            </span>
+                            <span class="term-label">arginase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3540966
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and nucleotide sequence of cDNA for human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0004053" data-r="PMID:3540966" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author statement of arginase activity from the original cloning of human liver arginase cDNA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function. The cloned cDNA conferred arginase activity on E. coli, and the enzyme is identified as EC 3.5.3.1 catalyzing the last urea-cycle step. Duplicate of the experimental arginase-activity annotations, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link">
+                                        PMID:3540966
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase activity was detected in Escherichia coli cells transformed with the plasmid carrying lambda hARG6 cDNA insert.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3540966
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and nucleotide sequence of cDNA for human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0005737" data-r="PMID:3540966" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author statement of cytoplasmic (liver) arginase localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general; cytosol (GO:0005829) is the more precise term. Retained as a valid broader localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                                        PMID:21728378
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006527" target="_blank" class="term-link">
+                                    GO:0006527
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3540966
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and nucleotide sequence of cDNA for human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05089" data-a="GO:0006527" data-r="PMID:3540966" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author statement of ARG1&#39;s role in L-arginine catabolism (the terminal urea-cycle step) from the original cloning paper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. ARG1 hydrolyzes L-arginine as the last step of the urea cycle. Duplicate of the IMP L-arginine catabolic process annotation, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link">
+                                        PMID:3540966
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle in the liver of ureotelic animals.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyzes the terminal step of the urea cycle - the manganese-dependent hydrolysis of L-arginine to L-ornithine and urea - regenerating ornithine to close the cycle and releasing the urea that is excreted for nitrogen disposal.</h3>
+                <span class="vote-buttons" data-g="P05089" data-a="FUNCTION: Catalyzes the terminal step of the urea cycle - th..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                            arginase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link">
+                                PMID:17562323
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Requires a binuclear manganese cluster (two Mn(2+) ions per subunit) for catalytic activity; manganese binding is an essential cofactor requirement of the arginase active site.</h3>
+                <span class="vote-buttons" data-g="P05089" data-a="FUNCTION: Requires a binuclear manganese cluster (two Mn(2+)..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                            arginase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                                PMID:16141327
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The ultrahigh-resolution structure of the human arginase I-ABH complex yields an unprecedented view of the binuclear manganese cluster</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Breaks down L-arginine (L-arginine catabolic process); loss of this activity in ARG1 causes hyperargininemia/argininemia, a urea cycle disorder.</h3>
+                <span class="vote-buttons" data-g="P05089" data-a="FUNCTION: Breaks down L-arginine (L-arginine catabolic proce..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004053" target="_blank" class="term-link">
+                            arginase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006527" target="_blank" class="term-link">
+                                L-arginine catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22959135" target="_blank" class="term-link">
+                                PMID:22959135
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">It is caused by the deficient activity of the enzyme arginase I, encoded by the gene ARG1.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15546957" target="_blank" class="term-link">
+                            PMID:15546957
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Arginase I is constitutively expressed in human granulocytes and participates in fungicidal activity.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Arginase I is constitutively expressed only in granulocytes among human leukocytes and is localized in azurophil granules, constituting an antimicrobial effector pathway via arginine depletion in the phagolysosome.</div>
+
+                        <div class="finding-text">"arginase I is localized in azurophil granules of neutrophils and constitutes a novel antimicrobial effector pathway, likely through arginine depletion in the phagolysosome"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16141327" target="_blank" class="term-link">
+                            PMID:16141327
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of human arginase I at 1.29-A resolution and exploration of inhibition in the immune response.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The 1.29-A structure reveals the binuclear manganese cluster of human arginase I and the structural basis of catalysis and inhibition.</div>
+
+                        <div class="finding-text">"The ultrahigh-resolution structure of the human arginase I-ABH complex yields an unprecedented view of the binuclear manganese cluster"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16709924" target="_blank" class="term-link">
+                            PMID:16709924
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Suppression of T-cell functions by human granulocyte arginase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Arginase I released from human granulocytes accumulates extracellularly during inflammation and suppresses T-cell proliferation and cytokine synthesis by depleting arginine, downregulating the CD3-zeta chain.</div>
+
+                        <div class="finding-text">"This T-cell phenotype is due to arginase-mediated depletion of arginine in the T-cell environment, which leads to CD3zeta chain down-regulation but does not alter T-cell viability"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17562323" target="_blank" class="term-link">
+                            PMID:17562323
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Expression, purification, assay, and crystal structure of perdeuterated human arginase I.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human arginase I is a manganese metalloenzyme that catalyzes hydrolysis of L-arginine to L-ornithine and urea, confirmed by assay and X-ray structure.</div>
+
+                        <div class="finding-text">"Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                            PMID:21630459
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A large-scale proteomic catalog identified 403 proteins in isolated human sperm nuclei; ARG1 is one large-scale MS detection, not a targeted study of nuclear arginase function.</div>
+
+                        <div class="finding-text">"403 different proteins have been identified from the isolated sperm nuclei"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21728378" target="_blank" class="term-link">
+                            PMID:21728378
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Binding of alpha,alpha-disubstituted amino acids to arginase suggests new avenues for inhibitor design.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Arginase is a binuclear manganese metalloenzyme that hydrolyzes L-arginine to L-ornithine and urea; arginase I is cytosolic and predominantly hepatic, whereas arginase II is mitochondrial.</div>
+
+                        <div class="finding-text">"Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22959135" target="_blank" class="term-link">
+                            PMID:22959135
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of novel ARG1 mutations causing hyperargininemia and correlation with arginase I activity in erythrocytes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Hyperargininemia is caused by deficient arginase I activity encoded by ARG1; the R308 residue is important for assembly of the ARG1 homotrimer.</div>
+
+                        <div class="finding-text">"Our study reinforced the role of Arg308 residue for assembly of the ARG1 homotrimer."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28813417" target="_blank" class="term-link">
+                            PMID:28813417
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CMTM6 maintains the expression of PD-L1 and regulates anti-tumour immunity.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">This study identifies CMTM6 as a regulator of PD-L1 cell-surface expression; ARG1 appears only as a mass-spectrometry co-precipitant of CMTM6, providing no functional evidence for an ARG1-specific role.</div>
+
+                        <div class="finding-text">"CMTM6 is a ubiquitously expressed protein that binds PD-L1 and maintains its cell surface expression."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3540966" target="_blank" class="term-link">
+                            PMID:3540966
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular cloning and nucleotide sequence of cDNA for human liver arginase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human liver arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle; cloned cDNA conferred arginase activity, and inherited deficiency causes argininemia.</div>
+
+                        <div class="finding-text">"Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle in the liver of ureotelic animals."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-6798749
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Exocytosis of specific granule lumen proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-6798751
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Exocytosis of azurophil granule lumen proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70569
+
+                    </span>
+                </div>
+
+                <div class="reference-title">arginine + H2O =&gt; ornithine + urea [ARG1]</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9956512
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ARG1 variants don&#39;t synthesize urea and ornithine</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9959871
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ARG1 gene expression</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond arginine depletion in the extracellular space/phagolysosome, does human ARG1 have any direct, arginine-independent immunoregulatory function, or are all of its immune effects a consequence of local arginine catabolism?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P05089" data-a="Q: Beyond arginine depletion in the extracellular spa..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the reported nuclear detection of ARG1 in sperm (PMID:21630459) functionally meaningful, or does it reflect cytoplasmic carryover in bulk proteomics?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P05089" data-a="Q: Is the reported nuclear detection of ARG1 in sperm..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided kinetic characterization of clinically observed missense variants (e.g. those affecting the Mn-binding residues or the R308 trimerization interface) to correlate residual arginase activity with argininemia phenotype severity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Argininemia severity is determined by residual arginase activity, which depends on how a given missense variant perturbs the Mn-binding active site or the R308 trimerization interface.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P05089" data-a="EXPERIMENT: Structure-guided kinetic characterization of clini..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative measurement of local arginine depletion and downstream T-cell CD3-zeta levels using ARG1-deficient versus wild-type human neutrophils to dissect the enzymatic basis of the immunosuppressive effect.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The immunosuppressive effect of neutrophil ARG1 is entirely due to enzymatic depletion of extracellular L-arginine.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P05089" data-a="EXPERIMENT: Quantitative measurement of local arginine depleti..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ARG1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P05089" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report on Human ARG1 (Arginase-1, P05089)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">42 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:03:07.024822</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ARG1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="ARG1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-on-human-arg1-arginase-1-p05089">Comprehensive Research Report on Human ARG1 (Arginase-1, P05089)</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>Human Arginase-1 (ARG1) is encoded by the <em>ARG1</em> gene located on chromosome 6q23, consisting of 8 exons (nteli2024argininemiapathophysiologyand pages 8-10). The protein is classified as EC 3.5.3.1 and is also known as liver-type arginase or type I arginase (anakha2022humanarginase1 pages 1-3). ARG1 belongs to the ureohydrolase/arginase protein family and contains a characteristic ureohydrolase domain with a manganese-binding site. Over 43 pathogenic mutations have been identified in the <em>ARG1</em> gene, distributed across exons and splice sites (nteli2024argininemiapathophysiologyand pages 8-10). In humans, three splice variants exist: isoform 1 (322 amino acids), mainly expressed in the liver; isoform 2 (330 amino acids), expressed in immune cells and erythrocytes; and isoform 3, whose function remains undefined (cane2025therolesof pages 1-2).</p>
+<p>The following table summarizes key properties of ARG1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>ARG1</strong> (arginase 1) (OpenTargets Search: -ARG1, nteli2024argininemiapathophysiologyand pages 2-3)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>P05089</strong> (user-provided target specification)</td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 3.5.3.1</strong> (anakha2022humanarginase1 pages 1-3)</td>
+</tr>
+<tr>
+<td>Protein mass</td>
+<td>Mature enzyme is described as a <strong>~105 kDa homotrimer</strong> with <strong>~35 kDa subunits</strong>; some reviews also report <strong>~130 kDa</strong> total trimer mass depending on construct/annotation conventions (anakha2022humanarginase1 pages 1-3, palte2021cryoemstructuresof pages 1-2, li2022reviewofarginase pages 3-5)</td>
+</tr>
+<tr>
+<td>Quaternary structure</td>
+<td><strong>Homotrimeric metalloenzyme</strong>; trimerization is required for full catalytic activity, and monomerization causes major loss of activity (&gt;90%) (anakha2022humanarginase1 pages 1-3, dechenne2025examiningarginase1trimerization pages 7-9, dechenne2025examiningarginase1trimerization pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Cytosol</strong> (especially hepatocyte cytosol); distinct from mitochondrial ARG2 (clemente2020arginaseasa pages 1-3, anakha2022humanarginase1 pages 1-3, cane2025therolesof pages 2-3)</td>
+</tr>
+<tr>
+<td>Primary tissue expression</td>
+<td><strong>Predominantly liver</strong>, especially <strong>periportal/zone 1 hepatocytes</strong>; also detected in erythrocytes, vasculature, and immune cells such as M2-like macrophages (nteli2024argininemiapathophysiologyand pages 2-3, zhu2026ureacycledysregulation pages 4-5, cane2025therolesof pages 1-2)</td>
+</tr>
+<tr>
+<td>Catalytic cofactor</td>
+<td><strong>Binuclear Mn2+ center</strong> with two manganese ions in each active site, bridged by hydroxide/water during catalysis (clemente2020arginaseasa pages 1-3, li2022reviewofarginase pages 3-5, palte2021cryoemstructuresof pages 1-2)</td>
+</tr>
+<tr>
+<td>Substrate</td>
+<td><strong>L-arginine</strong> is the physiological substrate; wild-type human ARG1 does <strong>not efficiently hydrolyze agmatine</strong> (clemente2020arginaseasa pages 1-3, orellana2022newinsightsinto pages 1-2, orellana2022newinsightsinto pages 6-7, orellana2022newinsightsinto pages 2-4)</td>
+</tr>
+<tr>
+<td>Products</td>
+<td><strong>L-ornithine + urea</strong> (anakha2022humanarginase1 pages 1-3, clemente2020arginaseasa pages 1-3, nteli2024argininemiapathophysiologyand pages 2-3)</td>
+</tr>
+<tr>
+<td>Km value</td>
+<td><strong>Km ~3.3 mM</strong> for ARG1 under the reported assay conditions (pH 7.4) (clemente2020arginaseasa pages 3-6)</td>
+</tr>
+<tr>
+<td>Reaction catalyzed</td>
+<td><strong>Hydrolysis of L-arginine to L-ornithine and urea</strong>; final step of the hepatic urea cycle and a key branchpoint in arginine metabolism (anakha2022humanarginase1 pages 1-3, nteli2024argininemiapathophysiologyand pages 2-3, clemente2020arginaseasa pages 1-3)</td>
+</tr>
+<tr>
+<td>Key disease associations</td>
+<td><strong>Arginase deficiency / argininemia</strong> (strong genetic disease association), plus links to <strong>cancer immune suppression/tumor microenvironment</strong>, and Open Targets associations with <strong>hereditary disease</strong>, <strong>type 2 diabetes mellitus</strong>, and <strong>obesity disorder</strong> (anakha2022humanarginase1 pages 3-4, nteli2024argininemiapathophysiologyand pages 5-7, nteli2024argininemiapathophysiologyand pages 2-3, marzetaassas2024pathophysiologyofarginases pages 13-14, grzybowski2025metabolomicreprogrammingof pages 2-3, OpenTargets Search: -ARG1)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes core biochemical, structural, localization, and disease-related properties of human Arginase-1 (ARG1/P05089). It is useful as a compact reference for functional annotation and interpretation of disease relevance.</em></p>
+<h2 id="2-enzymatic-function-and-catalytic-mechanism">2. Enzymatic Function and Catalytic Mechanism</h2>
+<h3 id="21-primary-reaction">2.1 Primary Reaction</h3>
+<p>ARG1 is a metalloenzyme that catalyzes the hydrolysis of L-arginine to produce L-ornithine and urea (anakha2022humanarginase1 pages 1-3, clemente2020arginaseasa pages 1-3). This reaction represents the fifth and final step of the hepatic urea cycle, completing the conversion of toxic ammonia to urea for renal excretion (nteli2024argininemiapathophysiologyand pages 2-3). The enzyme exhibits a Km of approximately 3.3 mM and a Vmax of 34 nmol·min⁻¹·mg⁻¹ at pH 7.4 (clemente2020arginaseasa pages 3-6).</p>
+<h3 id="22-catalytic-mechanism">2.2 Catalytic Mechanism</h3>
+<p>The catalytic mechanism of ARG1 depends on a binuclear manganese (Mn²⁺) cluster located at the active site. Two Mn²⁺ ions are positioned approximately 3.3 Å apart and are bridged by a hydroxide ion (clemente2020arginaseasa pages 1-3, palte2021cryoemstructuresof pages 1-2). During catalysis, the Mn²⁺ ions form a metal-bound hydroxide from a water molecule, which serves as the nucleophile that attacks the guanidinium carbon of L-arginine (anakha2022humanarginase1 pages 1-3, li2022reviewofarginase pages 3-5). This nucleophilic attack generates a tetrahedral intermediate that is stabilized by the binuclear Mn²⁺ center. Specific amino acid residues, including Asp128, provide stabilization through hydrogen bonding. A histidine residue (His-141 in ARG1) facilitates proton shuttling from bulk solvent to the active site, enabling L-ornithine dissociation (li2022reviewofarginase pages 3-5, clemente2020arginaseasa pages 3-6). The tetrahedral intermediate subsequently collapses to release the products L-ornithine and urea, and the metal ions recycle by rebinding water molecules for subsequent catalytic cycles (li2022reviewofarginase pages 3-5). Although Mn²⁺ is the preferred cofactor, Ni²⁺, Co²⁺, and Fe²⁺ can also activate the enzyme (li2022reviewofarginase pages 3-5).</p>
+<h3 id="23-substrate-specificity">2.3 Substrate Specificity</h3>
+<p>Wild-type human ARG1 is highly specific for L-arginine as its physiological substrate and does not efficiently hydrolyze agmatine (a decarboxylated arginine analog) (orellana2022newinsightsinto pages 1-2, orellana2022newinsightsinto pages 2-4). This specificity is determined by two critical loops at the entrance of the active site: Loop A (residues I129–L140) and Loop B (residues D181–P184) (orellana2022newinsightsinto pages 1-2). Loop A contains residues N130, S137, and N139 that specifically stabilize the α-carboxyl group of arginine through hydrogen bonding; since agmatine lacks this carboxyl group, these residues create a selectivity barrier (orellana2022newinsightsinto pages 2-4). Loop B interacts with the α-amino group of arginine and serves as a structural determinant of substrate affinity (orellana2022newinsightsinto pages 1-2, orellana2022newinsightsinto pages 11-12). Mutagenesis studies have demonstrated that engineered changes to Loop A (I129T/N130Y/T131A with deletion of P132-T134) can completely switch the enzyme's specificity from arginine to agmatine (orellana2022newinsightsinto pages 12-14, orellana2022newinsightsinto pages 6-7). Similarly, double mutations D181T/V182E in Loop B result in a 20-fold increase in Km for arginine, confirming these loops as the primary determinants of substrate recognition (orellana2022newinsightsinto pages 7-9).</p>
+<h2 id="3-quaternary-structure-and-assembly">3. Quaternary Structure and Assembly</h2>
+<p>ARG1 functions as an obligate homotrimer. Each monomer is approximately 35 kDa and adopts an α/β fold with a central β-sheet flanked by α-helices (clemente2020arginaseasa pages 3-6, palte2021cryoemstructuresof pages 1-2). The trimeric complex has a total molecular weight of approximately 105–130 kDa, depending on the construct and measurement method (anakha2022humanarginase1 pages 1-3, li2022reviewofarginase pages 3-5). Each monomer contains a separate active site with its own binuclear Mn²⁺ center (li2022reviewofarginase pages 3-5).</p>
+<p>Critically, only the trimeric form of ARG1 is catalytically active. Production of a monomeric form results in greater than 90% loss of enzymatic activity (dechenne2025examiningarginase1trimerization pages 7-9, dechenne2025examiningarginase1trimerization pages 1-2). The trimeric interface involves two α-helices and a C-terminal tail, with five key amino acids (M200, D204, R255, E256, R308) being essential for trimerization. Mutation of R255 to alanine produces a fully monomeric, inactive enzyme (dechenne2025examiningarginase1trimerization pages 7-9, dechenne2025examiningarginase1trimerization pages 2-5). The active site extends approximately 15 Å deep and terminates at the two catalytic manganese ions (palte2021cryoemstructuresof pages 1-2). This structural dependence on trimerization has been exploited as a novel drug target—phenylglyoxal covalently modifies a critical arginine residue (R205) within the allosteric trimerization pocket, disrupting oligomerization and partially reducing enzymatic activity (dechenne2025examiningarginase1trimerization pages 9-10, dechenne2025examiningarginase1trimerization pages 1-2). Cryo-EM structures of inhibitory antibodies complexed with ARG1 have been resolved at local resolutions of 3.5 Å or better, revealing both orthosteric and allosteric mechanisms of inhibition (palte2021cryoemstructuresof pages 1-2).</p>
+<h2 id="4-subcellular-localization-and-tissue-distribution">4. Subcellular Localization and Tissue Distribution</h2>
+<p>ARG1 is a cytosolic enzyme, in contrast to arginase 2 (ARG2), which localizes to the mitochondrial matrix (clemente2020arginaseasa pages 1-3, anakha2022humanarginase1 pages 1-3, cane2025therolesof pages 2-3). Its primary site of expression is the liver, where it is highly expressed in periportal (zone 1) hepatocytes—the region where blood arriving via the portal vein is rich in oxygen and amino acids, and where urea cycle enzymes are most active for ammonia detoxification (zhu2026ureacycledysregulation pages 4-5). Beyond the liver, ARG1 is also detected in erythrocytes, vascular endothelial cells, and immune cells, including M2-polarized macrophages, neutrophils, and myeloid-derived suppressor cells (MDSCs) (nteli2024argininemiapathophysiologyand pages 2-3, cane2025therolesof pages 1-2, cane2025therolesof pages 2-3). Neutrophils store ARG1 in gelatinase (tertiary) granules, from which it can be released upon degranulation (nteli2024argininemiapathophysiologyand pages 2-3).</p>
+<h2 id="5-biochemical-pathways">5. Biochemical Pathways</h2>
+<h3 id="51-the-urea-cycle">5.1 The Urea Cycle</h3>
+<p>In hepatocytes, ARG1 catalyzes the final step of the urea cycle by hydrolyzing L-arginine to L-ornithine and urea. The ornithine product is recycled into the urea cycle via ornithine transcarbamylase (OTC) in the mitochondria, while urea is transported through the bloodstream to the kidneys for excretion (nteli2024argininemiapathophysiologyand pages 2-3, clemente2020arginaseasa pages 1-3). This pathway is the primary route for nitrogen disposal in mammals, converting highly toxic ammonia to the relatively benign molecule urea.</p>
+<h3 id="52-downstream-metabolic-pathways">5.2 Downstream Metabolic Pathways</h3>
+<p>The L-ornithine produced by ARG1 serves as a critical metabolic branch-point feeding into two major downstream pathways, summarized in the following table:</p>
+<table>
+<thead>
+<tr>
+<th>Pathway/Step</th>
+<th>Enzyme(s)</th>
+<th>Substrate(s)</th>
+<th>Product(s)</th>
+<th>Biological significance</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ARG1 core reaction</td>
+<td>ARG1 (arginase-1)</td>
+<td>L-arginine + H2O</td>
+<td>L-ornithine + urea</td>
+<td>Final cytosolic step of the hepatic urea cycle; detoxifies ammonia by enabling urea excretion and generates ornithine as a branch-point metabolite for downstream biosynthesis (clemente2020arginaseasa pages 1-3, nteli2024argininemiapathophysiologyand pages 2-3)</td>
+</tr>
+<tr>
+<td>Polyamine pathway: ornithine to putrescine</td>
+<td>ODC/ODC1 (ornithine decarboxylase)</td>
+<td>L-ornithine</td>
+<td>Putrescine</td>
+<td>First rate-limiting step in polyamine synthesis; supports cell proliferation, repair, and metabolic reprogramming in immune and tumor contexts (li2026arg1polyamineaxiscelltypespecific pages 1-2, li2026arg1polyamineaxiscelltypespecific pages 2-3, xu2026molecularmechanismsand pages 3-4)</td>
+</tr>
+<tr>
+<td>Polyamine pathway: putrescine to spermidine</td>
+<td>SRM (spermidine synthase)</td>
+<td>Putrescine</td>
+<td>Spermidine</td>
+<td>Builds polyamine pools that support proliferation, differentiation, mitochondrial fitness, and epigenetic regulation (cane2025therolesof pages 2-3)</td>
+</tr>
+<tr>
+<td>Polyamine pathway: spermidine to spermine</td>
+<td>SMS (spermine synthase)</td>
+<td>Spermidine</td>
+<td>Spermine</td>
+<td>Extends polyamine pathway to support cell growth, migration, differentiation, and broader anabolic programs (cane2025therolesof pages 2-3)</td>
+</tr>
+<tr>
+<td>Proline/collagen pathway: ornithine transamination</td>
+<td>OAT (ornithine aminotransferase)</td>
+<td>L-ornithine</td>
+<td>L-glutamate 5-semialdehyde / P5C precursor</td>
+<td>Directs ARG1-derived ornithine toward proline biosynthesis, linking arginine catabolism to tissue repair, extracellular matrix production, and fibrosis/collagen programs (li2026arg1polyamineaxiscelltypespecific pages 1-2, li2026arg1polyamineaxiscelltypespecific pages 2-3, karadima2025argininemetabolismin pages 1-2)</td>
+</tr>
+<tr>
+<td>Proline/collagen pathway: P5C to proline</td>
+<td>PYCR</td>
+<td>P5C (1-pyrroline-5-carboxylate)</td>
+<td>Proline</td>
+<td>Supplies proline for collagen synthesis and extracellular matrix deposition, especially in wound healing, tissue remodeling, and reparative macrophage programs (cane2025therolesof pages 2-3)</td>
+</tr>
+<tr>
+<td>Competing arginine-utilization pathway</td>
+<td>NOS (nitric oxide synthase; iNOS/eNOS/nNOS)</td>
+<td>L-arginine</td>
+<td>Nitric oxide (NO) + citrulline</td>
+<td>Competes directly with ARG1 for L-arginine. NOS supports antimicrobial defense, vasodilation, and signaling, whereas ARG1 diverts arginine toward ornithine/polyamine/proline production. Although NOS has higher substrate affinity, arginase has a 10^3-10^4 higher Vmax, making ARG1 a powerful competitor for the shared substrate pool (li2026arg1polyamineaxiscelltypespecific pages 1-2, cane2025therolesof pages 2-3, li2026arg1polyamineaxiscelltypespecific pages 2-3, clemente2020arginaseasa pages 3-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main biochemical fates of ARG1-generated ornithine and the competing NOS branch from arginine. It is useful for understanding how ARG1 links the urea cycle to polyamine synthesis, proline/collagen production, and nitric-oxide-related signaling.</em></p>
+<p>First, L-ornithine enters the polyamine synthesis pathway, where ornithine decarboxylase (ODC/ODC1) converts it to putrescine in the rate-limiting first step. Putrescine is then sequentially converted to spermidine by spermidine synthase (SRM) and to spermine by spermine synthase (SMS). These polyamines are essential for cell proliferation, migration, epigenetic regulation, and differentiation (li2026arg1polyamineaxiscelltypespecific pages 1-2, cane2025therolesof pages 2-3, li2026arg1polyamineaxiscelltypespecific pages 2-3).</p>
+<p>Second, L-ornithine can be transaminated by ornithine aminotransferase (OAT) to produce L-glutamate 5-semialdehyde, which is further converted to 1-pyrroline-5-carboxylate (P5C) and then to L-proline by pyrroline-5-carboxylate reductase (PYCR). Proline is a critical building block for collagen and extracellular matrix deposition, linking ARG1 activity to tissue repair and fibrosis (cane2025therolesof pages 2-3, karadima2025argininemetabolismin pages 1-2).</p>
+<h3 id="53-competition-with-nitric-oxide-synthase">5.3 Competition with Nitric Oxide Synthase</h3>
+<p>A critically important aspect of ARG1 biology is its competition with nitric oxide synthase (NOS) for the shared substrate L-arginine (li2026arg1polyamineaxiscelltypespecific pages 1-2, li2026arg1polyamineaxiscelltypespecific pages 2-3). While ARG1 hydrolyzes L-arginine to ornithine and urea, NOS enzymes (iNOS, eNOS, nNOS) oxidize L-arginine to produce nitric oxide (NO) and citrulline. Although NOS has a higher substrate affinity (lower Km), ARG1 possesses a 10³–10⁴ times higher Vmax, making it a highly effective competitor that can deplete the L-arginine pool available for NO production (clemente2020arginaseasa pages 3-6). This competition has multiple downstream consequences: decreased L-arginine availability for NOS, potential uncoupling of NOS to produce harmful superoxide and peroxynitrite, and repression of NOS2 protein translation and stability (cane2025therolesof pages 2-3). The balance between the ARG1 and NOS pathways fundamentally determines whether cellular arginine metabolism favors immune suppression and tissue repair (via ornithine/polyamines/proline) or pro-inflammatory/antimicrobial responses (via NO) (li2026arg1polyamineaxiscelltypespecific pages 1-2, li2026arg1polyamineaxiscelltypespecific pages 2-3, karadima2025argininemetabolismin pages 1-2).</p>
+<h2 id="6-role-in-immune-regulation">6. Role in Immune Regulation</h2>
+<h3 id="61-macrophage-polarization">6.1 Macrophage Polarization</h3>
+<p>ARG1 is a defining marker and functional effector of M2 (alternatively activated, anti-inflammatory) macrophages. Its expression is induced by T helper 2 (Th2) cytokines IL-4 and IL-13 through JAK-STAT6 signaling, and by anti-inflammatory cytokines IL-10 and TGFβ. Pro-inflammatory cytokines IL-6 and TNF can also upregulate ARG1 through STAT3-dependent mechanisms (li2026arg1polyamineaxiscelltypespecific pages 4-5, pan2025harnessingaminoacid pages 8-10, cane2025therolesof pages 3-4). In macrophages, ARG1-derived ornithine fuels polyamine synthesis via ODC, promoting M2 polarization through enhanced mitochondrial oxidative phosphorylation, epigenetic modifications, autophagy, and efferocytosis (li2026arg1polyamineaxiscelltypespecific pages 4-5, pan2025harnessingaminoacid pages 8-10, li2026arg1polyamineaxiscelltypespecific pages 2-3). The ARG1/iNOS competitive axis represents a metabolic switch: in M1 pro-inflammatory macrophages, iNOS predominates to produce NO, whereas in M2 macrophages, ARG1 predominates to produce ornithine and polyamines (li2026arg1polyamineaxiscelltypespecific pages 5-7).</p>
+<h3 id="62-t-cell-suppression">6.2 T Cell Suppression</h3>
+<p>Myeloid cell-derived ARG1 represents a major immunosuppressive mechanism. By depleting extracellular L-arginine, ARG1 impairs T cell activation and proliferation through downregulation of the T cell receptor CD3ζ chain (pan2025harnessingaminoacid pages 8-10, grzybowski2025metabolomicreprogrammingof pages 2-3). This mechanism is operative in tumor-associated macrophages (TAMs), myeloid-derived suppressor cells (MDSCs), and tumor-associated neutrophils (TANs), all of which upregulate ARG1 to create an immunosuppressive tumor microenvironment (li2026arg1polyamineaxiscelltypespecific pages 4-5, li2026arg1polyamineaxiscelltypespecific pages 5-7, li2026arg1polyamineaxiscelltypespecific pages 3-4, cane2025therolesof pages 17-17). In pancreatic cancer, genetic inactivation of ARG1 in macrophages delays formation of invasive disease while increasing CD8⁺ T cell infiltration, directly demonstrating that ARG1 functions as more than a mere polarization marker—it actively drives immune suppression (li2026arg1polyamineaxiscelltypespecific pages 3-4). Lactic acid in the tumor microenvironment further induces ARG1 expression in TAMs via hypoxia-inducible factor stabilization (cane2025therolesof pages 3-4).</p>
+<h2 id="7-disease-associations">7. Disease Associations</h2>
+<h3 id="71-argininemia-arginase-deficiency">7.1 Argininemia (Arginase Deficiency)</h3>
+<p>Loss-of-function mutations in <em>ARG1</em> cause argininemia (arginase-1 deficiency, OMIM), a rare autosomal recessive urea cycle disorder (anakha2022humanarginase1 pages 1-3, nteli2024argininemiapathophysiologyand pages 2-3). The disease is characterized by severely elevated plasma arginine (&gt;300 µmol/L) and erythrocyte arginase activity below 1% of normal (nteli2024argininemiapathophysiologyand pages 5-7). Clinical manifestations include progressive spastic diplegia/paraparesis (the hallmark symptom beginning in the first decade of life), cognitive deficits, intellectual disability, seizures (in 60–75% of patients), and hepatic dysfunction ranging from neonatal jaundice to cirrhosis (nteli2024argininemiapathophysiologyand pages 2-3). The pathophysiology involves direct neurotoxicity of elevated arginine, accumulation of neurotoxic and epileptogenic guanidino compounds, excessive NO production leading to endothelial abnormalities, and decreased ornithine levels impairing oligodendrocyte function and causing dysmyelination (nteli2024argininemiapathophysiologyand pages 3-5). Current treatments include dietary protein restriction with essential amino acid supplementation, nitrogen scavengers (benzoate, phenylbutyrate), and liver transplantation, which effectively normalizes arginine and ammonia levels (nteli2024argininemiapathophysiologyand pages 5-7). Pegzilarginase (Co-rhARG1-PEG), a PEGylated cobalt-substituted recombinant human arginase 1 with improved stability and half-life, has received FDA Breakthrough Therapy Designation and has shown efficacy in reducing plasma arginine in approximately 50% of patients (anakha2022humanarginase1 pages 3-4). OpenTargets data confirms strong disease-target associations between ARG1 and arginase deficiency (score 0.78) and argininemia (score 0.80), as well as associations with hereditary disease (score 0.86), type 2 diabetes mellitus (score 0.44), and obesity disorder (score 0.36) (OpenTargets Search: -ARG1).</p>
+<h3 id="72-cancer-and-immunotherapy">7.2 Cancer and Immunotherapy</h3>
+<p>ARG1 is increasingly recognized as a therapeutic target in cancer immunotherapy. Elevated ARG1 activity in the tumor microenvironment correlates with poor prognosis across multiple cancer types by promoting immune evasion through L-arginine depletion and polyamine-mediated tumor cell proliferation (grzybowski2025metabolomicreprogrammingof pages 2-3). The arginase inhibitor CB-1158 (INCB001158/numidargistat), with an IC₅₀ of 98 nM for ARG1, was evaluated in a first-in-human phase 1 clinical trial (NCT02903914) in patients with advanced solid tumors. While generally well tolerated and showing pharmacodynamic activity (dose-dependent increases in plasma arginine), the limited antitumor activity observed as monotherapy or in combination with pembrolizumab suggested that the role of arginine depletion in cancer is multifaceted (marzetaassas2024pathophysiologyofarginases pages 13-14, marzetaassas2024pathophysiologyofarginases pages 11-13). A key limitation of CB-1158 is its restricted intracellular penetration, affecting primarily extracellular ARG1 (grzybowski2025metabolomicreprogrammingof pages 2-3). The next-generation dual ARG1/ARG2 inhibitor OATD-02 (IC₅₀ 20–48 nM) was designed to overcome this limitation by effectively inhibiting both extracellular and intracellular arginases (marzetaassas2024pathophysiologyofarginases pages 13-14, borek2023arginase12inhibitor pages 1-1). Preclinical studies show that OATD-02 restores intratumoral L-arginine while depleting polyamines, leading to increased CD8⁺ T cell infiltration, enhanced T cell activation, and improved response to anti-PD-1 checkpoint blockade (grzybowski2025metabolomicreprogrammingof pages 1-2). OATD-02 is currently undergoing clinical evaluation in a phase I/II trial (NCT05759923) (grzybowski2025metabolomicreprogrammingof pages 1-2).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>Human ARG1 is a cytosolic, homotrimeric, binuclear manganese metalloenzyme that catalyzes the final step of the urea cycle—the hydrolysis of L-arginine to L-ornithine and urea. Its enzymatic activity is strictly dependent on trimeric assembly and the presence of two Mn²⁺ ions at each active site. The enzyme is highly specific for L-arginine, with substrate recognition determined by two structural loops (Loop A and Loop B) at the active site entrance. ARG1 is predominantly expressed in liver periportal hepatocytes, where it functions in nitrogen detoxification, but is also expressed in immune cells (M2 macrophages, MDSCs, neutrophils), where it serves as a key immunomodulatory enzyme. Through competition with NOS for L-arginine and through production of ornithine-derived polyamines and proline, ARG1 occupies a critical metabolic branch-point linking nitrogen metabolism, immune regulation, tissue repair, and cell proliferation. Loss of ARG1 function causes the rare metabolic disorder argininemia, while overexpression in the tumor microenvironment contributes to immune evasion in cancer, making ARG1 an active target for both enzyme replacement therapy and immunotherapeutic inhibition.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(nteli2024argininemiapathophysiologyand pages 8-10): Despoina Nteli, Maria Nteli, Konstantinos Konstantinidis, Anastasia Foka, Foteini Charisi, Iliana Michailidou, Sotiria Stavropoulou De Lorenzo, Marina Boziki, Maria Tzitiridou-Chatzopoulou, Evangelia Spandou, Constantina Simeonidou, Christos Bakirtzis, and Evangelia Kesidou. Argininemia: pathophysiology and novel methods for evaluation of the disease. Applied Sciences, 14:1647, Feb 2024. URL: https://doi.org/10.3390/app14041647, doi:10.3390/app14041647. This article has 4 citations.</p>
+</li>
+<li>
+<p>(anakha2022humanarginase1 pages 1-3): J. Anakha, Priyanka S. Kawathe, Sayantap Datta, Snehal Sainath Jawalekar, Uttam Chand Banerjee, and Abhay H. Pande. Human arginase 1, a jack of all trades? 3 Biotech, Sep 2022. URL: https://doi.org/10.1007/s13205-022-03326-9, doi:10.1007/s13205-022-03326-9. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cane2025therolesof pages 1-2): Stefania Canè, Roger Geiger, and Vincenzo Bronte. The roles of arginases and arginine in immunity. Nature reviews. Immunology, Oct 2025. URL: https://doi.org/10.1038/s41577-024-01098-2, doi:10.1038/s41577-024-01098-2. This article has 118 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -ARG1): Open Targets Query (-ARG1, 13 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(nteli2024argininemiapathophysiologyand pages 2-3): Despoina Nteli, Maria Nteli, Konstantinos Konstantinidis, Anastasia Foka, Foteini Charisi, Iliana Michailidou, Sotiria Stavropoulou De Lorenzo, Marina Boziki, Maria Tzitiridou-Chatzopoulou, Evangelia Spandou, Constantina Simeonidou, Christos Bakirtzis, and Evangelia Kesidou. Argininemia: pathophysiology and novel methods for evaluation of the disease. Applied Sciences, 14:1647, Feb 2024. URL: https://doi.org/10.3390/app14041647, doi:10.3390/app14041647. This article has 4 citations.</p>
+</li>
+<li>
+<p>(palte2021cryoemstructuresof pages 1-2): Rachel L. Palte, Veronica Juan, Yacob Gomez-Llorente, Marc Andre Bailly, Kalyan Chakravarthy, Xun Chen, Daniel Cipriano, Ghassan N. Fayad, Laurence Fayadat-Dilman, Symon Gathiaka, Heiko Greb, Brian Hall, Mas Handa, Mark Hsieh, Esther Kofman, Heping Lin, J. Richard Miller, Nhung Nguyen, Jennifer O’Neil, Hussam Shaheen, Eric Sterner, Corey Strickland, Angie Sun, Shane Taremi, and Giovanna Scapin. Cryo-em structures of inhibitory antibodies complexed with arginase 1 provide insight into mechanism of action. Communications Biology, Jul 2021. URL: https://doi.org/10.1038/s42003-021-02444-z, doi:10.1038/s42003-021-02444-z. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2022reviewofarginase pages 3-5): Mengli Li, Jiufu Qin, Kai Xiong, Bo Jiang, and Tao Zhang. Review of arginase as a promising biocatalyst: characteristics, preparation, applications and future challenges. Critical Reviews in Biotechnology, 42:651-667, Oct 2022. URL: https://doi.org/10.1080/07388551.2021.1947962, doi:10.1080/07388551.2021.1947962. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dechenne2025examiningarginase1trimerization pages 7-9): Juhans Dechenne, Magdalena Wierzbicka, Reda Krimou, Asia El Aakchioui, Julia Malo Pueyo, Joris Messens, Marianne Fillet, Quentin Spillier, and Raphaël Frédérick. Examining arginase-1 trimerization uncovers a promising allosteric site for inhibition. Journal of medicinal chemistry, 68:1433-1445, Jan 2025. URL: https://doi.org/10.1021/acs.jmedchem.4c01993, doi:10.1021/acs.jmedchem.4c01993. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dechenne2025examiningarginase1trimerization pages 1-2): Juhans Dechenne, Magdalena Wierzbicka, Reda Krimou, Asia El Aakchioui, Julia Malo Pueyo, Joris Messens, Marianne Fillet, Quentin Spillier, and Raphaël Frédérick. Examining arginase-1 trimerization uncovers a promising allosteric site for inhibition. Journal of medicinal chemistry, 68:1433-1445, Jan 2025. URL: https://doi.org/10.1021/acs.jmedchem.4c01993, doi:10.1021/acs.jmedchem.4c01993. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(clemente2020arginaseasa pages 1-3): Gonçalo S. Clemente, Aren van Waarde, Inês F. Antunes, Alexander Dömling, and Philip H. Elsinga. Arginase as a potential biomarker of disease progression: a molecular imaging perspective. International Journal of Molecular Sciences, 21:5291, Jul 2020. URL: https://doi.org/10.3390/ijms21155291, doi:10.3390/ijms21155291. This article has 140 citations.</p>
+</li>
+<li>
+<p>(cane2025therolesof pages 2-3): Stefania Canè, Roger Geiger, and Vincenzo Bronte. The roles of arginases and arginine in immunity. Nature reviews. Immunology, Oct 2025. URL: https://doi.org/10.1038/s41577-024-01098-2, doi:10.1038/s41577-024-01098-2. This article has 118 citations.</p>
+</li>
+<li>
+<p>(zhu2026ureacycledysregulation pages 4-5): Boying Zhu, Chaoyang Wang, Peng Liu, Zhifeng Qu, Ran Qi, Shengjiang Chen, and Huanzhang Niu. Urea cycle dysregulation and arginine pathways in the pathogenesis of nafld and nash (review). International Journal of Molecular Medicine, 58:1-21, Jun 2026. URL: https://doi.org/10.3892/ijmm.2026.5886, doi:10.3892/ijmm.2026.5886. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(orellana2022newinsightsinto pages 1-2): María-Soledad Orellana, Gonzalo A. Jaña, Maximiliano Figueroa, José Martínez-Oyanedel, Fabiola E. Medina, Estefanía Tarifeño-Saldivia, Marcell Gatica, María Ángeles García-Robles, Nelson Carvajal, and Elena Uribe. New insights into the determinants of specificity in human type i arginase: generation of a mutant that is only active with agmatine as substrate. International Journal of Molecular Sciences, 23:6438, Jun 2022. URL: https://doi.org/10.3390/ijms23126438, doi:10.3390/ijms23126438. This article has 2 citations.</p>
+</li>
+<li>
+<p>(orellana2022newinsightsinto pages 6-7): María-Soledad Orellana, Gonzalo A. Jaña, Maximiliano Figueroa, José Martínez-Oyanedel, Fabiola E. Medina, Estefanía Tarifeño-Saldivia, Marcell Gatica, María Ángeles García-Robles, Nelson Carvajal, and Elena Uribe. New insights into the determinants of specificity in human type i arginase: generation of a mutant that is only active with agmatine as substrate. International Journal of Molecular Sciences, 23:6438, Jun 2022. URL: https://doi.org/10.3390/ijms23126438, doi:10.3390/ijms23126438. This article has 2 citations.</p>
+</li>
+<li>
+<p>(orellana2022newinsightsinto pages 2-4): María-Soledad Orellana, Gonzalo A. Jaña, Maximiliano Figueroa, José Martínez-Oyanedel, Fabiola E. Medina, Estefanía Tarifeño-Saldivia, Marcell Gatica, María Ángeles García-Robles, Nelson Carvajal, and Elena Uribe. New insights into the determinants of specificity in human type i arginase: generation of a mutant that is only active with agmatine as substrate. International Journal of Molecular Sciences, 23:6438, Jun 2022. URL: https://doi.org/10.3390/ijms23126438, doi:10.3390/ijms23126438. This article has 2 citations.</p>
+</li>
+<li>
+<p>(clemente2020arginaseasa pages 3-6): Gonçalo S. Clemente, Aren van Waarde, Inês F. Antunes, Alexander Dömling, and Philip H. Elsinga. Arginase as a potential biomarker of disease progression: a molecular imaging perspective. International Journal of Molecular Sciences, 21:5291, Jul 2020. URL: https://doi.org/10.3390/ijms21155291, doi:10.3390/ijms21155291. This article has 140 citations.</p>
+</li>
+<li>
+<p>(anakha2022humanarginase1 pages 3-4): J. Anakha, Priyanka S. Kawathe, Sayantap Datta, Snehal Sainath Jawalekar, Uttam Chand Banerjee, and Abhay H. Pande. Human arginase 1, a jack of all trades? 3 Biotech, Sep 2022. URL: https://doi.org/10.1007/s13205-022-03326-9, doi:10.1007/s13205-022-03326-9. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nteli2024argininemiapathophysiologyand pages 5-7): Despoina Nteli, Maria Nteli, Konstantinos Konstantinidis, Anastasia Foka, Foteini Charisi, Iliana Michailidou, Sotiria Stavropoulou De Lorenzo, Marina Boziki, Maria Tzitiridou-Chatzopoulou, Evangelia Spandou, Constantina Simeonidou, Christos Bakirtzis, and Evangelia Kesidou. Argininemia: pathophysiology and novel methods for evaluation of the disease. Applied Sciences, 14:1647, Feb 2024. URL: https://doi.org/10.3390/app14041647, doi:10.3390/app14041647. This article has 4 citations.</p>
+</li>
+<li>
+<p>(marzetaassas2024pathophysiologyofarginases pages 13-14): Patrycja Marzęta-Assas, Damian Jacenik, and Zbigniew Zasłona. Pathophysiology of arginases in cancer and efforts in their pharmacological inhibition. International Journal of Molecular Sciences, 25:9782, Sep 2024. URL: https://doi.org/10.3390/ijms25189782, doi:10.3390/ijms25189782. This article has 17 citations.</p>
+</li>
+<li>
+<p>(grzybowski2025metabolomicreprogrammingof pages 2-3): Marcin Mikołaj Grzybowski, Yasemin Uçal, Angelika Muchowicz, Tomasz Rejczak, Agnieszka Kikulska, Katarzyna Maria Głuchowska, Małgorzata Szostakowska-Rodzoś, Agnieszka Zagożdżon, Tobias Bausbacher, Agnieszka Tkaczyk, Magdalena Kulma, Paulina Pomper, Michał Mlącki, Adam Konrad Jagielski, Roman Błaszczyk, Carsten Hopf, and Zbigniew Zasłona. Metabolomic reprogramming of the tumor microenvironment by dual arginase inhibitor oatd-02 boosts anticancer immunity. Scientific Reports, May 2025. URL: https://doi.org/10.1038/s41598-025-03446-1, doi:10.1038/s41598-025-03446-1. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(orellana2022newinsightsinto pages 11-12): María-Soledad Orellana, Gonzalo A. Jaña, Maximiliano Figueroa, José Martínez-Oyanedel, Fabiola E. Medina, Estefanía Tarifeño-Saldivia, Marcell Gatica, María Ángeles García-Robles, Nelson Carvajal, and Elena Uribe. New insights into the determinants of specificity in human type i arginase: generation of a mutant that is only active with agmatine as substrate. International Journal of Molecular Sciences, 23:6438, Jun 2022. URL: https://doi.org/10.3390/ijms23126438, doi:10.3390/ijms23126438. This article has 2 citations.</p>
+</li>
+<li>
+<p>(orellana2022newinsightsinto pages 12-14): María-Soledad Orellana, Gonzalo A. Jaña, Maximiliano Figueroa, José Martínez-Oyanedel, Fabiola E. Medina, Estefanía Tarifeño-Saldivia, Marcell Gatica, María Ángeles García-Robles, Nelson Carvajal, and Elena Uribe. New insights into the determinants of specificity in human type i arginase: generation of a mutant that is only active with agmatine as substrate. International Journal of Molecular Sciences, 23:6438, Jun 2022. URL: https://doi.org/10.3390/ijms23126438, doi:10.3390/ijms23126438. This article has 2 citations.</p>
+</li>
+<li>
+<p>(orellana2022newinsightsinto pages 7-9): María-Soledad Orellana, Gonzalo A. Jaña, Maximiliano Figueroa, José Martínez-Oyanedel, Fabiola E. Medina, Estefanía Tarifeño-Saldivia, Marcell Gatica, María Ángeles García-Robles, Nelson Carvajal, and Elena Uribe. New insights into the determinants of specificity in human type i arginase: generation of a mutant that is only active with agmatine as substrate. International Journal of Molecular Sciences, 23:6438, Jun 2022. URL: https://doi.org/10.3390/ijms23126438, doi:10.3390/ijms23126438. This article has 2 citations.</p>
+</li>
+<li>
+<p>(dechenne2025examiningarginase1trimerization pages 2-5): Juhans Dechenne, Magdalena Wierzbicka, Reda Krimou, Asia El Aakchioui, Julia Malo Pueyo, Joris Messens, Marianne Fillet, Quentin Spillier, and Raphaël Frédérick. Examining arginase-1 trimerization uncovers a promising allosteric site for inhibition. Journal of medicinal chemistry, 68:1433-1445, Jan 2025. URL: https://doi.org/10.1021/acs.jmedchem.4c01993, doi:10.1021/acs.jmedchem.4c01993. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dechenne2025examiningarginase1trimerization pages 9-10): Juhans Dechenne, Magdalena Wierzbicka, Reda Krimou, Asia El Aakchioui, Julia Malo Pueyo, Joris Messens, Marianne Fillet, Quentin Spillier, and Raphaël Frédérick. Examining arginase-1 trimerization uncovers a promising allosteric site for inhibition. Journal of medicinal chemistry, 68:1433-1445, Jan 2025. URL: https://doi.org/10.1021/acs.jmedchem.4c01993, doi:10.1021/acs.jmedchem.4c01993. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2026arg1polyamineaxiscelltypespecific pages 1-2): Lexing Li, Guoyan Zhu, Meng-Zhang Chen, Bingqing Qiu, Yujia Li, Shiyu Liu, Wei Gu, and Leilei Liu. Arg1-polyamine axis: cell-type-specific functions in disease pathogenesis and therapeutic targeting. Frontiers in Immunology, Mar 2026. URL: https://doi.org/10.3389/fimmu.2026.1744890, doi:10.3389/fimmu.2026.1744890. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2026arg1polyamineaxiscelltypespecific pages 2-3): Lexing Li, Guoyan Zhu, Meng-Zhang Chen, Bingqing Qiu, Yujia Li, Shiyu Liu, Wei Gu, and Leilei Liu. Arg1-polyamine axis: cell-type-specific functions in disease pathogenesis and therapeutic targeting. Frontiers in Immunology, Mar 2026. URL: https://doi.org/10.3389/fimmu.2026.1744890, doi:10.3389/fimmu.2026.1744890. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2026molecularmechanismsand pages 3-4): Yuhang Xu, Mingxin Yu, Yi Zhang, Yiqing Jiang, Haiyan Zhu, Shujuan He, Guohua Yu, Niannian Li, Shuzhen Liu, and Bin Liu. Molecular mechanisms and therapies for tumor inhibition through the arginine metabolism pathway. Frontiers in Oncology, Feb 2026. URL: https://doi.org/10.3389/fonc.2026.1774392, doi:10.3389/fonc.2026.1774392. This article has 0 citations.</p>
+</li>
+<li>
+<p>(karadima2025argininemetabolismin pages 1-2): Eleftheria Karadima, Triantafyllos Chavakis, and Vasileia Ismini Alexaki. Arginine metabolism in myeloid cells in health and disease. Seminars in Immunopathology, Jan 2025. URL: https://doi.org/10.1007/s00281-025-01038-9, doi:10.1007/s00281-025-01038-9. This article has 67 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2026arg1polyamineaxiscelltypespecific pages 4-5): Lexing Li, Guoyan Zhu, Meng-Zhang Chen, Bingqing Qiu, Yujia Li, Shiyu Liu, Wei Gu, and Leilei Liu. Arg1-polyamine axis: cell-type-specific functions in disease pathogenesis and therapeutic targeting. Frontiers in Immunology, Mar 2026. URL: https://doi.org/10.3389/fimmu.2026.1744890, doi:10.3389/fimmu.2026.1744890. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pan2025harnessingaminoacid pages 8-10): Jiongli Pan, Yi Lin, Xinyuan Liu, Xiaozhen Zhang, Tingbo Liang, and Xueli Bai. Harnessing amino acid pathways to influence myeloid cell function in tumor immunity. Molecular Medicine, Feb 2025. URL: https://doi.org/10.1186/s10020-025-01099-4, doi:10.1186/s10020-025-01099-4. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cane2025therolesof pages 3-4): Stefania Canè, Roger Geiger, and Vincenzo Bronte. The roles of arginases and arginine in immunity. Nature reviews. Immunology, Oct 2025. URL: https://doi.org/10.1038/s41577-024-01098-2, doi:10.1038/s41577-024-01098-2. This article has 118 citations.</p>
+</li>
+<li>
+<p>(li2026arg1polyamineaxiscelltypespecific pages 5-7): Lexing Li, Guoyan Zhu, Meng-Zhang Chen, Bingqing Qiu, Yujia Li, Shiyu Liu, Wei Gu, and Leilei Liu. Arg1-polyamine axis: cell-type-specific functions in disease pathogenesis and therapeutic targeting. Frontiers in Immunology, Mar 2026. URL: https://doi.org/10.3389/fimmu.2026.1744890, doi:10.3389/fimmu.2026.1744890. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2026arg1polyamineaxiscelltypespecific pages 3-4): Lexing Li, Guoyan Zhu, Meng-Zhang Chen, Bingqing Qiu, Yujia Li, Shiyu Liu, Wei Gu, and Leilei Liu. Arg1-polyamine axis: cell-type-specific functions in disease pathogenesis and therapeutic targeting. Frontiers in Immunology, Mar 2026. URL: https://doi.org/10.3389/fimmu.2026.1744890, doi:10.3389/fimmu.2026.1744890. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cane2025therolesof pages 17-17): Stefania Canè, Roger Geiger, and Vincenzo Bronte. The roles of arginases and arginine in immunity. Nature reviews. Immunology, Oct 2025. URL: https://doi.org/10.1038/s41577-024-01098-2, doi:10.1038/s41577-024-01098-2. This article has 118 citations.</p>
+</li>
+<li>
+<p>(nteli2024argininemiapathophysiologyand pages 3-5): Despoina Nteli, Maria Nteli, Konstantinos Konstantinidis, Anastasia Foka, Foteini Charisi, Iliana Michailidou, Sotiria Stavropoulou De Lorenzo, Marina Boziki, Maria Tzitiridou-Chatzopoulou, Evangelia Spandou, Constantina Simeonidou, Christos Bakirtzis, and Evangelia Kesidou. Argininemia: pathophysiology and novel methods for evaluation of the disease. Applied Sciences, 14:1647, Feb 2024. URL: https://doi.org/10.3390/app14041647, doi:10.3390/app14041647. This article has 4 citations.</p>
+</li>
+<li>
+<p>(marzetaassas2024pathophysiologyofarginases pages 11-13): Patrycja Marzęta-Assas, Damian Jacenik, and Zbigniew Zasłona. Pathophysiology of arginases in cancer and efforts in their pharmacological inhibition. International Journal of Molecular Sciences, 25:9782, Sep 2024. URL: https://doi.org/10.3390/ijms25189782, doi:10.3390/ijms25189782. This article has 17 citations.</p>
+</li>
+<li>
+<p>(borek2023arginase12inhibitor pages 1-1): Bartlomiej Borek, Julita Nowicka, Anna Gzik, Marek Dziegielewski, Karol Jedrzejczak, Joanna Brzezinska, Marcin Grzybowski, Paulina Stanczak, Paulina Pomper, Agnieszka Zagozdzon, Tomasz Rejczak, Krzysztof Matyszewski, Adam Golebiowski, Jacek Olczak, Kamil Lisiecki, Magdalena Tyszkiewicz, Magdalena Kania, Sylwia Piasecka, Anna Cabaj, Paulina Dera, Krzysztof Mulewski, Jacek Chrzanowski, Damian Kusmirek, Elzbieta Sobolewska, Marta Magdycz, Lukasz Mucha, Marek Masnyk, Jakub Golab, Marcin Nowotny, Elzbieta Nowak, Agnieszka Napiorkowska-Gromadzka, Stanislaw Pikul, Radoslaw Jazwiec, Karolina Dzwonek, Pawel Dobrzanski, Michael Meyring, Krzysztof Skowronek, Piotr Iwanowski, Zbigniew Zaslona, and Roman Blaszczyk. Arginase 1/2 inhibitor oatd-02: from discovery to first-in-man setup in cancer immunotherapy. Molecular cancer therapeutics, 22:807-817, Mar 2023. URL: https://doi.org/10.1158/1535-7163.mct-22-0721, doi:10.1158/1535-7163.mct-22-0721. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(grzybowski2025metabolomicreprogrammingof pages 1-2): Marcin Mikołaj Grzybowski, Yasemin Uçal, Angelika Muchowicz, Tomasz Rejczak, Agnieszka Kikulska, Katarzyna Maria Głuchowska, Małgorzata Szostakowska-Rodzoś, Agnieszka Zagożdżon, Tobias Bausbacher, Agnieszka Tkaczyk, Magdalena Kulma, Paulina Pomper, Michał Mlącki, Adam Konrad Jagielski, Roman Błaszczyk, Carsten Hopf, and Zbigniew Zasłona. Metabolomic reprogramming of the tumor microenvironment by dual arginase inhibitor oatd-02 boosts anticancer immunity. Scientific Reports, May 2025. URL: https://doi.org/10.1038/s41598-025-03446-1, doi:10.1038/s41598-025-03446-1. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ARG1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="ARG1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>nteli2024argininemiapathophysiologyand pages 8-10</li>
+<li>cane2025therolesof pages 1-2</li>
+<li>clemente2020arginaseasa pages 3-6</li>
+<li>nteli2024argininemiapathophysiologyand pages 2-3</li>
+<li>li2022reviewofarginase pages 3-5</li>
+<li>orellana2022newinsightsinto pages 1-2</li>
+<li>orellana2022newinsightsinto pages 2-4</li>
+<li>orellana2022newinsightsinto pages 7-9</li>
+<li>palte2021cryoemstructuresof pages 1-2</li>
+<li>zhu2026ureacycledysregulation pages 4-5</li>
+<li>cane2025therolesof pages 2-3</li>
+<li>cane2025therolesof pages 3-4</li>
+<li>nteli2024argininemiapathophysiologyand pages 5-7</li>
+<li>nteli2024argininemiapathophysiologyand pages 3-5</li>
+<li>grzybowski2025metabolomicreprogrammingof pages 2-3</li>
+<li>grzybowski2025metabolomicreprogrammingof pages 1-2</li>
+<li>clemente2020arginaseasa pages 1-3</li>
+<li>orellana2022newinsightsinto pages 6-7</li>
+<li>marzetaassas2024pathophysiologyofarginases pages 13-14</li>
+<li>orellana2022newinsightsinto pages 11-12</li>
+<li>orellana2022newinsightsinto pages 12-14</li>
+<li>xu2026molecularmechanismsand pages 3-4</li>
+<li>karadima2025argininemetabolismin pages 1-2</li>
+<li>pan2025harnessingaminoacid pages 8-10</li>
+<li>cane2025therolesof pages 17-17</li>
+<li>marzetaassas2024pathophysiologyofarginases pages 11-13</li>
+<li>https://doi.org/10.3390/app14041647,</li>
+<li>https://doi.org/10.1007/s13205-022-03326-9,</li>
+<li>https://doi.org/10.1038/s41577-024-01098-2,</li>
+<li>https://doi.org/10.1038/s42003-021-02444-z,</li>
+<li>https://doi.org/10.1080/07388551.2021.1947962,</li>
+<li>https://doi.org/10.1021/acs.jmedchem.4c01993,</li>
+<li>https://doi.org/10.3390/ijms21155291,</li>
+<li>https://doi.org/10.3892/ijmm.2026.5886,</li>
+<li>https://doi.org/10.3390/ijms23126438,</li>
+<li>https://doi.org/10.3390/ijms25189782,</li>
+<li>https://doi.org/10.1038/s41598-025-03446-1,</li>
+<li>https://doi.org/10.3389/fimmu.2026.1744890,</li>
+<li>https://doi.org/10.3389/fonc.2026.1774392,</li>
+<li>https://doi.org/10.1007/s00281-025-01038-9,</li>
+<li>https://doi.org/10.1186/s10020-025-01099-4,</li>
+<li>https://doi.org/10.1158/1535-7163.mct-22-0721,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ARG1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P05089" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="arg1-arginase-1-human-uniprotkbp05089-review-notes">ARG1 (Arginase-1, human, UniProtKB:P05089) — review notes</h1>
+<h2 id="summary-of-function">Summary of function</h2>
+<p>ARG1 is the cytosolic, liver-type (type I) arginase, a binuclear manganese<br />
+metalloenzyme that catalyzes the terminal (fifth) step of the urea cycle:<br />
+L-arginine + H2O -&gt; L-ornithine + urea (EC 3.5.3.1). It regenerates ornithine to<br />
+close the cycle and produces the urea that is excreted. It is a homotrimer, each<br />
+subunit binding two Mn(2+) ions. Beyond hepatic ureagenesis, ARG1 is<br />
+constitutively expressed in neutrophil granules and released during inflammation,<br />
+where local arginine depletion suppresses T-cell (and NK-cell) proliferation /<br />
+cytokine production — a myeloid immunoregulatory role. Loss-of-function variants<br />
+cause argininemia / arginase deficiency, a urea cycle disorder distinguished by<br />
+progressive spastic diplegia/paraparesis rather than the neonatal hyperammonemic<br />
+crises typical of proximal UCDs.</p>
+<h2 id="key-verbatim-citations">Key verbatim citations</h2>
+<ul>
+<li>
+<p>Terminal urea-cycle step + disease:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/3540966" title="Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle in the liver of ureotelic animals. Inherited deficiency of the enzyme results in argininemia, an autosomal recessive disorder characterized by hyperammonemia.">PMID:3540966</a></p>
+</li>
+<li>
+<p>Catalytic activity / Mn metalloenzyme:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17562323" title="Arginase is a manganese metalloenzyme that catalyzes the hydrolysis of l-arginine to yield l-ornithine and urea.">PMID:17562323</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21728378" title="Arginase is a binuclear manganese metalloenzyme that hydrolyzes L-arginine to form L-ornithine and urea">PMID:21728378</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21728378" title="Arginase I is a cytosolic enzyme found predominantly in the liver, and arginase II is a mitochondrial enzyme found at highest concentrations in the kidney.">PMID:21728378</a></p>
+</li>
+<li>
+<p>Binuclear Mn cluster / structure:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16141327" title="The ultrahigh-resolution structure of the human arginase I-ABH complex yields an unprecedented view of the binuclear manganese cluster">PMID:16141327</a></p>
+</li>
+<li>
+<p>Homotrimer / quaternary structure:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22959135" title="Our study reinforced the role of Arg308 residue for assembly of the ARG1 homotrimer.">PMID:22959135</a></p>
+</li>
+<li>
+<p>Neutrophil/granulocyte expression + azurophil granule + antimicrobial:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15546957" title="in human leukocytes arginase I is constitutively expressed only in granulocytes">PMID:15546957</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15546957" title="arginase I is localized in azurophil granules of neutrophils and constitutes a novel antimicrobial effector pathway, likely through arginine depletion in the phagolysosome">PMID:15546957</a></p>
+</li>
+<li>
+<p>T-cell suppression via extracellular arginase / arginine depletion:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16709924" title="arginase I is liberated from human granulocytes, and very high activities accumulate extracellularly during purulent inflammatory reactions. Human granulocyte arginase induces a profound suppression of T-cell proliferation and cytokine synthesis. This T-cell phenotype is due to arginase-mediated depletion of arginine in the T-cell environment, which leads to CD3zeta chain down-regulation">PMID:16709924</a></p>
+</li>
+<li>
+<p>CMTM6 interaction (ARG1 identified as MS interactor in a PD-L1/CMTM6 study; ARG1 itself not the paper's focus):<br />
+  UniProt: "INTERACTION WITH CMTM6, AND IDENTIFICATION BY MASS SPECTROMETRY" (RN[15], PMID:28813417).<br />
+  Paper abstract is about CMTM6 regulating PD-L1; ARG1 is one MS-detected CMTM6 co-precipitant.</p>
+</li>
+<li>
+<p>Sperm nucleus proteomics (HDA nucleus): PMID:21630459 is a bulk sperm-nuclear<br />
+  proteome catalog (403 proteins); ARG1 detection is a large-scale MS hit, not a<br />
+  dedicated study of nuclear ARG1 function.</p>
+</li>
+</ul>
+<h2 id="disease-dismech-arginase_deficiencyyaml">Disease (dismech Arginase_Deficiency.yaml)</h2>
+<p>"progressive spastic diplegia or paraparesis, seizures, intellectual disability,<br />
+and growth retardation... relatively infrequent hyperammonemia compared to other<br />
+urea cycle disorders." Neurotoxicity from arginine + guanidino compounds.</p>
+<h2 id="go-term-definition-checks-ols">GO term-definition checks (OLS)</h2>
+<ul>
+<li>GO:0004053 arginase activity = "L-arginine + H2O = L-ornithine + urea" (exact MF). CORE.</li>
+<li>GO:0000050 urea cycle = full cycle; ARG1 does terminal step. CORE BP.</li>
+<li>GO:0016813 hydrolase acting on C-N linear amidines = PARENT of arginase activity<br />
+  (InterPro Mn-binding-site IEA); redundant/over-general vs GO:0004053 -&gt; MODIFY.</li>
+<li>GO:0046872 metal ion binding = PARENT of GO:0030145 manganese ion binding;<br />
+  general -&gt; MODIFY to GO:0030145 (which is verified, binuclear Mn cluster).</li>
+<li>GO:0006527 L-arginine catabolic process = verified BP (breakdown of L-arginine). ACCEPT.</li>
+<li>GO:0006525 arginine metabolic process = broader parent; keep (IBA/IEA).</li>
+<li>GO:0030145 manganese ion binding = binds 2 Mn2+/subunit. CORE MF (contributes_to).</li>
+<li>GO:0005829 cytosol = verified subcellular localization (arginase I cytosolic). CORE CC.</li>
+<li>GO:0005737 cytoplasm = parent of cytosol; keep.</li>
+<li>GO:0005576 extracellular region (IDA PMID:16709924) = neutrophil arginase released<br />
+  extracellularly; real but non-core (secondary immune role).</li>
+<li>GO:0035578 azurophil granule lumen / GO:0035580 specific granule lumen (Reactome<br />
+  neutrophil degranulation) = real neutrophil granule localization; non-core.</li>
+<li>GO:0005634 nucleus (HDA PMID:21630459) = bulk sperm-nucleus proteomics; likely<br />
+  not a functional nuclear localization -&gt; non-core / over-annotated.</li>
+<li>GO:0070947 neutrophil-mediated killing of fungus (IMP PMID:15546957) = supported<br />
+  by fungicidal-activity paper; non-core immune role.</li>
+<li>GO:0042130 neg reg T cell proliferation (IDA/IBA PMID:16709924) = supported; non-core.</li>
+<li>GO:0060336 neg reg type II IFN signaling (IMP PMID:16709924) = downstream immune<br />
+  effect; keep as non-core.</li>
+<li>GO:0042832 defense response to protozoan / GO:0046007 neg reg activated T cell<br />
+  proliferation / GO:2000552 neg reg Th2 cytokine production (Ensembl GO_REF:0000107<br />
+  IEA from mouse Q61176) = orthology-transferred mouse immune roles; keep non-core.</li>
+<li>GO:0042127 regulation of cell population proliferation (ARBA IEA) = very general;<br />
+  over-annotated relative to the specific T-cell terms -&gt; MARK_AS_OVER_ANNOTATED.</li>
+<li>GO:0005515 protein binding (IPI CMTM6, PMID:28813417) = uninformative; MS<br />
+  interactor from a PD-L1 study -&gt; non-informative binding, mark over-annotated.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>falcon deep-research launched (<code>just deep-research-falcon human P05089 --alias ARG1</code>);<br />
+FAILED after 600s ("All providers failed" — falcon endpoint timeout). No<br />
+-deep-research-falcon.md file produced. Review grounded in the UniProt record, all 9<br />
+cached publications, and dismech Arginase_Deficiency.yaml. No DR file fabricated.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P05089
+gene_symbol: ARG1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  Arginase-1 (liver-type/type I arginase) is the cytosolic, manganese-dependent
+  ureohydrolase that catalyzes the terminal step of the urea cycle, hydrolyzing
+  L-arginine and water to L-ornithine and urea (EC 3.5.3.1). It is a homotrimer,
+  each subunit containing a binuclear manganese cluster required for catalysis.
+  In the liver, where it is most abundantly expressed, arginase-1 regenerates
+  ornithine to sustain the urea cycle and produces the urea that is excreted,
+  making it central to nitrogen disposal; the distinct mitochondrial paralog
+  arginase-2 (ARG2) operates in extrahepatic tissues. Arginase-1 is also
+  constitutively expressed in the granules of human neutrophils and other
+  myeloid cells, where it acts as an immunoregulatory enzyme: released into the
+  extracellular space or phagolysosome, it depletes local L-arginine,
+  suppressing T-cell and NK-cell proliferation and cytokine production and
+  contributing to antimicrobial defense. Loss-of-function variants cause
+  argininemia (arginase deficiency), a urea cycle disorder characterized by
+  progressive spastic diplegia/paraparesis, seizures, and intellectual
+  disability, with hyperammonemia occurring less frequently than in proximal
+  urea cycle disorders.
+alternative_products:
+- name: &#39;1&#39;
+  id: P05089-1
+- name: 2 (Erythroid variant)
+  id: P05089-2
+  sequence_note: VSP_009330
+- name: &#39;3&#39;
+  id: P05089-3
+  sequence_note: VSP_009331
+existing_annotations:
+- term:
+    id: GO:0004053
+    label: arginase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (PAN-GO) inference of arginase activity, the defining and
+      core molecular function of ARG1.
+    action: ACCEPT
+    reason: This is the correct, specific molecular function. Arginase activity (EC
+      3.5.3.1, L-arginine + H2O = L-ornithine + urea) is directly demonstrated for
+      human ARG1 by crystallographic and enzymatic studies, so the IBA inference is
+      strongly supported.
+    supported_by:
+    - reference_id: PMID:17562323
+      supporting_text: Arginase is a manganese metalloenzyme that catalyzes the hydrolysis
+        of l-arginine to yield l-ornithine and urea.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic inference that ARG1 acts in the cytoplasm; consistent with
+      its established cytosolic localization.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but non-specific. ARG1 is a cytosolic enzyme; the more precise
+      term GO:0005829 (cytosol), also annotated, better captures the localization.
+      Retained as it is not wrong, but subordinate to the cytosol annotation.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0006525
+    label: arginine metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic inference that ARG1 participates in arginine metabolism;
+      correct but general.
+    action: KEEP_AS_NON_CORE
+    reason: Accurate at a general level. ARG1 catabolizes L-arginine, so involvement
+      in arginine metabolism is correct; the more specific L-arginine catabolic process
+      (GO:0006527) and urea cycle (GO:0000050) annotations capture the precise role.
+    supported_by:
+    - reference_id: PMID:17562323
+      supporting_text: Arginase is a manganese metalloenzyme that catalyzes the hydrolysis
+        of l-arginine to yield l-ornithine and urea.
+- term:
+    id: GO:0042130
+    label: negative regulation of T cell proliferation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic inference of an immunoregulatory role in suppressing T-cell
+      proliferation, corroborated by direct experimental evidence in human granulocyte
+      arginase.
+    action: KEEP_AS_NON_CORE
+    reason: Well-supported secondary (myeloid/immune) function. Extracellular arginase
+      released from human granulocytes depletes arginine and suppresses T-cell proliferation.
+      This is a genuine role but distinct from the core hepatic urea-cycle function.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: Human granulocyte arginase induces a profound suppression of
+        T-cell proliferation and cytokine synthesis.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic inference that ARG1 participates in the urea cycle; this
+      is a core biological process for the enzyme.
+    action: ACCEPT
+    reason: ARG1 catalyzes the terminal step of the urea cycle, regenerating ornithine
+      and releasing urea. This is a core biological process and the IBA inference
+      is strongly supported by direct evidence.
+    supported_by:
+    - reference_id: PMID:3540966
+      supporting_text: Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle
+        in the liver of ureotelic animals.
+- term:
+    id: GO:0030145
+    label: manganese ion binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic inference of manganese ion binding; ARG1 requires a binuclear
+      Mn(2+) cluster for catalysis.
+    action: ACCEPT
+    reason: Directly supported by high-resolution crystal structures showing two manganese
+      ions per subunit forming the catalytic binuclear cluster. Core molecular function
+      cofactor requirement.
+    supported_by:
+    - reference_id: PMID:16141327
+      supporting_text: The ultrahigh-resolution structure of the human arginase I-ABH
+        complex yields an unprecedented view of the binuclear manganese cluster
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic inference that ARG1 acts in the cytosol; this is the established
+      subcellular location of type I arginase.
+    action: ACCEPT
+    reason: Arginase I is a cytosolic enzyme (in contrast to mitochondrial ARG2).
+      This is the core localization where ureagenic arginine hydrolysis occurs.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0004053
+    label: arginase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Automated (multiple-method) inference of arginase activity, mapped from
+      RHEA:20569/EC:3.5.3.1 and orthology.
+    action: ACCEPT
+    reason: Correct and specific molecular function, consistent with the RHEA reaction
+      L-arginine + H2O = L-ornithine + urea and the experimental annotations. Duplicate
+      of the IBA/EXP arginase-activity annotations, which is acceptable.
+    supported_by:
+    - reference_id: PMID:16141327
+      supporting_text: we demonstrate the inhibition of arginase activity by ABH in
+        human and murine myeloid cells
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Automated mapping from the UniProt Cytoplasm subcellular-location keyword.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but general; cytosol (GO:0005829) is the more precise term for
+      this cytosolic enzyme. Retained as a valid broader localization.
+    supported_by:
+    - reference_id: PMID:16141327
+      supporting_text: exploration of inhibition in the immune response
+- term:
+    id: GO:0006525
+    label: arginine metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: InterPro2GO mapping (arginase domain) to arginine metabolic process.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but general. The specific catabolic role (L-arginine catabolic
+      process, GO:0006527) and urea cycle (GO:0000050) better capture ARG1&#39;s function;
+      this broad parent is acceptable as an IEA.
+    supported_by:
+    - reference_id: PMID:17562323
+      supporting_text: Arginase is a manganese metalloenzyme that catalyzes the hydrolysis
+        of l-arginine to yield l-ornithine and urea.
+- term:
+    id: GO:0016813
+    label: hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds,
+      in linear amidines
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO mapping (ureohydrolase Mn-binding site) to a broad hydrolase-on-C-N-linear-amidines
+      term.
+    action: MODIFY
+    reason: This is the parent term of the specific and experimentally established
+      arginase activity (GO:0004053). Arginase hydrolyzes the C-N bond of the linear
+      amidine L-arginine, so the term is not wrong, but it is over-general given the
+      precise activity is known. Replace with the specific molecular function.
+    proposed_replacement_terms:
+    - id: GO:0004053
+      label: arginase activity
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase is a binuclear manganese metalloenzyme that hydrolyzes
+        L-arginine to form L-ornithine and urea
+- term:
+    id: GO:0042127
+    label: regulation of cell population proliferation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: ARBA machine-learning inference of a general role in regulating cell
+      population proliferation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Overly general electronic annotation. ARG1&#39;s proliferation-related effects
+      are specifically on immune cells via arginine depletion (captured by the more
+      specific negative regulation of T-cell proliferation terms). This broad, direction-less
+      parent adds no functional specificity and is likely an over-annotation.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: Human granulocyte arginase induces a profound suppression of
+        T-cell proliferation and cytokine synthesis.
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO mapping to a generic metal ion binding term.
+    action: MODIFY
+    reason: The specific metal bound is known to be manganese (a binuclear Mn(2+)
+      cluster, two ions per subunit), captured by GO:0030145 (manganese ion binding),
+      which is also annotated. The generic parent should be specialized.
+    proposed_replacement_terms:
+    - id: GO:0030145
+      label: manganese ion binding
+    supported_by:
+    - reference_id: PMID:16141327
+      supporting_text: The ultrahigh-resolution structure of the human arginase I-ABH
+        complex yields an unprecedented view of the binuclear manganese cluster
+- term:
+    id: GO:0042832
+    label: defense response to protozoan
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl-Compara orthology transfer from mouse Arg1 (Q61176) of a role
+      in antiprotozoal defense.
+    action: KEEP_AS_NON_CORE
+    reason: This is an orthology-transferred (GO_REF:0000107, from mouse) immune role
+      consistent with ARG1&#39;s known myeloid arginine-depletion function in antimicrobial
+      defense, but it is a peripheral/species-informed role rather than the core hepatic
+      function. Retained as non-core; the underlying human evidence is indirect.
+    supported_by:
+    - reference_id: PMID:15546957
+      supporting_text: arginase I is localized in azurophil granules of neutrophils
+        and constitutes a novel antimicrobial effector pathway, likely through arginine
+        depletion in the phagolysosome
+- term:
+    id: GO:0046007
+    label: negative regulation of activated T cell proliferation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl-Compara orthology transfer from mouse Arg1 of negative regulation
+      of activated T-cell proliferation.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with the well-documented human function whereby extracellular/granulocyte
+      arginase depletes arginine and suppresses T-cell proliferation. A genuine secondary
+      immunoregulatory role; retained as non-core.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: Human granulocyte arginase induces a profound suppression of
+        T-cell proliferation and cytokine synthesis.
+- term:
+    id: GO:2000552
+    label: negative regulation of T-helper 2 cell cytokine production
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl-Compara orthology transfer from mouse Arg1 of a role in limiting
+      Th2 cytokine production.
+    action: KEEP_AS_NON_CORE
+    reason: Orthology-transferred (from mouse) immunoregulatory role. ARG1&#39;s arginine
+      depletion suppresses T-cell cytokine synthesis; this specific Th2 term reflects
+      the mouse ILC2/type-2 inflammation context. Retained as a plausible non-core
+      immune role; the direct human evidence is limited.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: Human granulocyte arginase induces a profound suppression of
+        T-cell proliferation and cytokine synthesis.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: UniPathway mapping (UPA00158) to the urea cycle.
+    action: ACCEPT
+    reason: Correct core biological process. ARG1 performs the terminal step of the
+      urea cycle. Duplicate of the IBA urea-cycle annotation, which is acceptable.
+    supported_by:
+    - reference_id: PMID:3540966
+      supporting_text: Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle
+        in the liver of ureotelic animals.
+- term:
+    id: GO:0070947
+    label: neutrophil-mediated killing of fungus
+  evidence_type: IMP
+  original_reference_id: PMID:15546957
+  qualifier: involved_in
+  review:
+    summary: Experimental (IMP) annotation from the study showing arginase I in azurophil
+      granules participates in fungicidal activity of human neutrophils.
+    action: KEEP_AS_NON_CORE
+    reason: Supported by the cited experimental study demonstrating a granulocyte
+      antimicrobial effector role via arginine depletion. This is a genuine, well-evidenced
+      secondary function in myeloid cells, distinct from the core hepatic urea-cycle
+      role. Note UniProt now uses the closely related term GO:0070965 (positive regulation
+      of neutrophil mediated killing of fungus) for the same evidence.
+    supported_by:
+    - reference_id: PMID:15546957
+      supporting_text: arginase I is localized in azurophil granules of neutrophils
+        and constitutes a novel antimicrobial effector pathway, likely through arginine
+        depletion in the phagolysosome
+- term:
+    id: GO:0006527
+    label: L-arginine catabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:22959135
+  qualifier: involved_in
+  review:
+    summary: Experimental (IMP) annotation from analysis of ARG1 mutations causing
+      hyperargininemia, correlating loss of arginase activity with impaired L-arginine
+      catabolism.
+    action: ACCEPT
+    reason: Core biological process. ARG1 catalyzes the breakdown of L-arginine; loss-of-function
+      mutations cause hyperargininemia (accumulation of arginine), directly demonstrating
+      its role in L-arginine catabolism. The curator assessed erythrocyte enzyme activity
+      across a patient mutation series.
+    supported_by:
+    - reference_id: PMID:22959135
+      supporting_text: It is caused by the deficient activity of the enzyme arginase
+        I, encoded by the gene ARG1.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9956512
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author annotation (ARG1 variant reaction) placing
+      ARG1 in the cytosol.
+    action: ACCEPT
+    reason: Correct core localization for the cytosolic type I arginase. Consistent
+      with the IBA cytosol annotation and biochemical evidence.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0004053
+    label: arginase activity
+  evidence_type: EXP
+  original_reference_id: PMID:16141327
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence of arginase activity from the 1.29-A crystal
+      structure and inhibition study of human arginase I.
+    action: ACCEPT
+    reason: Core molecular function established by direct enzymatic assay and structural
+      characterization of catalysis, including inhibition of arginase activity in
+      human myeloid cells.
+    supported_by:
+    - reference_id: PMID:16141327
+      supporting_text: we demonstrate the inhibition of arginase activity by ABH in
+        human and murine myeloid cells
+- term:
+    id: GO:0004053
+    label: arginase activity
+  evidence_type: EXP
+  original_reference_id: PMID:17562323
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence that (perdeuterated) human arginase I catalyzes
+      hydrolysis of L-arginine to L-ornithine and urea with wild-type activity.
+    action: ACCEPT
+    reason: Core molecular function, directly assayed. The enzyme is explicitly characterized
+      as a manganese metalloenzyme catalyzing L-arginine hydrolysis.
+    supported_by:
+    - reference_id: PMID:17562323
+      supporting_text: Arginase is a manganese metalloenzyme that catalyzes the hydrolysis
+        of l-arginine to yield l-ornithine and urea.
+- term:
+    id: GO:0004053
+    label: arginase activity
+  evidence_type: EXP
+  original_reference_id: PMID:21728378
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence (kinetic assay plus crystal structures)
+      of human arginase I catalytic activity.
+    action: ACCEPT
+    reason: Core molecular function, directly measured. The enzyme is characterized
+      as a binuclear manganese metalloenzyme hydrolyzing L-arginine to L-ornithine
+      and urea.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase is a binuclear manganese metalloenzyme that hydrolyzes
+        L-arginine to form L-ornithine and urea
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: EXP
+  original_reference_id: PMID:16141327
+  qualifier: located_in
+  review:
+    summary: Experimental subcellular localization of ARG1 to the cytoplasm.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but general. The more precise cytosol term (GO:0005829) better
+      captures the localization of this cytosolic enzyme. Retained as a valid broader
+      annotation.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28813417
+  qualifier: enables
+  review:
+    summary: IPI annotation recording an ARG1-CMTM6 interaction detected by mass spectrometry
+      in a study focused on CMTM6-mediated regulation of PD-L1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative and does not describe a molecular
+      function. The supporting paper is a CRISPR/proteomics study of CMTM6 as a regulator
+      of PD-L1; ARG1 appears only as one mass-spectrometry co-precipitant of CMTM6,
+      with no evidence that this interaction is functionally relevant to ARG1. Per
+      curation guidelines, avoid uninformative protein binding terms; this should
+      not be treated as a core function.
+    supported_by:
+    - reference_id: PMID:28813417
+      supporting_text: CMTM6 is a ubiquitously expressed protein that binds PD-L1 and
+        maintains its cell surface expression.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IDA
+  original_reference_id: PMID:16709924
+  qualifier: located_in
+  review:
+    summary: Direct experimental evidence that arginase I is liberated from human
+      granulocytes and accumulates extracellularly during inflammation.
+    action: KEEP_AS_NON_CORE
+    reason: Genuine, experimentally demonstrated secondary localization. Neutrophil
+      arginase is released into the extracellular space, where it depletes arginine.
+      This is real but peripheral to the core intracellular (cytosolic) hepatic function.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: arginase I is liberated from human granulocytes, and very high
+        activities accumulate extracellularly during purulent inflammatory reactions
+- term:
+    id: GO:0042130
+    label: negative regulation of T cell proliferation
+  evidence_type: IDA
+  original_reference_id: PMID:16709924
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence that human granulocyte arginase suppresses
+      T-cell proliferation via arginine depletion.
+    action: KEEP_AS_NON_CORE
+    reason: Well-supported secondary immunoregulatory function. Extracellular arginase
+      depletes arginine, downregulating CD3-zeta and suppressing T-cell proliferation.
+      Genuine but distinct from the core urea-cycle role.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: This T-cell phenotype is due to arginase-mediated depletion
+        of arginine in the T-cell environment, which leads to CD3zeta chain down-regulation
+        but does not alter T-cell viability
+- term:
+    id: GO:0060336
+    label: negative regulation of type II interferon-mediated signaling pathway
+  evidence_type: IMP
+  original_reference_id: PMID:16709924
+  qualifier: involved_in
+  review:
+    summary: IMP annotation of a downstream effect on IFN-gamma signaling, linked
+      to arginase-mediated suppression of T-cell cytokine synthesis.
+    action: KEEP_AS_NON_CORE
+    reason: A downstream immunoregulatory consequence of arginine depletion (suppressed
+      T-cell cytokine synthesis, including IFN-gamma responses) rather than a direct
+      biochemical function of ARG1. Retained as non-core; the curator (UniProt) made
+      this annotation from the full text.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: Human granulocyte arginase induces a profound suppression of
+        T-cell proliferation and cytokine synthesis.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  qualifier: located_in
+  review:
+    summary: Reactome annotation (exocytosis of specific granule lumen proteins) placing
+      ARG1 in the extracellular region upon neutrophil degranulation.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with the experimentally demonstrated release of neutrophil
+      arginase into the extracellular space during degranulation. A genuine secondary
+      localization, non-core relative to the cytosolic hepatic function.
+    supported_by:
+    - reference_id: PMID:16709924
+      supporting_text: arginase I is liberated from human granulocytes, and very high
+        activities accumulate extracellularly during purulent inflammatory reactions
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798751
+  qualifier: located_in
+  review:
+    summary: Reactome annotation (exocytosis of azurophil granule lumen proteins)
+      placing ARG1 in the extracellular region upon neutrophil degranulation.
+    action: KEEP_AS_NON_CORE
+    reason: Same as the other extracellular-region annotations - reflects release
+      of granule-stored neutrophil arginase. Genuine secondary localization; non-core.
+    supported_by:
+    - reference_id: PMID:15546957
+      supporting_text: arginase I is localized in azurophil granules of neutrophils
+        and constitutes a novel antimicrobial effector pathway, likely through arginine
+        depletion in the phagolysosome
+- term:
+    id: GO:0035578
+    label: azurophil granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798751
+  qualifier: located_in
+  review:
+    summary: Reactome annotation placing ARG1 in the azurophil granule lumen of neutrophils.
+    action: KEEP_AS_NON_CORE
+    reason: Directly supported by experimental localization of arginase I to azurophil
+      granules of neutrophils. A genuine myeloid-cell localization, non-core relative
+      to the core cytosolic hepatic function.
+    supported_by:
+    - reference_id: PMID:15546957
+      supporting_text: arginase I is localized in azurophil granules of neutrophils
+        and constitutes a novel antimicrobial effector pathway, likely through arginine
+        depletion in the phagolysosome
+- term:
+    id: GO:0035580
+    label: specific granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  qualifier: located_in
+  review:
+    summary: Reactome annotation placing ARG1 in the specific granule lumen of neutrophils.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects the granule storage of arginase I in neutrophils (the primary
+      experimental report emphasizes azurophil granules; Reactome models both granule
+      compartments). Genuine myeloid localization, non-core.
+    supported_by:
+    - reference_id: PMID:15546957
+      supporting_text: in human leukocytes arginase I is constitutively expressed
+        only in granulocytes
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: HDA
+  original_reference_id: PMID:21630459
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomics detection of ARG1 in an isolated human sperm
+      nucleus fraction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This annotation derives from a large-scale catalog of 403 proteins detected
+      in isolated sperm nuclei, not from a targeted study of nuclear ARG1 function.
+      ARG1 is a well-established cytosolic enzyme with no known nuclear function; the
+      detection likely reflects abundant cytoplasmic protein carryover in a bulk proteomic
+      fraction. Marked as over-annotated rather than removed, as a mass-spec detection.
+    supported_by:
+    - reference_id: PMID:21630459
+      supporting_text: 403 different proteins have been identified from the isolated
+        sperm nuclei
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70569
+  qualifier: located_in
+  review:
+    summary: Reactome annotation (arginine + H2O =&gt; ornithine + urea reaction) placing
+      ARG1 in the cytosol.
+    action: ACCEPT
+    reason: Core localization. This Reactome reaction is precisely the arginase reaction,
+      correctly localized to the cytosol where the cytosolic type I arginase acts.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9959871
+  qualifier: located_in
+  review:
+    summary: Reactome annotation (ARG1 gene expression) associated with cytosolic
+      localization.
+    action: ACCEPT
+    reason: Correct core localization for the cytosolic type I arginase; duplicate
+      of the other cytosol annotations, which is acceptable.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0004053
+    label: arginase activity
+  evidence_type: TAS
+  original_reference_id: PMID:3540966
+  qualifier: enables
+  review:
+    summary: Traceable-author statement of arginase activity from the original cloning
+      of human liver arginase cDNA.
+    action: ACCEPT
+    reason: Core molecular function. The cloned cDNA conferred arginase activity on
+      E. coli, and the enzyme is identified as EC 3.5.3.1 catalyzing the last urea-cycle
+      step. Duplicate of the experimental arginase-activity annotations, which is
+      acceptable.
+    supported_by:
+    - reference_id: PMID:3540966
+      supporting_text: Arginase activity was detected in Escherichia coli cells transformed
+        with the plasmid carrying lambda hARG6 cDNA insert.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: TAS
+  original_reference_id: PMID:3540966
+  qualifier: located_in
+  review:
+    summary: Traceable-author statement of cytoplasmic (liver) arginase localization.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but general; cytosol (GO:0005829) is the more precise term. Retained
+      as a valid broader localization.
+    supported_by:
+    - reference_id: PMID:21728378
+      supporting_text: Arginase I is a cytosolic enzyme found predominantly in the
+        liver, and arginase II is a mitochondrial enzyme found at highest concentrations
+        in the kidney.
+- term:
+    id: GO:0006527
+    label: L-arginine catabolic process
+  evidence_type: TAS
+  original_reference_id: PMID:3540966
+  qualifier: involved_in
+  review:
+    summary: Traceable-author statement of ARG1&#39;s role in L-arginine catabolism (the
+      terminal urea-cycle step) from the original cloning paper.
+    action: ACCEPT
+    reason: Core biological process. ARG1 hydrolyzes L-arginine as the last step of
+      the urea cycle. Duplicate of the IMP L-arginine catabolic process annotation,
+      which is acceptable.
+    supported_by:
+    - reference_id: PMID:3540966
+      supporting_text: Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle
+        in the liver of ureotelic animals.
+core_functions:
+- description: Catalyzes the terminal step of the urea cycle - the manganese-dependent
+    hydrolysis of L-arginine to L-ornithine and urea - regenerating ornithine to close
+    the cycle and releasing the urea that is excreted for nitrogen disposal.
+  molecular_function:
+    id: GO:0004053
+    label: arginase activity
+  supported_by:
+  - reference_id: PMID:17562323
+    supporting_text: Arginase is a manganese metalloenzyme that catalyzes the hydrolysis
+      of l-arginine to yield l-ornithine and urea.
+  directly_involved_in:
+  - id: GO:0000050
+    label: urea cycle
+  locations:
+  - id: GO:0005829
+    label: cytosol
+- description: Requires a binuclear manganese cluster (two Mn(2+) ions per subunit)
+    for catalytic activity; manganese binding is an essential cofactor requirement
+    of the arginase active site.
+  molecular_function:
+    id: GO:0004053
+    label: arginase activity
+  contributes_to_molecular_function:
+    id: GO:0030145
+    label: manganese ion binding
+  supported_by:
+  - reference_id: PMID:16141327
+    supporting_text: The ultrahigh-resolution structure of the human arginase I-ABH
+      complex yields an unprecedented view of the binuclear manganese cluster
+  locations:
+  - id: GO:0005829
+    label: cytosol
+- description: Breaks down L-arginine (L-arginine catabolic process); loss of this
+    activity in ARG1 causes hyperargininemia/argininemia, a urea cycle disorder.
+  molecular_function:
+    id: GO:0004053
+    label: arginase activity
+  directly_involved_in:
+  - id: GO:0006527
+    label: L-arginine catabolic process
+  supported_by:
+  - reference_id: PMID:22959135
+    supporting_text: It is caused by the deficient activity of the enzyme arginase
+      I, encoded by the gene ARG1.
+  locations:
+  - id: GO:0005829
+    label: cytosol
+proposed_new_terms: []
+suggested_questions:
+- question: Beyond arginine depletion in the extracellular space/phagolysosome, does
+    human ARG1 have any direct, arginine-independent immunoregulatory function, or
+    are all of its immune effects a consequence of local arginine catabolism?
+- question: Is the reported nuclear detection of ARG1 in sperm (PMID:21630459) functionally
+    meaningful, or does it reflect cytoplasmic carryover in bulk proteomics?
+suggested_experiments:
+- hypothesis: Argininemia severity is determined by residual arginase activity, which
+    depends on how a given missense variant perturbs the Mn-binding active site or
+    the R308 trimerization interface.
+  description: Structure-guided kinetic characterization of clinically observed missense
+    variants (e.g. those affecting the Mn-binding residues or the R308 trimerization
+    interface) to correlate residual arginase activity with argininemia phenotype
+    severity.
+- hypothesis: The immunosuppressive effect of neutrophil ARG1 is entirely due to enzymatic
+    depletion of extracellular L-arginine.
+  description: Quantitative measurement of local arginine depletion and downstream
+    T-cell CD3-zeta levels using ARG1-deficient versus wild-type human neutrophils
+    to dissect the enzymatic basis of the immunosuppressive effect.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15546957
+  title: Arginase I is constitutively expressed in human granulocytes and participates
+    in fungicidal activity.
+  findings:
+  - statement: Arginase I is constitutively expressed only in granulocytes among human
+      leukocytes and is localized in azurophil granules, constituting an antimicrobial
+      effector pathway via arginine depletion in the phagolysosome.
+    supporting_text: arginase I is localized in azurophil granules of neutrophils
+      and constitutes a novel antimicrobial effector pathway, likely through arginine
+      depletion in the phagolysosome
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; abstract-only cache but the myeloid-arginase/azurophil-granule
+      findings are the source for the neutrophil localization and antimicrobial annotations.
+- id: PMID:16141327
+  title: Crystal structure of human arginase I at 1.29-A resolution and exploration
+    of inhibition in the immune response.
+  findings:
+  - statement: The 1.29-A structure reveals the binuclear manganese cluster of human
+      arginase I and the structural basis of catalysis and inhibition.
+    supporting_text: The ultrahigh-resolution structure of the human arginase I-ABH
+      complex yields an unprecedented view of the binuclear manganese cluster
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; source for the binuclear Mn cluster and experimental
+      arginase-activity annotations.
+- id: PMID:16709924
+  title: Suppression of T-cell functions by human granulocyte arginase.
+  findings:
+  - statement: Arginase I released from human granulocytes accumulates extracellularly
+      during inflammation and suppresses T-cell proliferation and cytokine synthesis
+      by depleting arginine, downregulating the CD3-zeta chain.
+    supporting_text: This T-cell phenotype is due to arginase-mediated depletion of
+      arginine in the T-cell environment, which leads to CD3zeta chain down-regulation
+      but does not alter T-cell viability
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; source for extracellular localization and the T-cell
+      suppression / IFN-signaling immune annotations.
+- id: PMID:17562323
+  title: Expression, purification, assay, and crystal structure of perdeuterated human
+    arginase I.
+  findings:
+  - statement: Human arginase I is a manganese metalloenzyme that catalyzes hydrolysis
+      of L-arginine to L-ornithine and urea, confirmed by assay and X-ray structure.
+    supporting_text: Arginase is a manganese metalloenzyme that catalyzes the hydrolysis
+      of l-arginine to yield l-ornithine and urea.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; direct experimental support for arginase activity
+      and Mn dependence.
+- id: PMID:21630459
+  title: Proteomic characterization of the human sperm nucleus.
+  findings:
+  - statement: A large-scale proteomic catalog identified 403 proteins in isolated
+      human sperm nuclei; ARG1 is one large-scale MS detection, not a targeted study
+      of nuclear arginase function.
+    supporting_text: 403 different proteins have been identified from the isolated
+      sperm nuclei
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified; bulk sperm-nucleus proteome. Underpins the HDA
+      nucleus annotation, which is likely cytoplasmic carryover rather than functional
+      nuclear localization.
+- id: PMID:21728378
+  title: Binding of alpha,alpha-disubstituted amino acids to arginase suggests new
+    avenues for inhibitor design.
+  findings:
+  - statement: Arginase is a binuclear manganese metalloenzyme that hydrolyzes L-arginine
+      to L-ornithine and urea; arginase I is cytosolic and predominantly hepatic,
+      whereas arginase II is mitochondrial.
+    supporting_text: Arginase I is a cytosolic enzyme found predominantly in the liver,
+      and arginase II is a mitochondrial enzyme found at highest concentrations in
+      the kidney.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; full text explicitly contrasts cytosolic ARG1 with
+      mitochondrial ARG2 and confirms catalytic activity.
+- id: PMID:22959135
+  title: Analysis of novel ARG1 mutations causing hyperargininemia and correlation
+    with arginase I activity in erythrocytes.
+  findings:
+  - statement: Hyperargininemia is caused by deficient arginase I activity encoded
+      by ARG1; the R308 residue is important for assembly of the ARG1 homotrimer.
+    supporting_text: Our study reinforced the role of Arg308 residue for assembly
+      of the ARG1 homotrimer.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; source for the L-arginine catabolic process IMP
+      annotation and homotrimer quaternary structure.
+- id: PMID:28813417
+  title: CMTM6 maintains the expression of PD-L1 and regulates anti-tumour immunity.
+  findings:
+  - statement: This study identifies CMTM6 as a regulator of PD-L1 cell-surface expression;
+      ARG1 appears only as a mass-spectrometry co-precipitant of CMTM6, providing
+      no functional evidence for an ARG1-specific role.
+    supporting_text: CMTM6 is a ubiquitously expressed protein that binds PD-L1 and
+      maintains its cell surface expression.
+  reference_review:
+    relevance: LOW
+    correctness: MISCITED
+    review_notes: PubMed-verified paper, but it does not support a functional ARG1
+      annotation - ARG1 is only an MS interactor of CMTM6, and the resulting bare
+      protein-binding term is uninformative.
+- id: PMID:3540966
+  title: Molecular cloning and nucleotide sequence of cDNA for human liver arginase.
+  findings:
+  - statement: Human liver arginase (EC 3.5.3.1) catalyzes the last step of the urea
+      cycle; cloned cDNA conferred arginase activity, and inherited deficiency causes
+      argininemia.
+    supporting_text: Arginase (EC 3.5.3.1) catalyzes the last step of the urea cycle
+      in the liver of ureotelic animals.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; original cloning paper, foundational for arginase
+      activity, cytoplasmic localization, and urea-cycle/L-arginine-catabolism annotations.
+- id: Reactome:R-HSA-6798749
+  title: Exocytosis of specific granule lumen proteins
+  findings: []
+- id: Reactome:R-HSA-6798751
+  title: Exocytosis of azurophil granule lumen proteins
+  findings: []
+- id: Reactome:R-HSA-70569
+  title: arginine + H2O =&gt; ornithine + urea [ARG1]
+  findings: []
+- id: Reactome:R-HSA-9956512
+  title: ARG1 variants don&#39;t synthesize urea and ornithine
+  findings: []
+- id: Reactome:R-HSA-9959871
+  title: ARG1 gene expression
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/CPS1/CPS1-ai-review.html
+++ b/genes/human/CPS1/CPS1-ai-review.html
@@ -1,0 +1,9535 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CPS1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CPS1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P31327" target="_blank" class="term-link">
+                        P31327
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CPS1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P31327" data-a="DESCRIPTION: CPS1 (carbamoyl-phosphate synthase [ammonia], mito..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CPS1 (carbamoyl-phosphate synthase [ammonia], mitochondrial) is a ~1500-residue multidomain enzyme of the mitochondrial matrix that catalyzes the first and rate-limiting committed step of the urea cycle in ureotelic animals: the ATP-dependent condensation of ammonia and bicarbonate into carbamoyl phosphate (NH4+ + HCO3- + 2 ATP -&gt; carbamoyl phosphate + 2 ADP + phosphate + 2 H+; EC 6.3.4.16). It is highly expressed in liver and small intestine, where it initiates hepatic detoxification of ammonia derived from amino acid catabolism. Unlike the cytosolic glutamine-dependent CPS II (part of CAD) that feeds pyrimidine biosynthesis, CPS1 uses free ammonia rather than glutamine; its ancestral glutamine amidotransferase domain is catalytically defective (the catalytic cysteine is replaced by Ser294). CPS1 is an allosteric enzyme with an absolute requirement for the activator N-acetyl-L-glutamate (NAG), which binds the C-terminal MGS-like domain and, together with nucleotide binding, drives long-range conformational changes that build the intramolecular tunnel through which the labile carbamate intermediate migrates between the two ATP-grasp phosphorylation sites; in the absence of NAG the enzyme retains &lt;=2% of its maximal activity. Catalysis also requires the ionic activators potassium and magnesium. The enzyme behaves in solution as a monomer-dimer equilibrium in which the monomer predominates. Loss-of-function variants cause the autosomal recessive urea-cycle disorder carbamoyl phosphate synthetase 1 deficiency (CPS1D), which presents most severely as neonatal hyperammonemia with high mortality and neurological sequelae.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred carbamoyl-phosphate synthase (ammonia) activity. This is the correct, specific core molecular function of CPS1 and is directly supported by biochemical characterization of the recombinant human enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the well-established core catalytic function of CPS1 (EC 6.3.4.16), the ammonia-dependent carbamoyl-phosphate synthetase of the urea cycle. The IBA annotation is at the correct level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23649895" target="_blank" class="term-link">
+                                        PMID:23649895
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The kinetic and molecular properties of recombinant CPS1 are essentially the same as for natural human CPS1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation to cytoplasm. CPS1 is a mitochondrial-matrix protein; cytoplasm is far too general and does not capture the specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is imported into the mitochondrion via an N-terminal transit peptide and functions in the mitochondrial matrix, not the general cytoplasm. The more specific and accurate location GO:0005759 mitochondrial matrix is separately annotated (TAS). Replace the over-general cytoplasm term with mitochondrial matrix.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">carbamoyl phosphate synthase-1 (CPS-1), an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006541" target="_blank" class="term-link">
+                                    GO:0006541
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0006541" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation to glutamine metabolic process, inherited from the glutamine-dependent CPS family ancestor. Human CPS1 does not use glutamine.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is ammonia-dependent, not glutamine-dependent. Its ancestral glutamine amidotransferase (GATase) domain is catalytically defective, with the key catalytic cysteine replaced by serine (Ser294), so CPS1 does not hydrolyze or metabolize glutamine. This IBA term reflects the broader CPS family (which includes glutamine-hydrolyzing CPS II) rather than the specific human enzyme.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">GO_REF:0000033</span>
+
+                                    &middot; PAN-GO phylogenetic inference (CPS family tree)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Glutamine metabolism is a genuine property of glutamine-dependent CPS family members (e.g. CPS II/CAD), but human CPS1 has lost the glutaminase sub-activity (catalytic Cys-&gt;Ser294) and uses free ammonia.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The inability of human CPS1 to use glutamine is explained by the replacement by serine (Ser294) in this enzyme of the key catalytic cysteine of the catalytic triad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004088" target="_blank" class="term-link">
+                                    GO:0004088
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (glutamine-hydrolyzing) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004088" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation to the glutamine-hydrolyzing carbamoyl-phosphate synthase activity. This is the activity of the distinct cytosolic CPS II (CAD) enzyme of pyrimidine biosynthesis, not of CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0004088 uses L-glutamine (plus water) as the nitrogen donor; this is the activity of glutamine-dependent CPS II/CAD. Human CPS1 uses free ammonia and has a defective glutaminase domain, so this term is incorrect for CPS1. The essence (carbamoyl phosphate synthetase activity) is sound but the specific subtype is wrong; replace with the ammonia-dependent activity GO:0004087.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">GO_REF:0000033</span>
+
+                                    &middot; PAN-GO phylogenetic inference (CPS family tree)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The glutamine-hydrolyzing subtype (GO:0004088) is correct for glutamine-dependent CPS family members but not for human CPS1, which is ammonia-dependent; the ammonia subtype GO:0004087 is the correct term.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    carbamoyl-phosphate synthase (ammonia) activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Glutamine is utilized as the endogenous source of ammonia by all types of CPS31464748 except CPS12</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of the correct core catalytic activity of CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function, consistent with experimental and phylogenetic annotations of the same term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004088" target="_blank" class="term-link">
+                                    GO:0004088
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (glutamine-hydrolyzing) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004088" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to the glutamine-hydrolyzing CPS activity, transferred from the shared CPS domain architecture. This subtype belongs to CPS II, not CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same issue as the IBA GO:0004088 annotation: human CPS1 is ammonia-dependent with a defective glutaminase domain and cannot hydrolyze glutamine. Replace with the ammonia-dependent activity GO:0004087.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    carbamoyl-phosphate synthase (ammonia) activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The inability of human CPS1 to use glutamine is explained by the replacement by serine (Ser294) in this enzyme of the key catalytic cysteine of the catalytic triad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of ATP binding. CPS1 has two ATP-grasp phosphorylation domains and consumes 2 ATP per catalytic cycle; ATP binding is a genuine and required molecular activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP binding is directly supported by the catalytic mechanism (two ATP-grasp domains, L1 and L3) and by kinetic characterization (KM for ATP measured). This is a real, core-supporting cofactor/substrate activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the adenine ring sandwiched between the central β sheets of the B and C subdomains (for the boundaries between the A, B and C subdomains, see Supplementary Fig. 2), as is characteristic for the ATP-grasp fold</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                    GO:0005730
+                                </a>
+                            </span>
+                            <span class="term-label">nucleolus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005730" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to nucleolus derived from the UniProt subcellular location vocabulary. UniProt records a nucleus/nucleolus location from a large-scale spatial proteomics study, but the enzyme&#39;s function is in the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A nucleus/nucleolus localization is reported in UniProt (from PMID:22002106) and is separately supported by an IDA annotation, so it is retained, but it is a secondary/moonlighting localization unrelated to the core ureagenesis function of CPS1, which occurs in the mitochondrial matrix.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005739" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to mitochondrion, the correct organelle. CPS1 is a mitochondrial-matrix protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct organelle-level localization; consistent with the more specific mitochondrial matrix annotations and with the N-terminal mitochondrial transit peptide. Retained as a valid (if less specific) location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to plasma membrane. UniProt records a cell-membrane / hepatocyte cell-surface location inferred by similarity to the mouse ortholog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A cell-surface / plasma-membrane location is reported in UniProt as a peripheral membrane protein on the extracellular side (by similarity to mouse Q8C196, &#34;cell surface of hepatocytes&#34;). This is a reported secondary localization, not the compartment where the core catalytic function occurs. Keep as non-core rather than remove, since it is corroborated in UniProt.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006207" target="_blank" class="term-link">
+                                    GO:0006207
+                                </a>
+                            </span>
+                            <span class="term-label">&#39;de novo&#39; pyrimidine nucleobase biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0006207" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to de novo pyrimidine biosynthesis, transferred from the shared CPS domain architecture. Pyrimidine biosynthesis is the role of the cytosolic glutamine-dependent CPS II (CAD), not CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> In humans, carbamoyl phosphate for pyrimidine biosynthesis is made by the cytosolic CPS II activity of the multifunctional CAD protein, not by mitochondrial CPS1. CPS1-derived carbamoyl phosphate is committed to the urea cycle. This term is a domain-based over-annotation transferred from the broader CPS family.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human carbamoyl phosphate synthetase (CPS1), a 1500-residue multidomain enzyme, catalyzes the first step of ammonia detoxification to urea</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006541" target="_blank" class="term-link">
+                                    GO:0006541
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0006541" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to glutamine metabolic process, inherited from the glutamine-dependent CPS family. Human CPS1 does not use glutamine.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same rationale as the IBA GO:0006541 annotation: CPS1 is ammonia-dependent and has a defective glutaminase domain (Cys-&gt;Ser294), so it does not participate in glutamine metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The inability of human CPS1 to use glutamine is explained by the replacement by serine (Ser294) in this enzyme of the key catalytic cysteine of the catalytic triad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to metal ion binding. CPS1 uses Mg2+ (coordinated to ADP at both phosphorylation sites) and K+ as essential ionic activators.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Metal ion binding is genuine: catalysis requires magnesium (coordinating the nucleotides) and potassium (coordinated in the L1 K-loop). This broad term is an acceptable parent; the more specific potassium ion binding is separately annotated with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CPS1 affinities for its essential ionic activators potassium and magnesium are increased importantly by NAG</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090407" target="_blank" class="term-link">
+                                    GO:0090407
+                                </a>
+                            </span>
+                            <span class="term-label">organophosphate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0090407" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning electronic annotation to the very broad organophosphate biosynthetic process. Carbamoyl phosphate is an organophosphate, so this is not wrong, but it is far more general than the specific process CPS1 performs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The product carbamoyl phosphate is technically an organophosphate, so the term is not incorrect, but it is uninformatively broad. The specific process is better captured by GO:0070409 carbamoyl phosphate biosynthetic process, which is separately and experimentally annotated.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070409" target="_blank" class="term-link">
+                                    carbamoyl phosphate biosynthetic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12620389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel raf kinase protein-protein interactions found by an ex...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005515" data-r="PMID:12620389" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a high-throughput yeast two-hybrid screen for Raf kinase interactors (A-Raf / C-Raf bait). Uninformative and not a defined functional partnership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare protein binding is uninformative about molecular function. The interaction derives from an exhaustive Raf two-hybrid screen (CPS1 as one of many hits) with no established functional consequence for ureagenesis. Retained only as a low-value, non-core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link">
+                                        PMID:12620389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have performed an exhaustive unbiased yeast two-hybrid analysis to identify interaction partners of two human Raf kinase isoforms, A-Raf and C-Raf, using their N-terminal regulatory domain as &#34;bait.&#34;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15161933" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15161933
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comprehensive proteomic analysis of interphase and mitotic 1...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005515" data-r="PMID:15161933" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a comprehensive 14-3-3 affinity-capture proteomics screen. Uninformative and a large-scale-screen hit rather than a defined functional interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative. CPS1 was identified among many proteins binding 14-3-3 in a global proteomics screen with no demonstrated functional role in ureagenesis. Retained only as a low-value, non-core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15161933" target="_blank" class="term-link">
+                                        PMID:15161933
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we describe a global proteomics analysis to identify proteins that bind to 14-3-3s during interphase and mitosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20618440" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20618440
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic and biochemical analysis of 14-3-3-binding protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005515" data-r="PMID:20618440" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a 14-3-3-binding proteomics study during ceramide-induced apoptosis. Uninformative screen-derived interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative about molecular function, and the interaction comes from a large-scale 14-3-3 proteomics/affinity study. Retained only as a low-value, non-core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20618440" target="_blank" class="term-link">
+                                        PMID:20618440
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A combination of tandem affinity purification and liquid chromatography-tandem MS techniques identified 15 proteins involved in cell survival processes whose 14-3-3-binding status changed during C2-ceramide-induced apoptosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0000050" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer annotation to the urea cycle, the core biological process of CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 catalyzes the first committed step of the urea cycle; this is a core biological-process annotation, corroborated by TAS and NAS annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1840546" target="_blank" class="term-link">
+                                        PMID:1840546
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Carbamyl phosphate synthetase I (CPSI) is the first enzyme involved in urea synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001889" target="_blank" class="term-link">
+                                    GO:0001889
+                                </a>
+                            </span>
+                            <span class="term-label">liver development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0001889" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer annotation to liver development. CPS1 is highly expressed in liver but is a metabolic enzyme, not a developmental regulator.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a tissue/physiological-context transfer from rodent orthologs reflecting hepatic expression, not a demonstrated role of CPS1 in liver morphogenesis. Not a core function; keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004175" target="_blank" class="term-link">
+                                    GO:0004175
+                                </a>
+                            </span>
+                            <span class="term-label">endopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004175" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer annotation to endopeptidase activity. CPS1 is a ligase (EC 6.3.4.16), not a protease; this is biologically implausible.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Endopeptidase activity (hydrolysis of internal peptide bonds) is incompatible with the known ligase function and structure of CPS1. This is a spurious ortholog-transfer artifact with no supporting evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23649895" target="_blank" class="term-link">
+                                        PMID:23649895
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The kinetic and molecular properties of recombinant CPS1 are essentially the same as for natural human CPS1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                                    GO:0005509
+                                </a>
+                            </span>
+                            <span class="term-label">calcium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005509" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer annotation to calcium ion binding. CPS1&#39;s catalytically relevant ions are potassium and magnesium, not calcium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> There is no evidence that CPS1 binds calcium as a functional ligand. Its essential ionic activators are K+ and Mg2+. This is a spurious ortholog transfer.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CPS1 affinities for its essential ionic activators potassium and magnesium are increased importantly by NAG</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005543" target="_blank" class="term-link">
+                                    GO:0005543
+                                </a>
+                            </span>
+                            <span class="term-label">phospholipid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005543" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara ortholog-transfer annotation to phospholipid binding. No evidence that the matrix enzyme CPS1 binds phospholipids as part of its function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is a soluble mitochondrial-matrix ligase with no phospholipid-binding function established in the literature; this is a spurious ortholog-transfer artifact.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005743" data-r="GO_REF:0000107" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to mitochondrial inner membrane. CPS1 is a soluble matrix protein; it may associate with the matrix face of the inner membrane but functions in the matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is characterized as a soluble mitochondrial-matrix enzyme, not an integral inner-membrane protein. The more accurate location is the mitochondrial matrix (GO:0005759), which is separately annotated with TAS evidence.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to cytosol. CPS1 functions in the mitochondrial matrix, not the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 carries an N-terminal mitochondrial transit peptide and functions in the matrix. A cytosolic location contradicts the established mitochondrial localization; this ortholog-transfer term is inappropriate for the core enzyme. (Any transient cytosolic pool during import is not a functional location.)
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007494" target="_blank" class="term-link">
+                                    GO:0007494
+                                </a>
+                            </span>
+                            <span class="term-label">midgut development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0007494" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to midgut development, reflecting intestinal expression of CPS1 in model organisms. Not a demonstrated developmental role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is expressed in the small intestine, but this term reflects a tissue-context ortholog transfer rather than a role in gut morphogenesis. Not a core function; keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009410" target="_blank" class="term-link">
+                                    GO:0009410
+                                </a>
+                            </span>
+                            <span class="term-label">response to xenobiotic stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0009410" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to stimulus&#34; annotation from rodent expression studies. Reflects regulation of CPS1 abundance, not a core molecular role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> These transferred physiological-context terms describe conditions under which CPS1 expression changes rather than the enzyme&#39;s molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009636" target="_blank" class="term-link">
+                                    GO:0009636
+                                </a>
+                            </span>
+                            <span class="term-label">response to toxic substance</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0009636" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to toxic substance&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Physiological-context term transferred from orthologs; describes regulation of CPS1 rather than its molecular activity. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010043" target="_blank" class="term-link">
+                                    GO:0010043
+                                </a>
+                            </span>
+                            <span class="term-label">response to zinc ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0010043" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to zinc ion&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term; not a demonstrated molecular role of human CPS1. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014075" target="_blank" class="term-link">
+                                    GO:0014075
+                                </a>
+                            </span>
+                            <span class="term-label">response to amine</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0014075" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to amine&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term; describes conditions affecting CPS1 rather than its molecular activity. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016595" target="_blank" class="term-link">
+                                    GO:0016595
+                                </a>
+                            </span>
+                            <span class="term-label">glutamate binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0016595" data-r="GO_REF:0000107" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to glutamate binding. CPS1&#39;s allosteric activator is N-acetyl-L-glutamate (a modified amino acid), not free glutamate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functionally important ligand of CPS1&#39;s C-terminal allosteric domain is N-acetyl-L-glutamate (NAG), not free L-glutamate. Binding of the modified amino acid NAG is more accurately captured by GO:0072341 modified amino acid binding. The generic glutamate binding term mischaracterizes the actual allosteric ligand.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072341" target="_blank" class="term-link">
+                                    modified amino acid binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">NAG binding to CPS1 as observed in the crystal structure appears to genuinely reflect the binding of this effector to the enzyme in vivo.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032094" target="_blank" class="term-link">
+                                    GO:0032094
+                                </a>
+                            </span>
+                            <span class="term-label">response to food</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0032094" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to food&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting dietary regulation of CPS1 abundance; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032496" target="_blank" class="term-link">
+                                    GO:0032496
+                                </a>
+                            </span>
+                            <span class="term-label">response to lipopolysaccharide</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0032496" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to lipopolysaccharide&#34; annotation. Context transfer reflecting altered CPS1 levels/release under septic conditions, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects the observation that CPS1 abundance/release changes under LPS/septic conditions (see PMID:15897806), which is a downstream biomarker phenomenon rather than CPS1 executing an LPS-response function. Harmonized with the IDA annotation to the same term, which is also marked as over-annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0032991" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to the generic protein-containing complex. CPS1 acts predominantly as a monomer (monomer-dimer equilibrium); it is not a constitutive subunit of a defined complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 functions as a monomer (with a weak monomer-dimer equilibrium) rather than as part of a stable protein complex, and no specific complex is defined. The generic protein-containing complex term is uninformative and not supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the behavior of human CPS1 in solution as a monomer-dimer system in rapid equilibrium in which the monomer predominates</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033762" target="_blank" class="term-link">
+                                    GO:0033762
+                                </a>
+                            </span>
+                            <span class="term-label">response to glucagon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0033762" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to glucagon&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects hormonal regulation of CPS1 expression transferred from rodent orthologs; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034201" target="_blank" class="term-link">
+                                    GO:0034201
+                                </a>
+                            </span>
+                            <span class="term-label">response to oleic acid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0034201" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to oleic acid&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term; not a demonstrated molecular function of human CPS1. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042594" target="_blank" class="term-link">
+                                    GO:0042594
+                                </a>
+                            </span>
+                            <span class="term-label">response to starvation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0042594" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to starvation&#34; annotation. Fasting increases CPS1 glutarylation and urea-cycle flux, but this is a regulatory context, not a core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects fasting/starvation regulation of ureagenesis and CPS1 acylation rather than a distinct molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043200" target="_blank" class="term-link">
+                                    GO:0043200
+                                </a>
+                            </span>
+                            <span class="term-label">response to amino acid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0043200" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to amino acid&#34; annotation. Context/expression transfer reflecting dietary-protein regulation of ureagenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting protein/amino-acid-load regulation of the urea cycle; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044344" target="_blank" class="term-link">
+                                    GO:0044344
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to fibroblast growth factor stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0044344" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;cellular response to FGF&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term; not a demonstrated molecular role of human CPS1. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044877" target="_blank" class="term-link">
+                                    GO:0044877
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0044877" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to protein-containing complex binding. Generic and uninformative for CPS1, a predominantly monomeric enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No specific complex-binding function of CPS1 is established; this generic transferred term is uninformative. Keep as non-core rather than assert a defined functional interaction.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048545" target="_blank" class="term-link">
+                                    GO:0048545
+                                </a>
+                            </span>
+                            <span class="term-label">response to steroid hormone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0048545" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to steroid hormone&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting hormonal regulation of CPS1 expression; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051384" target="_blank" class="term-link">
+                                    GO:0051384
+                                </a>
+                            </span>
+                            <span class="term-label">response to glucocorticoid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0051384" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to glucocorticoid&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects glucocorticoid regulation of CPS1 expression transferred from rodent orthologs; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051591" target="_blank" class="term-link">
+                                    GO:0051591
+                                </a>
+                            </span>
+                            <span class="term-label">response to cAMP</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0051591" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to cAMP&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting cAMP-mediated regulation of CPS1; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055081" target="_blank" class="term-link">
+                                    GO:0055081
+                                </a>
+                            </span>
+                            <span class="term-label">monoatomic anion homeostasis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0055081" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer annotation to monoatomic anion homeostasis. Not a recognized function of CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This transferred term does not correspond to any established CPS1 function (its substrate bicarbonate is a polyatomic anion, and CPS1 is not an ion transporter/homeostasis factor). Weak transfer; keep as non-core rather than assert a role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060416" target="_blank" class="term-link">
+                                    GO:0060416
+                                </a>
+                            </span>
+                            <span class="term-label">response to growth hormone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0060416" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to growth hormone&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting hormonal regulation of CPS1 expression; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070365" target="_blank" class="term-link">
+                                    GO:0070365
+                                </a>
+                            </span>
+                            <span class="term-label">hepatocyte differentiation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0070365" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;hepatocyte differentiation&#34; annotation. CPS1 is a hepatocyte marker and highly expressed in differentiated hepatocytes, but is a metabolic enzyme rather than a differentiation driver.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is a marker of differentiated hepatocytes rather than a demonstrated regulator of hepatocyte differentiation; this reflects expression context. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071320" target="_blank" class="term-link">
+                                    GO:0071320
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to cAMP</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0071320" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;cellular response to cAMP&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting cAMP-mediated regulation of CPS1; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071377" target="_blank" class="term-link">
+                                    GO:0071377
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to glucagon stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0071377" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;cellular response to glucagon stimulus&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting glucagon regulation of ureagenesis/CPS1; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071400" target="_blank" class="term-link">
+                                    GO:0071400
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to oleic acid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0071400" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;cellular response to oleic acid&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term; not a demonstrated molecular function of human CPS1. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071548" target="_blank" class="term-link">
+                                    GO:0071548
+                                </a>
+                            </span>
+                            <span class="term-label">response to dexamethasone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0071548" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to dexamethasone&#34; annotation. Context/expression transfer reflecting glucocorticoid induction of CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term reflecting glucocorticoid (dexamethasone) induction of CPS1 expression; not a core molecular function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097305" target="_blank" class="term-link">
+                                    GO:0097305
+                                </a>
+                            </span>
+                            <span class="term-label">response to alcohol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0097305" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transfer &#34;response to alcohol&#34; annotation. Context/expression transfer, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transferred physiological-context term; not a demonstrated molecular function of human CPS1. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70635
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0000050" data-r="Reactome:R-HSA-70635" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of CPS1 in the urea cycle, the core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 catalyzes the first committed step of the urea cycle; this is a core, well-supported biological-process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1840546" target="_blank" class="term-link">
+                                        PMID:1840546
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Carbamyl phosphate synthetase I (CPSI) is the first enzyme involved in urea synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6249820" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6249820
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human carbamylphosphate synthetase I. Stabilization, purific...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="PMID:6249820" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration of carbamoyl-phosphate synthase (ammonia) activity from purified human liver CPS1, including Michaelis constants for NH4+, HCO3-, MgATP, and the activator N-acetyl-L-glutamate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for the core catalytic function using the purified human enzyme. This is the central molecular function of CPS1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6249820" target="_blank" class="term-link">
+                                        PMID:6249820
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent Michaelis constants for NH4+, HCO3-, MgATP, and the activator, N-acetyl-L-glutamic acid, were 0.8, 6.7, 1.1, and 0.1 mM, respectively.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                    GO:0005730
+                                </a>
+                            </span>
+                            <span class="term-label">nucleolus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005730" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence-based (IDA) annotation to nucleolus. UniProt records a nucleus/nucleolus localization from large-scale spatial proteomics, but the catalytic function is in the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A nucleus/nucleolus localization is reported in UniProt (PMID:22002106) and supported here by immunofluorescence curation, so it is retained; however it is a secondary localization unrelated to CPS1&#39;s core ureagenesis function in the mitochondrial matrix.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9955543
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005759" data-r="Reactome:R-HSA-9955543" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to the mitochondrial matrix, the correct functional location of CPS1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The mitochondrial matrix is the established site of CPS1 catalysis and is the correct, specific cellular location. Core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9955504
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005759" data-r="Reactome:R-HSA-9955504" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (SIRT5 deglutarylation of CPS1) to the mitochondrial matrix, the correct functional location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, specific core cellular location; consistent with all other matrix annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23649895" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23649895
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular characterization of carbamoyl-phosphate synthetase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="PMID:23649895" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration of the core catalytic activity using recombinant human CPS1, with full kinetic characterization; this is one of the two references anchoring the EC 6.3.4.16 assignment in UniProt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for the ammonia-dependent carbamoyl-phosphate synthase activity of recombinant human CPS1. Core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23649895" target="_blank" class="term-link">
+                                        PMID:23649895
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The kinetic and molecular properties of recombinant CPS1 are essentially the same as for natural human CPS1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24813853" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24813853
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Understanding carbamoyl phosphate synthetase (CPS1) deficien...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="PMID:24813853" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental characterization of recombinant human CPS1 catalytic activity (and the effect of clinical mutations on Vmax/Km); this is the second reference anchoring the EC 6.3.4.16 assignment in UniProt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for the core catalytic function of human CPS1. Core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24813853" target="_blank" class="term-link">
+                                        PMID:24813853
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the majority of the mutations also decreased from modestly to very drastically the specific activity of the fraction of the enzyme that remained soluble and that could be purified, apparently because they decreased V(max)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005886" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS) annotation to plasma membrane, consistent with the UniProt cell-surface location inferred from the mouse ortholog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A hepatocyte cell-surface / plasma-membrane location is reported in UniProt (by similarity to mouse Q8C196). This is a reported secondary localization, not the compartment of the core catalytic function. Keep as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial-proteome evidence localizing CPS1 to the mitochondrion, the correct organelle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established mitochondrial-matrix localization; a valid (organelle-level) location annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030955" target="_blank" class="term-link">
+                                    GO:0030955
+                                </a>
+                            </span>
+                            <span class="term-label">potassium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26592762
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human carbamoyl phosphate synthetase: decipheri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0030955" data-r="PMID:26592762" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental/structural evidence that CPS1 coordinates a potassium ion in the L1 K-loop; potassium is an essential ionic activator of the bicarbonate phosphorylation step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The crystal structure shows a coordinated potassium ion in the K-loop of the bicarbonate-phosphorylating domain, and potassium is required for catalysis. This is a genuine, functionally important cofactor-binding activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">being fully structured, having at its center a coordinated potassium ion (thus the name K-loop)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036094" target="_blank" class="term-link">
+                                    GO:0036094
+                                </a>
+                            </span>
+                            <span class="term-label">small molecule binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26592762
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human carbamoyl phosphate synthetase: decipheri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0036094" data-r="PMID:26592762" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to the very broad &#34;small molecule binding&#34; from the structural study, which resolved ADP, NAG, potassium and magnesium binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Small molecule binding&#34; is uninformatively broad. The structure specifically resolves binding of the allosteric activator N-acetyl-L-glutamate (a modified amino acid); more informative and specific terms (NAG/modified amino acid binding, ATP binding, potassium/metal ion binding) are separately annotated. Replace with the specific modified amino acid (NAG) binding term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072341" target="_blank" class="term-link">
+                                    modified amino acid binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One NAG molecule was found sitting with full occupancy in each subunit of ligand-bound CPS1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26592762
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human carbamoyl phosphate synthetase: decipheri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0046872" data-r="PMID:26592762" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental/structural evidence for metal ion binding (magnesium coordinating ADP; potassium in the K-loop) in the active enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Metal ion binding is directly supported by the structure (Mg2+ coordinated to the nucleotides and a coordinated K+); these ions are essential ionic activators of catalysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">besides having also two bound magnesium ions, hosted a potassium ion coordinated to its K-loop</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042311" target="_blank" class="term-link">
+                                    GO:0042311
+                                </a>
+                            </span>
+                            <span class="term-label">vasodilation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14718356
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Relationship between carbamoyl-phosphate synthetase genotype...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0042311" data-r="PMID:14718356" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to vasodilation from a study associating a CPS1 coding polymorphism (T1405N) with nitric-oxide-mediated forearm vasodilation. This is an indirect, downstream physiological consequence, not a molecular function of the enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 influences vascular NO indirectly, by supplying carbamoyl phosphate for citrulline/arginine synthesis; the study is a genotype-phenotype association of a polymorphism with vascular reactivity, not evidence that CPS1 executes a vasodilation process. This is an over-annotation of a distal physiological effect.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link">
+                                        PMID:14718356
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a polymorphism in the gene encoding carbamoyl-phosphate synthetase 1 influences nitric oxide production as well as vascular smooth muscle reactivity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070409" target="_blank" class="term-link">
+                                    GO:0070409
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl phosphate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21120950" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21120950
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular defects in human carbamoy phosphate synthetase I: ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0070409" data-r="PMID:21120950" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype evidence that CPS1 is required for carbamoyl phosphate biosynthesis, from the large CPS1D mutational-spectrum study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Carbamoyl phosphate biosynthesis is the direct product-forming process of CPS1, and loss-of-function CPS1 mutations abolish it (causing hyperammonemia). Core biological process, at an appropriate level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21120950" target="_blank" class="term-link">
+                                        PMID:21120950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Deficiency of carbamoyl phosphate synthetase I (CPSI) results in hyperammonemia ranging from neonatally lethal to environmentally induced adult-onset disease.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071242" target="_blank" class="term-link">
+                                    GO:0071242
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to ammonium ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21120950" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21120950
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular defects in human carbamoy phosphate synthetase I: ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0071242" data-r="PMID:21120950" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to cellular response to ammonium ion from the CPS1D mutational study. CPS1 consumes ammonia as a substrate for detoxification.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 uses ammonia as its nitrogen substrate, and its loss causes hyperammonemia, so participation in the cellular handling/detoxification of ammonium is reasonable. This is better regarded as a physiological framing of the core urea-cycle role than a distinct core function; keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21120950" target="_blank" class="term-link">
+                                        PMID:21120950
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Deficiency of carbamoyl phosphate synthetase I (CPSI) results in hyperammonemia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70555
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005759" data-r="Reactome:R-HSA-70555" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to the mitochondrial matrix (the CPS1 reaction event), the correct functional location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, specific core cellular location for the site of the CPS1-catalyzed reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9959874
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0005759" data-r="Reactome:R-HSA-9959874" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to the mitochondrial matrix (CPS1 gene-expression event context), the correct functional location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, specific core cellular location; consistent with all other matrix annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an abundant enzyme of the hepatic urea cycle, which is normally located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050667" target="_blank" class="term-link">
+                                    GO:0050667
+                                </a>
+                            </span>
+                            <span class="term-label">homocysteine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20031578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0050667" data-r="PMID:20031578" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to homocysteine metabolic process attributed to a genome-wide association study that linked a CPS1 SNP (rs7422339) to plasma homocysteine levels. There is no direct evidence that CPS1 acts in homocysteine metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited paper is a GWAS reporting a statistical association between a common CPS1 variant and plasma homocysteine concentration in women; it does not demonstrate that CPS1 participates in homocysteine metabolism, and the IDA evidence code is misapplied. The urea cycle and one-carbon/homocysteine pathways intersect only indirectly. This is an over-interpretation of a GWAS signal.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link">
+                                        PMID:20031578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we found novel associations with CPS1 (2q34; rs7422339; P=1.9 x 10(-11))</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072341" target="_blank" class="term-link">
+                                    GO:0072341
+                                </a>
+                            </span>
+                            <span class="term-label">modified amino acid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20031578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0072341" data-r="PMID:20031578" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to modified amino acid binding attributed to the homocysteine GWAS paper. The cited reference does not demonstrate direct ligand binding, but the molecular function is nonetheless correct for CPS1 for a different reason: the enzyme binds the modified amino acid N-acetyl-L-glutamate as its essential allosteric activator.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Modified amino acid binding is a genuine and functionally central activity of CPS1, whose obligatory allosteric activator N-acetyl-L-glutamate (an N-acetylated amino acid) binds a dedicated pocket in the C-terminal MGS-like domain, as shown structurally. Although the original GWAS reference is a weak basis, the term itself is correct and well supported by structural/biochemical data. Accept (supporting evidence re-anchored to the structural study).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                        PMID:26592762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One NAG molecule was found sitting with full occupancy in each subunit of ligand-bound CPS1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070409" target="_blank" class="term-link">
+                                    GO:0070409
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl phosphate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7416778" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7416778
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Detection of carbamyl phosphate synthetase 1 deficiency usin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0070409" data-r="PMID:7416778" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant/deficiency-phenotype evidence (reduced CPS1 activity in duodenal biopsy of a hyperammonemic patient) that CPS1 is required for carbamoyl phosphate biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reduced CPS1 activity in patient tissue with hyperammonemia supports CPS1&#39;s required role in carbamoyl phosphate biosynthesis. Core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7416778" target="_blank" class="term-link">
+                                        PMID:7416778
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All enzyme levels were normal except N-acetyl glutamate-dependent carbamyl phosphate synthetase 1 (CPS1) which was half the mean activity in normal control specimens.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1840546" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1840546
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning and sequence of a cDNA encoding human carbamyl phosp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0000050" data-r="PMID:1840546" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement that CPS1 is the first enzyme of urea synthesis, from the human CPS1 cDNA cloning paper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1&#39;s role in the urea cycle is a core, well-established biological process, here asserted from the cloning/sequence characterization of human CPS1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1840546" target="_blank" class="term-link">
+                                        PMID:1840546
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Carbamyl phosphate synthetase I (CPSI) is the first enzyme involved in urea synthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8486760" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8486760
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Carbamyl phosphate synthetase I deficiency. One base substit...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="PMID:8486760" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype evidence (a splicing mutation causing a 9-bp in-frame deletion, with markedly reduced CPS1 mRNA/protein) that links loss of CPS1 to its ammonia-dependent synthetase function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A disease-causing CPS1 mutation abolishing normal CPS1 supports the enzyme&#39;s core carbamoyl-phosphate synthase (ammonia) activity. Core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8486760" target="_blank" class="term-link">
+                                        PMID:8486760
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Northern and Western blots revealed a marked decrease in CPS I mRNA and enzyme protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                                    GO:0004087
+                                </a>
+                            </span>
+                            <span class="term-label">carbamoyl-phosphate synthase (ammonia) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9711878" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9711878
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prenatal diagnosis of carbamoyl phosphate synthetase I defic...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0004087" data-r="PMID:9711878" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype evidence: a homozygous Thr544Met missense mutation causing severe (lethal) CPS1 deficiency, supporting CPS1&#39;s core synthetase function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A disease-causing CPS1 missense mutation (Thr544Met, which structurally raises the Km for bicarbonate) causing severe CPS1 deficiency supports the core ammonia-dependent carbamoyl-phosphate synthase activity of CPS1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9711878" target="_blank" class="term-link">
+                                        PMID:9711878
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Direct sequencing of the complete CPS1 coding region revealed a disease-associated homozygous Thr544Met mutation in CPS1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019240" target="_blank" class="term-link">
+                                    GO:0019240
+                                </a>
+                            </span>
+                            <span class="term-label">L-citrulline biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14718356
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Relationship between carbamoyl-phosphate synthetase genotype...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0019240" data-r="PMID:14718356" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable statement associating CPS1 with citrulline formation, from the vascular-function polymorphism study. CPS1 does not itself synthesize citrulline; it makes carbamoyl phosphate, the precursor that OTC then combines with ornithine to form citrulline.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1&#39;s product (carbamoyl phosphate) feeds citrulline biosynthesis, but the committed citrulline-forming reaction is catalyzed by ornithine transcarbamylase (OTC), not CPS1. Annotating CPS1 to L-citrulline biosynthetic process over-extends its role to a downstream step it does not catalyze; the term is loosely (NAS) asserted in a vascular-genetics paper.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link">
+                                        PMID:14718356
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the enzyme catalyzing the rate-limiting step in l-citrulline formation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019433" target="_blank" class="term-link">
+                                    GO:0019433
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9711878" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9711878
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prenatal diagnosis of carbamoyl phosphate synthetase I defic...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0019433" data-r="PMID:9711878" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to triglyceride catabolic process attributed to an IMP in PMID:9711878. The cached record for this paper is abstract-only (full_text_available: false), and the abstract concerns a urea-cycle-defect (CPS1D) missense mutation with no triglyceride-catabolism content; there is no known biochemical basis linking CPS1 (a mitochondrial urea-cycle ligase) to triglyceride catabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an experimental (IMP) annotation whose full text is not available in the cache, so per project guidelines it should not be REMOVE&#39;d on the basis of the abstract alone. The annotation looks biologically implausible / likely misassigned, but adjudication is deferred pending the GOA source line or full text; a curator with access should verify what phenotype the IMP actually supports.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9711878" target="_blank" class="term-link">
+                                        PMID:9711878
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Carbamoyl phosphate synthetase I (CPS1) deficiency is an autosomal recessive metabolic disorder affecting the first enzymatic step of urea cycle.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032496" target="_blank" class="term-link">
+                                    GO:0032496
+                                </a>
+                            </span>
+                            <span class="term-label">response to lipopolysaccharide</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15897806
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Release of the mitochondrial enzyme carbamoyl phosphate synt...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0032496" data-r="PMID:15897806" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to response to LPS from a study showing that CPS1 is fragmented and released into the circulation under septic (LPS) conditions as a candidate biomarker of hepatic mitochondrial injury.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The observation is that CPS1 protein is cleaved and released during endotoxemia (making it a serum biomarker), not that CPS1 executes a functional response to LPS. This is a downstream biomarker phenomenon rather than a biological process in which CPS1 participates; it over-annotates the enzyme&#39;s role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                                        PMID:15897806
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We suggest that circulating CPS-1 might serve as a novel serum marker indicating mitochondrial impairment of the liver and/or the small intestine in critically ill patients.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042645" target="_blank" class="term-link">
+                                    GO:0042645
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial nucleoid</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18063578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18063578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The layered structure of human mitochondrial DNA nucleoids.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0042645" data-r="PMID:18063578" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to mitochondrial nucleoid from a study that biochemically purified mtDNA nucleoids. CPS1 is among the abundant matrix proteins that co-purify with native nucleoids, but the study notes several such metabolic proteins do not cross-link to mtDNA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 is an extremely abundant matrix protein that can co-purify with native nucleoid preparations, but the paper explicitly notes that several metabolic proteins identified in native nucleoids were not observed to cross-link to mtDNA, indicating co-purification rather than genuine nucleoid association. The core functional location of CPS1 is the mitochondrial matrix; nucleoid localization is likely a preparation artifact and is over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18063578" target="_blank" class="term-link">
+                                        PMID:18063578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Several other metabolic proteins and chaperones identified in native nucleoids, including ATAD3, were not observed to cross-link to mtDNA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046209" target="_blank" class="term-link">
+                                    GO:0046209
+                                </a>
+                            </span>
+                            <span class="term-label">nitric oxide metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14718356
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Relationship between carbamoyl-phosphate synthetase genotype...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P31327" data-a="GO:0046209" data-r="PMID:14718356" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to nitric oxide metabolic process from the CPS1-polymorphism vascular-function study. CPS1 affects NO only indirectly, by supplying carbamoyl phosphate for the citrulline/arginine precursor pool.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The link to NO is indirect and pathway-level: CPS1 provides carbamoyl phosphate for citrulline -&gt; arginine, the NO precursor, and a coding polymorphism was statistically associated with NO metabolites and vasodilation. CPS1 does not itself synthesize or metabolize nitric oxide; this over-annotates a distal metabolic consequence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link">
+                                        PMID:14718356
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a polymorphism in the gene encoding carbamoyl-phosphate synthetase 1 influences nitric oxide production as well as vascular smooth muscle reactivity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CPS1 catalyzes the first, committed and rate-limiting step of the urea cycle: the ATP-dependent, ammonia-utilizing synthesis of carbamoyl phosphate from ammonia and bicarbonate, using 2 ATP. This ammonia detoxification reaction occurs in the hepatic (and intestinal) mitochondrial matrix and has an absolute allosteric requirement for the activator N-acetyl-L-glutamate.</h3>
+                <span class="vote-buttons" data-g="P31327" data-a="FUNCTION: CPS1 catalyzes the first, committed and rate-limit..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004087" target="_blank" class="term-link">
+                            carbamoyl-phosphate synthase (ammonia) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070409" target="_blank" class="term-link">
+                                carbamoyl phosphate biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Substrates:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:28938" target="_blank" class="term-link">
+                                ammonium
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:17544" target="_blank" class="term-link">
+                                hydrogencarbonate
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:30616" target="_blank" class="term-link">
+                                ATP
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23649895" target="_blank" class="term-link">
+                                PMID:23649895
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The kinetic and molecular properties of recombinant CPS1 are essentially the same as for natural human CPS1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                                PMID:26592762
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Human carbamoyl phosphate synthetase (CPS1), a 1500-residue multidomain enzyme, catalyzes the first step of ammonia detoxification to urea requiring N-acetyl-L-glutamate (NAG) as essential activator</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link">
+                            PMID:12620389
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14718356" target="_blank" class="term-link">
+                            PMID:14718356
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Relationship between carbamoyl-phosphate synthetase genotype and systemic vascular function.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15161933" target="_blank" class="term-link">
+                            PMID:15161933
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comprehensive proteomic analysis of interphase and mitotic 14-3-3-binding proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15897806" target="_blank" class="term-link">
+                            PMID:15897806
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Release of the mitochondrial enzyme carbamoyl phosphate synthase under septic conditions.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18063578" target="_blank" class="term-link">
+                            PMID:18063578
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The layered structure of human mitochondrial DNA nucleoids.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1840546" target="_blank" class="term-link">
+                            PMID:1840546
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning and sequence of a cDNA encoding human carbamyl phosphate synthetase I: molecular analysis of hyperammonemia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link">
+                            PMID:20031578
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma homocysteine in a healthy population: a genome-wide evaluation of 13 974 participants in the Women&#39;s Genome Health Study.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20618440" target="_blank" class="term-link">
+                            PMID:20618440
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic and biochemical analysis of 14-3-3-binding proteins during C2-ceramide-induced apoptosis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21120950" target="_blank" class="term-link">
+                            PMID:21120950
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular defects in human carbamoy phosphate synthetase I: mutational spectrum, diagnostic and protein structure considerations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23649895" target="_blank" class="term-link">
+                            PMID:23649895
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular characterization of carbamoyl-phosphate synthetase (CPS1) deficiency using human recombinant CPS1 as a key tool.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24813853" target="_blank" class="term-link">
+                            PMID:24813853
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Understanding carbamoyl phosphate synthetase (CPS1) deficiency by using the recombinantly purified human enzyme: effects of CPS1 mutations that concentrate in a central domain of unknown function.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" target="_blank" class="term-link">
+                            PMID:26592762
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of human carbamoyl phosphate synthetase: deciphering the on/off switch of human ureagenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/6249820" target="_blank" class="term-link">
+                            PMID:6249820
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human carbamylphosphate synthetase I. Stabilization, purification, and partial characterization of the enzyme from human liver.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7416778" target="_blank" class="term-link">
+                            PMID:7416778
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Detection of carbamyl phosphate synthetase 1 deficiency using duodenal biopsy samples.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8486760" target="_blank" class="term-link">
+                            PMID:8486760
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Carbamyl phosphate synthetase I deficiency. One base substitution in an exon of the CPS I gene causes a 9-basepair deletion due to aberrant splicing.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9711878" target="_blank" class="term-link">
+                            PMID:9711878
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Prenatal diagnosis of carbamoyl phosphate synthetase I deficiency by identification of a missense mutation in CPS1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70555
+
+                    </span>
+                </div>
+
+                <div class="reference-title">2 ATP + NH4+ + HCO3- =&gt; 2 ADP + orthophosphate + carbamoyl phosphate [mitochondrial]</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70635
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Urea cycle</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9955504
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SIRT5 deglutarylates CPS1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9955543
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CPS1 variants don&#39;t synthesize carbamoyl phosphate</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9959874
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CPS1 gene expression</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CPS1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P31327" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Functional Annotation of Human CPS1 (Carbamoyl-Phosphate Synthase 1, Mitochondrial)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">44 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:24:21.724934</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="CPS1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-functional-annotation-of-human-cps1-carbamoyl-phosphate-synthase-1-mitochondrial">Comprehensive Functional Annotation of Human CPS1 (Carbamoyl-Phosphate Synthase 1, Mitochondrial)</h1>
+<h2 id="gene-and-protein-identity">Gene and Protein Identity</h2>
+<p><strong>CPS1</strong> (gene symbol: <em>CPS1</em>; UniProt accession: P31327; ENSG00000021826) encodes carbamoyl-phosphate synthase [ammonia], mitochondrial (also known as carbamoyl-phosphate synthetase I, CPSase I; EC 6.3.4.16). The gene is located on human chromosome 2q35 and comprises 38 exons (dong2024clinicalfeaturesand pages 5-6). The CPS1 protein is synthesized as a 1,500-amino acid precursor, with an N-terminal mitochondrial targeting sequence of approximately 38 residues that is cleaved upon import into the mitochondrial matrix, yielding a mature enzyme of 1,462 residues (~160 kDa) (fernandez2015usingrecombinanthuman pages 71-77, fernandez2015usingrecombinanthuman pages 106-110, fernandez2015usingrecombinanthuman pages 85-89). CPS1 is expressed exclusively in hepatocytes and enterocytes (liver and small intestine), where it constitutes an extraordinarily abundant enzyme, comprising 10–25% of the total mitochondrial matrix protein in liver (pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2, fernandez2015usingrecombinanthuman pages 37-41).</p>
+<p>The summary table below provides a quick-reference overview of CPS1's key properties:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>CPS1</strong> (carbamoyl-phosphate synthase 1) (OpenTargets Search: -CPS1, pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>Carbamoyl-phosphate synthase [ammonia], mitochondrial</strong>; carbamoyl-phosphate synthetase I; CPSase I (OpenTargets Search: -CPS1, pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2)</td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 6.3.4.16</strong> (OpenTargets Search: -CPS1, fernandez2015usingrecombinanthuman pages 71-77)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P31327</strong> (OpenTargets Search: -CPS1)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Homo sapiens (Human)</strong> (OpenTargets Search: -CPS1)</td>
+</tr>
+<tr>
+<td>Molecular weight</td>
+<td>~<strong>160 kDa</strong> mature mitochondrial enzyme (fernandez2015usingrecombinanthuman pages 71-77, fernandez2015usingrecombinanthuman pages 37-41)</td>
+</tr>
+<tr>
+<td>Precursor length</td>
+<td><strong>1500 aa precursor</strong> with N-terminal mitochondrial targeting sequence (pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2)</td>
+</tr>
+<tr>
+<td>Mature length</td>
+<td><strong>1462 aa</strong> after cleavage of ~38 aa transit peptide upon mitochondrial import (fernandez2015usingrecombinanthuman pages 106-110, fernandez2015usingrecombinanthuman pages 85-89)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Mitochondrial matrix</strong>; a substantial fraction also associates in clusters near the <strong>inner mitochondrial membrane</strong> with NAGS and OTC (fernandez2015usingrecombinanthuman pages 37-41, haskins2021mitochondrialenzymesof pages 2-3, haskins2021mitochondrialenzymesof pages 1-2)</td>
+</tr>
+<tr>
+<td>Tissue expression</td>
+<td>Expressed predominantly in <strong>hepatocytes</strong> and <strong>enterocytes</strong> (liver and small intestine) (pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2, fernandez2015usingrecombinanthuman pages 106-110)</td>
+</tr>
+<tr>
+<td>Substrates</td>
+<td><strong>2 ATP + NH3 + HCO3-</strong>; CPS1 uses <strong>free ammonia</strong> rather than glutamine (fernandez2015usingrecombinanthuman pages 37-41, fernandez2015usingrecombinanthuman pages 71-77, fernandez2015usingrecombinanthuman pages 24-31)</td>
+</tr>
+<tr>
+<td>Products</td>
+<td><strong>Carbamoyl phosphate + 2 ADP + Pi</strong> (fernandez2015usingrecombinanthuman pages 37-41, fernandez2015usingrecombinanthuman pages 71-77)</td>
+</tr>
+<tr>
+<td>Primary biochemical function</td>
+<td>Catalyzes the <strong>first and rate-limiting step of the urea cycle</strong>, producing carbamoyl phosphate for conversion with ornithine to citrulline by OTC (fernandez2015usingrecombinanthuman pages 37-41, yao2020smallmoleculeinhibition pages 1-3)</td>
+</tr>
+<tr>
+<td>Catalytic mechanism</td>
+<td>Three-step mechanism with <strong>carboxyphosphate</strong> and <strong>carbamate</strong> intermediates; two distinct phosphorylation sites for bicarbonate and carbamate phosphorylation (fernandez2015usingrecombinanthuman pages 37-41, fernandez2015usingrecombinanthuman pages 41-44)</td>
+</tr>
+<tr>
+<td>Allosteric activator</td>
+<td><strong>N-acetyl-L-glutamate (NAG)</strong> is an essential allosteric activator; CPS1 is inactive without it (fernandez2015usingrecombinanthuman pages 41-44, nakagawa2009sirt5deacetylatescarbamoyl pages 3-4, pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2)</td>
+</tr>
+<tr>
+<td>Key regulatory modification: SIRT5 deacetylation</td>
+<td><strong>SIRT5 deacetylates and activates CPS1</strong> in the mitochondrial matrix, especially during fasting/calorie restriction, promoting ammonia detoxification (nakagawa2009sirt5deacetylatescarbamoyl pages 3-4, nakagawa2009sirt5deacetylatescarbamoyl pages 7-8, nakagawa2009sirt5deacetylatescarbamoyl pages 6-7)</td>
+</tr>
+<tr>
+<td>Key regulatory modification: O-GlcNAcylation</td>
+<td><strong>O-GlcNAcylation regulates CPS1 activity</strong> in a nutrient-sensitive manner; reported sites include <strong>Thr109, Thr110, Thr1078</strong> that enhance catalytic efficiency for ammonia, while aging/dietary studies also identify nutrient-responsive O-GlcNAc regulation affecting ureagenesis (soria2022oglcnacylationenhancescps1 pages 4-4, soria2022oglcnacylationenhancescps1 pages 6-7, wu2022regulationofthe pages 1-2, wu2022regulationofthe pages 2-5)</td>
+</tr>
+<tr>
+<td>Structural/domain features</td>
+<td>Multidomain enzyme with bicarbonate-phosphorylation and carbamate-phosphorylation domains plus a <strong>C-terminal allosteric NAG-binding domain</strong> and integrating/unknown-function subdomain (fernandez2015usingrecombinanthuman pages 106-110, fernandez2015usingrecombinanthuman pages 41-44)</td>
+</tr>
+<tr>
+<td>Disease association: inherited disorder</td>
+<td><strong>CPS1 deficiency (OMIM 237300)</strong>, an autosomal recessive urea-cycle disorder causing severe <strong>hyperammonemia</strong>; neonatal and late-onset forms are reported (dong2024clinicalfeaturesand pages 1-2, pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2)</td>
+</tr>
+<tr>
+<td>Clinical features/statistics in recent cohorts</td>
+<td>In a 2024 Chinese series of <strong>7 patients</strong>, peak ammonia ranged <strong>160-1000 umol/L</strong>; <strong>4 died</strong> and <strong>3 survived</strong> with treatment; <strong>10 of 12 variants</strong> identified were novel (dong2024clinicalfeaturesand pages 4-5)</td>
+</tr>
+<tr>
+<td>Typical treatment/management</td>
+<td>Ammonia scavengers (<strong>sodium phenylbutyrate</strong>, <strong>sodium benzoate</strong>), <strong>arginine</strong>, low-protein diet, hemodialysis in crises, and sometimes <strong>liver transplantation</strong> (dong2024clinicalfeaturesand pages 4-5, wang2023clinicalandgenetic pages 3-5)</td>
+</tr>
+<tr>
+<td>Disease association: cancer</td>
+<td>CPS1 can be <strong>downregulated in hepatocellular carcinoma</strong> via promoter DNA methylation, but is <strong>upregulated in several other cancers</strong> where it supports <strong>pyrimidine synthesis</strong> and tumor growth (liu2011dnamethylationsuppresses pages 4-6, hajaj2023fromtheinside pages 4-5)</td>
+</tr>
+<tr>
+<td>Real-world/therapeutic relevance</td>
+<td>CPS1 is a candidate target in hyperammonemia and oncology; small-molecule inhibition in primary human hepatocytes reduces urea production and affects pyrimidine metabolism (yao2020smallmoleculeinhibition pages 8-8, yao2020smallmoleculeinhibition pages 1-3)</td>
+</tr>
+<tr>
+<td>PDB structure codes</td>
+<td><strong>5DOT</strong> (apo human CPS1 used as structural reference), <strong>5DOU</strong> (human CPS1 structure), <strong>6UEL</strong> (CPS1 in complex with allosteric inhibitor H3B-193 at 1.90 A resolution) (haskins2021mitochondrialenzymesof pages 1-2, yao2020smallmoleculeinhibition pages 14-15)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, biochemical function, regulation, localization, disease relevance, and structural resources for human CPS1 (UniProt P31327). It is useful as a compact reference for the main facts needed in a functional-annotation report.</em></p>
+<h2 id="enzymatic-reaction-and-catalytic-mechanism">Enzymatic Reaction and Catalytic Mechanism</h2>
+<p>CPS1 catalyzes the first and rate-limiting step of the urea cycle: the ATP-dependent synthesis of carbamoyl phosphate from ammonia, bicarbonate, and two molecules of ATP (fernandez2015usingrecombinanthuman pages 71-77, yao2020smallmoleculeinhibition pages 1-3). The overall reaction is:</p>
+<p><strong>2 ATP + NH₃ + HCO₃⁻ → carbamoyl phosphate + 2 ADP + Pᵢ</strong></p>
+<p>This reaction proceeds through a three-step catalytic mechanism involving two unstable intermediates (fernandez2015usingrecombinanthuman pages 37-41, fernandez2015usingrecombinanthuman pages 41-44):</p>
+<ol>
+<li><strong>Bicarbonate phosphorylation:</strong> The first ATP molecule phosphorylates bicarbonate at the N-terminal phosphorylation domain, forming the highly reactive intermediate <strong>carboxyphosphate</strong> (also referred to as "active CO₂").</li>
+<li><strong>Carbamate formation:</strong> Ammonia reacts with carboxyphosphate to form <strong>carbamate</strong>, releasing inorganic phosphate.</li>
+<li><strong>Carbamate phosphorylation:</strong> The second ATP molecule phosphorylates carbamate at the C-terminal phosphorylation domain, producing the final product, <strong>carbamoyl phosphate</strong>.</li>
+</ol>
+<p>The two reactive intermediates (carboxyphosphate and carbamate) are shielded from water as they migrate between the two phosphorylation centers through an intraenzymatic pathway (fernandez2015usingrecombinanthuman pages 41-44). An important kinetic feature is that the intraenzymatic reversible reaction between ATP and bicarbonate occurs much faster than the overall reaction, representing a rapid equilibrium step followed by slower ammonia incorporation (fernandez2015usingrecombinanthuman pages 37-41).</p>
+<p>A critical distinction from CPS2 (the cytosolic carbamoyl phosphate synthetase II, part of the CAD multienzymatic complex involved in pyrimidine biosynthesis) is that CPS1 uses <strong>free ammonia</strong> directly as its nitrogen source, rather than glutamine (fernandez2015usingrecombinanthuman pages 24-31). CPS1 possesses an approximately 100-fold higher affinity for ammonia compared to bacterial CPS, making it well-suited for detoxification of ammonia at portal blood concentrations (fernandez2015usingrecombinanthuman pages 37-41).</p>
+<h2 id="domain-architecture-and-structural-biology">Domain Architecture and Structural Biology</h2>
+<p>CPS1 is a multidomain enzyme organized as a single polypeptide chain with fused subunit domains that can be functionally divided into a small subunit region (~40 kDa) and a large subunit region (~120 kDa) (fernandez2015usingrecombinanthuman pages 106-110, fernandez2015usingrecombinanthuman pages 41-44). The large subunit region functions as a pseudohomodimer, containing two homologous ~60 kDa halves, each consisting of an ~45 kDa phosphorylation domain followed by an ~15 kDa domain:</p>
+<ul>
+<li><strong>N-terminal phosphorylation domain:</strong> Catalyzes bicarbonate phosphorylation (the "ATP A" domain).</li>
+<li><strong>C-terminal phosphorylation domain:</strong> Catalyzes carbamate phosphorylation (the "ATP B" domain).</li>
+<li><strong>Integrating domain (UFSD):</strong> A ~17.7 kDa subdomain (residues 822–973) connecting the two phosphorylation domains; it has no substrate sites or catalytic components but contains an allosteric pocket exploited by small-molecule inhibitors (fernandez2015usingrecombinanthuman pages 106-110, yao2020smallmoleculeinhibition pages 5-7).</li>
+<li><strong>Allosteric/regulatory domain (ASD):</strong> The C-terminal ~20 kDa domain (residues 1354–1500) binds the essential allosteric activator N-acetyl-L-glutamate (NAG) and controls the enzyme's on/off state (fernandez2015usingrecombinanthuman pages 106-110, fernandez2015usingrecombinanthuman pages 133-137).</li>
+</ul>
+<p>The crystal structure of human CPS1 has been determined, with key depositions in the Protein Data Bank including PDB 5DOT (apo form), 5DOU (liganded form), and 6UEL (CPS1 in complex with the allosteric inhibitor H3B-193, resolved at 1.90 Å) (yao2020smallmoleculeinhibition pages 5-7, yao2020smallmoleculeinhibition pages 14-15). The co-crystal structure of CPS1 with H3B-193 revealed a previously unknown allosteric pocket located between the integrating and ATP A domains, approximately 10 Å wide at its opening and 24 Å deep, lined with hydrophobic residues (M656, V664, F809, L813, I851). Binding of the inhibitor induces a conformational change in the flexible K-loop (residues V653–H659), which flips out of the ATP binding pocket to stabilize the inhibitor (yao2020smallmoleculeinhibition pages 5-7).</p>
+<h2 id="subcellular-localization-and-supramolecular-organization">Subcellular Localization and Supramolecular Organization</h2>
+<p>CPS1 resides in the <strong>mitochondrial matrix</strong> after cleavage of its N-terminal targeting peptide (fernandez2015usingrecombinanthuman pages 85-89, fernandez2015usingrecombinanthuman pages 37-41). Elegant studies using super-resolution gated stimulation emission depletion (gSTED) microscopy and biochemical fractionation have demonstrated that CPS1, together with N-acetylglutamate synthase (NAGS) and ornithine transcarbamylase (OTC), forms dynamic <strong>nanoclusters</strong> at the <strong>inner mitochondrial membrane (IMM)</strong> rather than functioning as isolated soluble matrix enzymes (haskins2021mitochondrialenzymesof pages 2-3, haskins2021mitochondrialenzymesof pages 1-2, haskins2021mitochondrialenzymesof pages 11-13). Approximately 35% of CPS1 and 30% of OTC partition with the IMM fraction, and these proteins co-immunoprecipitate (haskins2021mitochondrialenzymesof pages 11-13). The clusters measure 100–150 nm and contain multiple urea cycle enzymes, facilitating efficient channeling of the unstable intermediate carbamoyl phosphate and potentially increasing pathway flux up to 100-fold through increased local enzyme and metabolite concentrations (haskins2021mitochondrialenzymesof pages 13-14). The mammalian-specific "variable segment" of NAGS mediates the interaction between NAGS and CPS1 within these clusters (haskins2021mitochondrialenzymesof pages 1-2). Surface amino acid mutations in CPS1 and OTC that do not affect catalytic activity or protein stability can nonetheless impair ureagenesis by disrupting these enzyme–enzyme interactions, underscoring the functional importance of the supramolecular organization (haskins2021mitochondrialenzymesof pages 5-7, haskins2021mitochondrialenzymesof pages 7-10).</p>
+<h2 id="metabolic-pathway-context">Metabolic Pathway Context</h2>
+<h3 id="the-urea-cycle">The Urea Cycle</h3>
+<p>CPS1 catalyzes the first committed step of the urea cycle, which consists of five enzymatic reactions: CPS1 → OTC → argininosuccinate synthetase (ASS1) → argininosuccinate lyase (ASL) → arginase (ARG1) (mitchell2009geneticvariationin pages 2-3, yao2020smallmoleculeinhibition pages 1-3). The carbamoyl phosphate produced by CPS1 is immediately transferred to OTC, which combines it with ornithine to form citrulline—the first specific intermediate of the urea cycle (fernandez2015usingrecombinanthuman pages 37-41, haskins2021mitochondrialenzymesof pages 2-3). The urea cycle is the only mammalian pathway capable of efficiently converting ammonia into urea, sufficient to detoxify tens of grams of ammonia daily (zhu2026ureacycledysregulation pages 5-7). In the liver, the urea cycle operates as a high-capacity system for ammonia removal in periportal hepatocytes, complementing the high-affinity glutamine synthetase system in perivenous hepatocytes (fernandez2015usingrecombinanthuman pages 37-41).</p>
+<h3 id="connection-to-pyrimidine-biosynthesis">Connection to Pyrimidine Biosynthesis</h3>
+<p>Beyond the urea cycle, carbamoyl phosphate produced by CPS1 can leak from mitochondria to the cytosol, where it serves as a substrate for pyrimidine biosynthesis via the cytosolic CAD enzyme complex (CPS2/ATCase/DHOase). This alternative metabolic fate is particularly significant in cancer cells with high CPS1 expression, where increased carbamoyl phosphate production fuels nucleotide synthesis to support rapid proliferation (hajaj2023fromtheinside pages 4-5).</p>
+<h2 id="regulation-of-cps1-activity">Regulation of CPS1 Activity</h2>
+<h3 id="allosteric-activation-by-n-acetylglutamate-nag">Allosteric Activation by N-Acetylglutamate (NAG)</h3>
+<p>CPS1 is essentially <strong>inactive without its obligate allosteric activator, N-acetyl-L-glutamate (NAG)</strong>, which is synthesized by NAGS from acetyl-CoA and glutamate (nakagawa2009sirt5deacetylatescarbamoyl pages 3-4, pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2). NAG binds to the C-terminal allosteric domain and is required for the enzyme to adopt a catalytically competent conformation. This allosteric regulation provides the primary on/off switch for flux through the urea cycle (fernandez2015usingrecombinanthuman pages 133-137).</p>
+<h3 id="post-translational-regulation-by-sirt5">Post-Translational Regulation by SIRT5</h3>
+<p>The mitochondrial sirtuin <strong>SIRT5</strong>, an NAD⁺-dependent deacetylase localized to the mitochondrial matrix, was identified as a specific regulator of CPS1 (nakagawa2009sirt5deacetylatescarbamoyl pages 1-2, nakagawa2009sirt5deacetylatescarbamoyl pages 3-4). SIRT5 deacetylates CPS1, increasing its enzymatic activity. During fasting and calorie restriction, mitochondrial NAD⁺ levels rise approximately two-fold, upregulating SIRT5 activity and thereby promoting CPS1 deacetylation and ammonia disposal (nakagawa2009sirt5deacetylatescarbamoyl pages 5-6, nakagawa2009sirt5deacetylatescarbamoyl pages 6-7). SIRT5 knockout mice exhibit significantly elevated blood ammonia levels following fasting, demonstrating the physiological importance of this regulatory mechanism (nakagawa2009sirt5deacetylatescarbamoyl pages 6-7). This regulation is specific to SIRT5, as other mitochondrial sirtuins (SIRT3, SIRT4) do not affect CPS1 activity (nakagawa2009sirt5deacetylatescarbamoyl pages 3-4).</p>
+<h3 id="post-translational-regulation-by-o-glcnacylation">Post-Translational Regulation by O-GlcNAcylation</h3>
+<p>O-linked N-acetylglucosamine glycosylation (O-GlcNAcylation) represents another layer of nutrient-responsive CPS1 regulation. Two studies have provided complementary but mechanistically distinct findings:</p>
+<ul>
+<li>
+<p><strong>Soria et al. (2022, Nature Communications)</strong> demonstrated that O-GlcNAcylation at specific threonine residues (Thr109, Thr110, and Thr1078) <strong>enhances</strong> CPS1 catalytic efficiency for ammonia and promotes ureagenesis. Pharmacological inhibition of O-GlcNAcase (OGA) with Thiamet-G increased CPS1 O-GlcNAcylation and reduced hyperammonemia in mouse models of both genetic (propionic acidemia) and acquired (thioacetamide-induced liver failure) liver diseases (soria2022oglcnacylationenhancescps1 pages 4-4, soria2022oglcnacylationenhancescps1 pages 6-7, soria2022oglcnacylationenhancescps1 pages 7-8).</p>
+</li>
+<li>
+<p><strong>Wu et al. (2022, Journal of Molecular Cell Biology)</strong> found that global O-GlcNAc levels increase in aged tissues, with CPS1 being among the most heavily O-GlcNAcylated proteins in aged liver. In their model, high glucose stimulates CPS1 O-GlcNAcylation and <strong>inhibits</strong> CPS1 activity, while calorie restriction reverses CPS1 O-GlcNAcylation. The O-GlcNAcylation site Ser537 was identified as important for regulation (wu2022regulationofthe pages 1-2, wu2022regulationofthe pages 2-5, wu2022regulationofthe pages 5-6).</p>
+</li>
+</ul>
+<p>These findings collectively position CPS1 O-GlcNAcylation as a nutrient-sensing mechanism linking dietary status and aging to urea cycle regulation, though the opposing functional effects reported may reflect context-dependent or site-specific modifications (wu2022regulationofthe pages 7-9).</p>
+<h3 id="additional-post-translational-modifications">Additional Post-Translational Modifications</h3>
+<p>Beyond acetylation and O-GlcNAcylation, CPS1 has been found to undergo malonylation, succinylation, fatty acylation, and nitration, which generally have neutral or negative effects on enzyme activity (soria2022oglcnacylationenhancescps1 pages 6-7). Phosphorylation sites on CPS1, including pY590, pY852, and pY1450, have been mapped to binding domains for NAG, substrates, and dimer interfaces, suggesting additional regulatory inputs (evidence from phosphoproteomic studies).</p>
+<h2 id="disease-associations">Disease Associations</h2>
+<h3 id="cps1-deficiency-omim-237300">CPS1 Deficiency (OMIM 237300)</h3>
+<p>CPS1 deficiency (CPS1D) is a rare autosomal recessive inborn error of the urea cycle characterized by severe hyperammonemia (dong2024clinicalfeaturesand pages 1-2, pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2). The disease presents in two clinical forms:</p>
+<ul>
+<li><strong>Early-onset (neonatal):</strong> Manifests within the first days of life with poor feeding, vomiting, lethargy, seizures, and rapidly progressive encephalopathy. Without treatment, neonatal-onset CPS1D is typically lethal (dong2024clinicalfeaturesand pages 4-5, dong2024clinicalfeaturesand pages 1-2).</li>
+<li><strong>Late-onset:</strong> Presents from childhood to adulthood with variable severity, including developmental delay, psychiatric symptoms, and metabolic crises triggered by high-protein intake or acute illness (dong2024clinicalfeaturesand pages 4-5, wang2023clinicalandgenetic pages 3-5).</li>
+</ul>
+<p>In a 2024 cohort of seven Chinese patients, peak blood ammonia levels ranged from 160 to 1,000 µmol/L, with low citrulline and arginine levels being characteristic biochemical findings. Four of seven patients died, and 10 of 12 identified CPS1 variants were novel, highlighting the broad mutation spectrum without hotspot variants (dong2024clinicalfeaturesand pages 4-5, dong2024clinicalfeaturesand pages 5-6). Treatment modalities include ammonia scavengers (sodium phenylbutyrate, sodium benzoate), arginine supplementation, low-protein diet, hemodialysis during acute crises, and liver transplantation as definitive therapy (dong2024clinicalfeaturesand pages 4-5, wang2023clinicalandgenetic pages 3-5). Some patients may respond to N-carbamyl-L-glutamate (NCG), a stable NAG analog that can activate residual CPS1 enzyme activity (fernandez2015usingrecombinanthuman pages 133-137).</p>
+<p>CPS1 is also associated with hyperammonemia, kidney failure, venous thromboembolism, and skeletal abnormalities through genetic association studies (OpenTargets Search: -CPS1).</p>
+<h3 id="cps1-in-cancer">CPS1 in Cancer</h3>
+<p>CPS1 exhibits a paradoxical dual role in cancer. In hepatocellular carcinoma (HCC), CPS1 expression is frequently <strong>suppressed</strong> through DNA methylation of CpG dinucleotides near the transcription start site. In 80.6% of 36 HCC tumor samples examined, CPS1 mRNA levels were significantly lower than in noncancerous tissue (liu2011dnamethylationsuppresses pages 4-6). In non-alcoholic fatty liver disease (NAFLD/NASH), CPS1 mRNA levels are decreased by 30–40% on average, contributing to impaired urea production and hyperammonemia (zhu2026ureacycledysregulation pages 5-7).</p>
+<p>Conversely, CPS1 is <strong>upregulated</strong> in multiple extrahepatic cancers including rectal, stomach, melanoma, sarcoma, lung carcinoma, glioma, glioblastoma, and B-cell lymphoma (hajaj2023fromtheinside pages 4-5). In these contexts, elevated CPS1 activity increases carbamoyl phosphate production, which leaks from mitochondria to the cytosol and serves as substrate for pyrimidine biosynthesis, supporting tumor cell proliferation. Silencing CPS1 in such cancer cells results in cell death through pyrimidine depletion both in vitro and in vivo (hajaj2023fromtheinside pages 4-5). The first small-molecule CPS1 inhibitor, H3B-120 (IC₅₀ ~1.5 µM), was identified through high-throughput screening and demonstrated cellular activity in blocking both urea cycle function and pyrimidine biosynthesis support in primary human hepatocytes, establishing CPS1 as a druggable oncology target (yao2020smallmoleculeinhibition pages 4-5, yao2020smallmoleculeinhibition pages 1-3).</p>
+<h2 id="conclusions">Conclusions</h2>
+<p>CPS1 is a highly abundant mitochondrial matrix enzyme that catalyzes the first and rate-limiting reaction of the urea cycle, converting ammonia, bicarbonate, and two ATP molecules into carbamoyl phosphate through a three-step mechanism involving carboxyphosphate and carbamate intermediates. The enzyme absolutely requires N-acetylglutamate as an allosteric activator and is further regulated by multiple post-translational modifications including SIRT5-mediated deacetylation and O-GlcNAcylation, which link its activity to nutritional status and aging. CPS1, together with NAGS and OTC, forms dynamic nanoclusters at the inner mitochondrial membrane that facilitate efficient substrate channeling. Deficiency of CPS1 causes severe hyperammonemia with high morbidity and mortality, while its aberrant expression in cancer—either suppressed in HCC or upregulated in extrahepatic tumors—contributes to metabolic reprogramming. The availability of high-resolution crystal structures and the identification of druggable allosteric pockets position CPS1 as an active area of both basic and translational research.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(dong2024clinicalfeaturesand pages 5-6): Hui Dong, Tian Sang, Xue Ma, Jinqing Song, Zhehui Chen, Huiting Zhang, Ying Jin, Mengqiu Li, Dingding Dong, Liying Sun, Zhijun Zhu, Yao Zhang, and Yanling Yang. Clinical features and cps1 variants in chinese patients with carbamoyl phosphate synthetase 1 deficiency. BMC Pediatrics, Aug 2024. URL: https://doi.org/10.1186/s12887-024-05005-5, doi:10.1186/s12887-024-05005-5. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 71-77): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 106-110): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 85-89): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(pekkala2010understandingcarbamoyl‐phosphatesynthetase pages 1-2): Satu Pekkala, Ana I. Martínez, Belén Barcelona, Igor Yefimenko, Ulrich Finckh, Vicente Rubio, and Javier Cervera. Understanding carbamoyl‐phosphate synthetase i (cps1) deficiency by using expression studies and structure‐based analysis. Human Mutation, 31:801-808, Jul 2010. URL: https://doi.org/10.1002/humu.21272, doi:10.1002/humu.21272. This article has 50 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 37-41): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -CPS1): Open Targets Query (-CPS1, 9 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(haskins2021mitochondrialenzymesof pages 2-3): Nantaporn Haskins, Shivaprasad Bhuvanendran, Claudio Anselmi, Anna Gams, Tomas Kanholm, Kristen M. Kocher, Jonathan LoTempio, Kylie I. Krohmaly, Danielle Sohai, Nathaniel Stearrett, Erin Bonner, Mendel Tuchman, Hiroki Morizono, Jyoti K. Jaiswal, and Ljubica Caldovic. Mitochondrial enzymes of the urea cycle cluster at the inner mitochondrial membrane. Frontiers in Physiology, Jan 2021. URL: https://doi.org/10.3389/fphys.2020.542950, doi:10.3389/fphys.2020.542950. This article has 40 citations.</p>
+</li>
+<li>
+<p>(haskins2021mitochondrialenzymesof pages 1-2): Nantaporn Haskins, Shivaprasad Bhuvanendran, Claudio Anselmi, Anna Gams, Tomas Kanholm, Kristen M. Kocher, Jonathan LoTempio, Kylie I. Krohmaly, Danielle Sohai, Nathaniel Stearrett, Erin Bonner, Mendel Tuchman, Hiroki Morizono, Jyoti K. Jaiswal, and Ljubica Caldovic. Mitochondrial enzymes of the urea cycle cluster at the inner mitochondrial membrane. Frontiers in Physiology, Jan 2021. URL: https://doi.org/10.3389/fphys.2020.542950, doi:10.3389/fphys.2020.542950. This article has 40 citations.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 24-31): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(yao2020smallmoleculeinhibition pages 1-3): Shihua Yao, Tuong-Vi Nguyen, Alan Rolfe, Anant A. Agrawal, Jiyuan Ke, Shouyong Peng, Federico Colombo, Sean Yu, Patricia Bouchard, Jiayi Wu, Kuan-Chun Huang, Xingfeng Bao, Kiyoyuki Omoto, Anand Selvaraj, Lihua Yu, Stephanos Ioannidis, Frédéric H. Vaillancourt, Ping Zhu, Nicholas A. Larsen, and David M. Bolduc. Small molecule inhibition of cps1 activity through an allosteric pocket. Cell Chemical Biology, 27:259-268.e5, Mar 2020. URL: https://doi.org/10.1016/j.chembiol.2020.01.009, doi:10.1016/j.chembiol.2020.01.009. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 41-44): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(nakagawa2009sirt5deacetylatescarbamoyl pages 3-4): Takashi Nakagawa, David J. Lomb, Marcia C. Haigis, and Leonard Guarente. Sirt5 deacetylates carbamoyl phosphate synthetase 1 and regulates the urea cycle. Cell, 137:560-570, May 2009. URL: https://doi.org/10.1016/j.cell.2009.02.026, doi:10.1016/j.cell.2009.02.026. This article has 992 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakagawa2009sirt5deacetylatescarbamoyl pages 7-8): Takashi Nakagawa, David J. Lomb, Marcia C. Haigis, and Leonard Guarente. Sirt5 deacetylates carbamoyl phosphate synthetase 1 and regulates the urea cycle. Cell, 137:560-570, May 2009. URL: https://doi.org/10.1016/j.cell.2009.02.026, doi:10.1016/j.cell.2009.02.026. This article has 992 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakagawa2009sirt5deacetylatescarbamoyl pages 6-7): Takashi Nakagawa, David J. Lomb, Marcia C. Haigis, and Leonard Guarente. Sirt5 deacetylates carbamoyl phosphate synthetase 1 and regulates the urea cycle. Cell, 137:560-570, May 2009. URL: https://doi.org/10.1016/j.cell.2009.02.026, doi:10.1016/j.cell.2009.02.026. This article has 992 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(soria2022oglcnacylationenhancescps1 pages 4-4): Leandro R. Soria, Georgios Makris, Alfonso M. D’Alessio, Angela De Angelis, Iolanda Boffa, Veronica M. Pravata, Véronique Rüfenacht, Sergio Attanasio, Edoardo Nusco, Paola Arena, Andrew T. Ferenbach, Debora Paris, Paola Cuomo, Andrea Motta, Matthew Nitzahn, Gerald S. Lipshutz, Ainhoa Martínez-Pizarro, Eva Richard, Lourdes R. Desviat, Johannes Häberle, Daan M. F. van Aalten, and Nicola Brunetti-Pierri. O-glcnacylation enhances cps1 catalytic efficiency for ammonia and promotes ureagenesis. Nature Communications, Sep 2022. URL: https://doi.org/10.1038/s41467-022-32904-x, doi:10.1038/s41467-022-32904-x. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(soria2022oglcnacylationenhancescps1 pages 6-7): Leandro R. Soria, Georgios Makris, Alfonso M. D’Alessio, Angela De Angelis, Iolanda Boffa, Veronica M. Pravata, Véronique Rüfenacht, Sergio Attanasio, Edoardo Nusco, Paola Arena, Andrew T. Ferenbach, Debora Paris, Paola Cuomo, Andrea Motta, Matthew Nitzahn, Gerald S. Lipshutz, Ainhoa Martínez-Pizarro, Eva Richard, Lourdes R. Desviat, Johannes Häberle, Daan M. F. van Aalten, and Nicola Brunetti-Pierri. O-glcnacylation enhances cps1 catalytic efficiency for ammonia and promotes ureagenesis. Nature Communications, Sep 2022. URL: https://doi.org/10.1038/s41467-022-32904-x, doi:10.1038/s41467-022-32904-x. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2022regulationofthe pages 1-2): Jing Wu, Jiayu Liu, Kalina Lapenta, Reina Desrouleaux, Min-Dian Li, and Xiaoyong Yang. Regulation of the urea cycle by cps1 o-glcnacylation in response to dietary restriction and aging. Journal of Molecular Cell Biology, Mar 2022. URL: https://doi.org/10.1093/jmcb/mjac016, doi:10.1093/jmcb/mjac016. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2022regulationofthe pages 2-5): Jing Wu, Jiayu Liu, Kalina Lapenta, Reina Desrouleaux, Min-Dian Li, and Xiaoyong Yang. Regulation of the urea cycle by cps1 o-glcnacylation in response to dietary restriction and aging. Journal of Molecular Cell Biology, Mar 2022. URL: https://doi.org/10.1093/jmcb/mjac016, doi:10.1093/jmcb/mjac016. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dong2024clinicalfeaturesand pages 1-2): Hui Dong, Tian Sang, Xue Ma, Jinqing Song, Zhehui Chen, Huiting Zhang, Ying Jin, Mengqiu Li, Dingding Dong, Liying Sun, Zhijun Zhu, Yao Zhang, and Yanling Yang. Clinical features and cps1 variants in chinese patients with carbamoyl phosphate synthetase 1 deficiency. BMC Pediatrics, Aug 2024. URL: https://doi.org/10.1186/s12887-024-05005-5, doi:10.1186/s12887-024-05005-5. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dong2024clinicalfeaturesand pages 4-5): Hui Dong, Tian Sang, Xue Ma, Jinqing Song, Zhehui Chen, Huiting Zhang, Ying Jin, Mengqiu Li, Dingding Dong, Liying Sun, Zhijun Zhu, Yao Zhang, and Yanling Yang. Clinical features and cps1 variants in chinese patients with carbamoyl phosphate synthetase 1 deficiency. BMC Pediatrics, Aug 2024. URL: https://doi.org/10.1186/s12887-024-05005-5, doi:10.1186/s12887-024-05005-5. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2023clinicalandgenetic pages 3-5): Shangyu Wang, Jinglin Chen, Xiaoqi Zhu, Tingting Huang, Haifeng Xu, Guohuan Ying, Hao Qian, Wenxin Lin, Yiehen Tung, Kaleem Ullah Khan, Hu Guo, Guo Zheng, Haiying Lu, and Gang Zhang. Clinical and genetic analysis of a case of late onset carbamoyl phosphate synthase i deficiency caused by cps1 mutation and literature review. BMC Medical Genomics, Jun 2023. URL: https://doi.org/10.1186/s12920-023-01569-w, doi:10.1186/s12920-023-01569-w. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2011dnamethylationsuppresses pages 4-6): Hongyan Liu, Huijia Dong, Keith Robertson, and Chen Liu. Dna methylation suppresses expression of the urea cycle enzyme carbamoyl phosphate synthetase 1 (cps1) in human hepatocellular carcinoma. The American journal of pathology, 178 2:652-61, Feb 2011. URL: https://doi.org/10.1016/j.ajpath.2010.10.023, doi:10.1016/j.ajpath.2010.10.023. This article has 133 citations.</p>
+</li>
+<li>
+<p>(hajaj2023fromtheinside pages 4-5): Emma Hajaj, Sabina Pozzi, and Ayelet Erez. From the inside out: exposing the roles of urea cycle enzymes in tumors and their micro and macro environments. Cold Spring Harbor perspectives in medicine, 14:a041538, Sep 2024. URL: https://doi.org/10.1101/cshperspect.a041538, doi:10.1101/cshperspect.a041538. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2020smallmoleculeinhibition pages 8-8): Shihua Yao, Tuong-Vi Nguyen, Alan Rolfe, Anant A. Agrawal, Jiyuan Ke, Shouyong Peng, Federico Colombo, Sean Yu, Patricia Bouchard, Jiayi Wu, Kuan-Chun Huang, Xingfeng Bao, Kiyoyuki Omoto, Anand Selvaraj, Lihua Yu, Stephanos Ioannidis, Frédéric H. Vaillancourt, Ping Zhu, Nicholas A. Larsen, and David M. Bolduc. Small molecule inhibition of cps1 activity through an allosteric pocket. Cell Chemical Biology, 27:259-268.e5, Mar 2020. URL: https://doi.org/10.1016/j.chembiol.2020.01.009, doi:10.1016/j.chembiol.2020.01.009. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2020smallmoleculeinhibition pages 14-15): Shihua Yao, Tuong-Vi Nguyen, Alan Rolfe, Anant A. Agrawal, Jiyuan Ke, Shouyong Peng, Federico Colombo, Sean Yu, Patricia Bouchard, Jiayi Wu, Kuan-Chun Huang, Xingfeng Bao, Kiyoyuki Omoto, Anand Selvaraj, Lihua Yu, Stephanos Ioannidis, Frédéric H. Vaillancourt, Ping Zhu, Nicholas A. Larsen, and David M. Bolduc. Small molecule inhibition of cps1 activity through an allosteric pocket. Cell Chemical Biology, 27:259-268.e5, Mar 2020. URL: https://doi.org/10.1016/j.chembiol.2020.01.009, doi:10.1016/j.chembiol.2020.01.009. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2020smallmoleculeinhibition pages 5-7): Shihua Yao, Tuong-Vi Nguyen, Alan Rolfe, Anant A. Agrawal, Jiyuan Ke, Shouyong Peng, Federico Colombo, Sean Yu, Patricia Bouchard, Jiayi Wu, Kuan-Chun Huang, Xingfeng Bao, Kiyoyuki Omoto, Anand Selvaraj, Lihua Yu, Stephanos Ioannidis, Frédéric H. Vaillancourt, Ping Zhu, Nicholas A. Larsen, and David M. Bolduc. Small molecule inhibition of cps1 activity through an allosteric pocket. Cell Chemical Biology, 27:259-268.e5, Mar 2020. URL: https://doi.org/10.1016/j.chembiol.2020.01.009, doi:10.1016/j.chembiol.2020.01.009. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fernandez2015usingrecombinanthuman pages 133-137): CARMEN DÍEZ FERNÁNDEZ. USING RECOMBINANT HUMAN CARBAMOYL PHOSPHATE SYNTHETASE 1 (CPS1) FOR STUDYING THIS ENZYME'S FUNCTION, REGULATION, PATHOLOGY AND STRUCTURE. PhD thesis, Universitat Politecnica de Valencia, 2015. URL: https://doi.org/10.4995/thesis/10251/52855, doi:10.4995/thesis/10251/52855.</p>
+</li>
+<li>
+<p>(haskins2021mitochondrialenzymesof pages 11-13): Nantaporn Haskins, Shivaprasad Bhuvanendran, Claudio Anselmi, Anna Gams, Tomas Kanholm, Kristen M. Kocher, Jonathan LoTempio, Kylie I. Krohmaly, Danielle Sohai, Nathaniel Stearrett, Erin Bonner, Mendel Tuchman, Hiroki Morizono, Jyoti K. Jaiswal, and Ljubica Caldovic. Mitochondrial enzymes of the urea cycle cluster at the inner mitochondrial membrane. Frontiers in Physiology, Jan 2021. URL: https://doi.org/10.3389/fphys.2020.542950, doi:10.3389/fphys.2020.542950. This article has 40 citations.</p>
+</li>
+<li>
+<p>(haskins2021mitochondrialenzymesof pages 13-14): Nantaporn Haskins, Shivaprasad Bhuvanendran, Claudio Anselmi, Anna Gams, Tomas Kanholm, Kristen M. Kocher, Jonathan LoTempio, Kylie I. Krohmaly, Danielle Sohai, Nathaniel Stearrett, Erin Bonner, Mendel Tuchman, Hiroki Morizono, Jyoti K. Jaiswal, and Ljubica Caldovic. Mitochondrial enzymes of the urea cycle cluster at the inner mitochondrial membrane. Frontiers in Physiology, Jan 2021. URL: https://doi.org/10.3389/fphys.2020.542950, doi:10.3389/fphys.2020.542950. This article has 40 citations.</p>
+</li>
+<li>
+<p>(haskins2021mitochondrialenzymesof pages 5-7): Nantaporn Haskins, Shivaprasad Bhuvanendran, Claudio Anselmi, Anna Gams, Tomas Kanholm, Kristen M. Kocher, Jonathan LoTempio, Kylie I. Krohmaly, Danielle Sohai, Nathaniel Stearrett, Erin Bonner, Mendel Tuchman, Hiroki Morizono, Jyoti K. Jaiswal, and Ljubica Caldovic. Mitochondrial enzymes of the urea cycle cluster at the inner mitochondrial membrane. Frontiers in Physiology, Jan 2021. URL: https://doi.org/10.3389/fphys.2020.542950, doi:10.3389/fphys.2020.542950. This article has 40 citations.</p>
+</li>
+<li>
+<p>(haskins2021mitochondrialenzymesof pages 7-10): Nantaporn Haskins, Shivaprasad Bhuvanendran, Claudio Anselmi, Anna Gams, Tomas Kanholm, Kristen M. Kocher, Jonathan LoTempio, Kylie I. Krohmaly, Danielle Sohai, Nathaniel Stearrett, Erin Bonner, Mendel Tuchman, Hiroki Morizono, Jyoti K. Jaiswal, and Ljubica Caldovic. Mitochondrial enzymes of the urea cycle cluster at the inner mitochondrial membrane. Frontiers in Physiology, Jan 2021. URL: https://doi.org/10.3389/fphys.2020.542950, doi:10.3389/fphys.2020.542950. This article has 40 citations.</p>
+</li>
+<li>
+<p>(mitchell2009geneticvariationin pages 2-3): Sabrina Mitchell, Clint Ellingson, Thomas Coyne, Lynn Hall, Meaghan Neill, Natalie Christian, Catherine Higham, Steven F. Dobrowolski, Mendel Tuchman, and Marshall Summar. Genetic variation in the urea cycle: a model resource for investigating key candidate genes for common diseases. Human Mutation, 30:56-60, Jan 2009. URL: https://doi.org/10.1002/humu.20813, doi:10.1002/humu.20813. This article has 57 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhu2026ureacycledysregulation pages 5-7): Boying Zhu, Chaoyang Wang, Peng Liu, Zhifeng Qu, Ran Qi, Shengjiang Chen, and Huanzhang Niu. Urea cycle dysregulation and arginine pathways in the pathogenesis of nafld and nash (review). International Journal of Molecular Medicine, 58:1-21, Jun 2026. URL: https://doi.org/10.3892/ijmm.2026.5886, doi:10.3892/ijmm.2026.5886. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakagawa2009sirt5deacetylatescarbamoyl pages 1-2): Takashi Nakagawa, David J. Lomb, Marcia C. Haigis, and Leonard Guarente. Sirt5 deacetylates carbamoyl phosphate synthetase 1 and regulates the urea cycle. Cell, 137:560-570, May 2009. URL: https://doi.org/10.1016/j.cell.2009.02.026, doi:10.1016/j.cell.2009.02.026. This article has 992 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakagawa2009sirt5deacetylatescarbamoyl pages 5-6): Takashi Nakagawa, David J. Lomb, Marcia C. Haigis, and Leonard Guarente. Sirt5 deacetylates carbamoyl phosphate synthetase 1 and regulates the urea cycle. Cell, 137:560-570, May 2009. URL: https://doi.org/10.1016/j.cell.2009.02.026, doi:10.1016/j.cell.2009.02.026. This article has 992 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(soria2022oglcnacylationenhancescps1 pages 7-8): Leandro R. Soria, Georgios Makris, Alfonso M. D’Alessio, Angela De Angelis, Iolanda Boffa, Veronica M. Pravata, Véronique Rüfenacht, Sergio Attanasio, Edoardo Nusco, Paola Arena, Andrew T. Ferenbach, Debora Paris, Paola Cuomo, Andrea Motta, Matthew Nitzahn, Gerald S. Lipshutz, Ainhoa Martínez-Pizarro, Eva Richard, Lourdes R. Desviat, Johannes Häberle, Daan M. F. van Aalten, and Nicola Brunetti-Pierri. O-glcnacylation enhances cps1 catalytic efficiency for ammonia and promotes ureagenesis. Nature Communications, Sep 2022. URL: https://doi.org/10.1038/s41467-022-32904-x, doi:10.1038/s41467-022-32904-x. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2022regulationofthe pages 5-6): Jing Wu, Jiayu Liu, Kalina Lapenta, Reina Desrouleaux, Min-Dian Li, and Xiaoyong Yang. Regulation of the urea cycle by cps1 o-glcnacylation in response to dietary restriction and aging. Journal of Molecular Cell Biology, Mar 2022. URL: https://doi.org/10.1093/jmcb/mjac016, doi:10.1093/jmcb/mjac016. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2022regulationofthe pages 7-9): Jing Wu, Jiayu Liu, Kalina Lapenta, Reina Desrouleaux, Min-Dian Li, and Xiaoyong Yang. Regulation of the urea cycle by cps1 o-glcnacylation in response to dietary restriction and aging. Journal of Molecular Cell Biology, Mar 2022. URL: https://doi.org/10.1093/jmcb/mjac016, doi:10.1093/jmcb/mjac016. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2020smallmoleculeinhibition pages 4-5): Shihua Yao, Tuong-Vi Nguyen, Alan Rolfe, Anant A. Agrawal, Jiyuan Ke, Shouyong Peng, Federico Colombo, Sean Yu, Patricia Bouchard, Jiayi Wu, Kuan-Chun Huang, Xingfeng Bao, Kiyoyuki Omoto, Anand Selvaraj, Lihua Yu, Stephanos Ioannidis, Frédéric H. Vaillancourt, Ping Zhu, Nicholas A. Larsen, and David M. Bolduc. Small molecule inhibition of cps1 activity through an allosteric pocket. Cell Chemical Biology, 27:259-268.e5, Mar 2020. URL: https://doi.org/10.1016/j.chembiol.2020.01.009, doi:10.1016/j.chembiol.2020.01.009. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="CPS1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>dong2024clinicalfeaturesand pages 5-6</li>
+<li>dong2024clinicalfeaturesand pages 4-5</li>
+<li>fernandez2015usingrecombinanthuman pages 41-44</li>
+<li>fernandez2015usingrecombinanthuman pages 37-41</li>
+<li>fernandez2015usingrecombinanthuman pages 24-31</li>
+<li>yao2020smallmoleculeinhibition pages 5-7</li>
+<li>haskins2021mitochondrialenzymesof pages 11-13</li>
+<li>haskins2021mitochondrialenzymesof pages 13-14</li>
+<li>haskins2021mitochondrialenzymesof pages 1-2</li>
+<li>zhu2026ureacycledysregulation pages 5-7</li>
+<li>hajaj2023fromtheinside pages 4-5</li>
+<li>fernandez2015usingrecombinanthuman pages 133-137</li>
+<li>wu2022regulationofthe pages 7-9</li>
+<li>liu2011dnamethylationsuppresses pages 4-6</li>
+<li>fernandez2015usingrecombinanthuman pages 71-77</li>
+<li>fernandez2015usingrecombinanthuman pages 106-110</li>
+<li>fernandez2015usingrecombinanthuman pages 85-89</li>
+<li>haskins2021mitochondrialenzymesof pages 2-3</li>
+<li>yao2020smallmoleculeinhibition pages 1-3</li>
+<li>wu2022regulationofthe pages 1-2</li>
+<li>wu2022regulationofthe pages 2-5</li>
+<li>dong2024clinicalfeaturesand pages 1-2</li>
+<li>wang2023clinicalandgenetic pages 3-5</li>
+<li>yao2020smallmoleculeinhibition pages 8-8</li>
+<li>yao2020smallmoleculeinhibition pages 14-15</li>
+<li>haskins2021mitochondrialenzymesof pages 5-7</li>
+<li>haskins2021mitochondrialenzymesof pages 7-10</li>
+<li>mitchell2009geneticvariationin pages 2-3</li>
+<li>wu2022regulationofthe pages 5-6</li>
+<li>yao2020smallmoleculeinhibition pages 4-5</li>
+<li>ammonia</li>
+<li>https://doi.org/10.1186/s12887-024-05005-5,</li>
+<li>https://doi.org/10.4995/thesis/10251/52855,</li>
+<li>https://doi.org/10.1002/humu.21272,</li>
+<li>https://doi.org/10.3389/fphys.2020.542950,</li>
+<li>https://doi.org/10.1016/j.chembiol.2020.01.009,</li>
+<li>https://doi.org/10.1016/j.cell.2009.02.026,</li>
+<li>https://doi.org/10.1038/s41467-022-32904-x,</li>
+<li>https://doi.org/10.1093/jmcb/mjac016,</li>
+<li>https://doi.org/10.1186/s12920-023-01569-w,</li>
+<li>https://doi.org/10.1016/j.ajpath.2010.10.023,</li>
+<li>https://doi.org/10.1101/cshperspect.a041538,</li>
+<li>https://doi.org/10.1002/humu.20813,</li>
+<li>https://doi.org/10.3892/ijmm.2026.5886,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CPS1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P31327" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cps1-human-p31327-review-notes">CPS1 (human, P31327) review notes</h1>
+<p>Deep research: falcon run polled (~12 min) but did NOT land before review; grounded instead in<br />
+UniProt (P31327), seeded GOA, cached publications, and the dismech CPS1D disorder file.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>~1500-aa mitochondrial-matrix multidomain enzyme; catalyzes the FIRST committed step of the urea<br />
+  cycle: NH4+ + HCO3- + 2 ATP -&gt; carbamoyl phosphate + 2 ADP + Pi + 2 H+ (EC 6.3.4.16).<br />
+  [UniProt P31327 CATALYTIC ACTIVITY; Rhea:RHEA:18029]</li>
+<li>Glutamine-INDEPENDENT (ammonia-dependent). "Glutamine is utilized as the endogenous source of<br />
+  ammonia by all types of CPS except CPS1. The inability of human CPS1 to use glutamine is explained<br />
+  by the replacement by serine (Ser294) in this enzyme of the key catalytic cysteine of the catalytic<br />
+  triad." <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" title="Glutamine is utilized as the endogenous source of ammonia by all types of CPS31464748 except CPS12">PMID:26592762</a><br />
+  UniProt: "The type-1 glutamine amidotransferase domain is defective."</li>
+<li>ABSOLUTE requirement for the allosteric activator N-acetyl-L-glutamate (NAG). Without NAG, activity<br />
+  is &lt;=2% of NAG-saturated. <a href="https://pubmed.ncbi.nlm.nih.gov/26592762" title="in its absence CPS1 exhibits ≤2% of the activity at NAG saturation">PMID:26592762</a><br />
+  NAG binds the C-terminal L4 (MGS-like) domain. [UniProt BINDING 1391..1449 N-acetyl-L-glutamate]</li>
+<li>Ionic activators: potassium and magnesium; K+ coordinated in L1 K-loop, Mg2+ coordinates ADP.<br />
+  [PMID:26802762... PMID:26592762 "having at its center a coordinated potassium ion (thus the name K-loop)"; "CPS1 affinities for its essential ionic activators potassium and magnesium are increased importantly by NAG"]</li>
+<li>Location: mitochondrial matrix. [UniProt SUBCELLULAR LOCATION Mitochondrion; PMID:22002106; TRANSIT 1..38 Mitochondrion]</li>
+<li>Quaternary: monomer-dimer equilibrium, monomer predominant. [PMID:26592762 "behavior of human CPS1 in solution as a monomer-dimer system in rapid equilibrium in which the monomer predominates"; PMID:6249820 native MW ~190k, monomer ~165k]</li>
+<li>Km values: ATP 0.47 mM, HCO3- 4 mM, NH4+ 1 mM (recombinant) <a href="https://pubmed.ncbi.nlm.nih.gov/23649895">PMID:23649895</a>; NAG Km ~0.1 mM <a href="https://pubmed.ncbi.nlm.nih.gov/6249820">PMID:6249820</a></li>
+<li>Tissue: primarily liver and small intestine. [UniProt TISSUE SPECIFICITY]</li>
+<li>Disease: CPS1 deficiency (CPS1D), autosomal recessive urea-cycle disorder, severe neonatal<br />
+  hyperammonemia; &gt;130 private missense mutations. [PMID:21120950; MONDO:0009376; dismech]</li>
+<li>Recombinant human CPS1 established EC 6.3.4.16 and kinetics. [PMID:23649895, PMID:24813853]</li>
+<li>Regulation by acylation: glutarylation (increases fasting) and succinylation removed by SIRT5<br />
+  (deacylation activates). [UniProt PTM; PMID:24703693; Reactome R-HSA-9955504]</li>
+</ul>
+<h2 id="over-annotation-dubious-annotations">Over-annotation / dubious annotations</h2>
+<ul>
+<li>GO:0004088 carbamoyl-phosphate synthase (glutamine-hydrolyzing) activity (IBA/IEA): this is the<br />
+  activity of CPS II (CAD, cytosolic, pyrimidine). CPS1 is ammonia-dependent and lacks a functional<br />
+  glutaminase (defective GATase, Ser294). MODIFY -&gt; GO:0004087. [PMID:26592762; UniProt DOMAIN comment]</li>
+<li>GO:0004175 endopeptidase activity (IEA GO_REF:0000107, Ensembl Compara ortholog transfer): CPS1 is<br />
+  a ligase, not a protease. Implausible ortholog-transfer artifact. REMOVE.</li>
+<li>GO:0005509 calcium ion binding, GO:0005543 phospholipid binding (IEA GO_REF:0000107): no evidence;<br />
+  CPS1 uses K+/Mg2+ not Ca2+, no lipid-binding role in the matrix. REMOVE (ortholog-transfer).</li>
+<li>Bare GO:0005515 protein binding (IPI PMID:12620389 Raf 2-hybrid; PMID:15161933 &amp; PMID:20618440<br />
+  14-3-3 proteomics): uninformative; the interactions (ARAF/RAF1/YWHAZ in UniProt INTERACTION) are<br />
+  large-scale-screen hits, not established functional partners. MARK_AS_OVER_ANNOTATED / do not<br />
+  elevate to core; keep bare term as non-core at most.</li>
+<li>GO:0042311 vasodilation (IMP), GO:0046209 nitric oxide metabolic process (IMP), GO:0019240<br />
+  L-citrulline biosynthetic process (NAS) all from PMID:14718356: a T1405N-polymorphism genotype-<br />
+  association study of NO metabolites/forearm blood flow. Indirect downstream physiology (CPS1 -&gt;<br />
+  carbamoyl-P -&gt; citrulline -&gt; arginine -&gt; NO), not a direct CPS1 function. Over-annotation.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/14718356" title="a polymorphism in the gene encoding carbamoyl-phosphate synthetase 1 influences nitric oxide production as well as vascular smooth muscle reactivity">PMID:14718356</a></li>
+<li>GO:0050667 homocysteine metabolic process (IDA) and GO:0072341 modified amino acid binding (IDA)<br />
+  from PMID:20031578: this is a GWAS SNP-plasma-homocysteine association (rs7422339), NOT an IDA of<br />
+  direct binding or metabolism. The evidence code is misapplied. However GO:0072341 modified amino<br />
+  acid binding IS actually correct for CPS1 for a different reason: it binds N-acetyl-L-glutamate (a<br />
+  modified amino acid). <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" title="novel associations with CPS1 (2q34; rs7422339...">PMID:20031578</a></li>
+<li>GO:0019433 triglyceride catabolic process (IMP PMID:9711878): the cited paper is a prenatal<br />
+  diagnosis of CPS1D by a missense mutation; NO triglyceride content. Misassigned. REMOVE.</li>
+<li>GO:0032496 response to LPS (IDA PMID:15897806): CPS1 is released/fragmented into circulation under<br />
+  septic (LPS) conditions as a biomarker of hepatic mitochondrial injury; CPS1 is not a participant<br />
+  in the LPS-response process. Over-annotation of a downstream biomarker phenomenon.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15897806" title="circulating CPS-1 might serve as a novel serum marker indicating mitochondrial impairment">PMID:15897806</a></li>
+<li>GO:0042645 mitochondrial nucleoid (IDA PMID:18063578): CPS1 co-purifies with native mtDNA nucleoids<br />
+  as an abundant matrix protein; the paper explicitly notes several metabolic proteins "were not<br />
+  observed to cross-link to mtDNA." Likely co-purification, not a genuine nucleoid localization.</li>
+<li>GO:0005730 nucleolus (IEA GO_REF:0000044 + IDA GO_REF:0000052) and GO:0005886 plasma membrane<br />
+  (IEA/ISS): UniProt does list Nucleus/nucleolus (PMID:22002106) and Cell membrane (by similarity to<br />
+  mouse Q8C196, "cell surface of hepatocytes"). These are unusual moonlighting/secondary localizations<br />
+  for a matrix enzyme; keep as non-core.</li>
+<li>Ensembl-Compara IEA response-to-stimulus terms (GO_REF:0000107): a large block of "response to X"<br />
+  (glucagon, cAMP, glucocorticoid, LPS, zinc, oleic acid, starvation, food, FGF, GH, dexamethasone,<br />
+  alcohol, amino acid, amine, steroid hormone, toxic substance, xenobiotic) plus liver/midgut/<br />
+  hepatocyte development and monoatomic anion homeostasis. These are expression-regulation /<br />
+  physiological-context transfers from rodent orthologs, not core function; keep as non-core.</li>
+<li>GO:0006207 de novo pyrimidine nucleobase biosynthetic process (IEA GO_REF:0000002) and GO:0090407<br />
+  organophosphate biosynthetic process (IEA GO_REF:0000117 ARBA): pyrimidine biosynthesis is CPS II<br />
+  (CAD), not CPS1; MODIFY/over-annotation. organophosphate is a broad ARBA mapping.</li>
+<li>GO:0006541 L-glutamine metabolic process (IBA/IEA): reflects the glutamine-dependent CPS family<br />
+  ancestor; human CPS1 does NOT use glutamine. Over-annotation.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P31327
+gene_symbol: CPS1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  CPS1 (carbamoyl-phosphate synthase [ammonia], mitochondrial) is a ~1500-residue
+  multidomain enzyme of the mitochondrial matrix that catalyzes the first and
+  rate-limiting committed step of the urea cycle in ureotelic animals: the
+  ATP-dependent condensation of ammonia and bicarbonate into carbamoyl phosphate
+  (NH4+ + HCO3- + 2 ATP -&gt; carbamoyl phosphate + 2 ADP + phosphate + 2 H+; EC
+  6.3.4.16). It is highly expressed in liver and small intestine, where it initiates
+  hepatic detoxification of ammonia derived from amino acid catabolism. Unlike the
+  cytosolic glutamine-dependent CPS II (part of CAD) that feeds pyrimidine
+  biosynthesis, CPS1 uses free ammonia rather than glutamine; its ancestral
+  glutamine amidotransferase domain is catalytically defective (the catalytic
+  cysteine is replaced by Ser294). CPS1 is an allosteric enzyme with an absolute
+  requirement for the activator N-acetyl-L-glutamate (NAG), which binds the
+  C-terminal MGS-like domain and, together with nucleotide binding, drives
+  long-range conformational changes that build the intramolecular tunnel through
+  which the labile carbamate intermediate migrates between the two ATP-grasp
+  phosphorylation sites; in the absence of NAG the enzyme retains &lt;=2% of its
+  maximal activity. Catalysis also requires the ionic activators potassium and
+  magnesium. The enzyme behaves in solution as a monomer-dimer equilibrium in which
+  the monomer predominates. Loss-of-function variants cause the autosomal recessive
+  urea-cycle disorder carbamoyl phosphate synthetase 1 deficiency (CPS1D), which
+  presents most severely as neonatal hyperammonemia with high mortality and
+  neurological sequelae.
+alternative_products:
+- name: &#39;1&#39;
+  id: P31327-1
+- name: &#39;2&#39;
+  id: P31327-2
+  sequence_note: VSP_009332
+- name: &#39;3&#39;
+  id: P31327-3
+  sequence_note: VSP_046685
+existing_annotations:
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred carbamoyl-phosphate synthase (ammonia) activity.
+      This is the correct, specific core molecular function of CPS1 and is directly
+      supported by biochemical characterization of the recombinant human enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      This is the well-established core catalytic function of CPS1 (EC 6.3.4.16),
+      the ammonia-dependent carbamoyl-phosphate synthetase of the urea cycle. The
+      IBA annotation is at the correct level of specificity.
+    supported_by:
+    - reference_id: PMID:23649895
+      supporting_text: &gt;-
+        The kinetic and molecular properties of recombinant CPS1 are essentially
+        the same as for natural human CPS1.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic annotation to cytoplasm. CPS1 is a mitochondrial-matrix protein;
+      cytoplasm is far too general and does not capture the specific compartment.
+    action: MODIFY
+    reason: &gt;-
+      CPS1 is imported into the mitochondrion via an N-terminal transit peptide and
+      functions in the mitochondrial matrix, not the general cytoplasm. The more
+      specific and accurate location GO:0005759 mitochondrial matrix is separately
+      annotated (TAS). Replace the over-general cytoplasm term with mitochondrial
+      matrix.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+    proposed_replacement_terms:
+    - id: GO:0005759
+      label: mitochondrial matrix
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        carbamoyl phosphate synthase-1 (CPS-1), an abundant enzyme of the hepatic
+        urea cycle, which is normally located in the mitochondrial matrix.
+- term:
+    id: GO:0006541
+    label: L-glutamine metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic annotation to glutamine metabolic process, inherited from the
+      glutamine-dependent CPS family ancestor. Human CPS1 does not use glutamine.
+    action: REMOVE
+    reason: &gt;-
+      CPS1 is ammonia-dependent, not glutamine-dependent. Its ancestral glutamine
+      amidotransferase (GATase) domain is catalytically defective, with the key
+      catalytic cysteine replaced by serine (Ser294), so CPS1 does not hydrolyze or
+      metabolize glutamine. This IBA term reflects the broader CPS family (which
+      includes glutamine-hydrolyzing CPS II) rather than the specific human enzyme.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: GO_REF:0000033
+        source_label: PAN-GO phylogenetic inference (CPS family tree)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Glutamine metabolism is a genuine property of glutamine-dependent CPS
+          family members (e.g. CPS II/CAD), but human CPS1 has lost the glutaminase
+          sub-activity (catalytic Cys-&gt;Ser294) and uses free ammonia.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        The inability of human CPS1 to use glutamine is explained by the
+        replacement by serine (Ser294) in this enzyme of the key catalytic cysteine
+        of the catalytic triad
+- term:
+    id: GO:0004088
+    label: carbamoyl-phosphate synthase (glutamine-hydrolyzing) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Phylogenetic annotation to the glutamine-hydrolyzing carbamoyl-phosphate
+      synthase activity. This is the activity of the distinct cytosolic CPS II
+      (CAD) enzyme of pyrimidine biosynthesis, not of CPS1.
+    action: MODIFY
+    reason: &gt;-
+      GO:0004088 uses L-glutamine (plus water) as the nitrogen donor; this is the
+      activity of glutamine-dependent CPS II/CAD. Human CPS1 uses free ammonia and
+      has a defective glutaminase domain, so this term is incorrect for CPS1. The
+      essence (carbamoyl phosphate synthetase activity) is sound but the specific
+      subtype is wrong; replace with the ammonia-dependent activity GO:0004087.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: GO_REF:0000033
+        source_label: PAN-GO phylogenetic inference (CPS family tree)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          The glutamine-hydrolyzing subtype (GO:0004088) is correct for
+          glutamine-dependent CPS family members but not for human CPS1, which is
+          ammonia-dependent; the ammonia subtype GO:0004087 is the correct term.
+    proposed_replacement_terms:
+    - id: GO:0004087
+      label: carbamoyl-phosphate synthase (ammonia) activity
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        Glutamine is utilized as the endogenous source of ammonia by all types of
+        CPS31464748 except CPS12
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic annotation of the correct core catalytic activity of CPS1.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function, consistent with experimental and
+      phylogenetic annotations of the same term.
+- term:
+    id: GO:0004088
+    label: carbamoyl-phosphate synthase (glutamine-hydrolyzing) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to the glutamine-hydrolyzing CPS activity,
+      transferred from the shared CPS domain architecture. This subtype belongs to
+      CPS II, not CPS1.
+    action: MODIFY
+    reason: &gt;-
+      Same issue as the IBA GO:0004088 annotation: human CPS1 is ammonia-dependent
+      with a defective glutaminase domain and cannot hydrolyze glutamine. Replace
+      with the ammonia-dependent activity GO:0004087.
+    proposed_replacement_terms:
+    - id: GO:0004087
+      label: carbamoyl-phosphate synthase (ammonia) activity
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        The inability of human CPS1 to use glutamine is explained by the
+        replacement by serine (Ser294) in this enzyme of the key catalytic cysteine
+        of the catalytic triad
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic annotation of ATP binding. CPS1 has two ATP-grasp phosphorylation
+      domains and consumes 2 ATP per catalytic cycle; ATP binding is a genuine and
+      required molecular activity.
+    action: ACCEPT
+    reason: &gt;-
+      ATP binding is directly supported by the catalytic mechanism (two ATP-grasp
+      domains, L1 and L3) and by kinetic characterization (KM for ATP measured).
+      This is a real, core-supporting cofactor/substrate activity.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        the adenine ring sandwiched between the central β sheets of the B and C
+        subdomains (for the boundaries between the A, B and C subdomains, see
+        Supplementary Fig. 2), as is characteristic for the ATP-grasp fold
+- term:
+    id: GO:0005730
+    label: nucleolus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to nucleolus derived from the UniProt subcellular
+      location vocabulary. UniProt records a nucleus/nucleolus location from a
+      large-scale spatial proteomics study, but the enzyme&#39;s function is in the
+      mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A nucleus/nucleolus localization is reported in UniProt (from PMID:22002106)
+      and is separately supported by an IDA annotation, so it is retained, but it is
+      a secondary/moonlighting localization unrelated to the core ureagenesis
+      function of CPS1, which occurs in the mitochondrial matrix.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to mitochondrion, the correct organelle. CPS1 is a
+      mitochondrial-matrix protein.
+    action: ACCEPT
+    reason: &gt;-
+      Correct organelle-level localization; consistent with the more specific
+      mitochondrial matrix annotations and with the N-terminal mitochondrial transit
+      peptide. Retained as a valid (if less specific) location.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to plasma membrane. UniProt records a cell-membrane /
+      hepatocyte cell-surface location inferred by similarity to the mouse ortholog.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A cell-surface / plasma-membrane location is reported in UniProt as a
+      peripheral membrane protein on the extracellular side (by similarity to mouse
+      Q8C196, &#34;cell surface of hepatocytes&#34;). This is a reported secondary
+      localization, not the compartment where the core catalytic function occurs.
+      Keep as non-core rather than remove, since it is corroborated in UniProt.
+- term:
+    id: GO:0006207
+    label: &#39;&#39;&#39;de novo&#39;&#39; pyrimidine nucleobase biosynthetic process&#39;
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to de novo pyrimidine biosynthesis,
+      transferred from the shared CPS domain architecture. Pyrimidine biosynthesis
+      is the role of the cytosolic glutamine-dependent CPS II (CAD), not CPS1.
+    action: REMOVE
+    reason: &gt;-
+      In humans, carbamoyl phosphate for pyrimidine biosynthesis is made by the
+      cytosolic CPS II activity of the multifunctional CAD protein, not by
+      mitochondrial CPS1. CPS1-derived carbamoyl phosphate is committed to the urea
+      cycle. This term is a domain-based over-annotation transferred from the
+      broader CPS family.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        Human carbamoyl phosphate synthetase (CPS1), a 1500-residue multidomain
+        enzyme, catalyzes the first step of ammonia detoxification to urea
+- term:
+    id: GO:0006541
+    label: L-glutamine metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to glutamine metabolic process, inherited
+      from the glutamine-dependent CPS family. Human CPS1 does not use glutamine.
+    action: REMOVE
+    reason: &gt;-
+      Same rationale as the IBA GO:0006541 annotation: CPS1 is ammonia-dependent and
+      has a defective glutaminase domain (Cys-&gt;Ser294), so it does not participate
+      in glutamine metabolism.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        The inability of human CPS1 to use glutamine is explained by the
+        replacement by serine (Ser294) in this enzyme of the key catalytic cysteine
+        of the catalytic triad
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic annotation to metal ion binding. CPS1 uses Mg2+ (coordinated to
+      ADP at both phosphorylation sites) and K+ as essential ionic activators.
+    action: ACCEPT
+    reason: &gt;-
+      Metal ion binding is genuine: catalysis requires magnesium (coordinating the
+      nucleotides) and potassium (coordinated in the L1 K-loop). This broad term is
+      an acceptable parent; the more specific potassium ion binding is separately
+      annotated with experimental evidence.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        CPS1 affinities for its essential ionic activators potassium and magnesium
+        are increased importantly by NAG
+- term:
+    id: GO:0090407
+    label: organophosphate biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA machine-learning electronic annotation to the very broad organophosphate
+      biosynthetic process. Carbamoyl phosphate is an organophosphate, so this is
+      not wrong, but it is far more general than the specific process CPS1 performs.
+    action: MODIFY
+    reason: &gt;-
+      The product carbamoyl phosphate is technically an organophosphate, so the term
+      is not incorrect, but it is uninformatively broad. The specific process is
+      better captured by GO:0070409 carbamoyl phosphate biosynthetic process, which
+      is separately and experimentally annotated.
+    proposed_replacement_terms:
+    - id: GO:0070409
+      label: carbamoyl phosphate biosynthetic process
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12620389
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a high-throughput yeast two-hybrid screen for Raf
+      kinase interactors (A-Raf / C-Raf bait). Uninformative and not a defined
+      functional partnership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidelines, bare protein binding is uninformative about molecular
+      function. The interaction derives from an exhaustive Raf two-hybrid screen
+      (CPS1 as one of many hits) with no established functional consequence for
+      ureagenesis. Retained only as a low-value, non-core annotation.
+    supported_by:
+    - reference_id: PMID:12620389
+      supporting_text: &gt;-
+        We have performed an exhaustive unbiased yeast two-hybrid analysis to
+        identify interaction partners of two human Raf kinase isoforms, A-Raf and
+        C-Raf, using their N-terminal regulatory domain as &#34;bait.&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15161933
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a comprehensive 14-3-3 affinity-capture proteomics
+      screen. Uninformative and a large-scale-screen hit rather than a defined
+      functional interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding is uninformative. CPS1 was identified among many proteins
+      binding 14-3-3 in a global proteomics screen with no demonstrated functional
+      role in ureagenesis. Retained only as a low-value, non-core annotation.
+    supported_by:
+    - reference_id: PMID:15161933
+      supporting_text: &gt;-
+        Here we describe a global proteomics analysis to identify proteins that bind
+        to 14-3-3s during interphase and mitosis.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20618440
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a 14-3-3-binding proteomics study during
+      ceramide-induced apoptosis. Uninformative screen-derived interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding is uninformative about molecular function, and the
+      interaction comes from a large-scale 14-3-3 proteomics/affinity study.
+      Retained only as a low-value, non-core annotation.
+    supported_by:
+    - reference_id: PMID:20618440
+      supporting_text: &gt;-
+        A combination of tandem affinity purification and liquid
+        chromatography-tandem MS techniques identified 15 proteins involved in cell
+        survival processes whose 14-3-3-binding status changed during
+        C2-ceramide-induced apoptosis.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer annotation to the urea cycle, the core
+      biological process of CPS1.
+    action: ACCEPT
+    reason: &gt;-
+      CPS1 catalyzes the first committed step of the urea cycle; this is a core
+      biological-process annotation, corroborated by TAS and NAS annotations to the
+      same term.
+    supported_by:
+    - reference_id: PMID:1840546
+      supporting_text: &#39;Carbamyl phosphate synthetase I (CPSI) is the first enzyme involved in urea synthesis.&#39;
+- term:
+    id: GO:0001889
+    label: liver development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer annotation to liver development. CPS1 is
+      highly expressed in liver but is a metabolic enzyme, not a developmental
+      regulator.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a tissue/physiological-context transfer from rodent orthologs
+      reflecting hepatic expression, not a demonstrated role of CPS1 in liver
+      morphogenesis. Not a core function; keep as non-core.
+- term:
+    id: GO:0004175
+    label: endopeptidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer annotation to endopeptidase activity. CPS1
+      is a ligase (EC 6.3.4.16), not a protease; this is biologically implausible.
+    action: REMOVE
+    reason: &gt;-
+      Endopeptidase activity (hydrolysis of internal peptide bonds) is incompatible
+      with the known ligase function and structure of CPS1. This is a spurious
+      ortholog-transfer artifact with no supporting evidence.
+    supported_by:
+    - reference_id: PMID:23649895
+      supporting_text: &gt;-
+        The kinetic and molecular properties of recombinant CPS1 are essentially
+        the same as for natural human CPS1.
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer annotation to calcium ion binding. CPS1&#39;s
+      catalytically relevant ions are potassium and magnesium, not calcium.
+    action: REMOVE
+    reason: &gt;-
+      There is no evidence that CPS1 binds calcium as a functional ligand. Its
+      essential ionic activators are K+ and Mg2+. This is a spurious ortholog
+      transfer.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        CPS1 affinities for its essential ionic activators potassium and magnesium
+        are increased importantly by NAG
+- term:
+    id: GO:0005543
+    label: phospholipid binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara ortholog-transfer annotation to phospholipid binding. No
+      evidence that the matrix enzyme CPS1 binds phospholipids as part of its
+      function.
+    action: REMOVE
+    reason: &gt;-
+      CPS1 is a soluble mitochondrial-matrix ligase with no phospholipid-binding
+      function established in the literature; this is a spurious ortholog-transfer
+      artifact.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to mitochondrial inner membrane. CPS1 is a
+      soluble matrix protein; it may associate with the matrix face of the inner
+      membrane but functions in the matrix.
+    action: MODIFY
+    reason: &gt;-
+      CPS1 is characterized as a soluble mitochondrial-matrix enzyme, not an
+      integral inner-membrane protein. The more accurate location is the
+      mitochondrial matrix (GO:0005759), which is separately annotated with TAS
+      evidence.
+    proposed_replacement_terms:
+    - id: GO:0005759
+      label: mitochondrial matrix
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to cytosol. CPS1 functions in the mitochondrial
+      matrix, not the cytosol.
+    action: REMOVE
+    reason: &gt;-
+      CPS1 carries an N-terminal mitochondrial transit peptide and functions in the
+      matrix. A cytosolic location contradicts the established mitochondrial
+      localization; this ortholog-transfer term is inappropriate for the core
+      enzyme. (Any transient cytosolic pool during import is not a functional
+      location.)
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0007494
+    label: midgut development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to midgut development, reflecting intestinal
+      expression of CPS1 in model organisms. Not a demonstrated developmental role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      CPS1 is expressed in the small intestine, but this term reflects a
+      tissue-context ortholog transfer rather than a role in gut morphogenesis. Not
+      a core function; keep as non-core.
+- term:
+    id: GO:0009410
+    label: response to xenobiotic stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to stimulus&#34; annotation from rodent expression
+      studies. Reflects regulation of CPS1 abundance, not a core molecular role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      These transferred physiological-context terms describe conditions under which
+      CPS1 expression changes rather than the enzyme&#39;s molecular function. Keep as
+      non-core.
+- term:
+    id: GO:0009636
+    label: response to toxic substance
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to toxic substance&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Physiological-context term transferred from orthologs; describes regulation of
+      CPS1 rather than its molecular activity. Keep as non-core.
+- term:
+    id: GO:0010043
+    label: response to zinc ion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to zinc ion&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term; not a demonstrated molecular role of
+      human CPS1. Keep as non-core.
+- term:
+    id: GO:0014075
+    label: response to amine
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to amine&#34; annotation. Context/expression transfer,
+      not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term; describes conditions affecting CPS1
+      rather than its molecular activity. Keep as non-core.
+- term:
+    id: GO:0016595
+    label: glutamate binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to glutamate binding. CPS1&#39;s allosteric activator
+      is N-acetyl-L-glutamate (a modified amino acid), not free glutamate.
+    action: MODIFY
+    reason: &gt;-
+      The functionally important ligand of CPS1&#39;s C-terminal allosteric domain is
+      N-acetyl-L-glutamate (NAG), not free L-glutamate. Binding of the modified
+      amino acid NAG is more accurately captured by GO:0072341 modified amino acid
+      binding. The generic glutamate binding term mischaracterizes the actual
+      allosteric ligand.
+    proposed_replacement_terms:
+    - id: GO:0072341
+      label: modified amino acid binding
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        NAG binding to CPS1 as observed in the crystal structure appears to
+        genuinely reflect the binding of this effector to the enzyme in vivo.
+- term:
+    id: GO:0032094
+    label: response to food
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to food&#34; annotation. Context/expression transfer,
+      not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting dietary regulation of CPS1
+      abundance; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0032496
+    label: response to lipopolysaccharide
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to lipopolysaccharide&#34; annotation. Context transfer
+      reflecting altered CPS1 levels/release under septic conditions, not a core
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Reflects the observation that CPS1 abundance/release changes under LPS/septic
+      conditions (see PMID:15897806), which is a downstream biomarker phenomenon
+      rather than CPS1 executing an LPS-response function. Harmonized with the IDA
+      annotation to the same term, which is also marked as over-annotated.
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to the generic protein-containing complex. CPS1
+      acts predominantly as a monomer (monomer-dimer equilibrium); it is not a
+      constitutive subunit of a defined complex.
+    action: REMOVE
+    reason: &gt;-
+      CPS1 functions as a monomer (with a weak monomer-dimer equilibrium) rather
+      than as part of a stable protein complex, and no specific complex is defined.
+      The generic protein-containing complex term is uninformative and not
+      supported.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        the behavior of human CPS1 in solution as a monomer-dimer system in rapid
+        equilibrium in which the monomer predominates
+- term:
+    id: GO:0033762
+    label: response to glucagon
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to glucagon&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reflects hormonal regulation of CPS1 expression transferred from rodent
+      orthologs; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0034201
+    label: response to oleic acid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to oleic acid&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term; not a demonstrated molecular function
+      of human CPS1. Keep as non-core.
+- term:
+    id: GO:0042594
+    label: response to starvation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to starvation&#34; annotation. Fasting increases CPS1
+      glutarylation and urea-cycle flux, but this is a regulatory context, not a
+      core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reflects fasting/starvation regulation of ureagenesis and CPS1 acylation
+      rather than a distinct molecular function. Keep as non-core.
+- term:
+    id: GO:0043200
+    label: response to amino acid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to amino acid&#34; annotation. Context/expression
+      transfer reflecting dietary-protein regulation of ureagenesis.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting protein/amino-acid-load
+      regulation of the urea cycle; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0044344
+    label: cellular response to fibroblast growth factor stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;cellular response to FGF&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term; not a demonstrated molecular role of
+      human CPS1. Keep as non-core.
+- term:
+    id: GO:0044877
+    label: protein-containing complex binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to protein-containing complex binding. Generic
+      and uninformative for CPS1, a predominantly monomeric enzyme.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      No specific complex-binding function of CPS1 is established; this generic
+      transferred term is uninformative. Keep as non-core rather than assert a
+      defined functional interaction.
+- term:
+    id: GO:0048545
+    label: response to steroid hormone
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to steroid hormone&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting hormonal regulation of CPS1
+      expression; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0051384
+    label: response to glucocorticoid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to glucocorticoid&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reflects glucocorticoid regulation of CPS1 expression transferred from rodent
+      orthologs; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0051591
+    label: response to cAMP
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to cAMP&#34; annotation. Context/expression transfer,
+      not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting cAMP-mediated regulation of
+      CPS1; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0055081
+    label: monoatomic anion homeostasis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer annotation to monoatomic anion homeostasis. Not a
+      recognized function of CPS1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This transferred term does not correspond to any established CPS1 function
+      (its substrate bicarbonate is a polyatomic anion, and CPS1 is not an ion
+      transporter/homeostasis factor). Weak transfer; keep as non-core rather than
+      assert a role.
+- term:
+    id: GO:0060416
+    label: response to growth hormone
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to growth hormone&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting hormonal regulation of CPS1
+      expression; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0070365
+    label: hepatocyte differentiation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;hepatocyte differentiation&#34; annotation. CPS1 is a
+      hepatocyte marker and highly expressed in differentiated hepatocytes, but is
+      a metabolic enzyme rather than a differentiation driver.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      CPS1 is a marker of differentiated hepatocytes rather than a demonstrated
+      regulator of hepatocyte differentiation; this reflects expression context.
+      Keep as non-core.
+- term:
+    id: GO:0071320
+    label: cellular response to cAMP
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;cellular response to cAMP&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting cAMP-mediated regulation of
+      CPS1; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0071377
+    label: cellular response to glucagon stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;cellular response to glucagon stimulus&#34; annotation.
+      Context/expression transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting glucagon regulation of
+      ureagenesis/CPS1; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0071400
+    label: cellular response to oleic acid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;cellular response to oleic acid&#34; annotation.
+      Context/expression transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term; not a demonstrated molecular function
+      of human CPS1. Keep as non-core.
+- term:
+    id: GO:0071548
+    label: response to dexamethasone
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to dexamethasone&#34; annotation. Context/expression
+      transfer reflecting glucocorticoid induction of CPS1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term reflecting glucocorticoid (dexamethasone)
+      induction of CPS1 expression; not a core molecular function. Keep as non-core.
+- term:
+    id: GO:0097305
+    label: response to alcohol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transfer &#34;response to alcohol&#34; annotation. Context/expression
+      transfer, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transferred physiological-context term; not a demonstrated molecular function
+      of human CPS1. Keep as non-core.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70635
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement annotation of CPS1 in the urea cycle,
+      the core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      CPS1 catalyzes the first committed step of the urea cycle; this is a core,
+      well-supported biological-process annotation.
+    supported_by:
+    - reference_id: PMID:1840546
+      supporting_text: &#39;Carbamyl phosphate synthetase I (CPSI) is the first enzyme involved in urea synthesis.&#39;
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: EXP
+  original_reference_id: PMID:6249820
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental demonstration of carbamoyl-phosphate synthase (ammonia) activity
+      from purified human liver CPS1, including Michaelis constants for NH4+, HCO3-,
+      MgATP, and the activator N-acetyl-L-glutamate.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence for the core catalytic function using the
+      purified human enzyme. This is the central molecular function of CPS1.
+    supported_by:
+    - reference_id: PMID:6249820
+      supporting_text: &gt;-
+        The apparent Michaelis constants for NH4+, HCO3-, MgATP, and the activator,
+        N-acetyl-L-glutamic acid, were 0.8, 6.7, 1.1, and 0.1 mM, respectively.
+- term:
+    id: GO:0005730
+    label: nucleolus
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence-based (IDA) annotation to nucleolus. UniProt records a
+      nucleus/nucleolus localization from large-scale spatial proteomics, but the
+      catalytic function is in the mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A nucleus/nucleolus localization is reported in UniProt (PMID:22002106) and
+      supported here by immunofluorescence curation, so it is retained; however it
+      is a secondary localization unrelated to CPS1&#39;s core ureagenesis function in
+      the mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9955543
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to the mitochondrial matrix, the correct functional
+      location of CPS1.
+    action: ACCEPT
+    reason: &gt;-
+      The mitochondrial matrix is the established site of CPS1 catalysis and is the
+      correct, specific cellular location. Core localization.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9955504
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (SIRT5 deglutarylation of CPS1) to the mitochondrial
+      matrix, the correct functional location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct, specific core cellular location; consistent with all other matrix
+      annotations.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: EXP
+  original_reference_id: PMID:23649895
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental demonstration of the core catalytic activity using recombinant
+      human CPS1, with full kinetic characterization; this is one of the two
+      references anchoring the EC 6.3.4.16 assignment in UniProt.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence for the ammonia-dependent carbamoyl-phosphate
+      synthase activity of recombinant human CPS1. Core molecular function.
+    supported_by:
+    - reference_id: PMID:23649895
+      supporting_text: &gt;-
+        The kinetic and molecular properties of recombinant CPS1 are essentially
+        the same as for natural human CPS1.
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: EXP
+  original_reference_id: PMID:24813853
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental characterization of recombinant human CPS1 catalytic activity
+      (and the effect of clinical mutations on Vmax/Km); this is the second
+      reference anchoring the EC 6.3.4.16 assignment in UniProt.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence for the core catalytic function of human CPS1.
+      Core molecular function.
+    supported_by:
+    - reference_id: PMID:24813853
+      supporting_text: &gt;-
+        the majority of the mutations also decreased from modestly to very
+        drastically the specific activity of the fraction of the enzyme that
+        remained soluble and that could be purified, apparently because they
+        decreased V(max)
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Sequence-similarity (ISS) annotation to plasma membrane, consistent with the
+      UniProt cell-surface location inferred from the mouse ortholog.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A hepatocyte cell-surface / plasma-membrane location is reported in UniProt
+      (by similarity to mouse Q8C196). This is a reported secondary localization,
+      not the compartment of the core catalytic function. Keep as non-core.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial-proteome evidence localizing CPS1 to the
+      mitochondrion, the correct organelle.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the established mitochondrial-matrix localization; a valid
+      (organelle-level) location annotation.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0030955
+    label: potassium ion binding
+  evidence_type: EXP
+  original_reference_id: PMID:26592762
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental/structural evidence that CPS1 coordinates a potassium ion in the
+      L1 K-loop; potassium is an essential ionic activator of the bicarbonate
+      phosphorylation step.
+    action: ACCEPT
+    reason: &gt;-
+      The crystal structure shows a coordinated potassium ion in the K-loop of the
+      bicarbonate-phosphorylating domain, and potassium is required for catalysis.
+      This is a genuine, functionally important cofactor-binding activity.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        being fully structured, having at its center a coordinated potassium ion
+        (thus the name K-loop)
+- term:
+    id: GO:0036094
+    label: small molecule binding
+  evidence_type: EXP
+  original_reference_id: PMID:26592762
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental annotation to the very broad &#34;small molecule binding&#34; from the
+      structural study, which resolved ADP, NAG, potassium and magnesium binding.
+    action: MODIFY
+    reason: &gt;-
+      &#34;Small molecule binding&#34; is uninformatively broad. The structure specifically
+      resolves binding of the allosteric activator N-acetyl-L-glutamate (a modified
+      amino acid); more informative and specific terms (NAG/modified amino acid
+      binding, ATP binding, potassium/metal ion binding) are separately annotated.
+      Replace with the specific modified amino acid (NAG) binding term.
+    proposed_replacement_terms:
+    - id: GO:0072341
+      label: modified amino acid binding
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        One NAG molecule was found sitting with full occupancy in each subunit of
+        ligand-bound CPS1
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: EXP
+  original_reference_id: PMID:26592762
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental/structural evidence for metal ion binding (magnesium coordinating
+      ADP; potassium in the K-loop) in the active enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Metal ion binding is directly supported by the structure (Mg2+ coordinated to
+      the nucleotides and a coordinated K+); these ions are essential ionic
+      activators of catalysis.
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        besides having also two bound magnesium ions, hosted a potassium ion
+        coordinated to its K-loop
+- term:
+    id: GO:0042311
+    label: vasodilation
+  evidence_type: IMP
+  original_reference_id: PMID:14718356
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to vasodilation from a study associating a CPS1 coding
+      polymorphism (T1405N) with nitric-oxide-mediated forearm vasodilation. This is
+      an indirect, downstream physiological consequence, not a molecular function
+      of the enzyme.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      CPS1 influences vascular NO indirectly, by supplying carbamoyl phosphate for
+      citrulline/arginine synthesis; the study is a genotype-phenotype association
+      of a polymorphism with vascular reactivity, not evidence that CPS1 executes a
+      vasodilation process. This is an over-annotation of a distal physiological
+      effect.
+    supported_by:
+    - reference_id: PMID:14718356
+      supporting_text: &gt;-
+        a polymorphism in the gene encoding carbamoyl-phosphate synthetase 1
+        influences nitric oxide production as well as vascular smooth muscle
+        reactivity.
+- term:
+    id: GO:0070409
+    label: carbamoyl phosphate biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:21120950
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutant-phenotype evidence that CPS1 is required for carbamoyl phosphate
+      biosynthesis, from the large CPS1D mutational-spectrum study.
+    action: ACCEPT
+    reason: &gt;-
+      Carbamoyl phosphate biosynthesis is the direct product-forming process of
+      CPS1, and loss-of-function CPS1 mutations abolish it (causing hyperammonemia).
+      Core biological process, at an appropriate level of specificity.
+    supported_by:
+    - reference_id: PMID:21120950
+      supporting_text: &gt;-
+        Deficiency of carbamoyl phosphate synthetase I (CPSI) results in
+        hyperammonemia ranging from neonatally lethal to environmentally induced
+        adult-onset disease.
+- term:
+    id: GO:0071242
+    label: cellular response to ammonium ion
+  evidence_type: IMP
+  original_reference_id: PMID:21120950
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to cellular response to ammonium ion from the CPS1D mutational
+      study. CPS1 consumes ammonia as a substrate for detoxification.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      CPS1 uses ammonia as its nitrogen substrate, and its loss causes hyperammonemia,
+      so participation in the cellular handling/detoxification of ammonium is
+      reasonable. This is better regarded as a physiological framing of the core
+      urea-cycle role than a distinct core function; keep as non-core.
+    supported_by:
+    - reference_id: PMID:21120950
+      supporting_text: &gt;-
+        Deficiency of carbamoyl phosphate synthetase I (CPSI) results in
+        hyperammonemia
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70555
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to the mitochondrial matrix (the CPS1 reaction event),
+      the correct functional location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct, specific core cellular location for the site of the CPS1-catalyzed
+      reaction.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9959874
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to the mitochondrial matrix (CPS1 gene-expression
+      event context), the correct functional location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct, specific core cellular location; consistent with all other matrix
+      annotations.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        an abundant enzyme of the hepatic urea cycle, which is normally located in
+        the mitochondrial matrix.
+- term:
+    id: GO:0050667
+    label: homocysteine metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:20031578
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to homocysteine metabolic process attributed to a genome-wide
+      association study that linked a CPS1 SNP (rs7422339) to plasma homocysteine
+      levels. There is no direct evidence that CPS1 acts in homocysteine metabolism.
+    action: REMOVE
+    reason: &gt;-
+      The cited paper is a GWAS reporting a statistical association between a common
+      CPS1 variant and plasma homocysteine concentration in women; it does not
+      demonstrate that CPS1 participates in homocysteine metabolism, and the IDA
+      evidence code is misapplied. The urea cycle and one-carbon/homocysteine
+      pathways intersect only indirectly. This is an over-interpretation of a GWAS
+      signal.
+    supported_by:
+    - reference_id: PMID:20031578
+      supporting_text: &gt;-
+        we found novel associations with CPS1 (2q34; rs7422339; P=1.9 x 10(-11))
+- term:
+    id: GO:0072341
+    label: modified amino acid binding
+  evidence_type: IDA
+  original_reference_id: PMID:20031578
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Annotation to modified amino acid binding attributed to the homocysteine GWAS
+      paper. The cited reference does not demonstrate direct ligand binding, but the
+      molecular function is nonetheless correct for CPS1 for a different reason: the
+      enzyme binds the modified amino acid N-acetyl-L-glutamate as its essential
+      allosteric activator.
+    action: ACCEPT
+    reason: &gt;-
+      Modified amino acid binding is a genuine and functionally central activity of
+      CPS1, whose obligatory allosteric activator N-acetyl-L-glutamate (an
+      N-acetylated amino acid) binds a dedicated pocket in the C-terminal MGS-like
+      domain, as shown structurally. Although the original GWAS reference is a weak
+      basis, the term itself is correct and well supported by structural/biochemical
+      data. Accept (supporting evidence re-anchored to the structural study).
+    supported_by:
+    - reference_id: PMID:26592762
+      supporting_text: &gt;-
+        One NAG molecule was found sitting with full occupancy in each subunit of
+        ligand-bound CPS1
+- term:
+    id: GO:0070409
+    label: carbamoyl phosphate biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:7416778
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutant/deficiency-phenotype evidence (reduced CPS1 activity in duodenal biopsy
+      of a hyperammonemic patient) that CPS1 is required for carbamoyl phosphate
+      biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Reduced CPS1 activity in patient tissue with hyperammonemia supports CPS1&#39;s
+      required role in carbamoyl phosphate biosynthesis. Core biological process.
+    supported_by:
+    - reference_id: PMID:7416778
+      supporting_text: &gt;-
+        All enzyme levels were normal except N-acetyl glutamate-dependent carbamyl
+        phosphate synthetase 1 (CPS1) which was half the mean activity in normal
+        control specimens.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: NAS
+  original_reference_id: PMID:1840546
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-traceable author statement that CPS1 is the first enzyme of urea
+      synthesis, from the human CPS1 cDNA cloning paper.
+    action: ACCEPT
+    reason: &gt;-
+      CPS1&#39;s role in the urea cycle is a core, well-established biological process,
+      here asserted from the cloning/sequence characterization of human CPS1.
+    supported_by:
+    - reference_id: PMID:1840546
+      supporting_text: &#39;Carbamyl phosphate synthetase I (CPSI) is the first enzyme involved in urea synthesis.&#39;
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: IMP
+  original_reference_id: PMID:8486760
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Mutant-phenotype evidence (a splicing mutation causing a 9-bp in-frame
+      deletion, with markedly reduced CPS1 mRNA/protein) that links loss of CPS1 to
+      its ammonia-dependent synthetase function.
+    action: ACCEPT
+    reason: &gt;-
+      A disease-causing CPS1 mutation abolishing normal CPS1 supports the enzyme&#39;s
+      core carbamoyl-phosphate synthase (ammonia) activity. Core molecular function.
+    supported_by:
+    - reference_id: PMID:8486760
+      supporting_text: &gt;-
+        Northern and Western blots revealed a marked decrease in CPS I mRNA and
+        enzyme protein
+- term:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  evidence_type: IMP
+  original_reference_id: PMID:9711878
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Mutant-phenotype evidence: a homozygous Thr544Met missense mutation causing
+      severe (lethal) CPS1 deficiency, supporting CPS1&#39;s core synthetase function.
+    action: ACCEPT
+    reason: &gt;-
+      A disease-causing CPS1 missense mutation (Thr544Met, which structurally raises
+      the Km for bicarbonate) causing severe CPS1 deficiency supports the core
+      ammonia-dependent carbamoyl-phosphate synthase activity of CPS1.
+    supported_by:
+    - reference_id: PMID:9711878
+      supporting_text: &gt;-
+        Direct sequencing of the complete CPS1 coding region revealed a
+        disease-associated homozygous Thr544Met mutation in CPS1.
+- term:
+    id: GO:0019240
+    label: L-citrulline biosynthetic process
+  evidence_type: NAS
+  original_reference_id: PMID:14718356
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-traceable statement associating CPS1 with citrulline formation, from the
+      vascular-function polymorphism study. CPS1 does not itself synthesize
+      citrulline; it makes carbamoyl phosphate, the precursor that OTC then combines
+      with ornithine to form citrulline.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      CPS1&#39;s product (carbamoyl phosphate) feeds citrulline biosynthesis, but the
+      committed citrulline-forming reaction is catalyzed by ornithine transcarbamylase
+      (OTC), not CPS1. Annotating CPS1 to L-citrulline biosynthetic process
+      over-extends its role to a downstream step it does not catalyze; the term is
+      loosely (NAS) asserted in a vascular-genetics paper.
+    supported_by:
+    - reference_id: PMID:14718356
+      supporting_text: &gt;-
+        the enzyme catalyzing the rate-limiting step in l-citrulline formation
+- term:
+    id: GO:0019433
+    label: triglyceride catabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:9711878
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to triglyceride catabolic process attributed to an IMP in PMID:9711878.
+      The cached record for this paper is abstract-only (full_text_available: false),
+      and the abstract concerns a urea-cycle-defect (CPS1D) missense mutation with no
+      triglyceride-catabolism content; there is no known biochemical basis linking CPS1
+      (a mitochondrial urea-cycle ligase) to triglyceride catabolism.
+    action: UNDECIDED
+    reason: &gt;-
+      This is an experimental (IMP) annotation whose full text is not available in the
+      cache, so per project guidelines it should not be REMOVE&#39;d on the basis of the
+      abstract alone. The annotation looks biologically implausible / likely misassigned,
+      but adjudication is deferred pending the GOA source line or full text; a curator
+      with access should verify what phenotype the IMP actually supports.
+    supported_by:
+    - reference_id: PMID:9711878
+      supporting_text: &gt;-
+        Carbamoyl phosphate synthetase I (CPS1) deficiency is an autosomal recessive
+        metabolic disorder affecting the first enzymatic step of urea cycle.
+- term:
+    id: GO:0032496
+    label: response to lipopolysaccharide
+  evidence_type: IDA
+  original_reference_id: PMID:15897806
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to response to LPS from a study showing that CPS1 is fragmented and
+      released into the circulation under septic (LPS) conditions as a candidate
+      biomarker of hepatic mitochondrial injury.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The observation is that CPS1 protein is cleaved and released during
+      endotoxemia (making it a serum biomarker), not that CPS1 executes a functional
+      response to LPS. This is a downstream biomarker phenomenon rather than a
+      biological process in which CPS1 participates; it over-annotates the enzyme&#39;s
+      role.
+    supported_by:
+    - reference_id: PMID:15897806
+      supporting_text: &gt;-
+        We suggest that circulating CPS-1 might serve as a novel serum marker
+        indicating mitochondrial impairment of the liver and/or the small intestine
+        in critically ill patients.
+- term:
+    id: GO:0042645
+    label: mitochondrial nucleoid
+  evidence_type: IDA
+  original_reference_id: PMID:18063578
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Annotation to mitochondrial nucleoid from a study that biochemically purified
+      mtDNA nucleoids. CPS1 is among the abundant matrix proteins that co-purify with
+      native nucleoids, but the study notes several such metabolic proteins do not
+      cross-link to mtDNA.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      CPS1 is an extremely abundant matrix protein that can co-purify with native
+      nucleoid preparations, but the paper explicitly notes that several metabolic
+      proteins identified in native nucleoids were not observed to cross-link to
+      mtDNA, indicating co-purification rather than genuine nucleoid association. The
+      core functional location of CPS1 is the mitochondrial matrix; nucleoid
+      localization is likely a preparation artifact and is over-annotated.
+    supported_by:
+    - reference_id: PMID:18063578
+      supporting_text: &gt;-
+        Several other metabolic proteins and chaperones identified in native
+        nucleoids, including ATAD3, were not observed to cross-link to mtDNA.
+- term:
+    id: GO:0046209
+    label: nitric oxide metabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:14718356
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to nitric oxide metabolic process from the CPS1-polymorphism
+      vascular-function study. CPS1 affects NO only indirectly, by supplying
+      carbamoyl phosphate for the citrulline/arginine precursor pool.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The link to NO is indirect and pathway-level: CPS1 provides carbamoyl
+      phosphate for citrulline -&gt; arginine, the NO precursor, and a coding
+      polymorphism was statistically associated with NO metabolites and
+      vasodilation. CPS1 does not itself synthesize or metabolize nitric oxide; this
+      over-annotates a distal metabolic consequence.
+    supported_by:
+    - reference_id: PMID:14718356
+      supporting_text: &gt;-
+        a polymorphism in the gene encoding carbamoyl-phosphate synthetase 1
+        influences nitric oxide production as well as vascular smooth muscle
+        reactivity.
+core_functions:
+- description: &gt;-
+    CPS1 catalyzes the first, committed and rate-limiting step of the urea cycle:
+    the ATP-dependent, ammonia-utilizing synthesis of carbamoyl phosphate from
+    ammonia and bicarbonate, using 2 ATP. This ammonia detoxification reaction
+    occurs in the hepatic (and intestinal) mitochondrial matrix and has an absolute
+    allosteric requirement for the activator N-acetyl-L-glutamate.
+  molecular_function:
+    id: GO:0004087
+    label: carbamoyl-phosphate synthase (ammonia) activity
+  directly_involved_in:
+  - id: GO:0000050
+    label: urea cycle
+  - id: GO:0070409
+    label: carbamoyl phosphate biosynthetic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  substrates:
+  - id: CHEBI:28938
+    label: ammonium
+  - id: CHEBI:17544
+    label: hydrogencarbonate
+  - id: CHEBI:30616
+    label: ATP
+  supported_by:
+  - reference_id: PMID:23649895
+    supporting_text: &gt;-
+      The kinetic and molecular properties of recombinant CPS1 are essentially the
+      same as for natural human CPS1.
+  - reference_id: PMID:26592762
+    supporting_text: &gt;-
+      Human carbamoyl phosphate synthetase (CPS1), a 1500-residue multidomain
+      enzyme, catalyzes the first step of ammonia detoxification to urea requiring
+      N-acetyl-L-glutamate (NAG) as essential activator
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12620389
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast
+    two-hybrid analysis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput yeast two-hybrid screen for Raf kinase interactors; CPS1 is
+      one of many hits. Supports only a bare, low-value protein-binding annotation
+      with no established functional consequence for ureagenesis.
+- id: PMID:14718356
+  title: Relationship between carbamoyl-phosphate synthetase genotype and systemic
+    vascular function.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genotype-phenotype association of a CPS1 coding polymorphism (T1405N) with NO
+      metabolites and vasodilation. Supports only indirect, downstream physiological
+      links (vasodilation, NO metabolism, citrulline), which are over-annotations of
+      CPS1&#39;s actual molecular function.
+- id: PMID:15161933
+  title: Comprehensive proteomic analysis of interphase and mitotic 14-3-3-binding
+    proteins.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Global 14-3-3 affinity proteomics screen. Supports only a bare protein-binding
+      annotation.
+- id: PMID:15897806
+  title: Release of the mitochondrial enzyme carbamoyl phosphate synthase under septic
+    conditions.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Confirms CPS1 is normally a mitochondrial-matrix enzyme of the hepatic urea
+      cycle and shows it is fragmented/released as a serum biomarker under septic
+      (LPS) conditions. Supports matrix localization; the response-to-LPS annotation
+      is a biomarker phenomenon, not a functional role.
+- id: PMID:18063578
+  title: The layered structure of human mitochondrial DNA nucleoids.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: MISCITED
+    review_notes: &gt;-
+      Nucleoid co-purification study. CPS1 co-purifies as an abundant matrix protein,
+      but the paper notes several metabolic proteins in native nucleoids do not
+      cross-link to mtDNA; supports co-purification rather than genuine nucleoid
+      localization.
+- id: PMID:1840546
+  title: &#39;Cloning and sequence of a cDNA encoding human carbamyl phosphate synthetase
+    I: molecular analysis of hyperammonemia.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cloning/sequence of human CPS1 cDNA (1500-aa precursor with N-terminal
+      presequence); establishes CPS1 as the first enzyme of urea synthesis.
+- id: PMID:20031578
+  title: &#39;Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma homocysteine
+    in a healthy population: a genome-wide evaluation of 13 974 participants in the
+    Women&#39;&#39;s Genome Health Study.&#39;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: MISCITED
+    review_notes: &gt;-
+      GWAS association of a common CPS1 SNP with plasma homocysteine; does not
+      demonstrate that CPS1 acts in homocysteine metabolism or directly binds a
+      modified amino acid. The IDA annotations attributed to it (homocysteine
+      metabolic process; modified amino acid binding) are misapplied to this
+      reference, though modified amino acid binding is independently correct (NAG).
+- id: PMID:20618440
+  title: Proteomic and biochemical analysis of 14-3-3-binding proteins during C2-ceramide-induced
+    apoptosis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      14-3-3-binding proteomics/apoptosis study. Supports only a bare protein-binding
+      annotation.
+- id: PMID:21120950
+  title: &#39;Molecular defects in human carbamoy phosphate synthetase I: mutational spectrum,
+    diagnostic and protein structure considerations.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Comprehensive CPS1D mutational spectrum (222 changes); loss-of-function
+      mutations abolish carbamoyl phosphate biosynthesis and cause hyperammonemia.
+      Strong support for the core biological process.
+- id: PMID:23649895
+  title: Molecular characterization of carbamoyl-phosphate synthetase (CPS1) deficiency
+    using human recombinant CPS1 as a key tool.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Recombinant human CPS1 expression/purification with full kinetic
+      characterization; one of the two UniProt references anchoring EC 6.3.4.16.
+      Directly supports the core ammonia-dependent synthetase activity.
+- id: PMID:24813853
+  title: &#39;Understanding carbamoyl phosphate synthetase (CPS1) deficiency by using
+    the recombinantly purified human enzyme: effects of CPS1 mutations that concentrate
+    in a central domain of unknown function.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Recombinant human CPS1 mutational analysis (effects on Vmax/Km/stability);
+      second UniProt reference anchoring EC 6.3.4.16. Supports the core catalytic
+      function.
+- id: PMID:26592762
+  title: &#39;Structure of human carbamoyl phosphate synthetase: deciphering the on/off
+    switch of human ureagenesis.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structures of human CPS1 (apo and NAG/ADP-bound). Establishes the NAG
+      allosteric on/off switch, the two ATP-grasp phosphorylation sites, the
+      carbamate tunnel, coordinated potassium and magnesium, and the molecular basis
+      for CPS1&#39;s inability to use glutamine (Cys-&gt;Ser294). Anchors most core-function
+      and cofactor claims.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput mitochondrial-proteome study confirming CPS1&#39;s mitochondrial
+      localization.
+- id: PMID:6249820
+  title: Human carbamylphosphate synthetase I. Stabilization, purification, and partial
+    characterization of the enzyme from human liver.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Purification and partial characterization of CPS1 from human liver, including
+      Km values for NH4+, HCO3-, MgATP and the activator NAG; native MW ~190 kDa,
+      monomeric ~165 kDa. Directly supports the core catalytic activity and NAG
+      dependence.
+- id: PMID:7416778
+  title: Detection of carbamyl phosphate synthetase 1 deficiency using duodenal biopsy
+    samples.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Demonstrates reduced NAG-dependent CPS1 activity in duodenal biopsy of a
+      hyperammonemic patient; supports the requirement of CPS1 for carbamoyl
+      phosphate biosynthesis and its NAG dependence.
+- id: PMID:8486760
+  title: Carbamyl phosphate synthetase I deficiency. One base substitution in an exon
+    of the CPS I gene causes a 9-basepair deletion due to aberrant splicing.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Molecular characterization of a splicing mutation causing CPS1 deficiency;
+      supports the loss-of-function-to-phenotype link for the core synthetase
+      function.
+- id: PMID:9711878
+  title: Prenatal diagnosis of carbamoyl phosphate synthetase I deficiency by identification
+    of a missense mutation in CPS1.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Prenatal diagnosis of severe CPS1D via a homozygous Thr544Met mutation.
+      Supports the core synthetase function; the triglyceride-catabolism annotation
+      attributed to this paper is unsupported and should be removed.
+- id: Reactome:R-HSA-70555
+  title: 2 ATP + NH4+ + HCO3- =&gt; 2 ADP + orthophosphate + carbamoyl phosphate [mitochondrial]
+  findings: []
+- id: Reactome:R-HSA-70635
+  title: Urea cycle
+  findings: []
+- id: Reactome:R-HSA-9955504
+  title: SIRT5 deglutarylates CPS1
+  findings: []
+- id: Reactome:R-HSA-9955543
+  title: CPS1 variants don&#39;t synthesize carbamoyl phosphate
+  findings: []
+- id: Reactome:R-HSA-9959874
+  title: CPS1 gene expression
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/NAGS/NAGS-ai-review.html
+++ b/genes/human/NAGS/NAGS-ai-review.html
@@ -1,0 +1,3651 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NAGS - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>NAGS</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8N159" target="_blank" class="term-link">
+                        Q8N159
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "NAGS";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8N159" data-a="DESCRIPTION: N-acetylglutamate synthase (NAGS; EC 2.3.1.1) is a..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>N-acetylglutamate synthase (NAGS; EC 2.3.1.1) is a nuclear-encoded, mitochondrial-matrix enzyme that catalyzes the formation of N-acetyl-L-glutamate (NAG) from L-glutamate and acetyl-CoA. In mammals, NAG is the obligate allosteric activator of carbamoyl phosphate synthetase 1 (CPS1), the first and rate-limiting enzyme of the urea cycle; NAGS therefore functions as the regulatory gate of hepatic ureagenesis and ammonia detoxification. Although NAG is not consumed stoichiometrically in the urea cycle, the cycle cannot proceed without it. The enzyme is a homotetramer whose subunits comprise an N-terminal amino-acid-kinase (AAK) domain that binds the allosteric activator L-arginine (which enhances mammalian NAGS activity) and a C-terminal GCN5-related N-acetyltransferase (NAT) domain that is catalytically competent on its own. NAGS is expressed mainly in liver, kidney and small intestine and is imported into the mitochondrion via a cleaved N-terminal transit peptide. Biallelic loss-of-function variants cause N-acetylglutamate synthase deficiency, an autosomal recessive urea cycle disorder presenting with hyperammonemia (without orotic aciduria) that, uniquely among urea cycle disorders, is specifically treatable with the NAG analogue carglumic acid.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0006526" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to arginine biosynthesis. NAGS catalyzes the acetylation of L-glutamate to N-acetyl-L-glutamate, the committed first step of the acetylated ornithine route to L-arginine (UniProt PATHWAY UPA00068: &#34;N(2)-acetyl-L-ornithine from L-glutamate: step 1/4&#34;). This is the conserved ancestral function of the family across bacteria, plants and fungi. In mammals the NAG product is primarily used to activate CPS1 in the urea cycle rather than to make net arginine, but the enzymatic role at the head of the acetylornithine pathway is real and correctly captured.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported family-conserved involvement in the acetylglutamate branch that leads to arginine biosynthesis; consistent with UniProt PATHWAY annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link">
+                                        PMID:23894642
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In microorganisms and plants, NAG is further converted to NAG phosphate by NAG kinase (NAGK, EC 2.7.2.8) to continue the L-arginine biosynthetic pathway</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0005759" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing NAGS activity in the mitochondrial matrix. Human NAGS was purified from human liver mitochondria and carries a cleaved N-terminal mitochondrial transit peptide; the enzyme acts in the matrix where its substrates and CPS1 reside.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core subcellular location, supported experimentally by purification from human liver mitochondria and by the presence of a mitochondrial targeting sequence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7126172" target="_blank" class="term-link">
+                                        PMID:7126172
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">was isolated from human liver mitochondria by precipitation with (NH4)2SO4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    GO:0004042
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0004042" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation of the core catalytic activity (EC 2.3.1.1): acetylation of L-glutamate by acetyl-CoA to yield N-acetyl-L-glutamate and CoA (RHEA:24292). This is the defining molecular function of NAGS and is directly supported by human enzymology and structure.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the primary, experimentally established molecular function of the gene product.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12459178" target="_blank" class="term-link">
+                                        PMID:12459178
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-acetylglutamate synthase (NAGS, E.C. 2.3.1.1) is a mitochondrial enzyme catalyzing the formation of N-acetylglutamate (NAG)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006536" target="_blank" class="term-link">
+                                    GO:0006536
+                                </a>
+                            </span>
+                            <span class="term-label">glutamate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0006536" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to glutamate metabolism. NAGS consumes L-glutamate as a substrate, so the annotation is not incorrect, but &#34;glutamate metabolic process&#34; is a broad parent term that does not convey the specific biological role of NAGS (making the CPS1 activator NAG / feeding the acetylornithine pathway).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True but generic; L-glutamate is the substrate, yet the specific processes (arginine biosynthesis / urea cycle regulation) are more informative and are captured by other annotations. Retain as a peripheral, non-core process term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link">
+                                        PMID:23894642
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the conversion of AcCoA and L-glutamate to CoA and N-acetyl-L-glutamate (NAG)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    GO:0004042
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0004042" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) annotation of the core catalytic activity from combined automated methods (ARBA, RHEA:24292, InterPro, ortholog transfer). Consistent with the experimentally established EC 2.3.1.1 activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific molecular-function assignment; agrees with experimental annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) annotation from the UniProt Swiss-Prot subcellular-location mapping (SL-0170, mitochondrion matrix). Matches the experimentally supported matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location, corroborated by purification of the enzyme from liver mitochondria and by the IBA/TAS matrix annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                    GO:0006526
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0006526" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) annotation to arginine biosynthesis from InterPro/UniPathway (UPA00068). Same rationale as the IBA arginine-biosynthesis annotation: NAGS performs the committed acetylglutamate-forming step of the acetylornithine pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the conserved pathway role and with the IBA annotation of the same term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016747" target="_blank" class="term-link">
+                                    GO:0016747
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity, transferring groups other than amino-acyl groups</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0016747" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) InterPro2GO annotation derived from the generic GNAT/N-acetyltransferase domain signature (IPR000182). This is a broad parent term (&#34;acyltransferase activity, transferring groups other than amino-acyl groups&#34;) that only states NAGS is an acyltransferase. The specific, experimentally established activity of this enzyme, GO:0004042 (L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor), is already annotated, so the generic parent is an over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic acyltransferase term should be refined to the known specific activity GO:0004042. NAGS is not a general acyltransferase acting on multiple acceptors; its physiological (and only demonstrated) acetyl-acceptor is L-glutamate. Replace with the specific EC 2.3.1.1 term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link">
+                                        PMID:23894642
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The NAT domain has a typical GCN5-related NAT fold and a site that catalyzes NAG synthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090461" target="_blank" class="term-link">
+                                    GO:0090461
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular glutamate homeostasis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21757002" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21757002
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The nuclear receptor FXR regulates hepatic transport and met...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0090461" data-r="PMID:21757002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation (BHF-UCL) from a study showing that the nuclear receptor FXR regulates hepatic glutamine/glutamate metabolism and directly induces NAGS expression via an FXRE in the NAGS promoter. In this context NAGS contributes to handling of the intracellular glutamate pool by consuming glutamate to form NAG. The cached publication is abstract-only (full_text_available: false); the experimental annotation reflects the curator&#39;s reading of the full text and should not be removed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> NAGS uses glutamate as a substrate and its expression is coupled to hepatic glutamate/glutamine metabolism, so a role in intracellular glutamate homeostasis is defensible but peripheral. It is not the core evolved function (production of the CPS1 activator NAG), so retain as non-core rather than remove; defer to the experimental curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21757002" target="_blank" class="term-link">
+                                        PMID:21757002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Glutamine is taken up by periportal hepatocytes and is the major source of ammonia for urea synthesis and glutamate for N-acetylglutamate (NAG) synthesis, which is catalyzed by the N-acetylglutamate synthase (NAGS).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21757002" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21757002
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The nuclear receptor FXR regulates hepatic transport and met...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0000050" data-r="PMID:21757002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation (BHF-UCL) to the urea cycle. NAGS produces N-acetyl-L-glutamate, the obligate allosteric activator of CPS1, the first enzyme of the urea cycle; loss of NAGS causes hyperammonemia because CPS1 is inactive without NAG. NAGS is thus the regulatory gate of ureagenesis. The cached reference is abstract-only, but the urea-cycle role of NAGS is independently and strongly established by multiple sources.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological role. Although NAG is not stoichiometrically consumed in the cycle, NAGS is indispensable for urea cycle function; the annotation correctly captures this involvement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21757002" target="_blank" class="term-link">
+                                        PMID:21757002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">major source of ammonia for urea synthesis and glutamate for N-acetylglutamate (NAG) synthesis, which is catalyzed by the N-acetylglutamate synthase (NAGS)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12459178" target="_blank" class="term-link">
+                                        PMID:12459178
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Patients with NAGS deficiency develop hyperammonemia because CPSI is inactive without NAG.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    GO:0004042
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21757002" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21757002
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The nuclear receptor FXR regulates hepatic transport and met...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0004042" data-r="PMID:21757002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation of the core catalytic activity (EC 2.3.1.1). Redundant with the multiple experimental IDA/EXP and IBA/IEA annotations of the same term; correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct assignment of the specific molecular function; duplicate of the experimentally supported activity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9955697
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0005759" data-r="Reactome:R-HSA-9955697" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation (Reactome) placing NAGS in the mitochondrial matrix, consistent with all other localization evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location; agrees with the IBA/IEA/TAS matrix annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    GO:0004042
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12459178" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12459178
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning and expression of the human N-acetylglutamate syntha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0004042" data-r="PMID:12459178" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) annotation. Recombinant human NAGS (conserved domain) complemented an NAGS-deficient E. coli strain and displayed arginine-responsive NAGS catalytic activity, directly demonstrating the EC 2.3.1.1 activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental demonstration of the core catalytic activity in the human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12459178" target="_blank" class="term-link">
+                                        PMID:12459178
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the recombinant protein has arginine-responsive NAGS catalytic activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (HTP) annotation from a quantitative high-confidence human mitochondrial proteome study, identifying NAGS as a mitochondrial protein. Consistent with the more precise matrix localization; &#34;mitochondrion&#34; is a correct but less specific parent term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization supported by proteomics; the specific compartment (matrix) is captured by other annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    GO:0004042
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23894642
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the N-acetyltransferase domain of human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0004042" data-r="PMID:23894642" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation from the crystal structure and enzymology of the human NAGS N-acetyltransferase (NAT) domain in complex with N-acetyl-L-glutamate. The study directly measured NAGS catalytic activity (with substrate-dependence, mutagenesis of active-site residues) confirming EC 2.3.1.1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental (structural + kinetic) demonstration of the core catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link">
+                                        PMID:23894642
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">NAGS deficiency results in elevated levels of plasma ammonia which is neurotoxic. We report herein the first crystal structure of human NAGS, that of the catalytic N-acetyltransferase (hNAT) domain with N-acetyl-L-glutamate bound at 2.1 Å resolution.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                                    GO:0004042
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7126172" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7126172
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and properties of acetyl-CoA:L-glutamate N-acet...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0004042" data-r="PMID:7126172" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation from the classic purification and kinetic characterization of acetyl-CoA:L-glutamate N-acetyltransferase (EC 2.3.1.1) from human liver, establishing the substrate/product kinetics of the enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental demonstration of the core catalytic activity in native human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7126172" target="_blank" class="term-link">
+                                        PMID:7126172
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Acetyl-CoA:L-glutamate N-acetyltransferase (amino acid acetyltransferase, EC 2.3.1.1) was isolated from human liver mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7126172" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7126172
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and properties of acetyl-CoA:L-glutamate N-acet...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0005739" data-r="PMID:7126172" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation of mitochondrial localization, based on purification of the enzyme from human liver mitochondria. Correct; the finer matrix localization is captured by other annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct experimentally supported localization; consistent with the matrix annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7126172" target="_blank" class="term-link">
+                                        PMID:7126172
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">was isolated from human liver mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70542
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N159" data-a="GO:0005759" data-r="Reactome:R-HSA-70542" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation (Reactome) for the reaction &#34;glutamate + acetyl CoA =&gt; N-acetyl glutamate + CoA&#34; localizing NAGS to the mitochondrial matrix. Consistent with all other localization evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location; duplicate of the matrix annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>NAGS catalyzes the acetylation of L-glutamate by acetyl-CoA to produce N-acetyl-L-glutamate (NAG) and CoA (EC 2.3.1.1) in the mitochondrial matrix. NAG is the obligate allosteric activator of carbamoyl phosphate synthetase 1 (CPS1), so NAGS provides the essential regulatory input that gates the urea cycle and hepatic ammonia detoxification.</h3>
+                <span class="vote-buttons" data-g="Q8N159" data-a="FUNCTION: NAGS catalyzes the acetylation of L-glutamate by a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004042" target="_blank" class="term-link">
+                            L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006526" target="_blank" class="term-link">
+                                L-arginine biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12459178" target="_blank" class="term-link">
+                                PMID:12459178
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">N-acetylglutamate synthase (NAGS, E.C. 2.3.1.1) is a mitochondrial enzyme catalyzing the formation of N-acetylglutamate (NAG), an essential allosteric activator of carbamylphosphate synthase I (CPSI), the first enzyme of the urea cycle.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link">
+                                PMID:23894642
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">NAGS deficiency results in elevated levels of plasma ammonia which is neurotoxic.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12459178" target="_blank" class="term-link">
+                            PMID:12459178
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning and expression of the human N-acetylglutamate synthase gene.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21757002" target="_blank" class="term-link">
+                            PMID:21757002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The nuclear receptor FXR regulates hepatic transport and metabolism of glutamine and glutamate.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" target="_blank" class="term-link">
+                            PMID:23894642
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of the N-acetyltransferase domain of human N-acetyl-L-glutamate synthase in complex with N-acetyl-L-glutamate provides insights into its catalytic and regulatory mechanisms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7126172" target="_blank" class="term-link">
+                            PMID:7126172
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Purification and properties of acetyl-CoA:L-glutamate N-acetyltransferase from human liver.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70542
+
+                    </span>
+                </div>
+
+                <div class="reference-title">glutamate + acetyl CoA =&gt; N-acetyl glutamate + CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9955697
+
+                    </span>
+                </div>
+
+                <div class="reference-title">NAGS variants don&#39;t synthesize N-acetylglutamate</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NAGS-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N159" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: Human NAGS (N-Acetylglutamate Synthase)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">45 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:56:06.093810</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="NAGS-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-human-nags-n-acetylglutamate-synthase">Comprehensive Research Report: Human NAGS (N-Acetylglutamate Synthase)</h1>
+<h2 id="geneprotein-identity-verification">Gene/Protein Identity Verification</h2>
+<p>The gene symbol <strong>NAGS</strong> unambiguously corresponds to human <strong>N-acetylglutamate synthase, mitochondrial</strong> (UniProt: Q8N159; EC 2.3.1.1; Ensembl: ENSG00000161653). The protein belongs to the acetyltransferase family and contains the expected amino acid kinase-like (AAK) and GNAT acetyltransferase (NAT) domains, consistent with the UniProt annotation. The literature is concordant with this identity.</p>
+<p>The following table summarizes key properties of human NAGS:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Human NAGS summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene symbol</td>
+<td><strong>NAGS</strong> (N-acetylglutamate synthase) (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, caldovic2010nacetylglutamatesynthasestructure pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>Q8N159</strong></td>
+</tr>
+<tr>
+<td>EC number</td>
+<td><strong>EC 2.3.1.1</strong> (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, caldovic2024dataminingapproachesfor pages 2-4)</td>
+</tr>
+<tr>
+<td>Enzyme classification</td>
+<td><strong>Acetyltransferase</strong>; specifically an N-acetylglutamate synthase in the acetyltransferase family (shi2015thenacetylglutamatesynthase pages 1-3, caldovic2010nacetylglutamatesynthasestructure pages 1-2)</td>
+</tr>
+<tr>
+<td>Reaction catalyzed</td>
+<td><strong>L-glutamate + acetyl-CoA → N-acetylglutamate (NAG) + CoA</strong> (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, caldovic2010nacetylglutamatesynthasestructure pages 4-5, shi2015thenacetylglutamatesynthase pages 1-3)</td>
+</tr>
+<tr>
+<td>Substrates</td>
+<td><strong>L-glutamate</strong> and <strong>acetyl-CoA</strong>; human enzyme shows high specificity for these substrates (shi2015thenacetylglutamatesynthase pages 3-6, shi2015thenacetylglutamatesynthase pages 1-3)</td>
+</tr>
+<tr>
+<td>Product</td>
+<td><strong>N-acetylglutamate (NAG)</strong>, the essential allosteric activator of CPS1 (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, caldovic2003nacetylglutamateandits pages 7-8)</td>
+</tr>
+<tr>
+<td>Allosteric activator</td>
+<td><strong>L-arginine</strong>; activates mammalian NAGS about <strong>2–5-fold</strong>, with <strong>Ka ~30–50 µM</strong> (caldovic2003nacetylglutamateandits pages 7-8, shi2015thenacetylglutamatesynthase pages 3-6)</td>
+</tr>
+<tr>
+<td>Km for glutamate</td>
+<td>Reported range <strong>~1–8.1 mM</strong> depending on preparation/assay system (shi2015thenacetylglutamatesynthase pages 3-6)</td>
+</tr>
+<tr>
+<td>Km for acetyl-CoA</td>
+<td>Reported range <strong>~0.7–4.4 mM</strong> depending on preparation/assay system (shi2015thenacetylglutamatesynthase pages 3-6)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Mitochondrial matrix</strong> (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, shi2015thenacetylglutamatesynthase pages 3-6)</td>
+</tr>
+<tr>
+<td>Tissue expression</td>
+<td>Highest in <strong>liver</strong> and <strong>small intestine</strong>; lower expression reported in <strong>kidney, testis, spleen</strong> (morizono2004mammaliannacetylglutamatesynthase. pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein length</td>
+<td><strong>534 aa preprotein</strong> with N-terminal mitochondrial targeting sequence (morizono2004mammaliannacetylglutamatesynthase. pages 1-2)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>N-terminal <strong>AAK (amino acid kinase-like) domain</strong> plus C-terminal <strong>NAT/GNAT acetyltransferase domain</strong>; also contains an N-terminal variable segment (shi2015thenacetylglutamatesynthase pages 6-8, shi2015thenacetylglutamatesynthase pages 11-15, caldovic2010nacetylglutamatesynthasestructure pages 1-2)</td>
+</tr>
+<tr>
+<td>Oligomeric state</td>
+<td>Reported as <strong>trimeric</strong> in some studies, with evidence for arginine-dependent oligomerization behavior; vertebrate-like NAGS family members also discussed in relation to <strong>tetrameric</strong> organization/models (shi2015thenacetylglutamatesynthase pages 3-6, shi2015thenacetylglutamatesynthase pages 1-3)</td>
+</tr>
+<tr>
+<td>Disease association</td>
+<td><strong>NAGS deficiency (NAGSD)</strong> causing <strong>hyperammonemia</strong> / urea cycle dysfunction; strong disease-target association in Open Targets (morizono2004mammaliannacetylglutamatesynthase. pages 4-5, mew2011nacetylglutamatesynthasedeficiency pages 1-2, OpenTargets Search: -NAGS)</td>
+</tr>
+<tr>
+<td>Drug / functional replacement therapy</td>
+<td><strong>N-carbamylglutamate (carglumic acid / carbamylglutamate)</strong>, a stable NAG analog that activates CPS1 and can normalize ammonia in NAGSD (caldovic2010nacetylglutamatesynthasestructure pages 5-7, singh2024theefficacyof pages 1-2, mew2011nacetylglutamatesynthasedeficiency pages 5-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes core biochemical, cellular, and clinical properties of human NAGS, including its catalytic reaction, regulation, localization, and disease relevance. It is useful as a compact reference for the functional annotation of UniProt Q8N159.</em></p>
+<h2 id="1-enzymatic-function-and-catalytic-reaction">1. Enzymatic Function and Catalytic Reaction</h2>
+<p>Human N-acetylglutamate synthase (NAGS; EC 2.3.1.1) catalyzes the formation of N-acetylglutamate (NAG) from two substrates, L-glutamate and acetyl-coenzyme A (acetyl-CoA), releasing free CoA as a by-product (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, shi2015thenacetylglutamatesynthase pages 1-3). This acetylation reaction is the committed step in the production of NAG in mammalian hepatocytes. The catalytic mechanism involves a direct nucleophilic attack by the α-amino nitrogen of L-glutamate on the acetyl group of acetyl-CoA, rather than proceeding through a ping-pong mechanism (caldovic2010nacetylglutamatesynthasestructure pages 4-5).</p>
+<h3 id="substrate-specificity-and-kinetic-parameters">Substrate Specificity and Kinetic Parameters</h3>
+<p>Human NAGS exhibits high substrate specificity. Studies on human liver NAGS reported apparent Km values of 4.4 mM for acetyl-CoA and 8.1 mM for L-glutamate, whereas studies using recombinant rat NAGS yielded lower Km values of 0.7 mM for acetyl-CoA and 1 mM for L-glutamate, which are considered more representative of the purified enzyme (shi2015thenacetylglutamatesynthase pages 3-6). The enzyme displays very low activity with alternative amino acid substrates: only 5.0% activity with glutamine and 2.9% with glycine relative to glutamate. Similarly, acetyl-CoA is highly specific as the acyl donor, with only 4.3% activity toward propionyl-CoA and no measurable activity with other acyl-CoA derivatives (shi2015thenacetylglutamatesynthase pages 3-6).</p>
+<h2 id="2-domain-structure-and-protein-architecture">2. Domain Structure and Protein Architecture</h2>
+<p>Human NAGS is synthesized as a 534-amino acid preprotein (morizono2004mammaliannacetylglutamatesynthase. pages 1-2). The protein contains three structurally distinct regions:</p>
+<ul>
+<li><strong>Mitochondrial targeting signal (MTS):</strong> Residues 1–49 at the N-terminus, which direct the protein to the mitochondrial matrix and are cleaved upon import (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, morizono2004mammaliannacetylglutamatesynthase. pages 2-4).</li>
+<li><strong>Variable domain:</strong> A ~40–50 amino acid segment rich in charged residues and prolines that lacks defined secondary structure. This domain is unique to mammalian NAGS and may facilitate protein–protein interactions with other mitochondrial partners (shi2015thenacetylglutamatesynthase pages 6-8, shi2015thenacetylglutamatesynthase pages 15-17).</li>
+<li><strong>Conserved segment:</strong> Contains two independently folded functional domains connected by a short 1–3 amino acid linker:</li>
+<li>An N-terminal <strong>amino acid kinase-like (AAK) domain</strong> (approximately residues 137–373), featuring an eight-stranded β-sheet core flanked by α-helices. This domain binds L-arginine and provides the structural framework for allosteric regulation (shi2015thenacetylglutamatesynthase pages 6-8, shi2015thenacetylglutamatesynthase pages 11-15, caldovic2010nacetylglutamatesynthasestructure pages 1-2).</li>
+<li>A C-terminal <strong>N-acetyltransferase (NAT/GNAT) domain</strong> (approximately residues 377–472), adopting a seven-stranded β-sheet αβα sandwich fold characteristic of GCN5-related acetyltransferases. This domain harbors the catalytic site where both acetyl-CoA and L-glutamate bind (shi2015thenacetylglutamatesynthase pages 6-8, shi2015thenacetylglutamatesynthase pages 1-3, shi2015thenacetylglutamatesynthase pages 11-15).</li>
+</ul>
+<p>While only the NAT domain has significant NAGS catalytic activity, the AAK domain is essential for enhancing enzymatic activity and mediating arginine-dependent allosteric regulation (shi2015thenacetylglutamatesynthase pages 11-15, shi2015thenacetylglutamatesynthase pages 15-17). Vertebrate-like NAGS proteins have a tetrameric quaternary structure, distinguishing them from classical bacterial NAGS enzymes, which form hexamers (shi2015thenacetylglutamatesynthase pages 1-3). Mammalian NAGS exists as a trimer whose oligomerization state depends on L-arginine concentration (shi2015thenacetylglutamatesynthase pages 3-6).</p>
+<h2 id="3-subcellular-localization-and-tissue-expression">3. Subcellular Localization and Tissue Expression</h2>
+<p>Human NAGS is targeted to the <strong>mitochondrial matrix</strong> where it carries out its catalytic function (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, shi2015thenacetylglutamatesynthase pages 3-6). The N-terminal mitochondrial targeting signal is cleaved upon import into the mitochondria. Two possible signal peptide cleavage sites have been predicted after amino acid positions 31 and 49, generating long and short mature forms (morizono2004mammaliannacetylglutamatesynthase. pages 1-2).</p>
+<h3 id="post-translational-processing-and-multiple-forms">Post-translational Processing and Multiple Forms</h3>
+<p>Studies on mouse NAGS have revealed a bipartite mitochondrial import mechanism similar to ornithine transcarbamylase. Two cleavage events occur after mitochondrial import: (1) cleavage of the canonical mitochondrial leader peptide after amino acid 50, and (2) a second cleavage at the end of the variable domain after amino acid 91 (morizono2004mammaliannacetylglutamatesynthase. pages 4-5). This processing generates two mature forms:</p>
+<ul>
+<li><strong>NAGS-M (mature NAGS):</strong> Retains the variable domain after MTS removal.</li>
+<li><strong>NAGS-C (conserved domain NAGS):</strong> Lacks both the MTS and the variable segment.</li>
+</ul>
+<p>Both forms are catalytically active with similar substrate affinities; however, NAGS-C exhibits approximately two-fold higher maximal velocity compared to NAGS-M (caldovic2010nacetylglutamatesynthasestructure pages 1-2).</p>
+<h3 id="tissue-distribution">Tissue Distribution</h3>
+<p>NAGS is primarily expressed in <strong>liver</strong> and <strong>small intestine</strong>, the tissues where carbamoyl phosphate synthetase 1 (CPS1) is exclusively expressed (morizono2004mammaliannacetylglutamatesynthase. pages 1-2). Lower expression levels are also detectable in kidney, testis, and spleen, suggesting potential additional roles beyond the urea cycle (morizono2004mammaliannacetylglutamatesynthase. pages 1-2). Notably, one study reported that NAGS immunoreactivity was not detected in kidney or spleen tissue, indicating that the primary physiological expression is hepatic and intestinal (shi2015thenacetylglutamatesynthase pages 3-6).</p>
+<h2 id="4-role-in-the-urea-cycle-and-biochemical-pathway">4. Role in the Urea Cycle and Biochemical Pathway</h2>
+<p>The primary physiological role of human NAGS is to produce N-acetylglutamate (NAG), which serves as an <strong>essential and obligatory allosteric activator</strong> of carbamoyl phosphate synthetase 1 (CPS1), the first and rate-limiting enzyme of the urea cycle (morizono2004mammaliannacetylglutamatesynthase. pages 1-2, caldovic2003nacetylglutamateandits pages 7-8, haskins2016effectofarginine pages 1-2). Without NAG, CPS1 is catalytically inactive, and the entire urea cycle—which converts toxic ammonia into non-toxic urea—is effectively shut down.</p>
+<h3 id="regulatory-function-in-ureagenesis">Regulatory Function in Ureagenesis</h3>
+<p>NAG concentrations in liver mitochondria are similar to the activation constant (Ka) of CPS1 for NAG, positioning NAG as a key flux regulator of the urea cycle (caldovic2003nacetylglutamateandits pages 7-8, caldovic2003nacetylglutamateandits pages 6-7). The regulation operates through a <strong>double positive feedback loop</strong>: L-arginine (the end-product of the urea cycle) allosterically activates NAGS to produce NAG, which in turn activates CPS1 (caldovic2010nacetylglutamatesynthasestructure pages 2-4, haskins2008inversionofallosteric pages 9-10). This arrangement creates a rapid and robust ammonia detoxification system that protects the central nervous system from hyperammonemia (caldovic2010nacetylglutamatesynthasestructure pages 2-4).</p>
+<p>Increased dietary protein and ammonia intake are associated with elevated NAGS activity and hepatic NAG content, allowing modulation of urea cycle flux at relatively constant ammonium concentrations (caldovic2003nacetylglutamateandits pages 7-8).</p>
+<h2 id="5-allosteric-regulation-by-l-arginine">5. Allosteric Regulation by L-Arginine</h2>
+<p>L-arginine is the primary allosteric activator of mammalian NAGS, increasing enzymatic activity 2–5-fold at saturating substrate concentrations, with an activation constant (Ka) of 30–50 µM (caldovic2003nacetylglutamateandits pages 7-8, shi2015thenacetylglutamatesynthase pages 3-6). This Ka corresponds well to physiological liver arginine concentrations, ensuring physiological relevance of the activation mechanism. The activation is highly specific to L-arginine; among structural analogues, only L-argininic acid produces similar activation, and both bind to the same site (shi2015thenacetylglutamatesynthase pages 3-6). Arginine increases enzyme velocity without significantly affecting substrate affinity (caldovic2003nacetylglutamateandits pages 6-7, shi2015thenacetylglutamatesynthase pages 3-6).</p>
+<p>The arginine-binding site is located at the C-terminus of the AAK domain near the AAK-NAT domain interface and is defined by a conserved motif (E-(L/I)-(F/M)-(T/S)-X-X-G-X-G-T) (shi2015thenacetylglutamatesynthase pages 8-11). In mammalian NAGS, arginine binding induces a conformational change causing the NAT domain to undergo marked reorientation relative to the AAK domain, enabling their productive interaction (caldovic2010nacetylglutamatesynthasestructure pages 2-4). Arginine binding also affects NAGS oligomerization state: in mouse NAGS, the partition coefficient increases in the presence of L-arginine, suggesting a smaller hydrodynamic radius due to a conformational or oligomerization change (haskins2016effectofarginine pages 1-2).</p>
+<p>The physiological importance of arginine activation was demonstrated in vivo using NAGS knockout mice treated with AAV vectors encoding either wild-type NAGS or the arginine-insensitive E354A mutant. Mice expressing E354A mutant NAGS were viable but maintained chronically elevated plasma ammonia despite equivalent protein expression levels, demonstrating that arginine activation is essential for normal ureagenesis (sonaimuthu2021genedeliverycorrects pages 1-2, sonaimuthu2021genedeliverycorrects pages 8-11).</p>
+<h2 id="6-evolutionary-perspective">6. Evolutionary Perspective</h2>
+<p>NAGS has undergone a remarkable evolutionary transformation in its allosteric regulation. In microorganisms and plants, NAGS catalyzes the first committed step of arginine biosynthesis and is <strong>inhibited</strong> by arginine as part of end-product feedback regulation (haskins2008inversionofallosteric pages 8-9, caldovic2010nacetylglutamatesynthasestructure pages 1-2). During the evolution of vertebrates from aquatic to terrestrial habitats, the allosteric effect of arginine on NAGS inverted from inhibition to activation (haskins2008inversionofallosteric pages 8-9, haskins2008inversionofallosteric pages 9-10).</p>
+<p>This transition was gradual across vertebrate phylogeny: bacterial NAGS shows complete inhibition by arginine, fish NAGS (zebrafish, pufferfish) shows partial inhibition, and amphibian and mammalian NAGS shows full activation (haskins2008inversionofallosteric pages 9-10, haskins2008inversionofallosteric pages 1-2). The four invariant amino acids responsible for arginine binding are conserved from bacteria to mammals, indicating that the same binding site produces different conformational outcomes depending on species-specific structural context (haskins2008inversionofallosteric pages 8-9, haskins2008inversionofallosteric pages 4-5). This allosteric inversion coincided with the transition from CPS III (in fish) to CPS I (in tetrapods) and is considered a molecular marker for tetrapod evolution (haskins2008inversionofallosteric pages 8-9, haskins2008inversionofallosteric pages 9-10).</p>
+<p>Phylogenetically, mammalian NAGS evolved from a bifunctional N-acetylglutamate synthase-kinase (NAGS-K) ancestor, retaining the acetyltransferase activity while losing the kinase activity that is no longer needed in animals (qu2007anovelbifunctional pages 11-12, shi2015thenacetylglutamatesynthase pages 11-15). The mammalian NAGS gene was not identified until 2002 due to very low sequence similarity (~20–30%) with classical bacterial NAGS (shi2015thenacetylglutamatesynthase pages 1-3, caldovic2010nacetylglutamatesynthasestructure pages 2-4).</p>
+<h2 id="7-clinical-significance-nags-deficiency">7. Clinical Significance: NAGS Deficiency</h2>
+<h3 id="disease-overview">Disease Overview</h3>
+<p>NAGS deficiency (NAGSD; OMIM #237310) is an autosomal recessive urea cycle disorder and the <strong>rarest</strong> of all urea cycle defects, with an estimated incidence of less than 1 in 2,000,000 live births (singh2024theefficacyof pages 1-2). As of 2024, only approximately 105 cases from 79 families have been reported worldwide (caldovic2024dataminingapproachesfor pages 2-4). The condition is uniquely treatable among urea cycle disorders because a pharmacological substitute for NAG is available (mew2011nacetylglutamatesynthasedeficiency pages 5-6). OpenTargets analysis confirms strong disease-target associations for NAGS with hyperammonemia due to NAGS deficiency (association score 0.84) and hereditary disease (score 0.87) (OpenTargets Search: -NAGS).</p>
+<h3 id="clinical-presentation">Clinical Presentation</h3>
+<p>NAGS deficiency presents with hyperammonemia that can range from severe neonatal onset to mild late-onset forms. Neonatal presentations typically include poor feeding, vomiting, lethargy, hypertonia or hypotonia, seizures, and tachypnea (kenneson2020presentationandmanagement pages 6-7, singh2024theefficacyof pages 1-2). Late-onset cases may present with cyclic vomiting, behavioral changes, headaches, ataxia, and decreased consciousness, sometimes not diagnosed until adulthood (kenneson2020presentationandmanagement pages 6-7, logt2016hyperammonemiadueto pages 2-4). Biochemically, affected individuals show elevated plasma ammonia and glutamine, with low-to-normal citrulline and normal urinary orotic acid, a profile indistinguishable from CPS1 deficiency (mew2011nacetylglutamatesynthasedeficiency pages 1-2, caldovic2010nacetylglutamatesynthasestructure pages 5-7).</p>
+<h3 id="genotype-phenotype-correlations">Genotype-Phenotype Correlations</h3>
+<p>Missense mutations in the C-terminal NAT domain typically cause severe neonatal-onset disease with less than 5% residual enzyme activity, often involving frameshift or nonsense mutations (kenneson2020presentationandmanagement pages 6-7, caldovic2010nacetylglutamatesynthasestructure pages 5-7). Mutations in the AAK domain tend to cause later-onset phenotypes and may affect arginine regulation rather than catalysis directly (kenneson2020presentationandmanagement pages 6-7). Residual NAGS activity as low as 5% can result in milder, late-onset disease (caldovic2024dataminingapproachesfor pages 4-6).</p>
+<h3 id="treatment">Treatment</h3>
+<p>NAGS deficiency is uniquely treatable with <strong>N-carbamylglutamate (NCG; carglumic acid, Carbaglu®)</strong>, a stable structural analog of NAG that directly activates CPS1 and is resistant to enzymatic degradation by acylase (caldovic2010nacetylglutamatesynthasestructure pages 5-7, mew2011nacetylglutamatesynthasedeficiency pages 5-6). NCG normalizes plasma ammonia levels within 8 hours during acute hyperammonemic crises and is effective as long-term maintenance therapy at doses of 15–200 mg/kg/day (caldovic2010nacetylglutamatesynthasestructure pages 5-7, mew2011nacetylglutamatesynthasedeficiency pages 5-6). All patients studied have responded well to carbamylglutamate therapy, with normalization of plasma ammonia, citrulline, and urine orotic acid (singh2024theefficacyof pages 1-2). A 3-day NCG trial at 2.2 g/m²/day can serve both diagnostic and therapeutic purposes (caldovic2010nacetylglutamatesynthasestructure pages 5-7).</p>
+<h2 id="8-recent-developments-2024">8. Recent Developments (2024)</h2>
+<h3 id="recombinant-human-nags-for-variant-assessment">Recombinant Human NAGS for Variant Assessment</h3>
+<p>Gougeard et al. (2024) developed a stabilized chimeric form of human NAGS (the conserved domain fused with maltose binding protein, MBP-cHuNAGS) for assessing the pathogenicity of missense variants found in NAGSD patients. They characterized 23 nonsynonymous single-base changes and found that for all but one variant (A279T), disease causation was explained by the enzymatic alterations identified, including loss of arginine activation, increased Km for glutamate, active site inactivation, decreased thermal stability, and protein misfolding (gougeard2024useofpure pages 14-16). Importantly, 17 of the 23 variants showed increased tendency to misfold, suggesting that NAGSD may fundamentally function as a <strong>protein misfolding disease</strong>. The study also revealed that wild-type human NAGS loses 25% of activity at fever temperature (40°C), suggesting thermal instability as a clinically relevant disease mechanism. The authors suggest that pharmacochaperones could represent a novel therapeutic strategy (gougeard2024useofpure pages 14-16).</p>
+<h3 id="transcriptional-regulation-and-prevalence-studies">Transcriptional Regulation and Prevalence Studies</h3>
+<p>Caldovic et al. (2024) used datamining approaches to investigate the low prevalence of NAGSD and identify novel regulatory elements in the NAGS gene and other urea cycle genes. They discovered a <strong>novel regulatory element in the first intron</strong> of the NAGS gene through ENCODE database analysis and identified eight deleterious sequence variants in NAGS splicing regions and cis-acting regulatory elements (caldovic2024dataminingapproachesfor pages 2-4, caldovic2024dataminingapproachesfor pages 1-2). Their analysis suggests that the rarity of NAGSD may be due to several factors: (1) the NAGS protein fold tolerates amino acid substitutions unusually well, with NAGS monomers from different organisms sharing only ~20% sequence identity while maintaining similar three-dimensional structures; (2) the NAGS catalytic domain has a small genomic footprint (comprising only 29.5% of the protein); and (3) alternative metabolic sources of NAG or NCG may exist in the body (caldovic2024dataminingapproachesfor pages 4-6).</p>
+<h3 id="nutritional-management">Nutritional Management</h3>
+<p>Singh et al. (2024) reported on the efficacy of carbamylglutamate in seven NAGS deficiency cases, demonstrating that protein restriction is generally not necessary when patients are maintained on adequate carbamylglutamate therapy, though disruption of access to the drug can have severe consequences including hyperammonemic episodes with poor long-term outcomes (singh2024theefficacyof pages 1-2).</p>
+<h3 id="gene-therapy">Gene Therapy</h3>
+<p>Sonaimuthu et al. (2021) demonstrated successful AAV2/8-based gene therapy for NAGS deficiency in knockout mice. Doses of 10¹⁰ and 10¹¹ viral particles completely rescued Nags−/− mice from hyperammonemia, with NAGS protein expression matching or exceeding wild-type levels (sonaimuthu2021genedeliverycorrects pages 5-6, sonaimuthu2021genedeliverycorrects pages 6-8). The study also demonstrated that arginine-insensitive NAGS (E354A mutant) failed to fully correct hyperammonemia despite equivalent protein expression, confirming the physiological essentiality of arginine-mediated NAGS activation (sonaimuthu2021genedeliverycorrects pages 1-2, sonaimuthu2021genedeliverycorrects pages 8-11).</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>Human NAGS (Q8N159) is a mitochondrial matrix acetyltransferase that catalyzes the synthesis of N-acetylglutamate from L-glutamate and acetyl-CoA. Its primary biological role is to produce NAG, the obligatory allosteric activator of CPS1, the first and rate-limiting enzyme of the urea cycle. NAGS is allosterically activated by L-arginine, creating a double positive feedback loop that enables rapid and robust ammonia detoxification. The enzyme is predominantly expressed in liver and small intestine, consistent with its role in hepatic ureagenesis. NAGS deficiency is the rarest urea cycle disorder but is uniquely treatable with the NAG analog N-carbamylglutamate (carglumic acid). Recent research (2024) has revealed that many NAGSD-causing mutations lead to protein misfolding, opening potential therapeutic avenues with pharmacochaperones, while novel cis-regulatory elements in the NAGS gene continue to be discovered through genomic datamining approaches.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(morizono2004mammaliannacetylglutamatesynthase. pages 1-2): Hiroki Morizono, Ljubica Caldovic, Dashuang Shi, and Mendel Tuchman. Mammalian n-acetylglutamate synthase. Molecular genetics and metabolism, 81 Suppl 1:S4-11, Apr 2004. URL: https://doi.org/10.1016/j.ymgme.2003.10.017, doi:10.1016/j.ymgme.2003.10.017. This article has 76 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caldovic2010nacetylglutamatesynthasestructure pages 1-2): Ljubica Caldovic, Nicholas Ah Mew, Dashuang Shi, Hiroki Morizono, Marc Yudkoff, and Mendel Tuchman. N-acetylglutamate synthase: structure, function and defects. Molecular genetics and metabolism, 100 Suppl 1:S13-9, Jan 2010. URL: https://doi.org/10.1016/j.ymgme.2010.02.018, doi:10.1016/j.ymgme.2010.02.018. This article has 95 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caldovic2024dataminingapproachesfor pages 2-4): Ljubica Caldovic, Julie J. Ahn, Jacklyn Andricovic, Veronica M. Balick, Mallory Brayer, Pamela A. Chansky, Tyson Dawson, Alex C. Edwards, Sara E. Felsen, Karim Ismat, Sveta V. Jagannathan, Brendan T. Mann, Jacob A. Medina, Toshio Morizono, Michio Morizono, Shatha Salameh, Neerja Vashist, Emily C. Williams, Zhe Zhou, and Hiroki Morizono. Datamining approaches for examining the low prevalence of n‐acetylglutamate synthase deficiency and understanding transcriptional regulation of urea cycle genes. Journal of Inherited Metabolic Disease, 47:1175-1193, Nov 2024. URL: https://doi.org/10.1002/jimd.12687, doi:10.1002/jimd.12687. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shi2015thenacetylglutamatesynthase pages 1-3): Dashuang Shi, Norma Allewell, and Mendel Tuchman. The n-acetylglutamate synthase family: structures, function and mechanisms. International Journal of Molecular Sciences, 16:13004-13022, Jun 2015. URL: https://doi.org/10.3390/ijms160613004, doi:10.3390/ijms160613004. This article has 46 citations.</p>
+</li>
+<li>
+<p>(caldovic2010nacetylglutamatesynthasestructure pages 4-5): Ljubica Caldovic, Nicholas Ah Mew, Dashuang Shi, Hiroki Morizono, Marc Yudkoff, and Mendel Tuchman. N-acetylglutamate synthase: structure, function and defects. Molecular genetics and metabolism, 100 Suppl 1:S13-9, Jan 2010. URL: https://doi.org/10.1016/j.ymgme.2010.02.018, doi:10.1016/j.ymgme.2010.02.018. This article has 95 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shi2015thenacetylglutamatesynthase pages 3-6): Dashuang Shi, Norma Allewell, and Mendel Tuchman. The n-acetylglutamate synthase family: structures, function and mechanisms. International Journal of Molecular Sciences, 16:13004-13022, Jun 2015. URL: https://doi.org/10.3390/ijms160613004, doi:10.3390/ijms160613004. This article has 46 citations.</p>
+</li>
+<li>
+<p>(caldovic2003nacetylglutamateandits pages 7-8): Ljubica CALDOVIC and Mendel TUCHMAN. N-acetylglutamate and its changing role through evolution. The Biochemical journal, 372 Pt 2:279-90, Jun 2003. URL: https://doi.org/10.1042/bj20030002, doi:10.1042/bj20030002. This article has 194 citations.</p>
+</li>
+<li>
+<p>(shi2015thenacetylglutamatesynthase pages 6-8): Dashuang Shi, Norma Allewell, and Mendel Tuchman. The n-acetylglutamate synthase family: structures, function and mechanisms. International Journal of Molecular Sciences, 16:13004-13022, Jun 2015. URL: https://doi.org/10.3390/ijms160613004, doi:10.3390/ijms160613004. This article has 46 citations.</p>
+</li>
+<li>
+<p>(shi2015thenacetylglutamatesynthase pages 11-15): Dashuang Shi, Norma Allewell, and Mendel Tuchman. The n-acetylglutamate synthase family: structures, function and mechanisms. International Journal of Molecular Sciences, 16:13004-13022, Jun 2015. URL: https://doi.org/10.3390/ijms160613004, doi:10.3390/ijms160613004. This article has 46 citations.</p>
+</li>
+<li>
+<p>(morizono2004mammaliannacetylglutamatesynthase. pages 4-5): Hiroki Morizono, Ljubica Caldovic, Dashuang Shi, and Mendel Tuchman. Mammalian n-acetylglutamate synthase. Molecular genetics and metabolism, 81 Suppl 1:S4-11, Apr 2004. URL: https://doi.org/10.1016/j.ymgme.2003.10.017, doi:10.1016/j.ymgme.2003.10.017. This article has 76 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mew2011nacetylglutamatesynthasedeficiency pages 1-2): Nicholas Ah Mew and Nicholas Ah Mew. N-acetylglutamate synthase deficiency: an insight into the genetics, epidemiology, pathophysiology, and treatment. The Application of Clinical Genetics, pages 127, Aug 2011. URL: https://doi.org/10.2147/tacg.s12702, doi:10.2147/tacg.s12702. This article has 53 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -NAGS): Open Targets Query (-NAGS, 9 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(caldovic2010nacetylglutamatesynthasestructure pages 5-7): Ljubica Caldovic, Nicholas Ah Mew, Dashuang Shi, Hiroki Morizono, Marc Yudkoff, and Mendel Tuchman. N-acetylglutamate synthase: structure, function and defects. Molecular genetics and metabolism, 100 Suppl 1:S13-9, Jan 2010. URL: https://doi.org/10.1016/j.ymgme.2010.02.018, doi:10.1016/j.ymgme.2010.02.018. This article has 95 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2024theefficacyof pages 1-2): Rani H. Singh, Marie-Hélène Bourdages, Angela Kurtz, Erin MacLoed, Chelsea Norman, Suzanne Ratko, Sandra C. van Calcar, and Aileen Kenneson. The efficacy of carbamylglutamate impacts the nutritional management of patients with n-acetylglutamate synthase deficiency. Orphanet Journal of Rare Diseases, Apr 2024. URL: https://doi.org/10.1186/s13023-024-03167-0, doi:10.1186/s13023-024-03167-0. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mew2011nacetylglutamatesynthasedeficiency pages 5-6): Nicholas Ah Mew and Nicholas Ah Mew. N-acetylglutamate synthase deficiency: an insight into the genetics, epidemiology, pathophysiology, and treatment. The Application of Clinical Genetics, pages 127, Aug 2011. URL: https://doi.org/10.2147/tacg.s12702, doi:10.2147/tacg.s12702. This article has 53 citations.</p>
+</li>
+<li>
+<p>(morizono2004mammaliannacetylglutamatesynthase. pages 2-4): Hiroki Morizono, Ljubica Caldovic, Dashuang Shi, and Mendel Tuchman. Mammalian n-acetylglutamate synthase. Molecular genetics and metabolism, 81 Suppl 1:S4-11, Apr 2004. URL: https://doi.org/10.1016/j.ymgme.2003.10.017, doi:10.1016/j.ymgme.2003.10.017. This article has 76 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shi2015thenacetylglutamatesynthase pages 15-17): Dashuang Shi, Norma Allewell, and Mendel Tuchman. The n-acetylglutamate synthase family: structures, function and mechanisms. International Journal of Molecular Sciences, 16:13004-13022, Jun 2015. URL: https://doi.org/10.3390/ijms160613004, doi:10.3390/ijms160613004. This article has 46 citations.</p>
+</li>
+<li>
+<p>(haskins2016effectofarginine pages 1-2): N. Haskins, Amy Mumo, P. H. Brown, M. Tuchman, H. Morizono, and L. Caldovic. Effect of arginine on oligomerization and stability of n-acetylglutamate synthase. Scientific Reports, Dec 2016. URL: https://doi.org/10.1038/srep38711, doi:10.1038/srep38711. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caldovic2003nacetylglutamateandits pages 6-7): Ljubica CALDOVIC and Mendel TUCHMAN. N-acetylglutamate and its changing role through evolution. The Biochemical journal, 372 Pt 2:279-90, Jun 2003. URL: https://doi.org/10.1042/bj20030002, doi:10.1042/bj20030002. This article has 194 citations.</p>
+</li>
+<li>
+<p>(caldovic2010nacetylglutamatesynthasestructure pages 2-4): Ljubica Caldovic, Nicholas Ah Mew, Dashuang Shi, Hiroki Morizono, Marc Yudkoff, and Mendel Tuchman. N-acetylglutamate synthase: structure, function and defects. Molecular genetics and metabolism, 100 Suppl 1:S13-9, Jan 2010. URL: https://doi.org/10.1016/j.ymgme.2010.02.018, doi:10.1016/j.ymgme.2010.02.018. This article has 95 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haskins2008inversionofallosteric pages 9-10): Nantaporn Haskins, Maria Panglao, Qiuhao Qu, Himani Majumdar, Juan Cabrera-Luque, Hiroki Morizono, Mendel Tuchman, and Ljubica Caldovic. Inversion of allosteric effect of arginine on n-acetylglutamate synthase, a molecular marker for evolution of tetrapods. BMC Biochemistry, 9:24-24, Sep 2008. URL: https://doi.org/10.1186/1471-2091-9-24, doi:10.1186/1471-2091-9-24. This article has 38 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shi2015thenacetylglutamatesynthase pages 8-11): Dashuang Shi, Norma Allewell, and Mendel Tuchman. The n-acetylglutamate synthase family: structures, function and mechanisms. International Journal of Molecular Sciences, 16:13004-13022, Jun 2015. URL: https://doi.org/10.3390/ijms160613004, doi:10.3390/ijms160613004. This article has 46 citations.</p>
+</li>
+<li>
+<p>(sonaimuthu2021genedeliverycorrects pages 1-2): P. Sonaimuthu, E. Senkevitch, N. Haskins, P. Uapinyoying, M. McNutt, H. Morizono, M. Tuchman, and L. Caldovic. Gene delivery corrects n-acetylglutamate synthase deficiency and enables insights in the physiological impact of l-arginine activation of n-acetylglutamate synthase. Scientific Reports, Feb 2021. URL: https://doi.org/10.1038/s41598-021-82994-8, doi:10.1038/s41598-021-82994-8. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sonaimuthu2021genedeliverycorrects pages 8-11): P. Sonaimuthu, E. Senkevitch, N. Haskins, P. Uapinyoying, M. McNutt, H. Morizono, M. Tuchman, and L. Caldovic. Gene delivery corrects n-acetylglutamate synthase deficiency and enables insights in the physiological impact of l-arginine activation of n-acetylglutamate synthase. Scientific Reports, Feb 2021. URL: https://doi.org/10.1038/s41598-021-82994-8, doi:10.1038/s41598-021-82994-8. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haskins2008inversionofallosteric pages 8-9): Nantaporn Haskins, Maria Panglao, Qiuhao Qu, Himani Majumdar, Juan Cabrera-Luque, Hiroki Morizono, Mendel Tuchman, and Ljubica Caldovic. Inversion of allosteric effect of arginine on n-acetylglutamate synthase, a molecular marker for evolution of tetrapods. BMC Biochemistry, 9:24-24, Sep 2008. URL: https://doi.org/10.1186/1471-2091-9-24, doi:10.1186/1471-2091-9-24. This article has 38 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haskins2008inversionofallosteric pages 1-2): Nantaporn Haskins, Maria Panglao, Qiuhao Qu, Himani Majumdar, Juan Cabrera-Luque, Hiroki Morizono, Mendel Tuchman, and Ljubica Caldovic. Inversion of allosteric effect of arginine on n-acetylglutamate synthase, a molecular marker for evolution of tetrapods. BMC Biochemistry, 9:24-24, Sep 2008. URL: https://doi.org/10.1186/1471-2091-9-24, doi:10.1186/1471-2091-9-24. This article has 38 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haskins2008inversionofallosteric pages 4-5): Nantaporn Haskins, Maria Panglao, Qiuhao Qu, Himani Majumdar, Juan Cabrera-Luque, Hiroki Morizono, Mendel Tuchman, and Ljubica Caldovic. Inversion of allosteric effect of arginine on n-acetylglutamate synthase, a molecular marker for evolution of tetrapods. BMC Biochemistry, 9:24-24, Sep 2008. URL: https://doi.org/10.1186/1471-2091-9-24, doi:10.1186/1471-2091-9-24. This article has 38 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qu2007anovelbifunctional pages 11-12): Qiuhao Qu, Hiroki Morizono, Dashuang Shi, Mendel Tuchman, and Ljubica Caldovic. A novel bifunctional n-acetylglutamate synthase-kinase from xanthomonas campestris that is closely related to mammalian n-acetylglutamate synthase. BMC Biochemistry, 8:4-4, Apr 2007. URL: https://doi.org/10.1186/1471-2091-8-4, doi:10.1186/1471-2091-8-4. This article has 34 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kenneson2020presentationandmanagement pages 6-7): Aileen Kenneson and Rani H. Singh. Presentation and management of n-acetylglutamate synthase deficiency: a review of the literature. Orphanet Journal of Rare Diseases, Oct 2020. URL: https://doi.org/10.1186/s13023-020-01560-z, doi:10.1186/s13023-020-01560-z. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(logt2016hyperammonemiadueto pages 2-4): Anne-Els van de Logt, Leo A. J. Kluijtmans, Marleen C. D. G. Huigen, and Mirian C. H. Janssen. Hyperammonemia due to adult-onset n-acetylglutamate synthase deficiency. JIMD reports, 31:95-99, May 2016. URL: https://doi.org/10.1007/8904_2016_565, doi:10.1007/8904_2016_565. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caldovic2024dataminingapproachesfor pages 4-6): Ljubica Caldovic, Julie J. Ahn, Jacklyn Andricovic, Veronica M. Balick, Mallory Brayer, Pamela A. Chansky, Tyson Dawson, Alex C. Edwards, Sara E. Felsen, Karim Ismat, Sveta V. Jagannathan, Brendan T. Mann, Jacob A. Medina, Toshio Morizono, Michio Morizono, Shatha Salameh, Neerja Vashist, Emily C. Williams, Zhe Zhou, and Hiroki Morizono. Datamining approaches for examining the low prevalence of n‐acetylglutamate synthase deficiency and understanding transcriptional regulation of urea cycle genes. Journal of Inherited Metabolic Disease, 47:1175-1193, Nov 2024. URL: https://doi.org/10.1002/jimd.12687, doi:10.1002/jimd.12687. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gougeard2024useofpure pages 14-16): Nadine Gougeard, Enea Sancho‐Vaello, M. Leonor Fernández‐Murga, Borja Martínez‐Sinisterra, Badr Loukili‐Hassani, Johannes Häberle, Clara Marco‐Marín, and Vicente Rubio. Use of pure recombinant human enzymes to assess the disease‐causing potential of missense mutations in urea cycle disorders, applied to n‐acetylglutamate synthase deficiency. Journal of Inherited Metabolic Disease, 47:1194-1212, May 2024. URL: https://doi.org/10.1002/jimd.12747, doi:10.1002/jimd.12747. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caldovic2024dataminingapproachesfor pages 1-2): Ljubica Caldovic, Julie J. Ahn, Jacklyn Andricovic, Veronica M. Balick, Mallory Brayer, Pamela A. Chansky, Tyson Dawson, Alex C. Edwards, Sara E. Felsen, Karim Ismat, Sveta V. Jagannathan, Brendan T. Mann, Jacob A. Medina, Toshio Morizono, Michio Morizono, Shatha Salameh, Neerja Vashist, Emily C. Williams, Zhe Zhou, and Hiroki Morizono. Datamining approaches for examining the low prevalence of n‐acetylglutamate synthase deficiency and understanding transcriptional regulation of urea cycle genes. Journal of Inherited Metabolic Disease, 47:1175-1193, Nov 2024. URL: https://doi.org/10.1002/jimd.12687, doi:10.1002/jimd.12687. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sonaimuthu2021genedeliverycorrects pages 5-6): P. Sonaimuthu, E. Senkevitch, N. Haskins, P. Uapinyoying, M. McNutt, H. Morizono, M. Tuchman, and L. Caldovic. Gene delivery corrects n-acetylglutamate synthase deficiency and enables insights in the physiological impact of l-arginine activation of n-acetylglutamate synthase. Scientific Reports, Feb 2021. URL: https://doi.org/10.1038/s41598-021-82994-8, doi:10.1038/s41598-021-82994-8. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sonaimuthu2021genedeliverycorrects pages 6-8): P. Sonaimuthu, E. Senkevitch, N. Haskins, P. Uapinyoying, M. McNutt, H. Morizono, M. Tuchman, and L. Caldovic. Gene delivery corrects n-acetylglutamate synthase deficiency and enables insights in the physiological impact of l-arginine activation of n-acetylglutamate synthase. Scientific Reports, Feb 2021. URL: https://doi.org/10.1038/s41598-021-82994-8, doi:10.1038/s41598-021-82994-8. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="NAGS-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>shi2015thenacetylglutamatesynthase pages 3-6</li>
+<li>caldovic2010nacetylglutamatesynthasestructure pages 4-5</li>
+<li>shi2015thenacetylglutamatesynthase pages 1-3</li>
+<li>caldovic2010nacetylglutamatesynthasestructure pages 1-2</li>
+<li>caldovic2010nacetylglutamatesynthasestructure pages 2-4</li>
+<li>caldovic2003nacetylglutamateandits pages 7-8</li>
+<li>shi2015thenacetylglutamatesynthase pages 8-11</li>
+<li>haskins2016effectofarginine pages 1-2</li>
+<li>singh2024theefficacyof pages 1-2</li>
+<li>caldovic2024dataminingapproachesfor pages 2-4</li>
+<li>mew2011nacetylglutamatesynthasedeficiency pages 5-6</li>
+<li>kenneson2020presentationandmanagement pages 6-7</li>
+<li>caldovic2024dataminingapproachesfor pages 4-6</li>
+<li>caldovic2010nacetylglutamatesynthasestructure pages 5-7</li>
+<li>gougeard2024useofpure pages 14-16</li>
+<li>shi2015thenacetylglutamatesynthase pages 6-8</li>
+<li>shi2015thenacetylglutamatesynthase pages 11-15</li>
+<li>mew2011nacetylglutamatesynthasedeficiency pages 1-2</li>
+<li>shi2015thenacetylglutamatesynthase pages 15-17</li>
+<li>caldovic2003nacetylglutamateandits pages 6-7</li>
+<li>haskins2008inversionofallosteric pages 9-10</li>
+<li>sonaimuthu2021genedeliverycorrects pages 1-2</li>
+<li>sonaimuthu2021genedeliverycorrects pages 8-11</li>
+<li>haskins2008inversionofallosteric pages 8-9</li>
+<li>haskins2008inversionofallosteric pages 1-2</li>
+<li>haskins2008inversionofallosteric pages 4-5</li>
+<li>qu2007anovelbifunctional pages 11-12</li>
+<li>logt2016hyperammonemiadueto pages 2-4</li>
+<li>caldovic2024dataminingapproachesfor pages 1-2</li>
+<li>sonaimuthu2021genedeliverycorrects pages 5-6</li>
+<li>sonaimuthu2021genedeliverycorrects pages 6-8</li>
+<li>https://doi.org/10.1016/j.ymgme.2003.10.017,</li>
+<li>https://doi.org/10.1016/j.ymgme.2010.02.018,</li>
+<li>https://doi.org/10.1002/jimd.12687,</li>
+<li>https://doi.org/10.3390/ijms160613004,</li>
+<li>https://doi.org/10.1042/bj20030002,</li>
+<li>https://doi.org/10.2147/tacg.s12702,</li>
+<li>https://doi.org/10.1186/s13023-024-03167-0,</li>
+<li>https://doi.org/10.1038/srep38711,</li>
+<li>https://doi.org/10.1186/1471-2091-9-24,</li>
+<li>https://doi.org/10.1038/s41598-021-82994-8,</li>
+<li>https://doi.org/10.1186/1471-2091-8-4,</li>
+<li>https://doi.org/10.1186/s13023-020-01560-z,</li>
+<li>https://doi.org/10.1007/8904_2016_565,</li>
+<li>https://doi.org/10.1002/jimd.12747,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NAGS-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N159" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="nags-n-acetylglutamate-synthase-mitochondrial-review-notes">NAGS (N-acetylglutamate synthase, mitochondrial) — review notes</h1>
+<p>UniProt: Q8N159 (NAGS_HUMAN). Human, 534 aa precursor with N-terminal mitochondrial<br />
+transit peptide. EC 2.3.1.1.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>NAGS catalyzes: L-glutamate + acetyl-CoA = N-acetyl-L-glutamate (NAG) + CoA + H+<br />
+  (RHEA:24292, EC 2.3.1.1). This is the exact GO term GO:0004042<br />
+  "L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor"<br />
+  (synonym: "N-acetylglutamate synthase activity").<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12459178" title="N-acetylglutamate synthase (NAGS, E.C. 2.3.1.1) is a mitochondrial enzyme catalyzing the formation of N-acetylglutamate (NAG), an essential allosteric activator of carbamylphosphate synthase I (CPSI), the first enzyme of the urea cycle.">PMID:12459178</a></li>
+<li>NAG is the OBLIGATE allosteric activator of CPS1 (the first, rate-limiting enzyme of<br />
+  the urea cycle). Without NAG, CPS1 is inactive → hyperammonemia.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12459178" title="Patients with NAGS deficiency develop hyperammonemia because CPSI is inactive without NAG.">PMID:12459178</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23894642" title="an obligate cofactor for carbamyl phosphate synthetase I (CPSI) in the urea cycle">PMID:23894642</a></li>
+<li>Thus NAGS is the REGULATORY GATE of the urea cycle: not stoichiometrically part of the<br />
+  cycle, but the cycle cannot run without its product. In mammals NAG's role is entirely<br />
+  urea-cycle-related, NOT ongoing arginine biosynthesis (unlike bacteria/plants where NAG<br />
+  is the committed step of de novo arginine biosynthesis).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23894642" title="In microorganisms and plants, NAG is further converted to NAG phosphate by NAG kinase (NAGK, EC 2.7.2.8) to continue the L-arginine biosynthetic pathway ... However, in mammals, NAG has an entirely different role as the essential cofactor for carbamyl phosphate synthetase I (CPSI) in the urea cycle">PMID:23894642</a></li>
+<li>Localization: mitochondrial matrix (of hepatocytes and enterocytes). Enzyme purified<br />
+  from human liver mitochondria.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/7126172" title="Acetyl-CoA:L-glutamate N-acetyltransferase (amino acid acetyltransferase, EC 2.3.1.1) was isolated from human liver mitochondria">PMID:7126172</a></li>
+<li>Regulation: activity INCREASED by L-arginine in mammals (opposite of bacterial NAGS,<br />
+  which is arginine-inhibited). L-arginine binds the AAK (amino-acid kinase) domain.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23894642" title="in mammals, L-arginine enhances the NAGS activity">PMID:23894642</a></li>
+<li>Architecture: two domains — N-terminal AAK (amino-acid kinase-like, arginine binding /<br />
+  regulatory) and C-terminal NAT (GCN5-related N-acetyltransferase, catalytic). The NAT<br />
+  domain alone retains catalytic activity.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23894642" title="the hNAT domain retains catalytic activity in the absence of the amino acid kinase (AAK) domain. Instead, the major functions of the AAK domain appear to be providing a binding site for the allosteric activator, L-arginine, and an N-terminal proline-rich motif that is likely to function in signal transduction to CPS1.">PMID:23894642</a></li>
+<li>Quaternary structure: homodimer / homotetramer. <a href="https://pubmed.ncbi.nlm.nih.gov/23894642" title="native NAGS from human and mouse exists in tetrameric form">PMID:23894642</a></li>
+<li>Tissue: highly expressed in adult liver, kidney, small intestine. [UniProt TISSUE SPECIFICITY]</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>NAGS deficiency (NAGSD; MIM:237310; MONDO:0009377) — autosomal recessive urea cycle<br />
+disorder, hyperammonemia without orotic aciduria; clinically indistinguishable from CPS1<br />
+deficiency. Uniquely treatable with carglumic acid (N-carbamyl-L-glutamate), a stable NAG<br />
+analogue that directly activates CPS1. [dismech N-Acetylglutamate_Synthase_Deficiency.yaml]</p>
+<h2 id="annotation-specific-notes">Annotation-specific notes</h2>
+<ul>
+<li>GO:0016747 (acyltransferase activity, transferring groups other than amino-acyl groups):<br />
+  IEA from InterPro GNAT domain (IPR000182). This is a broad parent of GO:0004042. Since the<br />
+  specific activity GO:0004042 is experimentally established and also present, GO:0016747 is<br />
+  an over-annotation (too general) → MODIFY to GO:0004042.</li>
+<li>GO:0006536 (glutamate metabolic process): IBA, true (NAG synthesis consumes glutamate) but<br />
+  broad; keep as non-core.</li>
+<li>GO:0006526 (L-arginine biosynthetic process): IBA + IEA. NAGS catalyzes step 1 of the<br />
+  L-arginine/ornithine biosynthetic pathway from glutamate (UniProt PATHWAY: UPA00068 UER00106,<br />
+  "N(2)-acetyl-L-ornithine from L-glutamate: step 1/4"). This is the canonical phylogenetic<br />
+  function of the family; accept, though in mammals the NAG product is primarily used to<br />
+  activate CPS1 rather than for net arginine synthesis. Accept (family-conserved committed step).</li>
+<li>GO:0090461 (intracellular glutamate homeostasis) IDA + GO:0000050 (urea cycle) IDA from<br />
+  PMID:21757002 (FXR paper). Cached publication is abstract-only (full_text_available: false);<br />
+  the BHF-UCL curator read the full text. Do not remove experimental annotations. urea cycle is<br />
+  a genuine core role; intracellular glutamate homeostasis is more peripheral → keep as non-core.</li>
+<li>GO:0005739 mitochondrion (HTP PMID:34800366; IDA PMID:7126172): broader than matrix but<br />
+  correct; accept.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>Falcon deep-research file (NAGS-deep-research-falcon.md) did not land during the polling<br />
+window (~12+ min). Review grounded in UniProt Q8N159, seeded GOA, cached publications<br />
+(PMID:12459178, 7126172, 23894642, 21757002, 34800366), and dismech disorder entry.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8N159
+gene_symbol: NAGS
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  N-acetylglutamate synthase (NAGS; EC 2.3.1.1) is a nuclear-encoded, mitochondrial-matrix
+  enzyme that catalyzes the formation of N-acetyl-L-glutamate (NAG) from L-glutamate and
+  acetyl-CoA. In mammals, NAG is the obligate allosteric activator of carbamoyl phosphate
+  synthetase 1 (CPS1), the first and rate-limiting enzyme of the urea cycle; NAGS therefore
+  functions as the regulatory gate of hepatic ureagenesis and ammonia detoxification. Although
+  NAG is not consumed stoichiometrically in the urea cycle, the cycle cannot proceed without it.
+  The enzyme is a homotetramer whose subunits comprise an N-terminal amino-acid-kinase (AAK)
+  domain that binds the allosteric activator L-arginine (which enhances mammalian NAGS activity)
+  and a C-terminal GCN5-related N-acetyltransferase (NAT) domain that is catalytically competent
+  on its own. NAGS is expressed mainly in liver, kidney and small intestine and is imported into
+  the mitochondrion via a cleaved N-terminal transit peptide. Biallelic loss-of-function variants
+  cause N-acetylglutamate synthase deficiency, an autosomal recessive urea cycle disorder
+  presenting with hyperammonemia (without orotic aciduria) that, uniquely among urea cycle
+  disorders, is specifically treatable with the NAG analogue carglumic acid.
+existing_annotations:
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation to arginine biosynthesis. NAGS catalyzes the acetylation of
+      L-glutamate to N-acetyl-L-glutamate, the committed first step of the acetylated ornithine
+      route to L-arginine (UniProt PATHWAY UPA00068: &#34;N(2)-acetyl-L-ornithine from L-glutamate:
+      step 1/4&#34;). This is the conserved ancestral function of the family across bacteria, plants
+      and fungi. In mammals the NAG product is primarily used to activate CPS1 in the urea cycle
+      rather than to make net arginine, but the enzymatic role at the head of the acetylornithine
+      pathway is real and correctly captured.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported family-conserved involvement in the acetylglutamate branch that leads to
+      arginine biosynthesis; consistent with UniProt PATHWAY annotation.
+    supported_by:
+    - reference_id: PMID:23894642
+      supporting_text: &gt;-
+        In microorganisms and plants, NAG is further converted to NAG phosphate by NAG kinase
+        (NAGK, EC 2.7.2.8) to continue the L-arginine biosynthetic pathway
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation placing NAGS activity in the mitochondrial matrix. Human NAGS
+      was purified from human liver mitochondria and carries a cleaved N-terminal mitochondrial
+      transit peptide; the enzyme acts in the matrix where its substrates and CPS1 reside.
+    action: ACCEPT
+    reason: &gt;-
+      Core subcellular location, supported experimentally by purification from human liver
+      mitochondria and by the presence of a mitochondrial targeting sequence.
+    supported_by:
+    - reference_id: PMID:7126172
+      supporting_text: &gt;-
+        was isolated from human liver mitochondria by precipitation with (NH4)2SO4
+- term:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation of the core catalytic activity (EC 2.3.1.1): acetylation of
+      L-glutamate by acetyl-CoA to yield N-acetyl-L-glutamate and CoA (RHEA:24292). This is the
+      defining molecular function of NAGS and is directly supported by human enzymology and
+      structure.
+    action: ACCEPT
+    reason: &gt;-
+      This is the primary, experimentally established molecular function of the gene product.
+    supported_by:
+    - reference_id: PMID:12459178
+      supporting_text: &gt;-
+        N-acetylglutamate synthase (NAGS, E.C. 2.3.1.1) is a mitochondrial enzyme catalyzing the
+        formation of N-acetylglutamate (NAG)
+- term:
+    id: GO:0006536
+    label: glutamate metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation to glutamate metabolism. NAGS consumes L-glutamate as a
+      substrate, so the annotation is not incorrect, but &#34;glutamate metabolic process&#34; is a broad
+      parent term that does not convey the specific biological role of NAGS (making the CPS1
+      activator NAG / feeding the acetylornithine pathway).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True but generic; L-glutamate is the substrate, yet the specific processes (arginine
+      biosynthesis / urea cycle regulation) are more informative and are captured by other
+      annotations. Retain as a peripheral, non-core process term.
+    supported_by:
+    - reference_id: PMID:23894642
+      supporting_text: &gt;-
+        catalyzes the conversion of AcCoA and L-glutamate to CoA and N-acetyl-L-glutamate (NAG)
+- term:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (IEA) annotation of the core catalytic activity from combined automated methods
+      (ARBA, RHEA:24292, InterPro, ortholog transfer). Consistent with the experimentally
+      established EC 2.3.1.1 activity.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and specific molecular-function assignment; agrees with experimental annotations.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (IEA) annotation from the UniProt Swiss-Prot subcellular-location mapping
+      (SL-0170, mitochondrion matrix). Matches the experimentally supported matrix localization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct location, corroborated by purification of the enzyme from liver mitochondria and by
+      the IBA/TAS matrix annotations.
+- term:
+    id: GO:0006526
+    label: L-arginine biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (IEA) annotation to arginine biosynthesis from InterPro/UniPathway (UPA00068).
+      Same rationale as the IBA arginine-biosynthesis annotation: NAGS performs the committed
+      acetylglutamate-forming step of the acetylornithine pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the conserved pathway role and with the IBA annotation of the same term.
+- term:
+    id: GO:0016747
+    label: acyltransferase activity, transferring groups other than amino-acyl groups
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (IEA) InterPro2GO annotation derived from the generic GNAT/N-acetyltransferase
+      domain signature (IPR000182). This is a broad parent term (&#34;acyltransferase activity,
+      transferring groups other than amino-acyl groups&#34;) that only states NAGS is an
+      acyltransferase. The specific, experimentally established activity of this enzyme,
+      GO:0004042 (L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor), is
+      already annotated, so the generic parent is an over-annotation.
+    action: MODIFY
+    reason: &gt;-
+      The generic acyltransferase term should be refined to the known specific activity GO:0004042.
+      NAGS is not a general acyltransferase acting on multiple acceptors; its physiological (and
+      only demonstrated) acetyl-acceptor is L-glutamate. Replace with the specific EC 2.3.1.1 term.
+    proposed_replacement_terms:
+    - id: GO:0004042
+      label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+    supported_by:
+    - reference_id: PMID:23894642
+      supporting_text: &gt;-
+        The NAT domain has a typical GCN5-related NAT fold and a site that catalyzes NAG synthesis
+- term:
+    id: GO:0090461
+    label: intracellular glutamate homeostasis
+  evidence_type: IDA
+  original_reference_id: PMID:21757002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation (BHF-UCL) from a study showing that the nuclear receptor FXR regulates
+      hepatic glutamine/glutamate metabolism and directly induces NAGS expression via an FXRE in
+      the NAGS promoter. In this context NAGS contributes to handling of the intracellular
+      glutamate pool by consuming glutamate to form NAG. The cached publication is abstract-only
+      (full_text_available: false); the experimental annotation reflects the curator&#39;s reading of
+      the full text and should not be removed.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      NAGS uses glutamate as a substrate and its expression is coupled to hepatic glutamate/glutamine
+      metabolism, so a role in intracellular glutamate homeostasis is defensible but peripheral. It
+      is not the core evolved function (production of the CPS1 activator NAG), so retain as non-core
+      rather than remove; defer to the experimental curator.
+    supported_by:
+    - reference_id: PMID:21757002
+      supporting_text: &gt;-
+        Glutamine is taken up by periportal hepatocytes and is the major source of ammonia for urea
+        synthesis and glutamate for N-acetylglutamate (NAG) synthesis, which is catalyzed by the
+        N-acetylglutamate synthase (NAGS).
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: IDA
+  original_reference_id: PMID:21757002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation (BHF-UCL) to the urea cycle. NAGS produces N-acetyl-L-glutamate, the obligate
+      allosteric activator of CPS1, the first enzyme of the urea cycle; loss of NAGS causes
+      hyperammonemia because CPS1 is inactive without NAG. NAGS is thus the regulatory gate of
+      ureagenesis. The cached reference is abstract-only, but the urea-cycle role of NAGS is
+      independently and strongly established by multiple sources.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological role. Although NAG is not stoichiometrically consumed in the cycle, NAGS is
+      indispensable for urea cycle function; the annotation correctly captures this involvement.
+    supported_by:
+    - reference_id: PMID:21757002
+      supporting_text: &gt;-
+        major source of ammonia for urea synthesis and glutamate for N-acetylglutamate (NAG)
+        synthesis, which is catalyzed by the N-acetylglutamate synthase (NAGS)
+    - reference_id: PMID:12459178
+      supporting_text: &gt;-
+        Patients with NAGS deficiency develop hyperammonemia because CPSI is inactive without NAG.
+- term:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  evidence_type: TAS
+  original_reference_id: PMID:21757002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      TAS annotation of the core catalytic activity (EC 2.3.1.1). Redundant with the multiple
+      experimental IDA/EXP and IBA/IEA annotations of the same term; correct.
+    action: ACCEPT
+    reason: &gt;-
+      Correct assignment of the specific molecular function; duplicate of the experimentally
+      supported activity.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9955697
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAS annotation (Reactome) placing NAGS in the mitochondrial matrix, consistent with all other
+      localization evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location; agrees with the IBA/IEA/TAS matrix annotations.
+- term:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  evidence_type: EXP
+  original_reference_id: PMID:12459178
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (EXP) annotation. Recombinant human NAGS (conserved domain) complemented an
+      NAGS-deficient E. coli strain and displayed arginine-responsive NAGS catalytic activity,
+      directly demonstrating the EC 2.3.1.1 activity.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental demonstration of the core catalytic activity in the human enzyme.
+    supported_by:
+    - reference_id: PMID:12459178
+      supporting_text: &gt;-
+        the recombinant protein has arginine-responsive NAGS catalytic activity
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput (HTP) annotation from a quantitative high-confidence human mitochondrial
+      proteome study, identifying NAGS as a mitochondrial protein. Consistent with the more precise
+      matrix localization; &#34;mitochondrion&#34; is a correct but less specific parent term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization supported by proteomics; the specific compartment (matrix) is captured by
+      other annotations.
+- term:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  evidence_type: IDA
+  original_reference_id: PMID:23894642
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA annotation from the crystal structure and enzymology of the human NAGS N-acetyltransferase
+      (NAT) domain in complex with N-acetyl-L-glutamate. The study directly measured NAGS catalytic
+      activity (with substrate-dependence, mutagenesis of active-site residues) confirming EC 2.3.1.1.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental (structural + kinetic) demonstration of the core catalytic activity.
+    supported_by:
+    - reference_id: PMID:23894642
+      supporting_text: &gt;-
+        NAGS deficiency results in elevated levels of plasma ammonia which is neurotoxic. We report
+        herein the first crystal structure of human NAGS, that of the catalytic N-acetyltransferase
+        (hNAT) domain with N-acetyl-L-glutamate bound at 2.1 Å resolution.
+- term:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  evidence_type: IDA
+  original_reference_id: PMID:7126172
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA annotation from the classic purification and kinetic characterization of
+      acetyl-CoA:L-glutamate N-acetyltransferase (EC 2.3.1.1) from human liver, establishing the
+      substrate/product kinetics of the enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental demonstration of the core catalytic activity in native human enzyme.
+    supported_by:
+    - reference_id: PMID:7126172
+      supporting_text: &gt;-
+        Acetyl-CoA:L-glutamate N-acetyltransferase (amino acid acetyltransferase, EC 2.3.1.1) was
+        isolated from human liver mitochondria
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:7126172
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA annotation of mitochondrial localization, based on purification of the enzyme from human
+      liver mitochondria. Correct; the finer matrix localization is captured by other annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correct experimentally supported localization; consistent with the matrix annotations.
+    supported_by:
+    - reference_id: PMID:7126172
+      supporting_text: &gt;-
+        was isolated from human liver mitochondria
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70542
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAS annotation (Reactome) for the reaction &#34;glutamate + acetyl CoA =&gt; N-acetyl glutamate + CoA&#34;
+      localizing NAGS to the mitochondrial matrix. Consistent with all other localization evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location; duplicate of the matrix annotations.
+core_functions:
+- description: &gt;-
+    NAGS catalyzes the acetylation of L-glutamate by acetyl-CoA to produce N-acetyl-L-glutamate
+    (NAG) and CoA (EC 2.3.1.1) in the mitochondrial matrix. NAG is the obligate allosteric
+    activator of carbamoyl phosphate synthetase 1 (CPS1), so NAGS provides the essential
+    regulatory input that gates the urea cycle and hepatic ammonia detoxification.
+  molecular_function:
+    id: GO:0004042
+    label: L-glutamate N-acetyltransferase activity, acting on acetyl-CoA as donor
+  directly_involved_in:
+  - id: GO:0000050
+    label: urea cycle
+  - id: GO:0006526
+    label: L-arginine biosynthetic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:12459178
+    supporting_text: &gt;-
+      N-acetylglutamate synthase (NAGS, E.C. 2.3.1.1) is a mitochondrial enzyme catalyzing the
+      formation of N-acetylglutamate (NAG), an essential allosteric activator of carbamylphosphate
+      synthase I (CPSI), the first enzyme of the urea cycle.
+  - reference_id: PMID:23894642
+    supporting_text: &gt;-
+      NAGS deficiency results in elevated levels of plasma ammonia which is neurotoxic.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12459178
+  title: Cloning and expression of the human N-acetylglutamate synthase gene.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes human NAGS as a mitochondrial EC 2.3.1.1 enzyme producing NAG, the essential
+      allosteric activator of CPS1; recombinant human NAGS complements an NAGS-deficient E. coli
+      strain with arginine-responsive activity. Abstract-only cache but claims independently verified.
+- id: PMID:21757002
+  title: The nuclear receptor FXR regulates hepatic transport and metabolism of glutamine and
+    glutamate.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary source for the BHF-UCL IDA urea-cycle and glutamate-homeostasis annotations; shows FXR
+      directly induces NAGS expression via a promoter FXRE. Cached record is abstract-only
+      (full_text_available: false); the abstract supports NAGS catalyzing NAG synthesis and its
+      role in urea synthesis.
+- id: PMID:23894642
+  title: Crystal structure of the N-acetyltransferase domain of human N-acetyl-L-glutamate synthase
+    in complex with N-acetyl-L-glutamate provides insights into its catalytic and regulatory
+    mechanisms.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text structural/enzymology paper on human NAGS NAT domain; defines catalytic mechanism,
+      arginine regulation via the AAK domain, tetrameric assembly, and confirms EC 2.3.1.1 activity.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular
+    context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput mitochondrial proteomics supporting the HTP mitochondrion localization
+      annotation for NAGS.
+- id: PMID:7126172
+  title: Purification and properties of acetyl-CoA:L-glutamate N-acetyltransferase from human liver.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Classic purification of the native human liver enzyme from mitochondria with kinetic
+      characterization; supports EC 2.3.1.1 activity and mitochondrial localization.
+- id: Reactome:R-HSA-70542
+  title: glutamate + acetyl CoA =&gt; N-acetyl glutamate + CoA
+  findings: []
+- id: Reactome:R-HSA-9955697
+  title: NAGS variants don&#39;t synthesize N-acetylglutamate
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/SLC25A13/SLC25A13-ai-review.html
+++ b/genes/human/SLC25A13/SLC25A13-ai-review.html
@@ -1,0 +1,6828 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SLC25A13 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SLC25A13</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9UJS0" target="_blank" class="term-link">
+                        Q9UJS0
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SLC25A13";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9UJS0" data-a="DESCRIPTION: SLC25A13 encodes citrin (aspartate/glutamate carri..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SLC25A13 encodes citrin (aspartate/glutamate carrier 2, AGC2), the liver-type, calcium-binding member of the mitochondrial carrier (SLC25) family. It is an integral, multi-pass protein of the mitochondrial inner membrane that catalyzes the electrogenic exchange of L-aspartate for L-glutamate plus a proton: it exports L-aspartate from the mitochondrial matrix to the cytosol while importing cytosolic L-glutamate together with a proton. Because aspartate moves as the anion and glutamate is co-transported with a proton, the antiport is electrogenic and, in energized mitochondria, is driven in the direction of aspartate efflux. Citrin is a central component of the malate-aspartate NADH shuttle, transferring cytosolic reducing equivalents into the mitochondria and regenerating cytosolic NAD+, and it supplies the cytosolic aspartate consumed by argininosuccinate synthetase (ASS1) in the hepatic urea cycle and used in gluconeogenesis. Each protomer has a three-domain architecture: an N-terminal regulatory domain with EF-hand motifs (only EF-hand 2 binds calcium in the intermembrane space), a six-transmembrane SLC25 carrier domain that performs transport, and a C-terminal amphipathic helix; the full-length carrier assembles as a homodimer via the N-terminal domain while transporting substrate as a functional monomer. Citrin is expressed most abundantly in liver and other non-excitable tissues, in contrast to its paralog aralar (SLC25A12 / AGC1), the brain- and muscle-predominant isoform. Loss of citrin function causes citrin deficiency, which manifests across age as neonatal intrahepatic cholestasis (NICCD), failure to thrive and dyslipidemia (FTTDCD), and adult-onset citrullinemia type II (CTLN2) with hyperammonemic encephalopathy; the phenotype is broader than that of a pure urea cycle enzyme owing to citrin&#39;s additional role in the malate-aspartate shuttle and cellular redox balance.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005313" target="_blank" class="term-link">
+                                    GO:0005313
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005313" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of L-glutamate transporter activity. Citrin imports L-glutamate together with a proton as one half of its aspartate/glutamate antiport, so this is a correct component of the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by experimental reconstitution showing electrogenic exchange of aspartate for glutamate and a proton. This activity is one arm of the aspartate/glutamate antiport; the more specific antiporter term (GO:0000515) is the primary/core molecular function, but this term is accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015183" target="_blank" class="term-link">
+                                    GO:0015183
+                                </a>
+                            </span>
+                            <span class="term-label">L-aspartate transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015183" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of L-aspartate transporter activity. Citrin exports L-aspartate from the matrix as the other half of its antiport; a correct component of the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated. Aspartate efflux is one arm of the electrogenic aspartate/glutamate antiport (the core activity, GO:0000515). This transporter-activity term is accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043490" target="_blank" class="term-link">
+                                    GO:0043490
+                                </a>
+                            </span>
+                            <span class="term-label">malate-aspartate shuttle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0043490" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment placing citrin in the malate-aspartate NADH shuttle, which it participates in as the inner-membrane aspartate/glutamate exchange step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported: overexpression of citrin increases malate-aspartate shuttle activity in human cells, and the carrier is an integral component of the shuttle. Core biological process for citrin.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment to the mitochondrial inner membrane, where citrin is active as a multi-pass carrier. Correct and core subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with all experimental localization data and the multi-pass topology of the SLC25 carrier domain. Core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link">
+                                        PMID:39419476
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">located in the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015810" target="_blank" class="term-link">
+                                    GO:0015810
+                                </a>
+                            </span>
+                            <span class="term-label">aspartate transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015810" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) BP assignment for aspartate transmembrane transport, the process arm of citrin&#39;s aspartate efflux.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported process term corresponding to the aspartate half of the antiport. Accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015813" target="_blank" class="term-link">
+                                    GO:0015813
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015813" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) BP assignment for L-glutamate transmembrane transport, the process arm of citrin&#39;s glutamate import.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported process term corresponding to the glutamate half of the antiport. Accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000514" target="_blank" class="term-link">
+                                    GO:0000514
+                                </a>
+                            </span>
+                            <span class="term-label">3-sulfino-L-alanine: proton, glutamate antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0000514" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation for cysteinesulfinate (3-sulfino-L-alanine) / glutamate, proton antiport. Citrin exchanges cysteinesulfinate with glutamate and a proton experimentally; correct but a secondary (non-core) substrate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated as a secondary substrate exchange, but aspartate/glutamate antiport (GO:0000515) is the physiologically central function. Real but ancillary.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AGC also transports cysteinesulfinate in exchange for either aspartate or glutamate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000515" target="_blank" class="term-link">
+                                    GO:0000515
+                                </a>
+                            </span>
+                            <span class="term-label">aspartate:glutamate, proton antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0000515" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation for the aspartate:glutamate, proton antiporter activity, the primary catalytic function of citrin. Duplicated by an EXP and an IDA annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The primary/core molecular function of citrin, directly demonstrated by reconstitution and independently confirmed. The electronic annotation is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                                    GO:0005509
+                                </a>
+                            </span>
+                            <span class="term-label">calcium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005509" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (InterPro EF-hand) for calcium ion binding. Citrin has a regulatory N-terminal EF-hand domain; the structure confirms calcium binding at EF-hand 2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by X-ray structure showing calcium bound at EF-hand 2. Calcium binding is a genuine molecular activity of the regulatory domain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                                        PMID:25410934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Only EF-hand 2 binds calcium</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (multiple IEA methods / UniProt SubCell) for mitochondrial inner membrane localization. Correct and duplicated by EXP/IDA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental subcellular localization. Core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link">
+                                        PMID:39419476
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">located in the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015804" target="_blank" class="term-link">
+                                    GO:0015804
+                                </a>
+                            </span>
+                            <span class="term-label">neutral amino acid transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015804" data-r="GO_REF:0000108" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inter-ontology (GO_REF:0000108) inference from the cysteinesulfinate antiport term GO:0000514, classifying cysteinesulfinate transport as neutral amino acid transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin&#39;s physiological substrates aspartate and glutamate are acidic (anionic) amino acids, not neutral amino acids. This term is a logical by-product of the secondary cysteinesulfinate activity and mischaracterizes the core function; better captured by the aspartate/glutamate transport terms.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015810" target="_blank" class="term-link">
+                                    aspartate transmembrane transport
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015813" target="_blank" class="term-link">
+                                    L-glutamate transmembrane transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043490" target="_blank" class="term-link">
+                                    GO:0043490
+                                </a>
+                            </span>
+                            <span class="term-label">malate-aspartate shuttle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0043490" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation to the malate-aspartate shuttle, duplicating the IBA and IDA annotations to this term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; the malate-aspartate shuttle is a core biological process for citrin, independently supported by experimental data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051592" target="_blank" class="term-link">
+                                    GO:0051592
+                                </a>
+                            </span>
+                            <span class="term-label">response to calcium ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0051592" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation for response to calcium ion, reflecting calcium stimulation of citrin transport activity via its EF-hand domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin transport is stimulated by calcium binding at the intermembrane-space EF-hand domain, so a response-to-calcium annotation has an experimental basis. However this is a regulatory/response process rather than citrin&#39;s core transport function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stimulated by Ca</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to the generic transmembrane transport process from the mitochondrial carrier domain signature.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but very general parent term. The specific aspartate/glutamate transport processes and the malate-aspartate shuttle capture the core function; this broad term is a valid, non-core ancestor.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070778" target="_blank" class="term-link">
+                                    GO:0070778
+                                </a>
+                            </span>
+                            <span class="term-label">L-aspartate transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0070778" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (from the aspartate transporter/antiporter MF terms) for L-aspartate transmembrane transport, the process arm of citrin&#39;s aspartate efflux.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate specific process term for aspartate transport, consistent with the experimentally demonstrated aspartate efflux activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
+                                    GO:1902600
+                                </a>
+                            </span>
+                            <span class="term-label">proton transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:1902600" data-r="GO_REF:0000108" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inter-ontology inference (from GO:0000514) that citrin is involved in proton transmembrane transport, reflecting co-transport of a proton with glutamate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin co-transports a proton with glutamate, so proton translocation is part of its electrogenic mechanism; not wrong, but a mechanistic by-product rather than the primary amino-acid antiport function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput interactome (IPI) annotation with the paralog SLC25A12 / aralar (O75746) as the recorded partner. Uninformative bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare protein binding conveys no specific function. The recorded partner is the paralog SLC25A12, consistent with the mitochondrial-carrier context, but this generic term does not describe citrin&#39;s molecular function. The informative interaction (homodimerization) is captured by GO:0042802.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput interactome (IPI) annotation with the paralog SLC25A12 (O75746). Uninformative bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative and is discouraged. Duplicate large-scale interactome hit against the paralog SLC25A12; does not add functional specificity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40355756" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40355756
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The solute carrier superfamily interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005515" data-r="PMID:40355756" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Solute carrier interactome (IPI) annotation with the paralog SLC25A12 (O75746). Uninformative bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative. Large-scale SLC interactome hit against the paralog SLC25A12; no specific molecular function conveyed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005313" target="_blank" class="term-link">
+                                    GO:0005313
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005313" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara (GO_REF:0000107) orthology transfer from mouse Slc25a13 (Q9QXX4) of L-glutamate transporter activity. Duplicates the IBA annotation to this term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct: glutamate import is one arm of citrin&#39;s antiport, well supported experimentally. The orthology transfer is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005739" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology transfer of mitochondrion localization. Correct but less specific than the mitochondrial inner membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate but a broad parent of the specific mitochondrial inner membrane location that is the core annotation. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link">
+                                        PMID:39419476
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">located in the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0006094" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology transfer for involvement in gluconeogenesis, reflecting the requirement for cytosolic aspartate (supplied by citrin) in gluconeogenesis from lactate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin-supplied cytosolic aspartate is needed for the conversion of oxoglutarate to oxaloacetate in gluconeogenesis from lactate/alanine, so the process link is physiologically valid but downstream and tissue-context dependent rather than a core molecular function. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                                        PMID:25410934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cytosolic aspartate is also required for the conversion of oxoglutarate to oxaloacetate, a crucial step in gluconeogenesis from lactate and alanine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015172" target="_blank" class="term-link">
+                                    GO:0015172
+                                </a>
+                            </span>
+                            <span class="term-label">acidic amino acid transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015172" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology transfer of acidic amino acid transmembrane transporter activity, a parent term covering the transport of the acidic amino acids aspartate and glutamate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct as a broader (parent) molecular function: aspartate and glutamate are acidic amino acids. The specific aspartate:glutamate antiporter activity (GO:0000515) and the individual aspartate/glutamate transporter terms are the core annotations; this generalization is a valid non-core ancestor.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence-based (HPA, IDA) mitochondrial localization. Consistent with the established mitochondrial inner-membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than mitochondrial inner membrane; retain as non-core. Human Protein Atlas reports SLC25A13 as tissue-enriched in liver with mitochondrial staining.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000515" target="_blank" class="term-link">
+                                    GO:0000515
+                                </a>
+                            </span>
+                            <span class="term-label">aspartate:glutamate, proton antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38945283" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:38945283
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial aspartate/glutamate carrier does not trans...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0000515" data-r="PMID:38945283" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) confirmation of aspartate:glutamate, proton antiporter activity. Reconfirmed the canonical antiport and showed citrin does NOT transport GABA, sharpening substrate specificity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supports the primary/core molecular function; additionally excludes GABA as a substrate, refining specificity of the antiport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38945283" target="_blank" class="term-link">
+                                        PMID:38945283
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the human AGC isoforms (AGC1/aralar1 and AGC2/citrin) are unable to transport GABA both in homo- and in hetero-exchange with either glutamate or aspartate, i.e. the canonical substrates of AGC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10642534
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of a second member of the subfamily of calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="PMID:10642534" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization of citrin (Aralar2) to mitochondria in human cell lines. Core location, duplicated by other EXP/IDA/IBA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The mitochondrial localization of citrin was experimentally established in this characterization study; it is the core subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link">
+                                        PMID:10642534
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The localization of Aralar2/citrin expressed in human cell lines is mitochondrial</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:39419476
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Distinct roles for the domains of the mitochondrial aspartat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="PMID:39419476" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization to the mitochondrial inner membrane, from the domain-dissection study of citrin (which also showed N-terminal mutations cause a mitochondrial import defect). Core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental annotation of the core inner-membrane location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link">
+                                        PMID:39419476
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">located in the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043490" target="_blank" class="term-link">
+                                    GO:0043490
+                                </a>
+                            </span>
+                            <span class="term-label">malate-aspartate shuttle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37647199" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37647199
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The malate-aspartate shuttle is important for de novo serine...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0043490" data-r="PMID:37647199" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction (IGI) annotation from a panel of malate-aspartate-shuttle-deficient cell lines showing the shuttle (including its AGC component) is important for de novo serine biosynthesis. Places citrin in the malate-aspartate shuttle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The malate-aspartate shuttle is a core biological process for citrin. This genetic study of MAS components (full text assessed by the curator) supports the shuttle involvement; the abstract confirms the MAS focus. Consistent with the IBA/IDA annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37647199" target="_blank" class="term-link">
+                                        PMID:37647199
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we show that the MAS is important for de novo serine biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (HTP) placement of SLC25A13 in the mitochondrion (high-confidence mitochondrial proteome). Consistent with the established mitochondrial inner-membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but broader than the specific mitochondrial inner-membrane location; a proteome-scale mitochondrial call. Retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000514" target="_blank" class="term-link">
+                                    GO:0000514
+                                </a>
+                            </span>
+                            <span class="term-label">3-sulfino-L-alanine: proton, glutamate antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0000514" data-r="PMID:11566871" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) demonstration that citrin exchanges cysteinesulfinate (3-sulfino-L-alanine) for glutamate and a proton. A genuine but secondary substrate activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated secondary substrate exchange. Physiologically the aspartate/glutamate antiport (GO:0000515) is central; cysteinesulfinate exchange is ancillary. Retain as accurate but non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AGC also transports cysteinesulfinate in exchange for either aspartate or glutamate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000515" target="_blank" class="term-link">
+                                    GO:0000515
+                                </a>
+                            </span>
+                            <span class="term-label">aspartate:glutamate, proton antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0000515" data-r="PMID:11566871" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) demonstration of the electrogenic aspartate:glutamate, proton antiport by reconstituted citrin. The defining, core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The foundational experimental evidence for citrin&#39;s core function: reconstituted protein catalyzes electrogenic exchange of aspartate for glutamate and a proton. Primary molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="PMID:11566871" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) inner-membrane localization with defined multi-pass topology (N- and C-terminal domains in the intermembrane space; six-TM carrier domain). Core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental annotation of the core inner-membrane location and topology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ca(2+)-stimulated aspartate/glutamate transporters</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                                    GO:0005509
+                                </a>
+                            </span>
+                            <span class="term-label">calcium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25410934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Calcium-induced conformational changes of the regulatory dom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005509" data-r="PMID:25410934" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) calcium binding, from the X-ray structure of the citrin N-terminal domain showing calcium bound at EF-hand 2. Core molecular activity of the regulatory domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Crystallographic demonstration of calcium binding at EF-hand 2. Calcium binding by the regulatory EF-hand domain is a genuine, core molecular function of citrin.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                                        PMID:25410934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Only EF-hand 2 binds calcium</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25410934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Calcium-induced conformational changes of the regulatory dom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0042802" data-r="PMID:25410934" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) identical protein binding, reflecting the demonstrated homodimerization of citrin via its N-terminal domain (SEC-MALLS and the dimeric crystal structure).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin forms a homodimer via the N-terminal domain, so identical protein binding is experimentally supported and more informative than bare protein binding. However dimerization is a structural property rather than the core transport function (the carrier transports substrate as a functional monomer). Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                                        PMID:25410934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">demonstrating that the full-length carrier was dimeric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006839" target="_blank" class="term-link">
+                                    GO:0006839
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10642534
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of a second member of the subfamily of calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0006839" data-r="PMID:10642534" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement (NAS) that citrin functions in mitochondrial transport, from the initial characterization describing it as a calcium-regulated mitochondrial metabolite carrier.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but very general. The specific aspartate/glutamate antiport and its downstream processes (malate-aspartate shuttle, aspartate/glutamate transport) capture the core function; this broad process term is a valid non-core ancestor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link">
+                                        PMID:10642534
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">function as calcium-regulated metabolite (possibly anionic) carriers</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-372448
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="Reactome:R-HSA-372448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (Reactome) for mitochondrial inner-membrane localization, from the Reactome reaction in which SLC25A12/13 exchange L-Glu and L-Asp. Core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome curation consistent with all experimental localization data. Core inner-membrane location.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                                    GO:0005509
+                                </a>
+                            </span>
+                            <span class="term-label">calcium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10642534
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of a second member of the subfamily of calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005509" data-r="PMID:10642534" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) calcium binding from the initial characterization, where the N-terminal half of citrin was shown to bind calcium (requiring the two most distal EF-hands). Core molecular activity of the regulatory domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated calcium binding by the N-terminal EF-hand domain. Duplicates the structurally-supported IDA calcium-binding annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link">
+                                        PMID:10642534
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The N-terminal half of Aralar2/citrin is able to bind calcium and this requires the presence of the two most distal EF-hands</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10642534
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of a second member of the subfamily of calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005739" data-r="PMID:10642534" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) mitochondrial localization of citrin expressed in human cell lines. Consistent with the inner-membrane location; broader term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate but a broad parent of the specific mitochondrial inner membrane location. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link">
+                                        PMID:10642534
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The localization of Aralar2/citrin expressed in human cell lines is mitochondrial</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005743" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS) transfer from mouse Slc25a13 (Q9QXX4) of inner-membrane localization. Correct and duplicated by EXP/IDA/IBA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with all experimental localization data. Core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link">
+                                        PMID:39419476
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">located in the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10642534
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of a second member of the subfamily of calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005886" data-r="PMID:10642534" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement (NAS) placing citrin at the plasma membrane. Contradicts the extensive experimental evidence for a mitochondrial inner-membrane localization, including the conclusion of the same cited paper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin is an integral protein of the mitochondrial inner membrane; there is no experimental support for a plasma-membrane location, and the cited characterization study itself concludes the localization is mitochondrial. This NAS annotation is inconsistent with established biology and should be removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link">
+                                        PMID:10642534
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The localization of Aralar2/citrin expressed in human cell lines is mitochondrial</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006754" target="_blank" class="term-link">
+                                    GO:0006754
+                                </a>
+                            </span>
+                            <span class="term-label">ATP biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12851387" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12851387
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Recombinant expression of the Ca(2+)-sensitive aspartate/glu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0006754" data-r="PMID:12851387" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation that recombinant citrin increases mitochondrial ATP production in agonist-stimulated cells, linking its calcium-sensitive transport activity to mitochondrial energy metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported: citrin overexpression raises mitochondrial ATP upon calcium-mobilizing agonist stimulation, via its role in the malate-aspartate shuttle feeding reducing equivalents to oxidative phosphorylation. This is a downstream physiological consequence rather than citrin&#39;s direct molecular function; retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12851387" target="_blank" class="term-link">
+                                        PMID:12851387
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">larger in cells expressing aralar and citrin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045333" target="_blank" class="term-link">
+                                    GO:0045333
+                                </a>
+                            </span>
+                            <span class="term-label">cellular respiration</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12851387" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12851387
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Recombinant expression of the Ca(2+)-sensitive aspartate/glu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0045333" data-r="PMID:12851387" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation linking citrin to cellular respiration through its calcium-stimulated enhancement of mitochondrial ATP production and aerobic metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Citrin contributes to aerobic/oxidative metabolism by feeding cytosolic reducing equivalents into mitochondria via the malate-aspartate shuttle, and its overexpression stimulates mitochondrial ATP on agonist stimulation. Downstream physiological role rather than a core molecular function; retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12851387" target="_blank" class="term-link">
+                                        PMID:12851387
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the stimulation of aerobic metabolism</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0005739" data-r="PMID:11566871" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) mitochondrial localization from the functional reconstitution study. Consistent with the inner-membrane location; broader term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate but a broad parent of the specific mitochondrial inner membrane location. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ca(2+)-stimulated aspartate/glutamate transporters</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015810" target="_blank" class="term-link">
+                                    GO:0015810
+                                </a>
+                            </span>
+                            <span class="term-label">aspartate transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015810" data-r="PMID:11566871" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) aspartate transmembrane transport, the process arm of citrin&#39;s aspartate efflux, demonstrated by reconstitution.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported specific process term for aspartate transport (the aspartate half of the antiport). Accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015813" target="_blank" class="term-link">
+                                    GO:0015813
+                                </a>
+                            </span>
+                            <span class="term-label">L-glutamate transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0015813" data-r="PMID:11566871" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) L-glutamate transmembrane transport, the process arm of citrin&#39;s glutamate import, demonstrated by reconstitution.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported specific process term for glutamate transport (the glutamate half of the antiport). Accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043490" target="_blank" class="term-link">
+                                    GO:0043490
+                                </a>
+                            </span>
+                            <span class="term-label">malate-aspartate shuttle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0043490" data-r="PMID:11566871" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation to the malate-aspartate shuttle: citrin overexpression increased malate-aspartate shuttle activity in human cells. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Foundational experimental evidence that citrin is a component of the malate-aspartate NADH shuttle. Core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051592" target="_blank" class="term-link">
+                                    GO:0051592
+                                </a>
+                            </span>
+                            <span class="term-label">response to calcium ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0051592" data-r="PMID:11566871" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation for response to calcium ion: citrin transport activity is stimulated by calcium on the external face of the inner membrane, where its EF-hand domains reside.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported calcium stimulation of transport, a genuine regulatory response. However it is a regulatory process rather than citrin&#39;s core transport function, and the physiological significance of the calcium regulation has since been debated. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stimulated by Ca</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11566871
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UJS0" data-a="GO:0000050" data-r="PMID:11566871" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation. Citrin supplies the cytosolic aspartate consumed by argininosuccinate synthetase (ASS1) in the hepatic urea cycle; loss of this supply underlies the argininosuccinate synthetase deficiency and citrullinemia of citrin deficiency. Central role documented but not currently in the GOA for SLC25A13.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The urea cycle role is a defining, textbook function of citrin and mechanistically explains citrullinemia type II, yet no urea cycle (GO:0000050) annotation exists in the current GOA. Adding it captures a core biological process. Supported by the primary functional paper and the structural review.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                        PMID:11566871
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">urea cycle and the aspartate/malate NADH shuttle</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                                        PMID:25410934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In liver, cytosolic aspartate is required for the urea cycle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Electrogenic mitochondrial-inner-membrane aspartate/glutamate antiporter: exports L-aspartate from the matrix to the cytosol in exchange for cytosolic L-glutamate plus a proton.</h3>
+                <span class="vote-buttons" data-g="Q9UJS0" data-a="FUNCTION: Electrogenic mitochondrial-inner-membrane aspartat..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000515" target="_blank" class="term-link">
+                            aspartate:glutamate, proton antiporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043490" target="_blank" class="term-link">
+                                malate-aspartate shuttle
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                                PMID:11566871
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">shown to catalyze the electrogenic exchange of aspartate for glutamate and a H</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Calcium binding by the regulatory N-terminal EF-hand domain (EF-hand 2) in the mitochondrial intermembrane space, which modulates the carrier.</h3>
+                <span class="vote-buttons" data-g="Q9UJS0" data-a="FUNCTION: Calcium binding by the regulatory N-terminal EF-ha..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                            calcium ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                                PMID:25410934
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Only EF-hand 2 binds calcium</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10642534" target="_blank" class="term-link">
+                            PMID:10642534
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of a second member of the subfamily of calcium-binding mitochondrial carriers expressed in human non-excitable tissues.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cloned citrin (Aralar2) as a liver / non-excitable-tissue calcium-binding mitochondrial carrier, 78.3% identical to Aralar1; localizes to mitochondria in human cell lines and binds calcium via its N-terminal EF-hands.</div>
+
+                        <div class="finding-text">"The localization of Aralar2/citrin expressed in human cell lines is mitochondrial"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" target="_blank" class="term-link">
+                            PMID:11566871
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate transporters in mitochondria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reconstituted citrin catalyzes electrogenic exchange of aspartate for glutamate and a proton, identifying it as the mitochondrial aspartate/glutamate carrier; overexpression increases malate-aspartate shuttle activity, and the activity is calcium-stimulated.</div>
+
+                        <div class="finding-text">"shown to catalyze the electrogenic exchange of aspartate for glutamate and a H"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12851387" target="_blank" class="term-link">
+                            PMID:12851387
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Recombinant expression of the Ca(2+)-sensitive aspartate/glutamate carrier increases mitochondrial ATP production in agonist-stimulated Chinese hamster ovary cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Recombinant citrin (and aralar1) increase mitochondrial ATP production upon calcium-mobilizing agonist stimulation, linking calcium-sensitive aspartate/glutamate transport to mitochondrial energy metabolism.</div>
+
+                        <div class="finding-text">"larger in cells expressing aralar and citrin"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" target="_blank" class="term-link">
+                            PMID:25410934
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Calcium-induced conformational changes of the regulatory domain of human mitochondrial aspartate/glutamate carriers.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">X-ray structures of the citrin/aralar N- and C-terminal domains show a homodimer with a unique eight-EF-hand arch; only EF-hand 2 binds calcium, and calcium binding opens a vestibule regulating substrate access.</div>
+
+                        <div class="finding-text">"Only EF-hand 2 binds calcium"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37647199" target="_blank" class="term-link">
+                            PMID:37647199
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The malate-aspartate shuttle is important for de novo serine biosynthesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genetic disruption of malate-aspartate shuttle components (including the aspartate/glutamate carrier) reduces de novo serine biosynthesis, reflecting the shuttle&#39;s role in recycling cytosolic NADH to NAD+.</div>
+
+                        <div class="finding-text">"we show that the MAS is important for de novo serine biosynthesis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38945283" target="_blank" class="term-link">
+                            PMID:38945283
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The mitochondrial aspartate/glutamate carrier does not transport GABA.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human citrin (AGC2) and aralar (AGC1) transport aspartate and glutamate but do not transport GABA in homo- or hetero-exchange, refining the substrate specificity of the aspartate/glutamate antiport.</div>
+
+                        <div class="finding-text">"the human AGC isoforms (AGC1/aralar1 and AGC2/citrin) are unable to transport GABA both in homo- and in hetero-exchange with either glutamate or aspartate, i.e. the canonical substrates of AGC"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" target="_blank" class="term-link">
+                            PMID:39419476
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Distinct roles for the domains of the mitochondrial aspartate/glutamate carrier citrin in organellar localization and substrate transport.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Domain-dissection with 33 pathogenic variants: the carrier domain performs transport (identifying substrate-binding and dynamics residues), while N-terminal domain mutations cause a mitochondrial import defect rather than regulating transport via calcium.</div>
+
+                        <div class="finding-text">"located in the mitochondrial inner membrane"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40355756" target="_blank" class="term-link">
+                            PMID:40355756
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The solute carrier superfamily interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-372448
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SLC25A12,13 exchange L-Glu and L-Asp</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SLC25A13-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UJS0" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: SLC25A13 (Citrin) — Human Mitochondrial Aspartate/Glutamate Carrier 2</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">49 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:11:30.197628</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="SLC25A13-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-slc25a13-citrin-human-mitochondrial-aspartateglutamate-carrier-2">Comprehensive Research Report: SLC25A13 (Citrin) — Human Mitochondrial Aspartate/Glutamate Carrier 2</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>SLC25A13 (Solute Carrier Family 25 Member 13; UniProt Q9UJS0) encodes the mitochondrial aspartate/glutamate carrier isoform 2 (AGC2), commonly known as <strong>citrin</strong>. It is also referred to as ARALAR2 or calcium-binding mitochondrial carrier protein Aralar2 (palmieri2013themitochondrialtransporter pages 15-16, tavoulari2024distinctrolesfor pages 1-2). Citrin belongs to the SLC25 mitochondrial carrier family (TC 2.A.29), which comprises 53 members in humans that transport a wide variety of solutes across the inner mitochondrial membrane (kunji2025thepeculiarproperties pages 3-4, ruprecht2020theslc25mitochondrial pages 1-2). Citrin is one of two mammalian isoforms of aspartate/glutamate carriers, the other being aralar (AGC1/SLC25A12), which shares 78% sequence identity with citrin but differs markedly in tissue expression (gonzalezmoreno2023exogenousaralarslc25a12can pages 2-3).</p>
+<p>The following table summarizes the key properties of SLC25A13/citrin:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>SLC25A13</strong> (solute carrier family 25 member 13); also called <strong>AGC2</strong> (aspartate/glutamate carrier 2) (palmieri2013themitochondrialtransporter pages 15-16, holecek2023aspartateglutamatecarrier2 pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein names / aliases</td>
+<td><strong>Citrin</strong>; <strong>electrogenic aspartate/glutamate antiporter SLC25A13</strong>; <strong>mitochondrial aspartate-glutamate carrier 2 (AGC2)</strong>; <strong>ARALAR2</strong> / <strong>aralar-related gene 2</strong> (tavoulari2024distinctrolesfor pages 1-2, holecek2023aspartateglutamatecarrier2 pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>Q9UJS0</strong> (user-provided UniProt identity; matched in literature to human SLC25A13/citrin/AGC2) (tavoulari2024distinctrolesfor pages 1-2, vukovic2024thetherapeuticlandscape pages 1-2)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Homo sapiens (human)</strong> (user-provided identity; disease and biochemical literature consistently describe human SLC25A13/citrin deficiency) (vukovic2024thetherapeuticlandscape pages 1-2, kido2024clinicallandscapeof pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Member of the <strong>SLC25 mitochondrial carrier family</strong>; specifically an <strong>aspartate/glutamate carrier</strong> of the inner mitochondrial membrane (ruprecht2020theslc25mitochondrial pages 1-2, tavoulari2024distinctrolesfor pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Localized to the <strong>inner mitochondrial membrane</strong>; participates in metabolite exchange between mitochondrial matrix and cytosol/intermembrane-space-facing side (lacabanne2025currentunderstandingof pages 3-4, gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2)</td>
+</tr>
+<tr>
+<td>Primary tissue expression</td>
+<td>Highest functional importance in <strong>liver/hepatocytes</strong>, where it is the predominant or sole AGC isoform; also expressed in <strong>intestinal epithelium/small intestine</strong>; lower or restricted expression in <strong>kidney</strong> and <strong>heart</strong>, and low brain expression limited to select neuronal clusters (contreras2010lowlevelsof pages 1-2, broeks2021inborndisordersof pages 6-10, gonzalezmoreno2023exogenousaralarslc25a12can pages 2-3)</td>
+</tr>
+<tr>
+<td>Transport substrates</td>
+<td><strong>Exports aspartate</strong> from the mitochondrial matrix in exchange for <strong>import of glutamate plus H+</strong> into mitochondria (palmieri2013themitochondrialtransporter pages 15-16, tavoulari2024distinctrolesfor pages 1-2, broeks2021inborndisordersof pages 6-10)</td>
+</tr>
+<tr>
+<td>Transport mechanism</td>
+<td><strong>Electrogenic aspartate/glutamate antiport</strong> operating by an <strong>alternating-access</strong> mechanism with matrix-open and cytoplasmic-open states, controlled by conserved salt-bridge gate networks; proton-coupled glutamate import helps drive net flux in the malate-aspartate shuttle (kunji2025thepeculiarproperties pages 3-4, ruprecht2020theslc25mitochondrial pages 1-2, lacabanne2025currentunderstandingof pages 4-6)</td>
+</tr>
+<tr>
+<td>Key metabolic pathways</td>
+<td>Core component of the <strong>malate-aspartate shuttle</strong> for cytosolic NADH reoxidation and mitochondrial NADH generation; supplies cytosolic aspartate for the <strong>urea cycle</strong>; supports <strong>gluconeogenesis</strong> via oxaloacetate/aspartate coupling; also supports <strong>protein</strong>, <strong>purine</strong>, and <strong>pyrimidine</strong> synthesis and broader hepatic redox/energy metabolism (holecek2023aspartateglutamatecarrier2 pages 1-2, holecek2023aspartateglutamatecarrier2 pages 2-4, palmieri2013themitochondrialtransporter pages 15-16)</td>
+</tr>
+<tr>
+<td>Associated diseases</td>
+<td>Biallelic pathogenic variants cause <strong>citrin deficiency (CD)</strong> with age-dependent phenotypes: <strong>NICCD</strong> (neonatal intrahepatic cholestasis caused by citrin deficiency), <strong>FTTDCD</strong> (failure to thrive and dyslipidemia caused by citrin deficiency), and <strong>CTLN2/AACD</strong> (adult-onset type II citrullinemia / adolescent-adult citrin deficiency); complications include <strong>hyperammonemia</strong>, <strong>fatty liver</strong>, <strong>pancreatitis</strong>, <strong>cirrhosis</strong>, and risk of <strong>hepatocellular carcinoma</strong> (vukovic2024thetherapeuticlandscape pages 1-2, komatsu2023citrindeficiencyclinical pages 1-2, kido2022clinicalmanifestationand pages 7-11)</td>
+</tr>
+<tr>
+<td>Key structural features</td>
+<td>Unusual <strong>three-domain</strong> mitochondrial carrier with an <strong>N-terminal EF-hand domain</strong>, a <strong>canonical carrier domain</strong> of three repeated modules/six transmembrane helices, and a <strong>C-terminal amphipathic helix</strong>; forms <strong>homodimers</strong>; recent work indicates <strong>only EF-hand 2 binds Ca2+</strong> and that <strong>Ca2+ binding is not required for transport regulation</strong>, contrary to older models (tavoulari2024distinctrolesfor pages 1-2, lacabanne2025currentunderstandingof pages 3-4, tavoulari2024distinctrolesfor pages 11-12)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key molecular, cellular, metabolic, and disease-related properties of human SLC25A13/citrin. It is useful as a quick reference linking transporter function and structure to citrin deficiency phenotypes.</em></p>
+<h2 id="2-primary-transport-function-and-substrate-specificity">2. Primary Transport Function and Substrate Specificity</h2>
+<p>Citrin functions as an <strong>electrogenic aspartate/glutamate antiporter</strong> embedded in the inner mitochondrial membrane. Its primary transport activity is the export of aspartate anions from the mitochondrial matrix into the cytosol, coupled with the import of cytosolic glutamate anions plus a proton (H⁺) into the matrix (palmieri2013themitochondrialtransporter pages 15-16, tavoulari2024distinctrolesfor pages 1-2, ruprecht2020theslc25mitochondrial pages 1-2). This co-transport of glutamate with a proton is driven by the mitochondrial proton motive force, which renders the shuttle practically unidirectional toward oxidation of cytosolic NADH, maintaining the cytosolic NAD⁺/NADH pool in a more oxidized state than the mitochondrial matrix pool (kunji2025thepeculiarproperties pages 3-4).</p>
+<p>The electrogenic nature of this exchange—where aspartate carries a net negative charge of -1 and glutamate plus a proton is effectively neutral—means the transport is driven forward by the mitochondrial membrane potential (broeks2021inborndisordersof pages 6-10). This thermodynamic coupling ensures a robust unidirectional flow of aspartate out of mitochondria, which is critical for hepatocyte metabolism.</p>
+<h2 id="3-protein-structure-and-domain-architecture">3. Protein Structure and Domain Architecture</h2>
+<p>Citrin possesses an unusual <strong>three-domain architecture</strong> that distinguishes it from most other SLC25 family members (tavoulari2024distinctrolesfor pages 1-2, lacabanne2025currentunderstandingof pages 3-4):</p>
+<p><strong>N-terminal calcium-binding domain:</strong> This domain contains <strong>eight EF-hand motifs</strong>, of which only <strong>EF-hand 2</strong> possesses a functional calcium-binding site. EF-hands 4–8 do not bind calcium and instead form a <strong>dimerization interface</strong> (lacabanne2025currentunderstandingof pages 3-4). Importantly, recent work by Tavoulari et al. (2024) has demonstrated that calcium binding to EF-hand 2 is <strong>not required for transport regulation</strong>. A mutant in which the calcium-binding site was completely abolished (quadruple alanine substitution D66A/T68A/D70A/E77A) retained full transport activity and normal mitochondrial localization (tavoulari2024distinctrolesfor pages 11-12, tavoulari2024distinctrolesfor pages 7-9). The calcium-binding site is now proposed to be an evolutionary remnant (tavoulari2024distinctrolesfor pages 11-12). However, the N-terminal domain plays a critical role in <strong>mitochondrial targeting and localization</strong>, and pathogenic mutations in this region often cause localization defects rather than transport defects (tavoulari2024distinctrolesfor pages 9-11).</p>
+<p><strong>Carrier domain:</strong> This is the substrate-transporting module, consisting of three homologous sequence repeats, each containing two transmembrane α-helices connected by a loop harboring a short matrix helix, forming a <strong>six-helical bundle</strong> with a central water-filled cavity that serves as the substrate translocation pathway (lacabanne2025currentunderstandingof pages 3-4, ruprecht2020theslc25mitochondrial pages 2-3). The carrier operates through an <strong>alternating access mechanism</strong>, interconverting between a matrix-open (m-state) and a cytoplasmic-open (c-state) conformation. This switching is achieved through coordinated disruption and reformation of salt-bridge networks on either side of the carrier. Three gate elements on the cytoplasmic side and three core elements on the matrix side open and close in alternating fashion to permit substrate binding and translocation (tavoulari2024distinctrolesfor pages 1-2, lacabanne2025currentunderstandingof pages 4-6).</p>
+<p><strong>C-terminal amphipathic helix:</strong> This short domain contributes to the overall structural integrity and membrane association of the protein (tavoulari2024distinctrolesfor pages 1-2, lacabanne2025currentunderstandingof pages 3-4).</p>
+<p>Citrin is unique among SLC25 carriers in that it forms <strong>structural homodimers</strong> through its N-terminal domains, although the two carrier domains within the dimer appear to function independently rather than cooperatively (tavoulari2024distinctrolesfor pages 11-12, tavoulari2024distinctrolesfor pages 1-2). The full-length atomic structure of citrin has not yet been experimentally resolved, though structural models have been proposed based on domain structures and homology modeling with the ADP/ATP carrier (lacabanne2025currentunderstandingof pages 3-4).</p>
+<h2 id="4-subcellular-localization-and-tissue-expression">4. Subcellular Localization and Tissue Expression</h2>
+<p>Citrin is localized to the <strong>inner mitochondrial membrane</strong>, where it mediates metabolite exchange between the mitochondrial matrix and the intermembrane space/cytosol (lacabanne2025currentunderstandingof pages 3-4, gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2).</p>
+<p>The tissue expression pattern of citrin is distinctive and has profound implications for disease. In <strong>human liver</strong>, citrin is the <strong>sole or overwhelmingly dominant AGC isoform</strong>, with quantitative proteomics revealing a citrin-to-aralar molar ratio of approximately <strong>397:1</strong> (gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2, gonzalezmoreno2023exogenousaralarslc25a12can pages 8-9). This stands in stark contrast to mouse liver, where the ratio is only approximately 8:1, which explains why citrin-knockout mice display a much milder phenotype than human patients with citrin deficiency (gonzalezmoreno2023exogenousaralarslc25a12can pages 8-9, gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2). Beyond liver, citrin is abundantly expressed in <strong>intestinal epithelium</strong> and is also present in <strong>kidney</strong> and <strong>heart</strong> (where it coexists with aralar) (broeks2021inborndisordersof pages 6-10, gonzalezmoreno2023exogenousaralarslc25a12can pages 2-3, ahmed2024theroleof pages 11-13). In the <strong>adult brain</strong>, citrin expression is extremely low and restricted to discrete <strong>neuronal clusters</strong>, including the deep cerebellar nuclei, vestibular nuclei, reticular nuclei of the thalamus, reticular tegmental nuclei of the pons, and red magnocellular nuclei (contreras2010lowlevelsof pages 1-2, contreras2010lowlevelsof pages 4-6). No citrin expression is detected in brain glial cells (contreras2010lowlevelsof pages 4-6).</p>
+<h2 id="5-metabolic-pathways-and-biochemical-roles">5. Metabolic Pathways and Biochemical Roles</h2>
+<h3 id="51-the-malate-aspartate-shuttle-mas">5.1 The Malate-Aspartate Shuttle (MAS)</h3>
+<p>Citrin is the <strong>principal component of the malate-aspartate shuttle</strong> in hepatocytes, which is the primary mechanism for transferring reducing equivalents (NADH) produced in the cytosol during glycolysis, lactate oxidation, and ethanol oxidation into mitochondria for oxidative phosphorylation (holecek2023aspartateglutamatecarrier2 pages 1-2, gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2). In the MAS, cytosolic NADH reduces oxaloacetate to malate (via cytosolic malate dehydrogenase), malate enters the mitochondrial matrix via the oxoglutarate carrier, and is re-oxidized to oxaloacetate (via mitochondrial malate dehydrogenase), generating mitochondrial NADH. Oxaloacetate is then transaminated to aspartate (via mitochondrial GOT2), and citrin exports aspartate to the cytosol in exchange for glutamate. In the cytosol, aspartate is transaminated back to oxaloacetate, regenerating NAD⁺ (holecek2023aspartateglutamatecarrier2 pages 1-2, broeks2021inborndisordersof pages 6-10). This shuttle is essential for maintaining the cytosolic NAD⁺/NADH redox balance, mitochondrial respiration, and ATP synthesis (holecek2023aspartateglutamatecarrier2 pages 1-2).</p>
+<h3 id="52-the-urea-cycle">5.2 The Urea Cycle</h3>
+<p>Citrin plays a <strong>critical role in hepatic ureagenesis</strong> by exporting aspartate from mitochondria to the cytosol, where it serves as the substrate for <strong>argininosuccinate synthetase (ASS1)</strong>, the enzyme that condenses aspartate with citrulline to form argininosuccinate (holecek2023aspartateglutamatecarrier2 pages 1-2, cunningham202020000picometersunder pages 4-5). Aspartate provides one of the two nitrogen atoms in the urea molecule (the other being ammonia). When citrin is deficient, cytosolic aspartate availability is reduced, impairing the urea cycle and leading to hyperammonemia and citrullinemia (palmieri2013themitochondrialtransporter pages 15-16, gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2).</p>
+<h3 id="53-gluconeogenesis">5.3 Gluconeogenesis</h3>
+<p>Through its role in the MAS, citrin supports <strong>gluconeogenesis</strong> by facilitating the transfer of aspartate to the cytosol, where it can be transaminated to oxaloacetate—the starting substrate for the gluconeogenic pathway. This linkage is particularly important during starvation, exercise, and amino acid catabolism, when glucagon and catecholamines stimulate both the urea cycle and gluconeogenesis simultaneously (holecek2023aspartateglutamatecarrier2 pages 2-4, lacabanne2025currentunderstandingof pages 3-4).</p>
+<h3 id="54-nucleotide-and-protein-synthesis">5.4 Nucleotide and Protein Synthesis</h3>
+<p>The cytosolic aspartate supplied by citrin also serves as a precursor for <strong>de novo purine and pyrimidine nucleotide biosynthesis</strong> and for <strong>protein synthesis</strong> (palmieri2013themitochondrialtransporter pages 15-16, gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2, owusuansah2023nagscps1and pages 2-4). In cancer biology, citrin-mediated aspartate export has been shown to promote pyrimidine biosynthesis via the CAD complex, supporting tumor cell proliferation (owusuansah2023nagscps1and pages 2-4, owusuansah2023nagscps1and pages 1-2).</p>
+<h3 id="55-redox-regulation-and-energy-metabolism">5.5 Redox Regulation and Energy Metabolism</h3>
+<p>The fundamental consequence of citrin function is the maintenance of the <strong>cytosolic NAD⁺/NADH ratio</strong>, which is essential for glycolysis, gluconeogenesis, and fatty acid β-oxidation. When citrin is absent or dysfunctional, the cytosolic NADH/NAD⁺ ratio becomes elevated, suppressing glycolysis and gluconeogenesis, impairing fatty acid oxidation, and creating a cellular energy deficit (palmieri2013themitochondrialtransporter pages 15-16, nuyttens2025acrucialrole pages 2-3, nuyttens2025acrucialrole pages 9-11). Recent work using Slc25a13⁻/⁻ mice in the context of TNF-induced systemic inflammatory response syndrome (SIRS) has demonstrated that citrin deficiency exacerbates metabolic dysfunction, causing severe hyperlactatemia, hepatic lipid accumulation, and increased lethality through disrupted NAD⁺ regeneration (nuyttens2025acrucialrole pages 2-3, nuyttens2025acrucialrole pages 11-12, nuyttens2025acrucialrole pages 9-11).</p>
+<h2 id="6-calcium-regulation-a-revised-understanding">6. Calcium Regulation: A Revised Understanding</h2>
+<p>A long-standing model held that citrin's transport activity was stimulated by calcium binding to its N-terminal EF-hand domain (goyani2024calciumsignalingin pages 4-6, holecek2023aspartateglutamatecarrier2 pages 2-4). However, <strong>landmark recent studies</strong> have fundamentally revised this view. Tavoulari et al. (2024) demonstrated, using purified citrin reconstituted in liposomes, that transport activity is <strong>not regulated by calcium</strong> in vitro (tavoulari2024distinctrolesfor pages 1-2, tavoulari2024distinctrolesfor pages 7-9). Complete abolition of the calcium-binding site had no effect on transport function, mitochondrial localization, or dimerization (tavoulari2024distinctrolesfor pages 7-9). The calcium-binding site in EF-hand 2 is described as non-canonical and pre-formed, and is now proposed to be an <strong>evolutionary remnant</strong> (tavoulari2024distinctrolesfor pages 11-12). This finding, confirmed by Lacabanne et al. (2025), suggests that calcium does not play a direct role in citrin deficiency pathogenesis and that earlier observations of calcium-dependent activation may have been indirect or related to other regulatory mechanisms (lacabanne2025currentunderstandingof pages 4-6, kunji2025thepeculiarproperties pages 3-4).</p>
+<h2 id="7-disease-associations-citrin-deficiency">7. Disease Associations: Citrin Deficiency</h2>
+<p>Biallelic loss-of-function mutations in SLC25A13 cause <strong>citrin deficiency (CD)</strong>, an autosomal recessive metabolic disorder with three recognized age-dependent phenotypes (vukovic2024thetherapeuticlandscape pages 1-2, komatsu2023citrindeficiencyclinical pages 1-2, kido2024clinicallandscapeof pages 1-2):</p>
+<p><strong>NICCD (Neonatal Intrahepatic Cholestasis Caused by Citrin Deficiency):</strong> Presents in neonates/infants with prolonged jaundice, intrahepatic cholestasis, hepatomegaly, fatty liver, low birth weight, hypoproteinemia, coagulopathy, elevated alpha-fetoprotein, galactosemia, citrullinemia, and hypoglycemia. NICCD typically resolves spontaneously by one year of age, though severe cases may progress to liver failure (vukovic2024thetherapeuticlandscape pages 1-2, komatsu2023citrindeficiencyclinical pages 1-2, kido2022clinicalmanifestationand pages 1-7).</p>
+<p><strong>FTTDCD (Failure to Thrive and Dyslipidemia Caused by Citrin Deficiency):</strong> A post-NICCD intermediate phenotype characterized by growth impairment, recurrent hypoglycemia, fatigue, hypertriglyceridemia, pancreatitis, and non-obese non-alcoholic fatty liver disease (vukovic2024thetherapeuticlandscape pages 1-2, komatsu2023citrindeficiencyclinical pages 1-2, hayasaka2024pathogenesisandmanagement pages 2-4).</p>
+<p><strong>CTLN2/AACD (Adult-Onset Type II Citrullinemia / Adolescent and Adult Citrin Deficiency):</strong> The most severe form, developing in approximately 5% of citrin-deficient individuals (typically ages 10–70), characterized by sudden attacks of hyperammonemia, nocturnal encephalopathy, neuropsychological abnormalities including disorientation, abnormal behavior, convulsions, and coma (komatsu2023citrindeficiencyclinical pages 1-2, hayasaka2024pathogenesisandmanagement pages 2-4, kido2022clinicalmanifestationand pages 7-11). Complications include liver cirrhosis and hepatocellular carcinoma (kido2022clinicalmanifestationand pages 7-11).</p>
+<p>CD patients characteristically exhibit <strong>peculiar dietary preferences</strong>, disliking high-carbohydrate foods while preferring fat- and protein-rich foods, which represents a compensatory metabolic adaptation (komatsu2023citrindeficiencyclinical pages 1-2). The disease is <strong>highly prevalent in East Asian populations</strong> but is now recognized as a pan-ethnic, global condition (kido2024clinicallandscapeof pages 1-2, haberle2024citrindeficiency—theeast‐side pages 1-2). A nationwide Japanese study identified 68 genetic variants across 345 patients, with the c.852_855del variant being the most prevalent, found in 42% of NICCD/post-NICCD cases and 49% of AACD patients (kido2024clinicallandscapeof pages 1-2).</p>
+<p>Current treatment includes dietary management (low-carbohydrate, high-fat/protein diet), medium-chain triglyceride (MCT) supplementation, and in severe cases, liver transplantation as the sole curative option (vukovic2024thetherapeuticlandscape pages 1-2, hayasaka2024pathogenesisandmanagement pages 2-4). Gene therapy approaches are under development, including mRNA-based strategies (vukovic2024thetherapeuticlandscape pages 1-2).</p>
+<h2 id="8-relationship-to-aralar-agc1slc25a12">8. Relationship to Aralar (AGC1/SLC25A12)</h2>
+<p>Citrin and aralar share 78% sequence identity and perform the same fundamental transport function (aspartate/glutamate exchange), but differ critically in tissue distribution (gonzalezmoreno2023exogenousaralarslc25a12can pages 2-3). Aralar is predominantly expressed in brain, skeletal muscle, and heart, while citrin dominates in liver and intestine (gonzalezmoreno2023exogenousaralarslc25a12can pages 2-3, pardo2022agc1deficiencypathology pages 2-4). In human liver, aralar is virtually absent (citrin:aralar ratio ~400:1), making citrin absolutely indispensable for hepatic metabolism (gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2). Importantly, González-Moreno et al. (2023) demonstrated that exogenous aralar can functionally replace citrin in liver, restoring MAS activity and normalizing NADH/NAD⁺ ratios in citrin-deficient hepatocytes, suggesting a potential therapeutic strategy (gonzalezmoreno2023exogenousaralarslc25a12can pages 8-9, gonzalezmoreno2023exogenousaralarslc25a12can pages 9-10).</p>
+<h2 id="9-role-in-cancer">9. Role in Cancer</h2>
+<p>Citrin is <strong>upregulated in multiple cancer types</strong>, including glioblastoma, glioma, stomach adenocarcinoma, and lung adenocarcinoma (1.4- to 4-fold higher expression compared to matched normal tissues) (owusuansah2023nagscps1and pages 2-4). In cancer cells, citrin supports metabolic reprogramming by: (1) maintaining NAD⁺/NADH pools to sustain glycolysis and oxidative phosphorylation; (2) increasing cytosolic aspartate availability for pyrimidine biosynthesis via the CAD complex; and (3) promoting cancer cell migration and invasion through regulation of energy-consuming processes and MMP-9 expression (rabinovich2020themitochondrialcarrier pages 2-4, rabinovich2020themitochondrialcarrier pages 1-2, rabinovich2020themitochondrialcarrier pages 4-5). Citrin overexpression increases lactate production, glycolytic intermediates, and oxygen consumption rates, while citrin depletion restricts these processes (rabinovich2020themitochondrialcarrier pages 4-5). Citrin gene copy number correlates with mRNA expression in several tumor types (owusuansah2023nagscps1and pages 1-2). These findings suggest citrin may represent a novel therapeutic target in cancer (rabinovich2020themitochondrialcarrier pages 2-4, gao2024cancertherapeuticpotential pages 4-6).</p>
+<h2 id="10-conclusions">10. Conclusions</h2>
+<p>SLC25A13/citrin is a mitochondrial inner membrane aspartate/glutamate antiporter of central importance to hepatic metabolism. It exports aspartate from the mitochondrial matrix in exchange for glutamate plus a proton, thereby serving as the key component of the malate-aspartate shuttle in liver. This transport activity is essential for maintaining cytosolic NAD⁺/NADH redox balance, fueling the urea cycle, supporting gluconeogenesis, and providing aspartate for nucleotide and protein biosynthesis. Structurally, citrin is distinguished by its three-domain architecture and homodimeric organization, with recent work overturning the long-held view that calcium regulates its transport activity. Loss-of-function mutations cause citrin deficiency, a clinically complex metabolic disorder with age-dependent hepatic and neurological manifestations, while citrin upregulation in tumors supports cancer cell metabolic reprogramming and proliferation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(palmieri2013themitochondrialtransporter pages 15-16): Ferdinando Palmieri. The mitochondrial transporter family slc25: identification, properties and physiopathology. Molecular aspects of medicine, 34 2-3:465-84, Apr 2013. URL: https://doi.org/10.1016/j.mam.2012.05.005, doi:10.1016/j.mam.2012.05.005. This article has 740 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavoulari2024distinctrolesfor pages 1-2): Sotiria Tavoulari, Denis Lacabanne, Gonçalo C. Pereira, Chancievan Thangaratnarajah, Martin S. King, Jiuya He, Suvagata R. Chowdhury, Lisa Tilokani, Shane M. Palmer, Julien Prudent, John E. Walker, and Edmund R.S. Kunji. Distinct roles for the domains of the mitochondrial aspartate/glutamate carrier citrin in organellar localization and substrate transport. Dec 2024. URL: https://doi.org/10.1016/j.molmet.2024.102047, doi:10.1016/j.molmet.2024.102047. This article has 12 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kunji2025thepeculiarproperties pages 3-4): E. Kunji, Vasiliki Mavridou, Martin S King, Camila Cimadamore-Werthein, Stephany Jaiquel Baron, Scott A Jones, Alannah C. King, Roger J Springett, Deepak Chand, Shane M Palmer, Denis Lacabanne, Sotiria Tavoulari, and J. Ruprecht. The peculiar properties of mitochondrial carriers of the slc25 family. The Biochemical journal, Jul 2025. URL: https://doi.org/10.1042/bcj20253171, doi:10.1042/bcj20253171. This article has 14 citations.</p>
+</li>
+<li>
+<p>(ruprecht2020theslc25mitochondrial pages 1-2): Jonathan J. Ruprecht and Edmund R.S. Kunji. The slc25 mitochondrial carrier family: structure and mechanism. Trends in Biochemical Sciences, 45:244-258, Mar 2020. URL: https://doi.org/10.1016/j.tibs.2019.11.001, doi:10.1016/j.tibs.2019.11.001. This article has 440 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gonzalezmoreno2023exogenousaralarslc25a12can pages 2-3): Luis González-Moreno, Andrea Santamaría-Cano, Alberto Paradela, María Luz Martínez-Chantar, Miguel Á. Martín, Mercedes Pérez-Carreras, Alberto García-Picazo, Jesús Vázquez, Enrique Calvo, Gloria González-Aseguinolaza, Takeyori Saheki, Araceli del Arco, Jorgina Satrústegui, and Laura Contreras. Exogenous aralar/slc25a12 can replace citrin/slc25a13 as malate aspartate shuttle component in liver. Jun 2023. URL: https://doi.org/10.1016/j.ymgmr.2023.100967, doi:10.1016/j.ymgmr.2023.100967. This article has 9 citations.</p>
+</li>
+<li>
+<p>(holecek2023aspartateglutamatecarrier2 pages 1-2): Milan Holeček. Aspartate-glutamate carrier 2 (citrin): a role in glucose and amino acid metabolism in the liver. BMB Reports, 56:385-391, Jun 2023. URL: https://doi.org/10.5483/bmbrep.2023-0052, doi:10.5483/bmbrep.2023-0052. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vukovic2024thetherapeuticlandscape pages 1-2): Toni Vuković, Li Eon Kuek, Barbara Yu, Georgios Makris, and Johannes Häberle. The therapeutic landscape of citrin deficiency. Journal of Inherited Metabolic Disease, 47:1157-1174, Jul 2024. URL: https://doi.org/10.1002/jimd.12768, doi:10.1002/jimd.12768. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kido2024clinicallandscapeof pages 1-2): Jun Kido, Georgios Makris, Saikat Santra, and Johannes Häberle. Clinical landscape of citrin deficiency: a global perspective on a multifaceted condition. Journal of Inherited Metabolic Disease, 47:1144-1156, Mar 2024. URL: https://doi.org/10.1002/jimd.12722, doi:10.1002/jimd.12722. This article has 30 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lacabanne2025currentunderstandingof pages 3-4): Denis Lacabanne, Alice P. Sowton, Bosco Jose, Edmund R. S. Kunji, and Sotiria Tavoulari. Current understanding of pathogenic mechanisms and disease models of citrin deficiency. Journal of Inherited Metabolic Disease, Mar 2025. URL: https://doi.org/10.1002/jimd.70021, doi:10.1002/jimd.70021. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gonzalezmoreno2023exogenousaralarslc25a12can pages 1-2): Luis González-Moreno, Andrea Santamaría-Cano, Alberto Paradela, María Luz Martínez-Chantar, Miguel Á. Martín, Mercedes Pérez-Carreras, Alberto García-Picazo, Jesús Vázquez, Enrique Calvo, Gloria González-Aseguinolaza, Takeyori Saheki, Araceli del Arco, Jorgina Satrústegui, and Laura Contreras. Exogenous aralar/slc25a12 can replace citrin/slc25a13 as malate aspartate shuttle component in liver. Jun 2023. URL: https://doi.org/10.1016/j.ymgmr.2023.100967, doi:10.1016/j.ymgmr.2023.100967. This article has 9 citations.</p>
+</li>
+<li>
+<p>(contreras2010lowlevelsof pages 1-2): Laura Contreras, Almudena Urbieta, Keiko Kobayashi, Takeyori Saheki, and Jorgina Satrústegui. Low levels of citrin (slc25a13) expression in adult mouse brain restricted to neuronal clusters. Journal of Neuroscience Research, 88:1009-1016, Apr 2010. URL: https://doi.org/10.1002/jnr.22283, doi:10.1002/jnr.22283. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(broeks2021inborndisordersof pages 6-10): Melissa H. Broeks, Clara D. M. van Karnebeek, Ronald J. A. Wanders, Judith J. M. Jans, and Nanda M. Verhoeven‐Duif. Inborn disorders of the malate aspartate shuttle. Journal of Inherited Metabolic Disease, 44:792-808, May 2021. URL: https://doi.org/10.1002/jimd.12402, doi:10.1002/jimd.12402. This article has 93 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lacabanne2025currentunderstandingof pages 4-6): Denis Lacabanne, Alice P. Sowton, Bosco Jose, Edmund R. S. Kunji, and Sotiria Tavoulari. Current understanding of pathogenic mechanisms and disease models of citrin deficiency. Journal of Inherited Metabolic Disease, Mar 2025. URL: https://doi.org/10.1002/jimd.70021, doi:10.1002/jimd.70021. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holecek2023aspartateglutamatecarrier2 pages 2-4): Milan Holeček. Aspartate-glutamate carrier 2 (citrin): a role in glucose and amino acid metabolism in the liver. BMB Reports, 56:385-391, Jun 2023. URL: https://doi.org/10.5483/bmbrep.2023-0052, doi:10.5483/bmbrep.2023-0052. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(komatsu2023citrindeficiencyclinical pages 1-2): Michiharu Komatsu, Naoki Tanaka, Takefumi Kimura, and Masahide Yazaki. Citrin deficiency: clinical and nutritional features. Nutrients, 15:2284, May 2023. URL: https://doi.org/10.3390/nu15102284, doi:10.3390/nu15102284. This article has 19 citations.</p>
+</li>
+<li>
+<p>(kido2022clinicalmanifestationand pages 7-11): Jun Kido, Johannes Häberle, Keishin Sugawara, Toju Tanaka, Masayoshi Nagao, Takaaki Sawada, Yoichi Wada, Chikahiko Numakura, Kei Murayama, Yoriko Watanabe, Kanako Kojima‐Ishii, Hideo Sasai, Kiyotaka Kosugiyama, and Kimitoshi Nakamura. Clinical manifestation and long‐term outcome of citrin deficiency: report from a nationwide study in japan. Journal of Inherited Metabolic Disease, 45:431-444, Feb 2022. URL: https://doi.org/10.1002/jimd.12483, doi:10.1002/jimd.12483. This article has 39 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavoulari2024distinctrolesfor pages 11-12): Sotiria Tavoulari, Denis Lacabanne, Gonçalo C. Pereira, Chancievan Thangaratnarajah, Martin S. King, Jiuya He, Suvagata R. Chowdhury, Lisa Tilokani, Shane M. Palmer, Julien Prudent, John E. Walker, and Edmund R.S. Kunji. Distinct roles for the domains of the mitochondrial aspartate/glutamate carrier citrin in organellar localization and substrate transport. Dec 2024. URL: https://doi.org/10.1016/j.molmet.2024.102047, doi:10.1016/j.molmet.2024.102047. This article has 12 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavoulari2024distinctrolesfor pages 7-9): Sotiria Tavoulari, Denis Lacabanne, Gonçalo C. Pereira, Chancievan Thangaratnarajah, Martin S. King, Jiuya He, Suvagata R. Chowdhury, Lisa Tilokani, Shane M. Palmer, Julien Prudent, John E. Walker, and Edmund R.S. Kunji. Distinct roles for the domains of the mitochondrial aspartate/glutamate carrier citrin in organellar localization and substrate transport. Dec 2024. URL: https://doi.org/10.1016/j.molmet.2024.102047, doi:10.1016/j.molmet.2024.102047. This article has 12 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tavoulari2024distinctrolesfor pages 9-11): Sotiria Tavoulari, Denis Lacabanne, Gonçalo C. Pereira, Chancievan Thangaratnarajah, Martin S. King, Jiuya He, Suvagata R. Chowdhury, Lisa Tilokani, Shane M. Palmer, Julien Prudent, John E. Walker, and Edmund R.S. Kunji. Distinct roles for the domains of the mitochondrial aspartate/glutamate carrier citrin in organellar localization and substrate transport. Dec 2024. URL: https://doi.org/10.1016/j.molmet.2024.102047, doi:10.1016/j.molmet.2024.102047. This article has 12 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ruprecht2020theslc25mitochondrial pages 2-3): Jonathan J. Ruprecht and Edmund R.S. Kunji. The slc25 mitochondrial carrier family: structure and mechanism. Trends in Biochemical Sciences, 45:244-258, Mar 2020. URL: https://doi.org/10.1016/j.tibs.2019.11.001, doi:10.1016/j.tibs.2019.11.001. This article has 440 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gonzalezmoreno2023exogenousaralarslc25a12can pages 8-9): Luis González-Moreno, Andrea Santamaría-Cano, Alberto Paradela, María Luz Martínez-Chantar, Miguel Á. Martín, Mercedes Pérez-Carreras, Alberto García-Picazo, Jesús Vázquez, Enrique Calvo, Gloria González-Aseguinolaza, Takeyori Saheki, Araceli del Arco, Jorgina Satrústegui, and Laura Contreras. Exogenous aralar/slc25a12 can replace citrin/slc25a13 as malate aspartate shuttle component in liver. Jun 2023. URL: https://doi.org/10.1016/j.ymgmr.2023.100967, doi:10.1016/j.ymgmr.2023.100967. This article has 9 citations.</p>
+</li>
+<li>
+<p>(ahmed2024theroleof pages 11-13): Amer Ahmed, Giorgia Natalia Iaconisi, Daria Di Molfetta, Vincenzo Coppola, Antonello Caponio, Ansu Singh, Aasia Bibi, Loredana Capobianco, Luigi Palmieri, Vincenza Dolce, and Giuseppe Fiermonte. The role of mitochondrial solute carriers slc25 in cancer metabolic reprogramming: current insights and future perspectives. International Journal of Molecular Sciences, 26:92, Dec 2024. URL: https://doi.org/10.3390/ijms26010092, doi:10.3390/ijms26010092. This article has 18 citations.</p>
+</li>
+<li>
+<p>(contreras2010lowlevelsof pages 4-6): Laura Contreras, Almudena Urbieta, Keiko Kobayashi, Takeyori Saheki, and Jorgina Satrústegui. Low levels of citrin (slc25a13) expression in adult mouse brain restricted to neuronal clusters. Journal of Neuroscience Research, 88:1009-1016, Apr 2010. URL: https://doi.org/10.1002/jnr.22283, doi:10.1002/jnr.22283. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cunningham202020000picometersunder pages 4-5): Corey N Cunningham and Jared Rutter. 20,000 picometers under the omm: diving into the vastness of mitochondrial metabolite transport. EMBO reports, Apr 2020. URL: https://doi.org/10.15252/embr.202050071, doi:10.15252/embr.202050071. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(owusuansah2023nagscps1and pages 2-4): Melissa Owusu-Ansah, Nikita Guptan, Dylon Alindogan, Michio Morizono, and Ljubica Caldovic. Nags, cps1, and slc25a13 (citrin) at the crossroads of arginine and pyrimidines metabolism in tumor cells. International Journal of Molecular Sciences, 24:6754, Apr 2023. URL: https://doi.org/10.3390/ijms24076754, doi:10.3390/ijms24076754. This article has 16 citations.</p>
+</li>
+<li>
+<p>(owusuansah2023nagscps1and pages 1-2): Melissa Owusu-Ansah, Nikita Guptan, Dylon Alindogan, Michio Morizono, and Ljubica Caldovic. Nags, cps1, and slc25a13 (citrin) at the crossroads of arginine and pyrimidines metabolism in tumor cells. International Journal of Molecular Sciences, 24:6754, Apr 2023. URL: https://doi.org/10.3390/ijms24076754, doi:10.3390/ijms24076754. This article has 16 citations.</p>
+</li>
+<li>
+<p>(nuyttens2025acrucialrole pages 2-3): Louise Nuyttens, Marah Heyerick, Maxime Roes, Elise Moens, Céline Van Dender, Charlotte Wallaeys, Tino Hochepied, Steven Timmermans, Jolien Vandewalle, and Claude Libert. A crucial role of the malate aspartate shuttle in metabolic reprogramming in tnf-induced sirs. Frontiers in Immunology, Oct 2025. URL: https://doi.org/10.3389/fimmu.2025.1652516, doi:10.3389/fimmu.2025.1652516. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nuyttens2025acrucialrole pages 9-11): Louise Nuyttens, Marah Heyerick, Maxime Roes, Elise Moens, Céline Van Dender, Charlotte Wallaeys, Tino Hochepied, Steven Timmermans, Jolien Vandewalle, and Claude Libert. A crucial role of the malate aspartate shuttle in metabolic reprogramming in tnf-induced sirs. Frontiers in Immunology, Oct 2025. URL: https://doi.org/10.3389/fimmu.2025.1652516, doi:10.3389/fimmu.2025.1652516. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nuyttens2025acrucialrole pages 11-12): Louise Nuyttens, Marah Heyerick, Maxime Roes, Elise Moens, Céline Van Dender, Charlotte Wallaeys, Tino Hochepied, Steven Timmermans, Jolien Vandewalle, and Claude Libert. A crucial role of the malate aspartate shuttle in metabolic reprogramming in tnf-induced sirs. Frontiers in Immunology, Oct 2025. URL: https://doi.org/10.3389/fimmu.2025.1652516, doi:10.3389/fimmu.2025.1652516. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(goyani2024calciumsignalingin pages 4-6): Shanikumar Goyani, Shatakshi Shukla, Pooja Jadiya, and Dhanendra Tomar. Calcium signaling in mitochondrial intermembrane space. Biochemical Society transactions, 52:2215-2229, Oct 2024. URL: https://doi.org/10.1042/bst20240319, doi:10.1042/bst20240319. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kido2022clinicalmanifestationand pages 1-7): Jun Kido, Johannes Häberle, Keishin Sugawara, Toju Tanaka, Masayoshi Nagao, Takaaki Sawada, Yoichi Wada, Chikahiko Numakura, Kei Murayama, Yoriko Watanabe, Kanako Kojima‐Ishii, Hideo Sasai, Kiyotaka Kosugiyama, and Kimitoshi Nakamura. Clinical manifestation and long‐term outcome of citrin deficiency: report from a nationwide study in japan. Journal of Inherited Metabolic Disease, 45:431-444, Feb 2022. URL: https://doi.org/10.1002/jimd.12483, doi:10.1002/jimd.12483. This article has 39 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hayasaka2024pathogenesisandmanagement pages 2-4): Kiyoshi Hayasaka. Pathogenesis and management of citrin deficiency. Internal Medicine, 63:1977-1986, Jul 2024. URL: https://doi.org/10.2169/internalmedicine.2595-23, doi:10.2169/internalmedicine.2595-23. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haberle2024citrindeficiency—theeast‐side pages 1-2): Johannes Häberle. Citrin deficiency—the east‐side story. Journal of Inherited Metabolic Disease, 47:1129-1133, Jul 2024. URL: https://doi.org/10.1002/jimd.12772, doi:10.1002/jimd.12772. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pardo2022agc1deficiencypathology pages 2-4): Beatriz Pardo, Eduardo Herrada-Soler, Jorgina Satrústegui, Laura Contreras, and Araceli del Arco. Agc1 deficiency: pathology and molecular and cellular mechanisms of the disease. International Journal of Molecular Sciences, 23:528, Jan 2022. URL: https://doi.org/10.3390/ijms23010528, doi:10.3390/ijms23010528. This article has 32 citations.</p>
+</li>
+<li>
+<p>(gonzalezmoreno2023exogenousaralarslc25a12can pages 9-10): Luis González-Moreno, Andrea Santamaría-Cano, Alberto Paradela, María Luz Martínez-Chantar, Miguel Á. Martín, Mercedes Pérez-Carreras, Alberto García-Picazo, Jesús Vázquez, Enrique Calvo, Gloria González-Aseguinolaza, Takeyori Saheki, Araceli del Arco, Jorgina Satrústegui, and Laura Contreras. Exogenous aralar/slc25a12 can replace citrin/slc25a13 as malate aspartate shuttle component in liver. Jun 2023. URL: https://doi.org/10.1016/j.ymgmr.2023.100967, doi:10.1016/j.ymgmr.2023.100967. This article has 9 citations.</p>
+</li>
+<li>
+<p>(rabinovich2020themitochondrialcarrier pages 2-4): Shiran Rabinovich, Alon Silberman, Lital Adler, Shani Agron, Smadar Levin-Zaidman, Amir Bahat, Ziv Porat, Efrat Ben-Zeev, Inbal Geva, Maxim Itkin, Sergey Malitsky, Adam Buchaklian, Daniel Helbling, David Dimmock, and Ayelet Erez. The mitochondrial carrier citrin plays a role in regulating cellular energy during carcinogenesis. Oncogene, 39:164-175, Aug 2020. URL: https://doi.org/10.1038/s41388-019-0976-2, doi:10.1038/s41388-019-0976-2. This article has 39 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rabinovich2020themitochondrialcarrier pages 1-2): Shiran Rabinovich, Alon Silberman, Lital Adler, Shani Agron, Smadar Levin-Zaidman, Amir Bahat, Ziv Porat, Efrat Ben-Zeev, Inbal Geva, Maxim Itkin, Sergey Malitsky, Adam Buchaklian, Daniel Helbling, David Dimmock, and Ayelet Erez. The mitochondrial carrier citrin plays a role in regulating cellular energy during carcinogenesis. Oncogene, 39:164-175, Aug 2020. URL: https://doi.org/10.1038/s41388-019-0976-2, doi:10.1038/s41388-019-0976-2. This article has 39 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rabinovich2020themitochondrialcarrier pages 4-5): Shiran Rabinovich, Alon Silberman, Lital Adler, Shani Agron, Smadar Levin-Zaidman, Amir Bahat, Ziv Porat, Efrat Ben-Zeev, Inbal Geva, Maxim Itkin, Sergey Malitsky, Adam Buchaklian, Daniel Helbling, David Dimmock, and Ayelet Erez. The mitochondrial carrier citrin plays a role in regulating cellular energy during carcinogenesis. Oncogene, 39:164-175, Aug 2020. URL: https://doi.org/10.1038/s41388-019-0976-2, doi:10.1038/s41388-019-0976-2. This article has 39 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gao2024cancertherapeuticpotential pages 4-6): Renzhuo Gao, Dan Zhou, Xingpeng Qiu, Jiayi Zhang, Daya Luo, Xiaohong Yang, Caiyun Qian, and Zhuoqi Liu. Cancer therapeutic potential and prognostic value of the slc25 mitochondrial carrier family: a review. Cancer Control : Journal of the Moffitt Cancer Center, Jan 2024. URL: https://doi.org/10.1177/10732748241287905, doi:10.1177/10732748241287905. This article has 12 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="SLC25A13-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kunji2025thepeculiarproperties pages 3-4</li>
+<li>broeks2021inborndisordersof pages 6-10</li>
+<li>lacabanne2025currentunderstandingof pages 3-4</li>
+<li>tavoulari2024distinctrolesfor pages 11-12</li>
+<li>tavoulari2024distinctrolesfor pages 9-11</li>
+<li>contreras2010lowlevelsof pages 4-6</li>
+<li>tavoulari2024distinctrolesfor pages 7-9</li>
+<li>kido2022clinicalmanifestationand pages 7-11</li>
+<li>komatsu2023citrindeficiencyclinical pages 1-2</li>
+<li>kido2024clinicallandscapeof pages 1-2</li>
+<li>vukovic2024thetherapeuticlandscape pages 1-2</li>
+<li>rabinovich2020themitochondrialcarrier pages 4-5</li>
+<li>palmieri2013themitochondrialtransporter pages 15-16</li>
+<li>tavoulari2024distinctrolesfor pages 1-2</li>
+<li>contreras2010lowlevelsof pages 1-2</li>
+<li>lacabanne2025currentunderstandingof pages 4-6</li>
+<li>ahmed2024theroleof pages 11-13</li>
+<li>nuyttens2025acrucialrole pages 2-3</li>
+<li>nuyttens2025acrucialrole pages 9-11</li>
+<li>nuyttens2025acrucialrole pages 11-12</li>
+<li>goyani2024calciumsignalingin pages 4-6</li>
+<li>kido2022clinicalmanifestationand pages 1-7</li>
+<li>hayasaka2024pathogenesisandmanagement pages 2-4</li>
+<li>rabinovich2020themitochondrialcarrier pages 2-4</li>
+<li>rabinovich2020themitochondrialcarrier pages 1-2</li>
+<li>gao2024cancertherapeuticpotential pages 4-6</li>
+<li>https://doi.org/10.1016/j.mam.2012.05.005,</li>
+<li>https://doi.org/10.1016/j.molmet.2024.102047,</li>
+<li>https://doi.org/10.1042/bcj20253171,</li>
+<li>https://doi.org/10.1016/j.tibs.2019.11.001,</li>
+<li>https://doi.org/10.1016/j.ymgmr.2023.100967,</li>
+<li>https://doi.org/10.5483/bmbrep.2023-0052,</li>
+<li>https://doi.org/10.1002/jimd.12768,</li>
+<li>https://doi.org/10.1002/jimd.12722,</li>
+<li>https://doi.org/10.1002/jimd.70021,</li>
+<li>https://doi.org/10.1002/jnr.22283,</li>
+<li>https://doi.org/10.1002/jimd.12402,</li>
+<li>https://doi.org/10.3390/nu15102284,</li>
+<li>https://doi.org/10.1002/jimd.12483,</li>
+<li>https://doi.org/10.3390/ijms26010092,</li>
+<li>https://doi.org/10.15252/embr.202050071,</li>
+<li>https://doi.org/10.3390/ijms24076754,</li>
+<li>https://doi.org/10.3389/fimmu.2025.1652516,</li>
+<li>https://doi.org/10.1042/bst20240319,</li>
+<li>https://doi.org/10.2169/internalmedicine.2595-23,</li>
+<li>https://doi.org/10.1002/jimd.12772,</li>
+<li>https://doi.org/10.3390/ijms23010528,</li>
+<li>https://doi.org/10.1038/s41388-019-0976-2,</li>
+<li>https://doi.org/10.1177/10732748241287905,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SLC25A13-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UJS0" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="slc25a13-citrin-agc2-review-notes">SLC25A13 (citrin / AGC2) review notes</h1>
+<p>UniProtKB Q9UJS0. Human liver-type calcium-binding mitochondrial aspartate/glutamate<br />
+carrier (AGC2). Paralog of SLC25A12 (aralar / AGC1), the brain/muscle isoform (77% identical).</p>
+<h2 id="core-molecular-function">Core molecular function</h2>
+<ul>
+<li>Electrogenic aspartate/glutamate antiporter: exports mitochondrial L-aspartate to the<br />
+  cytosol in exchange for cytosolic L-glutamate + H+. Electrogenic because aspartate is<br />
+  transported as the anion while glutamate is co-transported with a proton.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11566871" title="shown to catalyze the electrogenic exchange of aspartate for glutamate and a H +">PMID:11566871</a></li>
+<li>Reaction (RHEA:70783): L-aspartate(in) + L-glutamate(out) + H+(out) = L-aspartate(out) +<br />
+  L-glutamate(in) + H+(in) (UniProt CATALYTIC ACTIVITY).</li>
+<li>Confirmed independently and shown NOT to transport GABA (EXP; PMID:38945283).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38945283" title="the human AGC isoforms (AGC1/aralar1 and AGC2/citrin) are unable to transport GABA both in homo- and in hetero-exchange with either glutamate or aspartate">PMID:38945283</a></li>
+<li>Also exchanges L-cysteinesulfinate (3-sulfino-L-alanine) for glutamate+H+ or for aspartate<br />
+  (secondary substrate). <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" title="AGC also transports cysteinesulfinate in exchange for either aspartate or glutamate">PMID:11566871</a></li>
+<li>Functions as a monomer with ping-pong kinetics for transport (PMID:38937634), though the<br />
+  full-length protein is a structural homodimer via the N-terminal domain (PMID:25410934).</li>
+</ul>
+<h2 id="biological-process">Biological process</h2>
+<ul>
+<li>Component of the malate-aspartate NADH shuttle: overexpression increases MAS activity.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11566871" title="Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle">PMID:11566871</a><br />
+  MAS transfers cytosolic reducing equivalents into mitochondria and regenerates cytosolic NAD+.</li>
+<li>Urea cycle: supplies cytosolic aspartate consumed by ASS1 (argininosuccinate synthetase).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11566871" title="The mitochondrial aspartate/glutamate carrier catalyzes an important step in both the urea cycle and the aspartate/malate NADH shuttle">PMID:11566871</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25410934" title="In liver, cytosolic aspartate is required for the urea cycle11, which is crucial for the production of urea from the deamination of amino acids">PMID:25410934</a><br />
+  Note: urea cycle (GO:0000050) is NOT currently in GOA for SLC25A13 -&gt; add as NEW.</li>
+<li>Gluconeogenesis: cytosolic aspartate needed for oxaloacetate production.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25410934" title="Cytosolic aspartate is also required for the conversion of oxoglutarate to oxaloacetate, a crucial step in gluconeogenesis from lactate and alanine">PMID:25410934</a></li>
+<li>MAS important for de novo serine biosynthesis (IGI panel of MAS-deficient cells; PMID:37647199,<br />
+  full text unavailable in cache but title/abstract support MAS role; SLC25A13 was one MAS component knocked out).</li>
+</ul>
+<h2 id="regulation-calcium-binding">Regulation / calcium binding</h2>
+<ul>
+<li>N-terminal regulatory domain with EF-hands binds calcium in the intermembrane space; only<br />
+  EF-hand 2 binds Ca2+ (X-ray structure PDB 4P5W). <a href="https://pubmed.ncbi.nlm.nih.gov/25410934" title="Only EF-hand 2 binds calcium">PMID:25410934</a><br />
+  Ca2+ binding stimulates transport / MAS. <a href="https://pubmed.ncbi.nlm.nih.gov/11566871" title="stimulated by Ca 2+ on the external side of the inner mitochondrial membrane">PMID:11566871</a></li>
+<li>NB caveat: PMID:39419476 argues the N-terminal domain does NOT regulate transport via calcium<br />
+  as previously thought; instead N-terminal mutations cause a mitochondrial import defect.<br />
+  But calcium ion binding by EF-hand 2 is directly demonstrated (IDA, PMID:25410934) regardless<br />
+  of its regulatory role -&gt; calcium ion binding annotation is valid.</li>
+<li>Ca2+-stimulated activity raises mitochondrial ATP on agonist stimulation (IDA; PMID:12851387).</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Mitochondrial inner membrane, multi-pass (6 TM in carrier domain; N- and C-terminal domains<br />
+  protrude into the intermembrane space). <a href="https://pubmed.ncbi.nlm.nih.gov/39419476" title="located in the mitochondrial inner membrane">PMID:39419476</a><br />
+  Well supported by EXP/IDA (PMID:10642534, PMID:11566871, PMID:39419476).</li>
+<li>The PMID:10642534 NAS "plasma membrane" annotation is inconsistent with all experimental<br />
+  data (mitochondrial inner membrane). The paper itself concludes mitochondrial localization<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10642534" title="The localization of Aralar2/citrin expressed in human cell lines is mitochondrial">PMID:10642534</a>.<br />
+  -&gt; REMOVE the plasma membrane annotation.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Citrin deficiency (autosomal recessive): NICCD (neonatal intrahepatic cholestasis), FTTDCD,<br />
+  and adult-onset CTLN2 (citrullinemia type II) with hyperammonemic encephalopathy. Broader than<br />
+  a pure urea-cycle-enzyme phenotype because of the MAS/redox role. (dismech Citrin_Deficiency.yaml;<br />
+  UniProt DISEASE CDAA/CDNI.)</li>
+</ul>
+<h2 id="interactions">Interactions</h2>
+<ul>
+<li>IntAct IPI annotations (PMID:28514442, PMID:33961781, PMID:40355756) all cite WITH/FROM<br />
+  UniProtKB:O75746 (SLC25A12 / aralar). UniProt records the Q9UJS0-O75746 interaction. These are<br />
+  bare "protein binding" -&gt; uninformative, MARK_AS_OVER_ANNOTATED. GO:0042802 identical protein<br />
+  binding (PMID:25410934) reflects the demonstrated N-terminal homodimer -&gt; KEEP_AS_NON_CORE.</li>
+</ul>
+<h2 id="falcon-deep-research">Falcon deep research</h2>
+<p>Falcon deep-research file did not land within the polling window; review grounded in the UniProt<br />
+record, the dismech Citrin_Deficiency.yaml disorder model, and cached publications.<br />
+</content></p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9UJS0
+gene_symbol: SLC25A13
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  SLC25A13 encodes citrin (aspartate/glutamate carrier 2, AGC2), the liver-type,
+  calcium-binding member of the mitochondrial carrier (SLC25) family. It is an
+  integral, multi-pass protein of the mitochondrial inner membrane that catalyzes
+  the electrogenic exchange of L-aspartate for L-glutamate plus a proton: it
+  exports L-aspartate from the mitochondrial matrix to the cytosol while importing
+  cytosolic L-glutamate together with a proton. Because aspartate moves as the anion
+  and glutamate is co-transported with a proton, the antiport is electrogenic and, in
+  energized mitochondria, is driven in the direction of aspartate efflux. Citrin
+  is a central component of the malate-aspartate NADH shuttle, transferring
+  cytosolic reducing equivalents into the mitochondria and regenerating cytosolic
+  NAD+, and it supplies the cytosolic aspartate consumed by argininosuccinate
+  synthetase (ASS1) in the hepatic urea cycle and used in gluconeogenesis. Each
+  protomer has a three-domain architecture: an N-terminal regulatory domain with
+  EF-hand motifs (only EF-hand 2 binds calcium in the intermembrane space), a
+  six-transmembrane SLC25 carrier domain that performs transport, and a C-terminal
+  amphipathic helix; the full-length carrier assembles as a homodimer via the
+  N-terminal domain while transporting substrate as a functional monomer. Citrin is
+  expressed most abundantly in liver and other non-excitable tissues, in contrast
+  to its paralog aralar (SLC25A12 / AGC1), the brain- and muscle-predominant
+  isoform. Loss of citrin function causes citrin deficiency, which manifests across
+  age as neonatal intrahepatic cholestasis (NICCD), failure to thrive and
+  dyslipidemia (FTTDCD), and adult-onset citrullinemia type II (CTLN2) with
+  hyperammonemic encephalopathy; the phenotype is broader than that of a pure urea
+  cycle enzyme owing to citrin&#39;s additional role in the malate-aspartate shuttle
+  and cellular redox balance.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9UJS0-1
+- name: &#39;2&#39;
+  id: Q9UJS0-2
+  sequence_note: VSP_043747
+existing_annotations:
+- term:
+    id: GO:0005313
+    label: L-glutamate transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of L-glutamate transporter activity. Citrin
+      imports L-glutamate together with a proton as one half of its aspartate/glutamate
+      antiport, so this is a correct component of the core function.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by experimental reconstitution showing electrogenic exchange
+      of aspartate for glutamate and a proton. This activity is one arm of the
+      aspartate/glutamate antiport; the more specific antiporter term (GO:0000515) is
+      the primary/core molecular function, but this term is accurate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0015183
+    label: L-aspartate transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of L-aspartate transporter activity. Citrin exports
+      L-aspartate from the matrix as the other half of its antiport; a correct component
+      of the core function.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally demonstrated. Aspartate efflux is one arm of the electrogenic
+      aspartate/glutamate antiport (the core activity, GO:0000515). This transporter-activity
+      term is accurate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0043490
+    label: malate-aspartate shuttle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment placing citrin in the malate-aspartate NADH shuttle,
+      which it participates in as the inner-membrane aspartate/glutamate exchange step.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported: overexpression of citrin increases malate-aspartate shuttle activity
+      in human cells, and the carrier is an integral component of the shuttle. Core biological
+      process for citrin.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment to the mitochondrial inner membrane, where citrin is
+      active as a multi-pass carrier. Correct and core subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with all experimental localization data and the multi-pass topology of
+      the SLC25 carrier domain. Core location.
+    supported_by:
+    - reference_id: PMID:39419476
+      supporting_text: &#34;located in the mitochondrial inner membrane&#34;
+- term:
+    id: GO:0015810
+    label: aspartate transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) BP assignment for aspartate transmembrane transport, the process
+      arm of citrin&#39;s aspartate efflux.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported process term corresponding to the aspartate half of the
+      antiport. Accurate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0015813
+    label: L-glutamate transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) BP assignment for L-glutamate transmembrane transport, the process
+      arm of citrin&#39;s glutamate import.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported process term corresponding to the glutamate half of the
+      antiport. Accurate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0000514
+    label: &#39;3-sulfino-L-alanine: proton, glutamate antiporter activity&#39;
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA electronic annotation for cysteinesulfinate (3-sulfino-L-alanine) / glutamate,
+      proton antiport. Citrin exchanges cysteinesulfinate with glutamate and a proton
+      experimentally; correct but a secondary (non-core) substrate.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally demonstrated as a secondary substrate exchange, but aspartate/glutamate
+      antiport (GO:0000515) is the physiologically central function. Real but ancillary.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;AGC also transports cysteinesulfinate in exchange for either aspartate or glutamate&#34;
+- term:
+    id: GO:0000515
+    label: aspartate:glutamate, proton antiporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA electronic annotation for the aspartate:glutamate, proton antiporter activity,
+      the primary catalytic function of citrin. Duplicated by an EXP and an IDA annotation.
+    action: ACCEPT
+    reason: &gt;-
+      The primary/core molecular function of citrin, directly demonstrated by reconstitution
+      and independently confirmed. The electronic annotation is correct.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic annotation (InterPro EF-hand) for calcium ion binding. Citrin has a
+      regulatory N-terminal EF-hand domain; the structure confirms calcium binding at EF-hand 2.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by X-ray structure showing calcium bound at EF-hand 2. Calcium binding is a
+      genuine molecular activity of the regulatory domain.
+    supported_by:
+    - reference_id: PMID:25410934
+      supporting_text: &#34;Only EF-hand 2 binds calcium&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation (multiple IEA methods / UniProt SubCell) for mitochondrial inner
+      membrane localization. Correct and duplicated by EXP/IDA annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with experimental subcellular localization. Core location.
+    supported_by:
+    - reference_id: PMID:39419476
+      supporting_text: &#34;located in the mitochondrial inner membrane&#34;
+- term:
+    id: GO:0015804
+    label: neutral amino acid transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Inter-ontology (GO_REF:0000108) inference from the cysteinesulfinate antiport term
+      GO:0000514, classifying cysteinesulfinate transport as neutral amino acid transport.
+    action: MODIFY
+    reason: &gt;-
+      Citrin&#39;s physiological substrates aspartate and glutamate are acidic (anionic) amino acids,
+      not neutral amino acids. This term is a logical by-product of the secondary cysteinesulfinate
+      activity and mischaracterizes the core function; better captured by the aspartate/glutamate
+      transport terms.
+    proposed_replacement_terms:
+    - id: GO:0015810
+      label: aspartate transmembrane transport
+    - id: GO:0015813
+      label: L-glutamate transmembrane transport
+- term:
+    id: GO:0043490
+    label: malate-aspartate shuttle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic annotation to the malate-aspartate shuttle, duplicating the IBA and IDA
+      annotations to this term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct; the malate-aspartate shuttle is a core biological process for citrin, independently
+      supported by experimental data.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle&#34;
+- term:
+    id: GO:0051592
+    label: response to calcium ion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic annotation for response to calcium ion, reflecting calcium stimulation of
+      citrin transport activity via its EF-hand domain.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Citrin transport is stimulated by calcium binding at the intermembrane-space EF-hand domain,
+      so a response-to-calcium annotation has an experimental basis. However this is a
+      regulatory/response process rather than citrin&#39;s core transport function. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;stimulated by Ca&#34;
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to the generic transmembrane transport process from the
+      mitochondrial carrier domain signature.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but very general parent term. The specific aspartate/glutamate transport processes
+      and the malate-aspartate shuttle capture the core function; this broad term is a valid,
+      non-core ancestor.
+- term:
+    id: GO:0070778
+    label: L-aspartate transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic annotation (from the aspartate transporter/antiporter MF terms) for L-aspartate
+      transmembrane transport, the process arm of citrin&#39;s aspartate efflux.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate specific process term for aspartate transport, consistent with the experimentally
+      demonstrated aspartate efflux activity.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Inter-ontology inference (from GO:0000514) that citrin is involved in proton transmembrane
+      transport, reflecting co-transport of a proton with glutamate.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Citrin co-transports a proton with glutamate, so proton translocation is part of its
+      electrogenic mechanism; not wrong, but a mechanistic by-product rather than the primary
+      amino-acid antiport function. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput interactome (IPI) annotation with the paralog SLC25A12 / aralar (O75746) as
+      the recorded partner. Uninformative bare protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidelines, bare protein binding conveys no specific function. The recorded
+      partner is the paralog SLC25A12, consistent with the mitochondrial-carrier context, but this
+      generic term does not describe citrin&#39;s molecular function. The informative interaction
+      (homodimerization) is captured by GO:0042802.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput interactome (IPI) annotation with the paralog SLC25A12 (O75746). Uninformative
+      bare protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding is uninformative and is discouraged. Duplicate large-scale interactome hit
+      against the paralog SLC25A12; does not add functional specificity.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40355756
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Solute carrier interactome (IPI) annotation with the paralog SLC25A12 (O75746). Uninformative
+      bare protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding is uninformative. Large-scale SLC interactome hit against the paralog
+      SLC25A12; no specific molecular function conveyed.
+- term:
+    id: GO:0005313
+    label: L-glutamate transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara (GO_REF:0000107) orthology transfer from mouse Slc25a13 (Q9QXX4) of L-glutamate
+      transporter activity. Duplicates the IBA annotation to this term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct: glutamate import is one arm of citrin&#39;s antiport, well supported experimentally. The
+      orthology transfer is appropriate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara orthology transfer of mitochondrion localization. Correct but less specific
+      than the mitochondrial inner membrane annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate but a broad parent of the specific mitochondrial inner membrane location that is the
+      core annotation. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:39419476
+      supporting_text: &#34;located in the mitochondrial inner membrane&#34;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara orthology transfer for involvement in gluconeogenesis, reflecting the
+      requirement for cytosolic aspartate (supplied by citrin) in gluconeogenesis from lactate.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Citrin-supplied cytosolic aspartate is needed for the conversion of oxoglutarate to
+      oxaloacetate in gluconeogenesis from lactate/alanine, so the process link is physiologically
+      valid but downstream and tissue-context dependent rather than a core molecular function.
+      Retain as non-core.
+    supported_by:
+    - reference_id: PMID:25410934
+      supporting_text: &#34;Cytosolic aspartate is also required for the conversion of oxoglutarate to oxaloacetate, a crucial step in gluconeogenesis from lactate and alanine&#34;
+- term:
+    id: GO:0015172
+    label: acidic amino acid transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara orthology transfer of acidic amino acid transmembrane transporter activity, a
+      parent term covering the transport of the acidic amino acids aspartate and glutamate.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct as a broader (parent) molecular function: aspartate and glutamate are acidic amino
+      acids. The specific aspartate:glutamate antiporter activity (GO:0000515) and the individual
+      aspartate/glutamate transporter terms are the core annotations; this generalization is a valid
+      non-core ancestor.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence-based (HPA, IDA) mitochondrial localization. Consistent with the established
+      mitochondrial inner-membrane location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but less specific than mitochondrial inner membrane; retain as non-core. Human Protein
+      Atlas reports SLC25A13 as tissue-enriched in liver with mitochondrial staining.
+- term:
+    id: GO:0000515
+    label: aspartate:glutamate, proton antiporter activity
+  evidence_type: EXP
+  original_reference_id: PMID:38945283
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (EXP) confirmation of aspartate:glutamate, proton antiporter activity. Reconfirmed
+      the canonical antiport and showed citrin does NOT transport GABA, sharpening substrate specificity.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supports the primary/core molecular function; additionally excludes GABA as a substrate,
+      refining specificity of the antiport.
+    supported_by:
+    - reference_id: PMID:38945283
+      supporting_text: &#34;the human AGC isoforms (AGC1/aralar1 and AGC2/citrin) are unable to transport GABA both in homo- and in hetero-exchange with either glutamate or aspartate, i.e. the canonical substrates of AGC&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: EXP
+  original_reference_id: PMID:10642534
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental localization of citrin (Aralar2) to mitochondria in human cell lines. Core location,
+      duplicated by other EXP/IDA/IBA annotations.
+    action: ACCEPT
+    reason: &gt;-
+      The mitochondrial localization of citrin was experimentally established in this characterization
+      study; it is the core subcellular location.
+    supported_by:
+    - reference_id: PMID:10642534
+      supporting_text: &#34;The localization of Aralar2/citrin expressed in human cell lines is mitochondrial&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: EXP
+  original_reference_id: PMID:39419476
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental localization to the mitochondrial inner membrane, from the domain-dissection study
+      of citrin (which also showed N-terminal mutations cause a mitochondrial import defect). Core location.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported experimental annotation of the core inner-membrane location.
+    supported_by:
+    - reference_id: PMID:39419476
+      supporting_text: &#34;located in the mitochondrial inner membrane&#34;
+- term:
+    id: GO:0043490
+    label: malate-aspartate shuttle
+  evidence_type: IGI
+  original_reference_id: PMID:37647199
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction (IGI) annotation from a panel of malate-aspartate-shuttle-deficient cell lines
+      showing the shuttle (including its AGC component) is important for de novo serine biosynthesis.
+      Places citrin in the malate-aspartate shuttle.
+    action: ACCEPT
+    reason: &gt;-
+      The malate-aspartate shuttle is a core biological process for citrin. This genetic study of MAS
+      components (full text assessed by the curator) supports the shuttle involvement; the abstract
+      confirms the MAS focus. Consistent with the IBA/IDA annotations to the same term.
+    supported_by:
+    - reference_id: PMID:37647199
+      supporting_text: &#34;we show that the MAS is important for de novo serine biosynthesis&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomics (HTP) placement of SLC25A13 in the mitochondrion (high-confidence
+      mitochondrial proteome). Consistent with the established mitochondrial inner-membrane location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but broader than the specific mitochondrial inner-membrane location; a proteome-scale
+      mitochondrial call. Retain as non-core.
+- term:
+    id: GO:0000514
+    label: &#39;3-sulfino-L-alanine: proton, glutamate antiporter activity&#39;
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) demonstration that citrin exchanges cysteinesulfinate
+      (3-sulfino-L-alanine) for glutamate and a proton. A genuine but secondary substrate activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally demonstrated secondary substrate exchange. Physiologically the aspartate/glutamate
+      antiport (GO:0000515) is central; cysteinesulfinate exchange is ancillary. Retain as accurate but
+      non-core.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;AGC also transports cysteinesulfinate in exchange for either aspartate or glutamate&#34;
+- term:
+    id: GO:0000515
+    label: aspartate:glutamate, proton antiporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) demonstration of the electrogenic aspartate:glutamate, proton antiport
+      by reconstituted citrin. The defining, core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      The foundational experimental evidence for citrin&#39;s core function: reconstituted protein catalyzes
+      electrogenic exchange of aspartate for glutamate and a proton. Primary molecular function.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) inner-membrane localization with defined multi-pass topology (N- and
+      C-terminal domains in the intermembrane space; six-TM carrier domain). Core location.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported experimental annotation of the core inner-membrane location and topology.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;Ca(2+)-stimulated aspartate/glutamate transporters&#34;
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  evidence_type: IDA
+  original_reference_id: PMID:25410934
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) calcium binding, from the X-ray structure of the citrin N-terminal domain
+      showing calcium bound at EF-hand 2. Core molecular activity of the regulatory domain.
+    action: ACCEPT
+    reason: &gt;-
+      Crystallographic demonstration of calcium binding at EF-hand 2. Calcium binding by the regulatory
+      EF-hand domain is a genuine, core molecular function of citrin.
+    supported_by:
+    - reference_id: PMID:25410934
+      supporting_text: &#34;Only EF-hand 2 binds calcium&#34;
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IDA
+  original_reference_id: PMID:25410934
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) identical protein binding, reflecting the demonstrated homodimerization
+      of citrin via its N-terminal domain (SEC-MALLS and the dimeric crystal structure).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Citrin forms a homodimer via the N-terminal domain, so identical protein binding is experimentally
+      supported and more informative than bare protein binding. However dimerization is a structural
+      property rather than the core transport function (the carrier transports substrate as a functional
+      monomer). Retain as non-core.
+    supported_by:
+    - reference_id: PMID:25410934
+      supporting_text: &#34;demonstrating that the full-length carrier was dimeric&#34;
+- term:
+    id: GO:0006839
+    label: mitochondrial transport
+  evidence_type: NAS
+  original_reference_id: PMID:10642534
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-traceable author statement (NAS) that citrin functions in mitochondrial transport, from the
+      initial characterization describing it as a calcium-regulated mitochondrial metabolite carrier.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but very general. The specific aspartate/glutamate antiport and its downstream processes
+      (malate-aspartate shuttle, aspartate/glutamate transport) capture the core function; this broad
+      process term is a valid non-core ancestor.
+    supported_by:
+    - reference_id: PMID:10642534
+      supporting_text: &#34;function as calcium-regulated metabolite (possibly anionic) carriers&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-372448
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable author statement (Reactome) for mitochondrial inner-membrane localization, from the
+      Reactome reaction in which SLC25A12/13 exchange L-Glu and L-Asp. Core location.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome curation consistent with all experimental localization data. Core inner-membrane location.
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  evidence_type: IDA
+  original_reference_id: PMID:10642534
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) calcium binding from the initial characterization, where the N-terminal
+      half of citrin was shown to bind calcium (requiring the two most distal EF-hands). Core molecular
+      activity of the regulatory domain.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally demonstrated calcium binding by the N-terminal EF-hand domain. Duplicates the
+      structurally-supported IDA calcium-binding annotation.
+    supported_by:
+    - reference_id: PMID:10642534
+      supporting_text: &#34;The N-terminal half of Aralar2/citrin is able to bind calcium and this requires the presence of the two most distal EF-hands&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:10642534
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) mitochondrial localization of citrin expressed in human cell lines.
+      Consistent with the inner-membrane location; broader term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate but a broad parent of the specific mitochondrial inner membrane location. Retain as
+      non-core.
+    supported_by:
+    - reference_id: PMID:10642534
+      supporting_text: &#34;The localization of Aralar2/citrin expressed in human cell lines is mitochondrial&#34;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Sequence-similarity (ISS) transfer from mouse Slc25a13 (Q9QXX4) of inner-membrane localization.
+      Correct and duplicated by EXP/IDA/IBA annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with all experimental localization data. Core location.
+    supported_by:
+    - reference_id: PMID:39419476
+      supporting_text: &#34;located in the mitochondrial inner membrane&#34;
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: NAS
+  original_reference_id: PMID:10642534
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Non-traceable author statement (NAS) placing citrin at the plasma membrane. Contradicts the
+      extensive experimental evidence for a mitochondrial inner-membrane localization, including the
+      conclusion of the same cited paper.
+    action: REMOVE
+    reason: &gt;-
+      Citrin is an integral protein of the mitochondrial inner membrane; there is no experimental
+      support for a plasma-membrane location, and the cited characterization study itself concludes the
+      localization is mitochondrial. This NAS annotation is inconsistent with established biology and
+      should be removed.
+    supported_by:
+    - reference_id: PMID:10642534
+      supporting_text: &#34;The localization of Aralar2/citrin expressed in human cell lines is mitochondrial&#34;
+- term:
+    id: GO:0006754
+    label: ATP biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:12851387
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation that recombinant citrin increases mitochondrial ATP production
+      in agonist-stimulated cells, linking its calcium-sensitive transport activity to mitochondrial
+      energy metabolism.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported: citrin overexpression raises mitochondrial ATP upon calcium-mobilizing
+      agonist stimulation, via its role in the malate-aspartate shuttle feeding reducing equivalents to
+      oxidative phosphorylation. This is a downstream physiological consequence rather than citrin&#39;s
+      direct molecular function; retain as non-core.
+    supported_by:
+    - reference_id: PMID:12851387
+      supporting_text: &#34;larger in cells expressing aralar and citrin&#34;
+- term:
+    id: GO:0045333
+    label: cellular respiration
+  evidence_type: IDA
+  original_reference_id: PMID:12851387
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation linking citrin to cellular respiration through its
+      calcium-stimulated enhancement of mitochondrial ATP production and aerobic metabolism.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Citrin contributes to aerobic/oxidative metabolism by feeding cytosolic reducing equivalents into
+      mitochondria via the malate-aspartate shuttle, and its overexpression stimulates mitochondrial ATP
+      on agonist stimulation. Downstream physiological role rather than a core molecular function;
+      retain as non-core.
+    supported_by:
+    - reference_id: PMID:12851387
+      supporting_text: &#34;the stimulation of aerobic metabolism&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) mitochondrial localization from the functional reconstitution study.
+      Consistent with the inner-membrane location; broader term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate but a broad parent of the specific mitochondrial inner membrane location. Retain as
+      non-core.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;Ca(2+)-stimulated aspartate/glutamate transporters&#34;
+- term:
+    id: GO:0015810
+    label: aspartate transmembrane transport
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) aspartate transmembrane transport, the process arm of citrin&#39;s aspartate
+      efflux, demonstrated by reconstitution.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported specific process term for aspartate transport (the aspartate half of the
+      antiport). Accurate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0015813
+    label: L-glutamate transmembrane transport
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) L-glutamate transmembrane transport, the process arm of citrin&#39;s
+      glutamate import, demonstrated by reconstitution.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported specific process term for glutamate transport (the glutamate half of the
+      antiport). Accurate.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- term:
+    id: GO:0043490
+    label: malate-aspartate shuttle
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation to the malate-aspartate shuttle: citrin overexpression
+      increased malate-aspartate shuttle activity in human cells. Core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Foundational experimental evidence that citrin is a component of the malate-aspartate NADH shuttle.
+      Core biological process.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;Overexpression of the carriers in transfected human cells increased the activity of the malate/aspartate NADH shuttle&#34;
+- term:
+    id: GO:0051592
+    label: response to calcium ion
+  evidence_type: IDA
+  original_reference_id: PMID:11566871
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation for response to calcium ion: citrin transport activity is
+      stimulated by calcium on the external face of the inner membrane, where its EF-hand domains reside.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported calcium stimulation of transport, a genuine regulatory response. However
+      it is a regulatory process rather than citrin&#39;s core transport function, and the physiological
+      significance of the calcium regulation has since been debated. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;stimulated by Ca&#34;
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: TAS
+  original_reference_id: PMID:11566871
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation. Citrin supplies the cytosolic aspartate consumed by argininosuccinate
+      synthetase (ASS1) in the hepatic urea cycle; loss of this supply underlies the argininosuccinate
+      synthetase deficiency and citrullinemia of citrin deficiency. Central role documented but not
+      currently in the GOA for SLC25A13.
+    action: NEW
+    reason: &gt;-
+      The urea cycle role is a defining, textbook function of citrin and mechanistically explains
+      citrullinemia type II, yet no urea cycle (GO:0000050) annotation exists in the current GOA. Adding
+      it captures a core biological process. Supported by the primary functional paper and the structural
+      review.
+    supported_by:
+    - reference_id: PMID:11566871
+      supporting_text: &#34;urea cycle and the aspartate/malate NADH shuttle&#34;
+    - reference_id: PMID:25410934
+      supporting_text: &#34;In liver, cytosolic aspartate is required for the urea cycle&#34;
+core_functions:
+- description: &gt;-
+    Electrogenic mitochondrial-inner-membrane aspartate/glutamate antiporter: exports L-aspartate
+    from the matrix to the cytosol in exchange for cytosolic L-glutamate plus a proton.
+  molecular_function:
+    id: GO:0000515
+    label: aspartate:glutamate, proton antiporter activity
+  directly_involved_in:
+  - id: GO:0043490
+    label: malate-aspartate shuttle
+  - id: GO:0000050
+    label: urea cycle
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:11566871
+    supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+- description: &gt;-
+    Calcium binding by the regulatory N-terminal EF-hand domain (EF-hand 2) in the mitochondrial
+    intermembrane space, which modulates the carrier.
+  molecular_function:
+    id: GO:0005509
+    label: calcium ion binding
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:25410934
+    supporting_text: &#34;Only EF-hand 2 binds calcium&#34;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10642534
+  title: Characterization of a second member of the subfamily of calcium-binding mitochondrial
+    carriers expressed in human non-excitable tissues.
+  findings:
+  - statement: &gt;-
+      Cloned citrin (Aralar2) as a liver / non-excitable-tissue calcium-binding mitochondrial
+      carrier, 78.3% identical to Aralar1; localizes to mitochondria in human cell lines and
+      binds calcium via its N-terminal EF-hands.
+    supporting_text: &#34;The localization of Aralar2/citrin expressed in human cell lines is mitochondrial&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache (full_text_available: false). Original characterization establishing
+      citrin identity, mitochondrial localization and calcium binding; the plasma-membrane NAS
+      annotation attributed to this paper contradicts its own mitochondrial conclusion.
+- id: PMID:11566871
+  title: Citrin and aralar1 are Ca(2+)-stimulated aspartate/glutamate transporters
+    in mitochondria.
+  findings:
+  - statement: &gt;-
+      Reconstituted citrin catalyzes electrogenic exchange of aspartate for glutamate and a proton,
+      identifying it as the mitochondrial aspartate/glutamate carrier; overexpression increases
+      malate-aspartate shuttle activity, and the activity is calcium-stimulated.
+    supporting_text: &#34;shown to catalyze the electrogenic exchange of aspartate for glutamate and a H&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available and verified. Foundational functional paper for citrin&#39;s core molecular
+      function, malate-aspartate shuttle role, calcium regulation, and urea cycle connection.
+- id: PMID:12851387
+  title: Recombinant expression of the Ca(2+)-sensitive aspartate/glutamate carrier
+    increases mitochondrial ATP production in agonist-stimulated Chinese hamster ovary
+    cells.
+  findings:
+  - statement: &gt;-
+      Recombinant citrin (and aralar1) increase mitochondrial ATP production upon calcium-mobilizing
+      agonist stimulation, linking calcium-sensitive aspartate/glutamate transport to mitochondrial
+      energy metabolism.
+    supporting_text: &#34;larger in cells expressing aralar and citrin&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache. Supports the downstream ATP-biosynthesis / cellular-respiration (non-core)
+      annotations via the calcium-sensitive shuttle role.
+- id: PMID:25410934
+  title: Calcium-induced conformational changes of the regulatory domain of human
+    mitochondrial aspartate/glutamate carriers.
+  findings:
+  - statement: &gt;-
+      X-ray structures of the citrin/aralar N- and C-terminal domains show a homodimer with a unique
+      eight-EF-hand arch; only EF-hand 2 binds calcium, and calcium binding opens a vestibule regulating
+      substrate access.
+    supporting_text: &#34;Only EF-hand 2 binds calcium&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available. Structural basis for calcium ion binding (IDA) and homodimerization
+      (identical protein binding, IDA).
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput interactome dataset; supports only a bare protein-binding IPI annotation with the
+      paralog SLC25A12 (O75746). Not functionally informative for citrin.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput interactome dataset; supports only a bare protein-binding IPI annotation with the
+      paralog SLC25A12 (O75746).
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale mitochondrial localization evidence (HTP). Supports mitochondrion localization at a
+      broad level.
+- id: PMID:37647199
+  title: The malate-aspartate shuttle is important for de novo serine biosynthesis.
+  findings:
+  - statement: &gt;-
+      Genetic disruption of malate-aspartate shuttle components (including the aspartate/glutamate carrier)
+      reduces de novo serine biosynthesis, reflecting the shuttle&#39;s role in recycling cytosolic NADH to NAD+.
+    supporting_text: &#34;we show that the MAS is important for de novo serine biosynthesis&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache (full text not available). Supports the malate-aspartate shuttle involvement
+      (IGI); assessed as consistent with the well-established shuttle role, deferring to curator judgment on
+      full text.
+- id: PMID:38945283
+  title: The mitochondrial aspartate/glutamate carrier does not transport GABA.
+  findings:
+  - statement: &gt;-
+      Human citrin (AGC2) and aralar (AGC1) transport aspartate and glutamate but do not transport GABA in
+      homo- or hetero-exchange, refining the substrate specificity of the aspartate/glutamate antiport.
+    supporting_text: &#34;the human AGC isoforms (AGC1/aralar1 and AGC2/citrin) are unable to transport GABA both in homo- and in hetero-exchange with either glutamate or aspartate, i.e. the canonical substrates of AGC&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache. EXP re-confirmation of the aspartate:glutamate antiport (GO:0000515) and
+      exclusion of GABA as a substrate.
+- id: PMID:39419476
+  title: Distinct roles for the domains of the mitochondrial aspartate/glutamate carrier
+    citrin in organellar localization and substrate transport.
+  findings:
+  - statement: &gt;-
+      Domain-dissection with 33 pathogenic variants: the carrier domain performs transport (identifying
+      substrate-binding and dynamics residues), while N-terminal domain mutations cause a mitochondrial
+      import defect rather than regulating transport via calcium.
+    supporting_text: &#34;located in the mitochondrial inner membrane&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available. Supports inner-membrane localization (EXP) and reassigns the role of the
+      N-terminal domain to organellar import; relevant caveat for calcium-regulation annotations.
+- id: PMID:40355756
+  title: The solute carrier superfamily interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale SLC interactome dataset; supports only a bare protein-binding IPI annotation with the
+      paralog SLC25A12 (O75746).
+- id: Reactome:R-HSA-372448
+  title: SLC25A12,13 exchange L-Glu and L-Asp
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome curation of the aspartate/glutamate exchange, consistent with the core function and
+      inner-membrane location.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/SLC25A15/SLC25A15-ai-review.html
+++ b/genes/human/SLC25A15/SLC25A15-ai-review.html
@@ -1,0 +1,4861 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SLC25A15 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SLC25A15</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9Y619" target="_blank" class="term-link">
+                        Q9Y619
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SLC25A15";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9Y619" data-a="DESCRIPTION: SLC25A15 (ORNT1, mitochondrial ornithine transport..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SLC25A15 (ORNT1, mitochondrial ornithine transporter 1) is a member of the SLC25 mitochondrial carrier family that resides in the inner mitochondrial membrane as a multi-pass membrane protein built from three tandem Solcar (mitochondrial carrier) repeats. It catalyzes the electroneutral ornithine/citrulline antiport that couples the cytosolic and matrix halves of the urea cycle; cytosolic L-ornithine is imported into the matrix in exchange for the export of matrix L-citrulline, together with a proton that neutralizes the ornithine charge. In vitro the carrier also exchanges the basic amino acids L-lysine and L-arginine, and can perform ornithine/H+ and lysine/H+ uniport, reflecting a broad basic-amino-acid specificity, but ornithine is its highest-affinity and principal physiological substrate. The protein is most highly expressed in liver, pancreas, testis, lung and small intestine, consistent with its urea-cycle role. Loss of function causes the autosomal recessive urea-cycle disorder hyperornithinemia-hyperammonemia-homocitrullinuria (HHH) syndrome. A closely related paralog, SLC25A2/ORNT2, has overlapping and broader substrate specificity and partially compensates for defective ORNT1.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment placing ORNT1 activity in the mitochondrion. This is correct but general; the specific and experimentally supported location is the mitochondrial inner membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ORNT1 is a mitochondrial carrier that acts in the mitochondrion; the IBA call across the SLC25 ornithine-carrier clade is sound. It is a correct parent of the more specific mitochondrial inner membrane annotation, so it is retained as accurate though non-core. The precise location is captured by GO:0005743.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                                    GO:0000064
+                                </a>
+                            </span>
+                            <span class="term-label">L-ornithine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000064" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of L-ornithine transmembrane transporter activity, the core molecular function of ORNT1 and its fungal orthologs (N. crassa ARG13, S. cerevisiae ARG11/ORT1).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function, directly supported by reconstitution assays and by the disease mechanism, and is consistent across the ornithine-carrier phylogenetic clade.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Our results show that ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is defective in HHH syndrome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990575" target="_blank" class="term-link">
+                                    GO:1990575
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial L-ornithine transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:1990575" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the biological process of transporting L-ornithine across the mitochondrial membrane, the process this carrier mediates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the core biological process (movement of L-ornithine across the inner mitochondrial membrane) that ORNT1 performs as part of urea-cycle function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ORNT1 expression restores ornithine metabolism in fibroblasts from patients with hyperammonaemia-hyperornithinaemia-homocitrullinuria (HHH) syndrome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                                    GO:0000064
+                                </a>
+                            </span>
+                            <span class="term-label">L-ornithine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000064" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning electronic annotation of the core L-ornithine transmembrane transporter activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicates the well-supported core molecular function (also assigned by IBA, EXP, and TAS). The electronic mapping is at the correct level of specificity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005743" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (multi-method IEA) assignment of mitochondrial inner membrane location, from UniProt subcellular-location mapping (SL-0168).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location for this multi-pass SLC25 inner-membrane carrier; concordant with the UniProt subcellular location and the ISS-from-ortholog call.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015297" target="_blank" class="term-link">
+                                    GO:0015297
+                                </a>
+                            </span>
+                            <span class="term-label">antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0015297" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation of generic antiporter activity, reflecting the exchange (antiport) transport mechanism of ORNT1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ORNT1 is genuinely an antiporter (ornithine/citrulline exchange), so the term is correct although general. It is retained as a true parent of the more informative specific antiport function; the physiologically meaningful antiport is the arginine:ornithine / ornithine:citrulline exchange captured by GO:0043858 and by the ornithine-transporter terms.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0031966" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (UniProt subcellular-location mapping, SL-0171) of mitochondrial membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than mitochondrial inner membrane. Retained as a true parent; the precise, experimentally consistent location is GO:0005743.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70635
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000050" data-r="Reactome:R-HSA-70635" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assignment placing ORNT1 in the urea cycle, which it connects by shuttling ornithine and citrulline across the inner mitochondrial membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. ORNT1 physically links the cytosolic and matrix halves of the urea cycle; its loss causes the urea-cycle disorder HHH syndrome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is defective in HHH syndrome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9956519
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005743" data-r="Reactome:R-HSA-9956519" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assignment of mitochondrial inner membrane location (from the Reactome reaction describing ornithine/citrulline translocation).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location. Although the source Reactome event concerns disease variants that fail to translocate, the localization to the inner membrane is a correct statement about the wild-type protein.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                                    GO:0000064
+                                </a>
+                            </span>
+                            <span class="term-label">L-ornithine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9956519
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000064" data-r="Reactome:R-HSA-9956519" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assignment of the core L-ornithine transmembrane transporter activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicates the well-supported core molecular function. Correct level of specificity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005743" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS) transfer of mitochondrial inner membrane location from the S. cerevisiae ortholog ORT1/Q12375.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location; concordant with UniProt and electronic annotations and with the multi-pass SLC25 topology.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0031966" data-r="PMID:10369256" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization of ORNT1 to the mitochondrial membrane in the original disease-gene study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported mitochondrial membrane localization. The term is correct though more general than the inner-membrane call; retained as a true and experimentally grounded parent.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mutations in a gene encoding a mitochondrial ornithine transporter</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043858" target="_blank" class="term-link">
+                                    GO:0043858
+                                </a>
+                            </span>
+                            <span class="term-label">arginine:ornithine antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0043858" data-r="PMID:12807890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally demonstrated arginine/ornithine antiport by reconstituted, purified ORNT1 (ORC1). This is a specific antiport activity of the carrier and corresponds to the UniProt/Rhea reaction L-arginine(out) + L-ornithine(in) = L-arginine(in) + L-ornithine(out) (RHEA:34991).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly measured for reconstituted ORNT1 and matches the GO term direction (arginine(out) + ornithine(in) = arginine(in) + ornithine(out)). It represents a real, specific antiport function of the carrier. The physiologically dominant exchange is ornithine/citrulline, but arginine:ornithine antiport is a genuine biochemical activity and captures the carrier antiport mechanism more precisely than generic antiporter activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial-proteome study detecting ORNT1 in the mitochondrion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the well-established mitochondrial localization, though less specific than the experimentally supported inner-membrane location and derived from a high-throughput proteomic dataset. Retained as a correct but corroborative, non-core localization annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015189" target="_blank" class="term-link">
+                                    GO:0015189
+                                </a>
+                            </span>
+                            <span class="term-label">L-lysine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0015189" data-r="PMID:12807890" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay of reconstituted ORNT1 showed transport of L-lysine, reflecting the carrier broad basic-amino-acid specificity (UniProt Rhea reaction L-ornithine(out) + L-lysine(in) = L-ornithine(in) + L-lysine(out), RHEA:70799).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated in the reconstituted system (do not remove an IDA activity). However, lysine is a lower-affinity substrate than ornithine (Km 0.8 vs 0.22 mM) and lysine transport is not the physiological role of the carrier; the urea-cycle-relevant function is ornithine/citrulline exchange. Marked non-core to reflect the broad in vitro specificity rather than the primary biological function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015297" target="_blank" class="term-link">
+                                    GO:0015297
+                                </a>
+                            </span>
+                            <span class="term-label">antiporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0015297" data-r="PMID:12807890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct demonstration that ORNT1 transports basic amino acids by an exchange (antiport) mechanism in reconstituted proteoliposomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, experimentally grounded description of the antiport mechanism, although general. Retained as a true parent of the specific antiport activities; the more informative specific term is GO:0043858 (arginine:ornithine antiporter).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061459" target="_blank" class="term-link">
+                                    GO:0061459
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0061459" data-r="PMID:12807890" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay of reconstituted ORNT1 showed transport of L-arginine, reflecting the carrier broad basic-amino-acid specificity (UniProt Rhea reaction RHEA:34991).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated (do not remove an IDA activity). Arginine is a lower-affinity substrate than ornithine (Km 1.58 vs 0.22 mM) and arginine transport is not the carrier principal physiological role, which is ornithine/citrulline exchange in the urea cycle. Marked non-core to reflect the broad in vitro specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903401" target="_blank" class="term-link">
+                                    GO:1903401
+                                </a>
+                            </span>
+                            <span class="term-label">L-lysine transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:1903401" data-r="PMID:12807890" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biological-process counterpart of the demonstrated L-lysine transport activity by reconstituted ORNT1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported but non-core; a manifestation of the carrier broad basic-amino-acid specificity rather than its urea-cycle role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903826" target="_blank" class="term-link">
+                                    GO:1903826
+                                </a>
+                            </span>
+                            <span class="term-label">L-arginine transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:1903826" data-r="PMID:12807890" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biological-process counterpart of the demonstrated L-arginine transport activity by reconstituted ORNT1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported but non-core; reflects broad basic-amino-acid specificity, not the primary urea-cycle function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005739" data-r="PMID:10369256" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental localization of ORNT1 to the mitochondrion in the original disease-gene identification study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported mitochondrial localization, consistent with the more specific inner-membrane location. Retained as a correct parent, non-core relative to the specific mitochondrial inner membrane location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mutations in a gene encoding a mitochondrial ornithine transporter</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                                    GO:0000064
+                                </a>
+                            </span>
+                            <span class="term-label">L-ornithine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12807890
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial ornithine transporter. Bacterial expressio...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000064" data-r="PMID:12807890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration (reconstituted, purified ORNT1) of L-ornithine transport, establishing the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly measured core molecular function; ornithine is the highest-affinity substrate (Km 0.22 mM). This is the defining activity of the carrier.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                        PMID:12807890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                                    GO:0000064
+                                </a>
+                            </span>
+                            <span class="term-label">L-ornithine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12948741" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12948741
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning and characterization of human ORNT2: a second mitoch...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000064" data-r="PMID:12948741" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental support for L-ornithine transporter activity in the study characterizing ORNT2 and confirming the ornithine-transport function shared with ORNT1 (functional rescue of ornithine metabolism in HHH patient fibroblasts).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reinforces the core molecular function of the ORNT ornithine carriers. The paper demonstrates the ornithine-transport function that ORNT1 provides in the urea cycle and that ORNT2 can partially replace.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12948741" target="_blank" class="term-link">
+                                        PMID:12948741
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">When ORNT2 is overexpressed transiently in cultured fibroblasts from HHH patients, it rescues the deficient ornithine metabolism in these cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70634
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005743" data-r="Reactome:R-HSA-70634" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assignment of mitochondrial inner membrane location, from the reaction describing cytosolic/mitochondrial ornithine-citrulline exchange.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location, concordant with all other localization annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                    GO:0000050
+                                </a>
+                            </span>
+                            <span class="term-label">urea cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000050" data-r="PMID:10369256" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (TAS) involvement of ORNT1 in the urea cycle, from the disease-gene identification study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. ORNT1 connects the cytosolic and matrix reactions of the urea cycle; its deficiency causes the urea-cycle disorder HHH syndrome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is defective in HHH syndrome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                                    GO:0000064
+                                </a>
+                            </span>
+                            <span class="term-label">L-ornithine transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0000064" data-r="PMID:10369256" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (TAS) L-ornithine transporter activity for ORNT1 in the disease-gene study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicates the well-supported core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mutations in a gene encoding a mitochondrial ornithine transporter</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0005743" data-r="PMID:10369256" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (TAS) mitochondrial inner membrane location for ORNT1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location, consistent with experimental and electronic annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transport ornithine across the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:0016020" data-r="PMID:10369256" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (TAS) generic membrane location, superseded by the specific mitochondrial inner membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect (ORNT1 is a multi-pass membrane protein), but GO:0016020 is uninformative given the well-established mitochondrial inner membrane localization. It is a legacy general term that adds no biological information beyond the specific inner-membrane annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990575" target="_blank" class="term-link">
+                                    GO:1990575
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial L-ornithine transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10369256
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y619" data-a="GO:1990575" data-r="PMID:10369256" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (TAS) biological process of L-ornithine transport across the mitochondrial membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, concordant with the IBA assignment and the urea-cycle role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                        PMID:10369256
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transport ornithine across the mitochondrial inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Ornithine/citrulline antiport across the inner mitochondrial membrane that couples the cytosolic and matrix halves of the urea cycle, importing cytosolic L-ornithine into the matrix in exchange for exporting matrix L-citrulline.</h3>
+                <span class="vote-buttons" data-g="Q9Y619" data-a="FUNCTION: Ornithine/citrulline antiport across the inner mit..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                            L-ornithine transmembrane transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000050" target="_blank" class="term-link">
+                                urea cycle
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                                PMID:12807890
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                PMID:10369256
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is defective in HHH syndrome.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Transmembrane movement of L-ornithine across the mitochondrial inner membrane, the transport process that ORNT1 mediates.</h3>
+                <span class="vote-buttons" data-g="Q9Y619" data-a="FUNCTION: Transmembrane movement of L-ornithine across the m..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000064" target="_blank" class="term-link">
+                            L-ornithine transmembrane transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990575" target="_blank" class="term-link">
+                                mitochondrial L-ornithine transmembrane transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                                PMID:10369256
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ORNT1 expression restores ornithine metabolism in fibroblasts from patients with hyperammonaemia-hyperornithinaemia-homocitrullinuria (HHH) syndrome.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10369256" target="_blank" class="term-link">
+                            PMID:10369256
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrome is caused by mutations in a gene encoding a mitochondrial ornithine transporter.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Identified ORNT1 (SLC25A15) by orthology to fungal mitochondrial ornithine carriers, showed it restores ornithine metabolism in HHH patient fibroblasts, and established that its mutations cause HHH syndrome.</div>
+
+                        <div class="finding-text">"ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is defective in HHH syndrome."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12807890" target="_blank" class="term-link">
+                            PMID:12807890
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The mitochondrial ornithine transporter. Bacterial expression, reconstitution, functional characterization, and tissue distribution of two human isoforms.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reconstituted, purified ORNT1 (ORC1) transports L-ornithine, L-lysine, L-arginine and L-citrulline by exchange and unidirectional mechanisms; ORNT2 (ORC2) has broader specificity; both are most highly expressed in liver.</div>
+
+                        <div class="finding-text">"Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12948741" target="_blank" class="term-link">
+                            PMID:12948741
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning and characterization of human ORNT2: a second mitochondrial ornithine transporter that can rescue a defective ORNT1 in patients with the hyperornithinemia-hyperammonemia-homocitrullinuria syndrome, a urea cycle disorder.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ORNT2 (SLC25A2) is a paralog ~88% identical to ORNT1 that targets to mitochondria and rescues deficient ornithine metabolism in HHH patient fibroblasts, explaining partial functional redundancy.</div>
+
+                        <div class="finding-text">"When ORNT2 is overexpressed transiently in cultured fibroblasts from HHH patients, it rescues the deficient ornithine metabolism in these cells."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-throughput mitochondrial-proteome study detecting SLC25A15 in the mitochondrion.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22262851" target="_blank" class="term-link">
+                            PMID:22262851
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Mutagenesis of substrate-binding residues (R179, E180, W224) in ORNT1 shifts relative ornithine versus arginine/lysine transport, defining the substrate-specificity determinants of the carrier.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70634
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ornithine (cytosolic) + citrulline (mitochondrial) =&gt; ornithine (mitochondrial) + citrulline (cytosolic)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70635
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Urea cycle</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9956519
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SLC25A15 variants don&#39;t translocate ornithine and citrulline</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SLC25A15-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y619" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: SLC25A15 (Mitochondrial Ornithine Transporter 1 / ORC1 / ORNT1)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">40 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:56:54.667433</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="SLC25A15-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="SLC25A15-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-slc25a15-mitochondrial-ornithine-transporter-1-orc1-ornt1">Comprehensive Research Report: SLC25A15 (Mitochondrial Ornithine Transporter 1 / ORC1 / ORNT1)</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>SLC25A15 (Solute Carrier Family 25 Member 15) encodes Mitochondrial Ornithine Transporter 1, also known as Ornithine Carrier 1 (ORC1) or ORNT1 (UniProt: Q9Y619). It is a member of the mitochondrial carrier family (SLC25/TC 2.A.29), a large family of transport proteins embedded in the inner mitochondrial membrane that facilitate the translocation of diverse small molecules between the mitochondrial intermembrane space and the matrix (palmieri2013themitochondrialtransporter pages 3-6). The gene is located on human chromosome 13q14 and encodes a 301 amino acid protein (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</p>
+<p>The following table summarizes the key properties of SLC25A15/ORC1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>SLC25A15</strong> (solute carrier family 25 member 15) (OpenTargets Search: -SLC25A15, gutierrezaguilar2013physiologicalandpathological pages 3-4)</td>
+</tr>
+<tr>
+<td>Aliases</td>
+<td><strong>ORC1</strong>, <strong>ORNT1</strong> (gutierrezaguilar2013physiologicalandpathological pages 3-4, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td><strong>Mitochondrial ornithine transporter 1</strong> / <strong>ornithine carrier 1 (ORC1)</strong> (gao2024cancertherapeuticpotential pages 6-7, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>Q9Y619</strong> (provided target identity)</td>
+</tr>
+<tr>
+<td>Chromosomal location</td>
+<td><strong>13q14</strong> / chromosome 13 locus reported for human <strong>SLC25A15</strong> (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, tessa2009identificationofnovel pages 3-4)</td>
+</tr>
+<tr>
+<td>Protein length</td>
+<td><strong>301 amino acids</strong> (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Inner mitochondrial membrane</strong>; carrier with N- and C-termini exposed to the cytosolic/intermembrane-space side (tessa2009identificationofnovel pages 5-6, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td>Primary substrates</td>
+<td><strong>L-ornithine, L-citrulline, L-arginine, L-lysine</strong>; transport is stereoselective for the L-forms in ORC1 (monne2012substratespecificityof pages 1-2, monne2012substratespecificityof pages 3-4)</td>
+</tr>
+<tr>
+<td>Transport mechanism</td>
+<td><strong>Electroneutral antiport</strong>, classically exchanging <strong>cytosolic ornithine</strong> for <strong>matrix citrulline + H+</strong> in a strict 1:1 mode (gao2024cancertherapeuticpotential pages 6-7, monne2012substratespecificityof pages 3-4, palmieri2020diseasescausedby pages 13-15)</td>
+</tr>
+<tr>
+<td>Tissue expression</td>
+<td>Highest/major expression reported in <strong>liver, pancreas, lung, kidney</strong>; broader tissue expression also noted (gutierrezaguilar2013physiologicalandpathological pages 3-4, ahmed2024theroleof pages 16-18)</td>
+</tr>
+<tr>
+<td>Key substrate-binding / mechanistic residues</td>
+<td><strong>E77, R179, E180</strong> directly contribute to substrate binding; <strong>W224</strong> and <strong>R275</strong> help couple binding to conformational change/translocation (monne2012substratespecificityof pages 1-2, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, monne2012substratespecificityof pages 7-8)</td>
+</tr>
+<tr>
+<td>Structural class</td>
+<td>Member of the <strong>mitochondrial carrier family (SLC25)</strong> with <strong>6 transmembrane α-helices</strong> and tripartite architecture (tessa2009identificationofnovel pages 5-6, palmieri2013themitochondrialtransporter pages 3-6)</td>
+</tr>
+<tr>
+<td>Associated disease</td>
+<td><strong>Hyperornithinemia-hyperammonemia-homocitrullinuria (HHH) syndrome</strong> / ornithine translocase deficiency (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, palmieri2020diseasescausedby pages 13-15, OpenTargets Search: -SLC25A15)</td>
+</tr>
+<tr>
+<td>Paralogues / related compensatory carriers</td>
+<td><strong>ORC2 / SLC25A2</strong>: 87% identical paralogue with lower affinity and broader substrate range; <strong>ORNT3 / SLC25A29</strong>: related basic amino acid carrier that can rescue ornithine metabolism in HHH fibroblasts (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9, gutierrezaguilar2013physiologicalandpathological pages 3-4, camacho2009thehumanand pages 6-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identity, localization, transport properties, structural determinants, disease relevance, and related paralogues of human SLC25A15/ORC1. It is useful as a compact reference for functional annotation and pathway interpretation.</em></p>
+<h2 id="2-primary-transport-function-and-substrate-specificity">2. Primary Transport Function and Substrate Specificity</h2>
+<p>SLC25A15/ORC1 functions as an <strong>electroneutral antiporter</strong> at the inner mitochondrial membrane, catalyzing the <strong>1:1 exchange of cytoplasmic L-ornithine for mitochondrial matrix L-citrulline plus a proton (H+)</strong> (palmieri2020diseasescausedby pages 13-15, monne2012substratespecificityof pages 3-4). This transport is the physiologically essential step that bridges the mitochondrial and cytoplasmic segments of the urea cycle (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, cunningham202020000picometersunder pages 4-5). The proton co-transport neutralizes the positive charge of ornithine during the exchange process, rendering the transport electrically neutral (gao2024cancertherapeuticpotential pages 6-7).</p>
+<p>The substrate specificity of ORC1 is restricted to the <strong>L-forms of ornithine, citrulline, lysine, and arginine</strong> (monne2012substratespecificityof pages 1-2). Among these, ORC1 shows highest affinity for L-ornithine, followed by L-arginine and L-lysine (mentel2021learningfromyeast pages 20-21). The stereospecificity for L-isomers is a distinguishing feature of ORC1 compared to ORC2, which can also transport D-isomers and histidine (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9, mentel2021learningfromyeast pages 21-22). ORC1 operates as a strict 1:1 antiporter, meaning it exchanges substrates in a one-to-one stoichiometric ratio across the membrane (monne2012substratespecificityof pages 3-4).</p>
+<p>Transport activity has been characterized through reconstitution of bacterially expressed ORC1 protein into proteoliposomes, enabling detailed kinetic and substrate specificity measurements (tessa2009identificationofnovel pages 1-2, tessa2009identificationofnovel pages 3-4).</p>
+<h2 id="3-protein-structure-and-transport-mechanism">3. Protein Structure and Transport Mechanism</h2>
+<p>ORC1 adopts the characteristic <strong>tripartite architecture</strong> of the SLC25 mitochondrial carrier family, consisting of three tandemly repeated homologous domains, each approximately 100 amino acids in length and containing two hydrophobic transmembrane stretches (palmieri2013themitochondrialtransporter pages 3-6). The protein forms a barrel-like structure composed of <strong>six transmembrane α-helices (H1–H6)</strong> arranged counter-clockwise that surround a central cavity open toward the cytosolic (intermembrane space) side (tessa2009identificationofnovel pages 5-6, palmieri2013themitochondrialtransporter pages 3-6). Three additional short α-helices (h12, h34, h56) lie parallel to the membrane plane on the matrix side (tessa2009identificationofnovel pages 5-6). Both the N- and C-termini are exposed on the cytosolic side (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</p>
+<h3 id="31-substrate-binding-site">3.1 Substrate Binding Site</h3>
+<p>The substrate binding site is located within the central cavity and consists of <strong>three major contact points</strong> (monne2012substratespecificityof pages 1-2, monne2012substratespecificityof pages 2-3):</p>
+<ul>
+<li><strong>Contact Point I</strong>: Glu-77 (E77) likely interacts with the terminal amino group of the substrate side chain (monne2012substratespecificityof pages 1-2, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</li>
+<li><strong>Contact Point II</strong>: Arg-179 (R179) and Glu-180 (E180) bind the Cα carboxylate and amino group of the substrates, respectively. R179 is a critical determinant of substrate specificity — the difference between R179 (in ORC1) and Q179 (in ORC2) is largely responsible for the differing substrate profiles of the two isoforms, and swapping this single residue can interchange their substrate specificities (monne2012substratespecificityof pages 1-2, monne2012substratespecificityof pages 3-4, monne2012substratespecificityof pages 8-9).</li>
+<li><strong>Contact Point III</strong>: Arg-275 (R275), a highly conserved residue, is connected to R179 through Trp-224 (W224) via cation-π interactions, and is important for triggering substrate-induced conformational changes required for translocation (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, monne2012substratespecificityof pages 7-8).</li>
+</ul>
+<p>Additional residues Asn-74 (N74) and Asn-78 (N78) contribute to the substrate binding pocket (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, monne2012substratespecificityof pages 7-8).</p>
+<h3 id="32-gating-and-transport-cycle">3.2 Gating and Transport Cycle</h3>
+<p>Transport follows a <strong>"single binding center gated pore" model</strong> (also described as an alternating-access mechanism) involving opening and closing of gates on the cytoplasmic and matrix sides to alternately expose the common substrate binding site (monne2012substratespecificityof pages 1-2). Three characteristic signature sequence motifs (PFDTMK, PTELVK, and PVDCIK) contain proline residues that kink the odd-numbered transmembrane helices (tessa2009identificationofnovel pages 5-6). A <strong>salt-bridge network</strong> formed by charged residues (D31-K131, K34-D231, K234-E128) closes the cavity on the matrix side and constitutes the matrix gate (tessa2009identificationofnovel pages 5-6, palmieri2013themitochondrialtransporter pages 3-6). Substrate binding to R179, as the rate-limiting step, triggers conformational changes that open the matrix gate, allowing substrate translocation (monne2012substratespecificityof pages 8-9).</p>
+<p>The structural model of ORC1 was built based on the crystal structure of the bovine ADP/ATP carrier (tessa2009identificationofnovel pages 5-6, monne2012substratespecificityof pages 2-3).</p>
+<h2 id="4-role-in-the-urea-cycle-and-ornithine-metabolism">4. Role in the Urea Cycle and Ornithine Metabolism</h2>
+<p>The urea cycle is a metabolic pathway that detoxifies nitrogen by converting ammonia into urea, operating across both the mitochondrial matrix and the cytoplasm of hepatocytes. SLC25A15/ORC1 provides the <strong>essential transport link</strong> between these two compartments by importing cytoplasmic ornithine into the mitochondrial matrix while simultaneously exporting citrulline to the cytoplasm (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, palmieri2020diseasescausedby pages 13-15, cunningham202020000picometersunder pages 4-5).</p>
+<p>In the mitochondrial matrix, imported ornithine serves as a substrate for <strong>ornithine transcarbamylase (OTC)</strong>, which combines ornithine with carbamyl phosphate (produced by carbamoyl phosphate synthetase I) to generate citrulline (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11). The citrulline produced is then exported to the cytoplasm via ORC1, where <strong>argininosuccinate synthase</strong> reacts citrulline with ATP and aspartate to generate argininosuccinate, continuing the cytoplasmic portion of the urea cycle (cunningham202020000picometersunder pages 4-5).</p>
+<p>Beyond the urea cycle, ORC1 also supports <strong>arginine biosynthesis and polyamine synthesis</strong>, as export of mitochondrial ornithine to the cytosol provides the substrate for ornithine decarboxylase, a key enzyme in polyamine production (mentel2021learningfromyeast pages 20-21, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9).</p>
+<h2 id="5-subcellular-localization-and-tissue-expression">5. Subcellular Localization and Tissue Expression</h2>
+<p>ORC1 is an <strong>integral membrane protein of the inner mitochondrial membrane</strong> (tessa2009identificationofnovel pages 5-6, palmieri2013themitochondrialtransporter pages 3-6). It is expressed broadly across tissues, with highest expression levels reported in <strong>liver, pancreas, lung, and kidney</strong> (gutierrezaguilar2013physiologicalandpathological pages 3-4, ahmed2024theroleof pages 16-18). Expression in the liver is particularly important given that the urea cycle is principally operative in periportal hepatocytes (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9). Expression has also been noted in testes, small intestine, and other organs (cai2026argininetransportersin pages 10-12, gutierrezaguilar2013physiologicalandpathological pages 3-4).</p>
+<h2 id="6-paralogues-and-functional-redundancy">6. Paralogues and Functional Redundancy</h2>
+<p>Three human mitochondrial carriers can transport ornithine:</p>
+<ul>
+<li>
+<p><strong>ORC2/SLC25A2 (ORNT2)</strong>: Shares 87% sequence identity with ORC1 but has <strong>lower affinity</strong> for ornithine and citrulline and <strong>broader substrate specificity</strong>, including the ability to transport histidine, homocitrulline, and D-isomers of amino acids (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9, arco2005newmitochondrialcarriers pages 10-11). ORC2 expression is consistently lower than ORC1 in all tissues examined (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9, gutierrezaguilar2013physiologicalandpathological pages 3-4). ORC2 originated through retrotransposition and orthologues are found only in mammalian genomes (arco2005newmitochondrialcarriers pages 10-11).</p>
+</li>
+<li>
+<p><strong>SLC25A29 (ORNT3)</strong>: A related basic amino acid carrier that can rescue ornithine metabolism in fibroblasts from HHH syndrome patients, demonstrating compensatory capacity (camacho2009thehumanand pages 6-7, mentel2021learningfromyeast pages 21-22). ORNT3 shows higher expression in the central nervous system than in the liver, suggesting tissue-specific compensatory roles (camacho2009thehumanand pages 6-7).</p>
+</li>
+</ul>
+<p>The redundancy provided by ORC2 and SLC25A29 may explain the variable severity and relatively milder phenotypes of HHH syndrome compared to deficiencies in urea cycle enzymes themselves (mentel2021learningfromyeast pages 20-21, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9, arco2005newmitochondrialcarriers pages 10-11).</p>
+<h2 id="7-disease-associations">7. Disease Associations</h2>
+<h3 id="71-hhh-syndrome-hyperornithinemia-hyperammonemia-homocitrullinuria">7.1 HHH Syndrome (Hyperornithinemia-Hyperammonemia-Homocitrullinuria)</h3>
+<p>Loss-of-function mutations in SLC25A15 cause <strong>HHH syndrome</strong> (OMIM #238970), a rare autosomal recessive disorder of the urea cycle (palmieri2020diseasescausedby pages 13-15, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11). Over 100 patients have been identified worldwide, with major prevalence clusters in Canada, Italy, and Japan (palmieri2020diseasescausedby pages 13-15). The molecular pathogenesis proceeds through a defined cascade:</p>
+<ol>
+<li><strong>Impaired ornithine transport</strong> into mitochondria reduces the availability of ornithine for OTC in the matrix (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</li>
+<li><strong>Cytoplasmic ornithine accumulates</strong> (hyperornithinemia) while mitochondrial ornithine is depleted (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</li>
+<li><strong>Urea cycle dysfunction</strong> leads to ammonia accumulation (hyperammonemia) (palmieri2020diseasescausedby pages 13-15, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</li>
+<li>Accumulated carbamyl phosphate reacts with <strong>lysine to form homocitrulline</strong> (homocitrullinuria), a hallmark metabolite (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, tunalı2014anovelmutation pages 1-2).</li>
+<li>High cytoplasmic ornithine <strong>inhibits arginine-glycine amidotransferase (AGAT)</strong>, causing secondary creatine deficiency, which compounds neurological vulnerability (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</li>
+<li>Excessive ornithine and homocitrulline cause <strong>protein and lipid oxidation</strong>, impairing brain oxidative phosphorylation and Krebs cycle function (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</li>
+</ol>
+<p>Clinical manifestations include acute episodes of vomiting, confusion, and coma; chronic features include developmental delay, intellectual disability, spastic paraplegia, cerebellar ataxia, seizures, and pyramidal dysfunction (palmieri2020diseasescausedby pages 13-15, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11). More than 35 disease-causing mutations have been identified (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11).</p>
+<p>The following table summarizes the spectrum of known pathogenic mutations:</p>
+<table>
+<thead>
+<tr>
+<th>Mutation</th>
+<th>Type</th>
+<th style="text-align: right;">Residual transport activity</th>
+<th>Structural location</th>
+<th>Population prevalence / recurrence</th>
+<th>Functional/pathogenic note</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>F188del</strong></td>
+<td>In-frame deletion</td>
+<td style="text-align: right;">Defective; markedly reduced activity</td>
+<td>Likely TM4 / pore region</td>
+<td>~30% of reported HHH patients; enriched in French-Canadian cases (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16)</td>
+<td>One of the two most common HHH alleles; affects a residue lining the internal translocation pore, consistent with impaired substrate translocation (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td><strong>R179*</strong> (also reported as <strong>R179X</strong>)</td>
+<td>Nonsense</td>
+<td style="text-align: right;">Predicted null</td>
+<td>Contact-point II / pore-facing region, near matrix gate</td>
+<td>~15% of reported HHH patients; recurrent in Japanese and Middle Eastern/Palestinian families (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, tessa2009identificationofnovel pages 3-4, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16, dweikat2022clinicalheterogeneityof pages 9-9)</td>
+<td>Truncates ORC1; residue 179 is a key determinant of substrate recognition in wild-type ORC1, so loss is expected to abolish transport (monne2012substratespecificityof pages 1-2, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td><strong>M37R</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">~0% (virtually incapable of transport)</td>
+<td>TM1 / matrix salt-bridge network region (H1) (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+<td>Novel/reported in HHH families; no major founder prevalence stated (tessa2009identificationofnovel pages 6-8)</td>
+<td>Disrupts salt-bridge networks critical for carrier gating and strongly impairs transport of ornithine, arginine, lysine, and citrulline (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>L71Q</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Reduced; within reported mutant range of ~4–19% of wild type</td>
+<td>TM2 / H2 helix package (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+<td>Reported in HHH families; no major founder prevalence stated (tessa2009identificationofnovel pages 6-8)</td>
+<td>Hydrophilic substitution perturbs H2 helix packing and carrier structural integrity (tessa2009identificationofnovel pages 6-8)</td>
+</tr>
+<tr>
+<td><strong>A15V</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Nearly abolished / dramatically inhibited</td>
+<td>N-terminal region / early TM1 vicinity (tunalı2014anovelmutation pages 1-2)</td>
+<td>Identified in a Turkish patient (tunalı2014anovelmutation pages 1-2, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16)</td>
+<td>Functional assay showed near-complete loss of ornithine transport, supporting pathogenicity (tunalı2014anovelmutation pages 1-2)</td>
+</tr>
+<tr>
+<td><strong>G27E</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Defective; exact % not stated</td>
+<td>TM1 / pore-proximal region</td>
+<td>Recurrent in Japanese patients; also reported in Palestinian families (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16, dweikat2022clinicalheterogeneityof pages 9-9)</td>
+<td>Associated with decreased ornithine transport activity in liver mitochondria/ORC1 deficiency (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16, dweikat2022clinicalheterogeneityof pages 9-9)</td>
+</tr>
+<tr>
+<td><strong>G216S</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Reduced; within reported mutant range of ~4–19% of wild type</td>
+<td>Likely TM5 / pore-facing region (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+<td>Reported in HHH families (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 3-4)</td>
+<td>Alters carrier structure/function and contributes to markedly reduced transport (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>T272I</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Reduced; within reported mutant range of ~4–19% of wild type</td>
+<td>TM6 region (tessa2009identificationofnovel pages 6-8)</td>
+<td>Reported in HHH families (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 3-4)</td>
+<td>Causes steric interference with crucial intramolecular interactions required for catalytic function (tessa2009identificationofnovel pages 6-8)</td>
+</tr>
+<tr>
+<td><strong>L283F</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Reduced; within reported mutant range of ~4–19% of wild type</td>
+<td>TM6 region / late C-terminal helix (tessa2009identificationofnovel pages 6-8)</td>
+<td>Reported in HHH families (tessa2009identificationofnovel pages 6-8)</td>
+<td>Bulky substitution likely perturbs helix packing and transport pathway geometry (tessa2009identificationofnovel pages 6-8)</td>
+</tr>
+<tr>
+<td><strong>E180K</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Pathogenic; exact residual % not stated</td>
+<td>Contact-point II substrate-binding site near residue R179 (monne2012substratespecificityof pages 1-2, cunningham202020000picometersunder pages 4-5, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+<td>Reported missense HHH allele (cunningham202020000picometersunder pages 4-5)</td>
+<td>E180 is a key substrate-binding residue in wild-type ORC1; substitution is expected to disrupt ligand recognition and translocation (monne2012substratespecificityof pages 1-2, martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11)</td>
+</tr>
+<tr>
+<td><strong>F188D</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Pathogenic; exact residual % not stated</td>
+<td>Around residue 188 in pore/TM4 region (cunningham202020000picometersunder pages 4-5)</td>
+<td>Reported missense HHH allele (cunningham202020000picometersunder pages 4-5)</td>
+<td>Missense change near the recurrent F188 hotspot; associated with HHH syndrome and impaired urea-cycle transport (cunningham202020000picometersunder pages 4-5)</td>
+</tr>
+<tr>
+<td><strong>P126R</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Defective; exact % not stated</td>
+<td>Likely TM3 / central cavity region (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16)</td>
+<td>Reported in affected families (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16)</td>
+<td>Likely disrupts conserved carrier helix geometry important for alternating-access transport (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16, tessa2009identificationofnovel pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>R275X</strong></td>
+<td>Nonsense</td>
+<td style="text-align: right;">Predicted null</td>
+<td>TM6 / contact-point III vicinity; R275 is mechanistically important in wild type (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, monne2012substratespecificityof pages 7-8)</td>
+<td>Reported in affected families (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16)</td>
+<td>Premature stop removes C-terminal region; wild-type Arg275 contributes to substrate-triggered conformational change (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, monne2012substratespecificityof pages 7-8)</td>
+</tr>
+<tr>
+<td><strong>T32R</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Defective; exact % not stated</td>
+<td>TM1 / matrix-gate neighborhood (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16, tessa2009identificationofnovel pages 5-6)</td>
+<td>Reported in affected families (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16)</td>
+<td>Likely perturbs local charge environment near matrix-side gating residues (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16, tessa2009identificationofnovel pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>p.K245X</strong></td>
+<td>Nonsense</td>
+<td style="text-align: right;">Predicted null</td>
+<td>C-terminal half / likely TM5-TM6 region (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+<td>Identified among 13 mutations in HHH families (tessa2009identificationofnovel pages 5-6, tessa2009identificationofnovel pages 3-4)</td>
+<td>Premature truncation expected to abolish functional carrier assembly/transport (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>p.S175fsX192</strong></td>
+<td>Frameshift</td>
+<td style="text-align: right;">Predicted null</td>
+<td>Mid-protein / around TM4 entry (tessa2009identificationofnovel pages 5-6)</td>
+<td>Reported in HHH families (tessa2009identificationofnovel pages 5-6)</td>
+<td>Frameshift with premature termination; expected severe loss of ORC1 function (tessa2009identificationofnovel pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>c.552-555delTTTC (p.Phe185SerfsTer8)</strong></td>
+<td>Frameshift deletion</td>
+<td style="text-align: right;">Predicted null</td>
+<td>Around residue 185 / pore hotspot region (dweikat2022clinicalheterogeneityof pages 9-9)</td>
+<td>Novel homozygous variant in 9 Palestinian patients (dweikat2022clinicalheterogeneityof pages 9-9)</td>
+<td>Expected nonsense-mediated decay or severely truncated protein; expands the HHH molecular spectrum (dweikat2022clinicalheterogeneityof pages 9-9)</td>
+</tr>
+<tr>
+<td><strong>c.446delG (p.Ser149ThrfsTer45)</strong></td>
+<td>Frameshift deletion</td>
+<td style="text-align: right;">Predicted null</td>
+<td>Mid-protein / central carrier region (dweikat2022clinicalheterogeneityof pages 9-9)</td>
+<td>Recurrent homozygous variant in 4 Palestinian patients (dweikat2022clinicalheterogeneityof pages 9-9)</td>
+<td>Frameshift expected to abrogate transporter function; associated with marked clinical heterogeneity despite shared genotype (dweikat2022clinicalheterogeneityof pages 9-9)</td>
+</tr>
+<tr>
+<td><strong>Overall missense class</strong></td>
+<td>Missense</td>
+<td style="text-align: right;">Typically ~4–19% of wild-type transport, except severe alleles such as M37R (~0%) and A15V (near-abolished) (tessa2009identificationofnovel pages 5-6, tessa2009identificationofnovel pages 1-2, tunalı2014anovelmutation pages 1-2)</td>
+<td>Frequently in transmembrane helices H1–H6 and residues protruding into the internal pore (tessa2009identificationofnovel pages 6-8, tessa2009identificationofnovel pages 5-6)</td>
+<td>No clear genotype-phenotype correlation overall (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, tessa2009identificationofnovel pages 1-2)</td>
+<td>Many pathogenic residues cluster in the translocation pore or gating networks, interfering with substrate binding, helix movement, or conformational switching (martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11, tessa2009identificationofnovel pages 6-8, monne2012substratespecificityof pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes representative disease-causing SLC25A15 variants reported in hyperornithinemia-hyperammonemia-homocitrullinuria syndrome, including mutation class, functional impact, structural context, and recurrence. It is useful for connecting genotype to transporter mechanism and clinical interpretation.</em></p>
+<h3 id="72-cancer-associations">7.2 Cancer Associations</h3>
+<p>Emerging evidence implicates SLC25A15 in cancer biology in a context-dependent manner:</p>
+<ul>
+<li>
+<p><strong>Hepatocellular carcinoma (HCC)</strong>: ORC1 is downregulated in HCC and functions as a <strong>tumor suppressor</strong>. Its downregulation leads to ammonia accumulation, which activates mTORC1, promotes glutamine uptake, and redirects glutamine metabolism toward reductive carboxylation and de novo lipogenesis, thereby driving HCC progression. ORC1 downregulation also confers resistance to anti-PD-L1 therapy (ahmed2024theroleof pages 16-18).</p>
+</li>
+<li>
+<p><strong>Diffuse large B-cell lymphoma (DLBCL)</strong>: In contrast, SLC25A15 is <strong>highly expressed</strong> in DLBCL where it serves as a survival factor. It supports purine nucleotide homeostasis and genomic stability; its downregulation leads to impaired purine nucleotide synthesis, dGTP depletion, and DNA damage, identifying it as a potential metabolic vulnerability and therapeutic target (su2026pufabiflavone pages 12-14, su2026pufabiflavone pages 7-12, su2026pufabiflavone pages 1-2).</p>
+</li>
+</ul>
+<p>OpenTargets disease-target association analysis confirms strong associations of SLC25A15 with ornithine translocase deficiency (score 0.85) and HHH syndrome (score 0.84), as well as weaker associations with inflammatory bowel disease and autoimmune CNS disorders (OpenTargets Search: -SLC25A15).</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>SLC25A15/ORC1 is the principal human mitochondrial ornithine transporter, embedded in the inner mitochondrial membrane, where it catalyzes the electroneutral 1:1 antiport exchange of cytoplasmic L-ornithine for mitochondrial L-citrulline plus a proton. Its primary biological role is to bridge the mitochondrial and cytoplasmic reactions of the urea cycle, ensuring both ornithine availability for OTC in the matrix and citrulline export for argininosuccinate synthase in the cytosol. The protein adopts the canonical six-transmembrane-helix architecture of the SLC25 family, with substrate binding determined by key residues at three contact points (E77, R179/E180, R275). Loss-of-function mutations cause HHH syndrome, a rare urea cycle disorder, while emerging evidence points to context-dependent roles in cancer metabolism. Paralogous carriers ORC2 and SLC25A29 provide partial functional redundancy that may modulate disease severity.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(palmieri2013themitochondrialtransporter pages 3-6): Ferdinando Palmieri. The mitochondrial transporter family slc25: identification, properties and physiopathology. Molecular aspects of medicine, 34 2-3:465-84, Apr 2013. URL: https://doi.org/10.1016/j.mam.2012.05.005, doi:10.1016/j.mam.2012.05.005. This article has 740 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 9-11): Diego Martinelli, Daria Diodato, Emanuela Ponzi, Magnus Monné, Sara Boenzi, Enrico Bertini, Giuseppe Fiermonte, and Carlo Dionisi-Vici. The hyperornithinemia–hyperammonemia-homocitrullinuria syndrome. Orphanet Journal of Rare Diseases, Mar 2015. URL: https://doi.org/10.1186/s13023-015-0242-9, doi:10.1186/s13023-015-0242-9. This article has 121 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -SLC25A15): Open Targets Query (-SLC25A15, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(gutierrezaguilar2013physiologicalandpathological pages 3-4): Manuel Gutiérrez-Aguilar and Christopher P. Baines. Physiological and pathological roles of mitochondrial slc25 carriers. The Biochemical journal, 454 3:371-86, Sep 2013. URL: https://doi.org/10.1042/bj20121753, doi:10.1042/bj20121753. This article has 178 citations.</p>
+</li>
+<li>
+<p>(gao2024cancertherapeuticpotential pages 6-7): Renzhuo Gao, Dan Zhou, Xingpeng Qiu, Jiayi Zhang, Daya Luo, Xiaohong Yang, Caiyun Qian, and Zhuoqi Liu. Cancer therapeutic potential and prognostic value of the slc25 mitochondrial carrier family: a review. Cancer Control : Journal of the Moffitt Cancer Center, Jan 2024. URL: https://doi.org/10.1177/10732748241287905, doi:10.1177/10732748241287905. This article has 12 citations.</p>
+</li>
+<li>
+<p>(tessa2009identificationofnovel pages 3-4): Alessandra Tessa, Giuseppe Fiermonte, Carlo Dionisi-Vici, Eleonora Paradies, Matthias R. Baumgartner, Yin-Hsiu Chien, Carmela Loguercio, Helene Ogier de Baulny, Marie-Cecile Nassogne, Manuel Schiff, Federica Deodato, Giancarlo Parenti, S. Lane Rutledge, M. Antonia Vilaseca, Mariarosa A.B. Melone, Gioacchino Scarano, Luiz Aldamiz-Echevarría, Guy Besley, John Walter, Eugenia Martinez-Hernandez, Jose M. Hernandez, Ciro L. Pierri, Ferdinando Palmieri, and Filippo M. Santorelli. Identification of novel mutations in the slc25a15 gene in hyperornithinemia‐hyperammonemia‐homocitrullinuria (hhh) syndrome: a clinical, molecular, and functional study. Human Mutation, 30:741-748, May 2009. URL: https://doi.org/10.1002/humu.20930, doi:10.1002/humu.20930. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tessa2009identificationofnovel pages 5-6): Alessandra Tessa, Giuseppe Fiermonte, Carlo Dionisi-Vici, Eleonora Paradies, Matthias R. Baumgartner, Yin-Hsiu Chien, Carmela Loguercio, Helene Ogier de Baulny, Marie-Cecile Nassogne, Manuel Schiff, Federica Deodato, Giancarlo Parenti, S. Lane Rutledge, M. Antonia Vilaseca, Mariarosa A.B. Melone, Gioacchino Scarano, Luiz Aldamiz-Echevarría, Guy Besley, John Walter, Eugenia Martinez-Hernandez, Jose M. Hernandez, Ciro L. Pierri, Ferdinando Palmieri, and Filippo M. Santorelli. Identification of novel mutations in the slc25a15 gene in hyperornithinemia‐hyperammonemia‐homocitrullinuria (hhh) syndrome: a clinical, molecular, and functional study. Human Mutation, 30:741-748, May 2009. URL: https://doi.org/10.1002/humu.20930, doi:10.1002/humu.20930. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(monne2012substratespecificityof pages 1-2): Magnus Monné, Daniela Valeria Miniero, Lucia Daddabbo, Alan J. Robinson, Edmund R.S. Kunji, and Ferdinando Palmieri. Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site. Journal of Biological Chemistry, 287:7925-7934, Mar 2012. URL: https://doi.org/10.1074/jbc.m111.324855, doi:10.1074/jbc.m111.324855. This article has 65 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(monne2012substratespecificityof pages 3-4): Magnus Monné, Daniela Valeria Miniero, Lucia Daddabbo, Alan J. Robinson, Edmund R.S. Kunji, and Ferdinando Palmieri. Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site. Journal of Biological Chemistry, 287:7925-7934, Mar 2012. URL: https://doi.org/10.1074/jbc.m111.324855, doi:10.1074/jbc.m111.324855. This article has 65 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(palmieri2020diseasescausedby pages 13-15): Ferdinando Palmieri, Pasquale Scarcia, and Magnus Monné. Diseases caused by mutations in mitochondrial carrier genes slc25: a review. Biomolecules, 10:655, Apr 2020. URL: https://doi.org/10.3390/biom10040655, doi:10.3390/biom10040655. This article has 135 citations.</p>
+</li>
+<li>
+<p>(ahmed2024theroleof pages 16-18): Amer Ahmed, Giorgia Natalia Iaconisi, Daria Di Molfetta, Vincenzo Coppola, Antonello Caponio, Ansu Singh, Aasia Bibi, Loredana Capobianco, Luigi Palmieri, Vincenza Dolce, and Giuseppe Fiermonte. The role of mitochondrial solute carriers slc25 in cancer metabolic reprogramming: current insights and future perspectives. International Journal of Molecular Sciences, 26:92, Dec 2024. URL: https://doi.org/10.3390/ijms26010092, doi:10.3390/ijms26010092. This article has 18 citations.</p>
+</li>
+<li>
+<p>(monne2012substratespecificityof pages 7-8): Magnus Monné, Daniela Valeria Miniero, Lucia Daddabbo, Alan J. Robinson, Edmund R.S. Kunji, and Ferdinando Palmieri. Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site. Journal of Biological Chemistry, 287:7925-7934, Mar 2012. URL: https://doi.org/10.1074/jbc.m111.324855, doi:10.1074/jbc.m111.324855. This article has 65 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 8-9): Diego Martinelli, Daria Diodato, Emanuela Ponzi, Magnus Monné, Sara Boenzi, Enrico Bertini, Giuseppe Fiermonte, and Carlo Dionisi-Vici. The hyperornithinemia–hyperammonemia-homocitrullinuria syndrome. Orphanet Journal of Rare Diseases, Mar 2015. URL: https://doi.org/10.1186/s13023-015-0242-9, doi:10.1186/s13023-015-0242-9. This article has 121 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(camacho2009thehumanand pages 6-7): Josée A Camacho and Natalia Rioseco-Camacho. The human and mouse slc25a29 mitochondrial transporters rescue the deficient ornithine metabolism in fibroblasts of patients with the hyperornithinemia-hyperammonemia-homocitrullinuria (hhh) syndrome. Jul 2009. URL: https://doi.org/10.1203/pdr.0b013e3181a283c1, doi:10.1203/pdr.0b013e3181a283c1. This article has 41 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cunningham202020000picometersunder pages 4-5): Corey N Cunningham and Jared Rutter. 20,000 picometers under the omm: diving into the vastness of mitochondrial metabolite transport. EMBO reports, Apr 2020. URL: https://doi.org/10.15252/embr.202050071, doi:10.15252/embr.202050071. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mentel2021learningfromyeast pages 20-21): Marek Mentel, Petra Chovančíková, Igor Zeman, and Peter Polčic. Learning from yeast about mitochondrial carriers. Microorganisms, 9:2044, Sep 2021. URL: https://doi.org/10.3390/microorganisms9102044, doi:10.3390/microorganisms9102044. This article has 7 citations.</p>
+</li>
+<li>
+<p>(mentel2021learningfromyeast pages 21-22): Marek Mentel, Petra Chovančíková, Igor Zeman, and Peter Polčic. Learning from yeast about mitochondrial carriers. Microorganisms, 9:2044, Sep 2021. URL: https://doi.org/10.3390/microorganisms9102044, doi:10.3390/microorganisms9102044. This article has 7 citations.</p>
+</li>
+<li>
+<p>(tessa2009identificationofnovel pages 1-2): Alessandra Tessa, Giuseppe Fiermonte, Carlo Dionisi-Vici, Eleonora Paradies, Matthias R. Baumgartner, Yin-Hsiu Chien, Carmela Loguercio, Helene Ogier de Baulny, Marie-Cecile Nassogne, Manuel Schiff, Federica Deodato, Giancarlo Parenti, S. Lane Rutledge, M. Antonia Vilaseca, Mariarosa A.B. Melone, Gioacchino Scarano, Luiz Aldamiz-Echevarría, Guy Besley, John Walter, Eugenia Martinez-Hernandez, Jose M. Hernandez, Ciro L. Pierri, Ferdinando Palmieri, and Filippo M. Santorelli. Identification of novel mutations in the slc25a15 gene in hyperornithinemia‐hyperammonemia‐homocitrullinuria (hhh) syndrome: a clinical, molecular, and functional study. Human Mutation, 30:741-748, May 2009. URL: https://doi.org/10.1002/humu.20930, doi:10.1002/humu.20930. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(monne2012substratespecificityof pages 2-3): Magnus Monné, Daniela Valeria Miniero, Lucia Daddabbo, Alan J. Robinson, Edmund R.S. Kunji, and Ferdinando Palmieri. Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site. Journal of Biological Chemistry, 287:7925-7934, Mar 2012. URL: https://doi.org/10.1074/jbc.m111.324855, doi:10.1074/jbc.m111.324855. This article has 65 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(monne2012substratespecificityof pages 8-9): Magnus Monné, Daniela Valeria Miniero, Lucia Daddabbo, Alan J. Robinson, Edmund R.S. Kunji, and Ferdinando Palmieri. Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site. Journal of Biological Chemistry, 287:7925-7934, Mar 2012. URL: https://doi.org/10.1074/jbc.m111.324855, doi:10.1074/jbc.m111.324855. This article has 65 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cai2026argininetransportersin pages 10-12): Xichen Cai, Li Shang, Yue-Qin Li, Ya Cao, and Feng Shi. Arginine transporters in human cancers: emerging mechanisms and clinical implications. Biomolecules, 16:132, Jan 2026. URL: https://doi.org/10.3390/biom16010132, doi:10.3390/biom16010132. This article has 2 citations.</p>
+</li>
+<li>
+<p>(arco2005newmitochondrialcarriers pages 10-11): A. del Arco and J. Satrústegui. New mitochondrial carriers: an overview. Cellular and Molecular Life Sciences CMLS, 62:2204-2227, Aug 2005. URL: https://doi.org/10.1007/s00018-005-5197-x, doi:10.1007/s00018-005-5197-x. This article has 114 citations.</p>
+</li>
+<li>
+<p>(tunalı2014anovelmutation pages 1-2): Nagehan Ersoy Tunalı, Carlo M.T. Marobbio, N. Ozan Tiryakioğlu, Giuseppe Punzi, Seha K. Saygılı, Hasan Önal, and Ferdinando Palmieri. A novel mutation in the slc25a15 gene in a turkish patient with hhh syndrome: functional analysis of the mutant protein. Molecular Genetics and Metabolism, 112(1):25-29, May 2014. URL: https://doi.org/10.1016/j.ymgme.2014.03.002, doi:10.1016/j.ymgme.2014.03.002. This article has 34 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(martinelli2015thehyperornithinemia–hyperammonemiahomocitrullinuriasyndrome pages 16-16): Diego Martinelli, Daria Diodato, Emanuela Ponzi, Magnus Monné, Sara Boenzi, Enrico Bertini, Giuseppe Fiermonte, and Carlo Dionisi-Vici. The hyperornithinemia–hyperammonemia-homocitrullinuria syndrome. Orphanet Journal of Rare Diseases, Mar 2015. URL: https://doi.org/10.1186/s13023-015-0242-9, doi:10.1186/s13023-015-0242-9. This article has 121 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dweikat2022clinicalheterogeneityof pages 9-9): Imad Dweikat and Reham Khalaf-Nazzal. Clinical heterogeneity of hyperornithinemia-hyperammonemia-homocitrullinuria syndrome in thirteen palestinian patients and report of a novel variant in the slc25a15 gene. Frontiers in Genetics, Nov 2022. URL: https://doi.org/10.3389/fgene.2022.1004598, doi:10.3389/fgene.2022.1004598. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tessa2009identificationofnovel pages 6-8): Alessandra Tessa, Giuseppe Fiermonte, Carlo Dionisi-Vici, Eleonora Paradies, Matthias R. Baumgartner, Yin-Hsiu Chien, Carmela Loguercio, Helene Ogier de Baulny, Marie-Cecile Nassogne, Manuel Schiff, Federica Deodato, Giancarlo Parenti, S. Lane Rutledge, M. Antonia Vilaseca, Mariarosa A.B. Melone, Gioacchino Scarano, Luiz Aldamiz-Echevarría, Guy Besley, John Walter, Eugenia Martinez-Hernandez, Jose M. Hernandez, Ciro L. Pierri, Ferdinando Palmieri, and Filippo M. Santorelli. Identification of novel mutations in the slc25a15 gene in hyperornithinemia‐hyperammonemia‐homocitrullinuria (hhh) syndrome: a clinical, molecular, and functional study. Human Mutation, 30:741-748, May 2009. URL: https://doi.org/10.1002/humu.20930, doi:10.1002/humu.20930. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(su2026pufabiflavone pages 12-14): Chang Su, Guige Lu, Lijia Ou, Liang Liang, Caiqin Wang, Yizi He, Ruolan Zeng, Yajun Li, Hui Zhou, and Ling Xiao. Puf, a biflavone monomer, triggers dna damage through slc25a15 downregulation and purine metabolic suppression in dlbcl. Journal of Translational Medicine, Feb 2026. URL: https://doi.org/10.1186/s12967-026-07797-9, doi:10.1186/s12967-026-07797-9. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(su2026pufabiflavone pages 7-12): Chang Su, Guige Lu, Lijia Ou, Liang Liang, Caiqin Wang, Yizi He, Ruolan Zeng, Yajun Li, Hui Zhou, and Ling Xiao. Puf, a biflavone monomer, triggers dna damage through slc25a15 downregulation and purine metabolic suppression in dlbcl. Journal of Translational Medicine, Feb 2026. URL: https://doi.org/10.1186/s12967-026-07797-9, doi:10.1186/s12967-026-07797-9. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(su2026pufabiflavone pages 1-2): Chang Su, Guige Lu, Lijia Ou, Liang Liang, Caiqin Wang, Yizi He, Ruolan Zeng, Yajun Li, Hui Zhou, and Ling Xiao. Puf, a biflavone monomer, triggers dna damage through slc25a15 downregulation and purine metabolic suppression in dlbcl. Journal of Translational Medicine, Feb 2026. URL: https://doi.org/10.1186/s12967-026-07797-9, doi:10.1186/s12967-026-07797-9. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="SLC25A15-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="SLC25A15-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>palmieri2013themitochondrialtransporter pages 3-6</li>
+<li>gao2024cancertherapeuticpotential pages 6-7</li>
+<li>monne2012substratespecificityof pages 1-2</li>
+<li>mentel2021learningfromyeast pages 20-21</li>
+<li>monne2012substratespecificityof pages 3-4</li>
+<li>tessa2009identificationofnovel pages 5-6</li>
+<li>monne2012substratespecificityof pages 8-9</li>
+<li>arco2005newmitochondrialcarriers pages 10-11</li>
+<li>camacho2009thehumanand pages 6-7</li>
+<li>palmieri2020diseasescausedby pages 13-15</li>
+<li>tessa2009identificationofnovel pages 6-8</li>
+<li>tunalı2014anovelmutation pages 1-2</li>
+<li>dweikat2022clinicalheterogeneityof pages 9-9</li>
+<li>ahmed2024theroleof pages 16-18</li>
+<li>gutierrezaguilar2013physiologicalandpathological pages 3-4</li>
+<li>tessa2009identificationofnovel pages 3-4</li>
+<li>monne2012substratespecificityof pages 7-8</li>
+<li>mentel2021learningfromyeast pages 21-22</li>
+<li>tessa2009identificationofnovel pages 1-2</li>
+<li>monne2012substratespecificityof pages 2-3</li>
+<li>cai2026argininetransportersin pages 10-12</li>
+<li>su2026pufabiflavone pages 12-14</li>
+<li>su2026pufabiflavone pages 7-12</li>
+<li>su2026pufabiflavone pages 1-2</li>
+<li>https://doi.org/10.1016/j.mam.2012.05.005,</li>
+<li>https://doi.org/10.1186/s13023-015-0242-9,</li>
+<li>https://doi.org/10.1042/bj20121753,</li>
+<li>https://doi.org/10.1177/10732748241287905,</li>
+<li>https://doi.org/10.1002/humu.20930,</li>
+<li>https://doi.org/10.1074/jbc.m111.324855,</li>
+<li>https://doi.org/10.3390/biom10040655,</li>
+<li>https://doi.org/10.3390/ijms26010092,</li>
+<li>https://doi.org/10.1203/pdr.0b013e3181a283c1,</li>
+<li>https://doi.org/10.15252/embr.202050071,</li>
+<li>https://doi.org/10.3390/microorganisms9102044,</li>
+<li>https://doi.org/10.3390/biom16010132,</li>
+<li>https://doi.org/10.1007/s00018-005-5197-x,</li>
+<li>https://doi.org/10.1016/j.ymgme.2014.03.002,</li>
+<li>https://doi.org/10.3389/fgene.2022.1004598,</li>
+<li>https://doi.org/10.1186/s12967-026-07797-9,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SLC25A15-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y619" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="slc25a15-ornt1-q9y619-review-notes">SLC25A15 / ORNT1 (Q9Y619) review notes</h1>
+<h2 id="identity-and-family">Identity and family</h2>
+<ul>
+<li>Mitochondrial ornithine transporter 1 (ORNT1); Solute carrier family 25 member 15.</li>
+<li>301 aa, mitochondrial carrier (SLC25 / TC 2.A.29) family: three Solcar repeats, six TM helices, MCP domain (UniProt Q9Y619).</li>
+<li>TCDB 2.A.29.19.2. Paralog SLC25A2/ORNT2 (~88% identical, retrotransposon-derived) has overlapping, broader specificity and partially compensates for ORNT1 loss.</li>
+</ul>
+<h2 id="core-molecular-function">Core molecular function</h2>
+<ul>
+<li>Mitochondrial inner-membrane ornithine/citrulline antiporter: imports cytosolic L-ornithine into the matrix in exchange for exporting matrix L-citrulline (with an H+ making transport electroneutral).</li>
+<li>UniProt FUNCTION: "Mitochondrial ornithine-citrulline antiporter ... Catalyzes the exchange between cytosolic ornithine and mitochondrial citrulline plus an H(+), the proton compensates the positive charge of ornithine thus leading to an electroneutral transport. Plays a crucial role in the urea cycle, by connecting the cytosolic and the intramitochondrial reactions of the urea cycle" (UniProt Q9Y619, [PubMed:12807890], [PubMed:22262851]).</li>
+<li>Rhea catalytic activity: RHEA:70787 L-citrulline(in) + L-ornithine(out) + H+(in) = L-citrulline(out) + L-ornithine(in) + H+(out).</li>
+</ul>
+<h2 id="broad-basic-amino-acid-specificity-in-vitro">Broad basic-amino-acid specificity (in vitro)</h2>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12807890" title="Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange and by unidirectional mechanisms, and they are inactivated by the same inhibitors.">PMID:12807890</a> ORC1=ORNT1; ORC2=ORNT2.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12807890" title="ORC2 has a broader specificity than ORC1, and L- and D-histidine, L-homoarginine, and D-isomers of ornithine, lysine, and ornithine are all substrates.">PMID:12807890</a></li>
+<li>Km values (UniProt, PubMed:12807890): ornithine 0.22 mM, lysine 0.8 mM, arginine 1.58 mM, citrulline 2.52 mM — ornithine highest affinity, consistent with ornithine being the primary physiological substrate.</li>
+<li>Additional Rhea reactions in UniProt: L-arginine/L-ornithine antiport (RHEA:34991, EXP PubMed:12807890), L-ornithine/L-lysine antiport (RHEA:70799, EXP PubMed:12807890), plus by-similarity ornithine/H+ and lysine/H+ uniport.</li>
+</ul>
+<h2 id="substrate-specificity-determinants">Substrate-specificity determinants</h2>
+<ul>
+<li>[PMID:22262851 title "Substrate specificity of the two mitochondrial ornithine carriers can be swapped by single mutation in substrate binding site."] Mutagenesis (R179, E180, W224) alters relative ornithine vs arginine/lysine transport (UniProt MUTAGEN features).</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Mitochondrial inner membrane; multi-pass membrane protein (UniProt SUBCELLULAR LOCATION; ISS from yeast ortholog Q12375). Original disease paper localized to mitochondrial membrane (EXP PubMed:10369256). HTP mito proteome (PMID:34800366).</li>
+</ul>
+<h2 id="urea-cycle-role-disease">Urea cycle role &amp; disease</h2>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/10369256" title="Our results show that ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is defective in HHH syndrome.">PMID:10369256</a></li>
+<li>Neurospora crassa ARG13 / S. cerevisiae ARG11 are the fungal orthologs; identified ORNT1 by orthology; expression high in liver and dietary-protein regulated (<a href="https://pubmed.ncbi.nlm.nih.gov/10369256">PMID:10369256</a>).</li>
+<li>HHH syndrome (hyperornithinemia-hyperammonemia-homocitrullinuria; MIM:238970; MONDO:0009393): autosomal recessive urea-cycle disorder from biallelic SLC25A15 LoF. Confirmed by dismech KB (Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml). Many pathogenic HHH variants (G27R, E180K, F188del, R275Q, etc.) abolish/reduce transport.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12948741" title="ORNT1, the gene defective in the hyperornithinemia-hyperammonemia-homocitrullinuria (HHH) syndrome, a urea cycle disorder">PMID:12948741</a> ORNT2 rescues defective ornithine metabolism in HHH patient fibroblasts.</li>
+</ul>
+<h2 id="go-term-verification-ols-current-labels">GO term verification (OLS, current labels)</h2>
+<ul>
+<li>GO:0000064 L-ornithine transmembrane transporter activity — MF, correct core.</li>
+<li>GO:1990575 mitochondrial L-ornithine transmembrane transport — BP; "L-ornithine is transported across a mitochondrial membrane" — correct core BP.</li>
+<li>GO:0000050 urea cycle — BP, correct.</li>
+<li>GO:0005743 mitochondrial inner membrane — CC, correct core location.</li>
+<li>GO:0043858 arginine:ornithine antiporter activity — MF; direction matches RHEA:34991; EXP-supported.</li>
+<li>GO:0015189 L-lysine / GO:0061459 L-arginine transmembrane transporter activity — IDA-supported broad specificity; non-core (physiological role is ornithine/citrulline).</li>
+<li>GO:0015297 antiporter activity — parent MF; correct but general.</li>
+<li>No dedicated "ornithine:citrulline antiporter" MF term exists in GO (searched OLS).</li>
+</ul>
+<h2 id="curation-stance">Curation stance</h2>
+<ul>
+<li>Core: GO:0000064 (MF), ornithine/citrulline antiport captured by GO:0043858 + GO:0015297, GO:1990575 (BP ornithine transport), GO:0000050 (urea cycle BP), GO:0005743 (CC).</li>
+<li>Non-core but experimentally real: lysine/arginine transporter MF + BP (broad basic-AA specificity in reconstituted system).</li>
+<li>Keep general CC (mitochondrion, mitochondrial membrane, membrane) as ACCEPT/non-core supporting the specific inner-membrane call.</li>
+<li>Reactome R-HSA-9956519 "SLC25A15 variants don't translocate ornithine and citrulline" is a variant/disease reaction but is used here to support the WT normal function annotations (GO:0005743, GO:0000064) — accept, these are correct for the gene.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9Y619
+gene_symbol: SLC25A15
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  SLC25A15 (ORNT1, mitochondrial ornithine transporter 1) is a member of the SLC25
+  mitochondrial carrier family that resides in the inner mitochondrial membrane as a
+  multi-pass membrane protein built from three tandem Solcar (mitochondrial carrier)
+  repeats. It catalyzes the electroneutral ornithine/citrulline antiport that couples
+  the cytosolic and matrix halves of the urea cycle; cytosolic L-ornithine is imported
+  into the matrix in exchange for the export of matrix L-citrulline, together with a
+  proton that neutralizes the ornithine charge. In vitro the carrier also exchanges the
+  basic amino acids L-lysine and L-arginine, and can perform ornithine/H+ and lysine/H+
+  uniport, reflecting a broad basic-amino-acid specificity, but ornithine is its
+  highest-affinity and principal physiological substrate. The protein is most highly
+  expressed in liver, pancreas, testis, lung and small intestine, consistent with its
+  urea-cycle role. Loss of function causes the autosomal recessive urea-cycle disorder
+  hyperornithinemia-hyperammonemia-homocitrullinuria (HHH) syndrome. A closely related
+  paralog, SLC25A2/ORNT2, has overlapping and broader substrate specificity and
+  partially compensates for defective ORNT1.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment placing ORNT1 activity in the mitochondrion. This is
+      correct but general; the specific and experimentally supported location is the
+      mitochondrial inner membrane.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ORNT1 is a mitochondrial carrier that acts in the mitochondrion; the IBA call
+      across the SLC25 ornithine-carrier clade is sound. It is a correct parent of the
+      more specific mitochondrial inner membrane annotation, so it is retained as
+      accurate though non-core. The precise location is captured by GO:0005743.
+- term:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of L-ornithine transmembrane transporter activity,
+      the core molecular function of ORNT1 and its fungal orthologs (N. crassa ARG13,
+      S. cerevisiae ARG11/ORT1).
+    action: ACCEPT
+    reason: &gt;-
+      This is the core molecular function, directly supported by reconstitution assays
+      and by the disease mechanism, and is consistent across the ornithine-carrier
+      phylogenetic clade.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: &gt;-
+        Our results show that ORNT1 encodes the mitochondrial ornithine transporter
+        involved in UC function and is defective in HHH syndrome.
+- term:
+    id: GO:1990575
+    label: mitochondrial L-ornithine transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of the biological process of transporting L-ornithine
+      across the mitochondrial membrane, the process this carrier mediates.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly captures the core biological process (movement of L-ornithine across the
+      inner mitochondrial membrane) that ORNT1 performs as part of urea-cycle function.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: &gt;-
+        ORNT1 expression restores ornithine metabolism in fibroblasts from patients with
+        hyperammonaemia-hyperornithinaemia-homocitrullinuria (HHH) syndrome.
+- term:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA machine-learning electronic annotation of the core L-ornithine transmembrane
+      transporter activity.
+    action: ACCEPT
+    reason: &gt;-
+      Duplicates the well-supported core molecular function (also assigned by IBA, EXP,
+      and TAS). The electronic mapping is at the correct level of specificity.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (multi-method IEA) assignment of mitochondrial inner membrane location,
+      from UniProt subcellular-location mapping (SL-0168).
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location for this multi-pass SLC25 inner-membrane carrier; concordant
+      with the UniProt subcellular location and the ISS-from-ortholog call.
+- term:
+    id: GO:0015297
+    label: antiporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA electronic annotation of generic antiporter activity, reflecting the exchange
+      (antiport) transport mechanism of ORNT1.
+    action: ACCEPT
+    reason: &gt;-
+      ORNT1 is genuinely an antiporter (ornithine/citrulline exchange), so the term is
+      correct although general. It is retained as a true parent of the more informative
+      specific antiport function; the physiologically meaningful antiport is the
+      arginine:ornithine / ornithine:citrulline exchange captured by GO:0043858 and by
+      the ornithine-transporter terms.
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation (UniProt subcellular-location mapping, SL-0171) of
+      mitochondrial membrane location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct but less specific than mitochondrial inner membrane. Retained as a true
+      parent; the precise, experimentally consistent location is GO:0005743.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70635
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome-traceable assignment placing ORNT1 in the urea cycle, which it connects by
+      shuttling ornithine and citrulline across the inner mitochondrial membrane.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process. ORNT1 physically links the cytosolic and matrix halves of
+      the urea cycle; its loss causes the urea-cycle disorder HHH syndrome.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: &gt;-
+        ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and
+        is defective in HHH syndrome.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9956519
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-traceable assignment of mitochondrial inner membrane location (from the
+      Reactome reaction describing ornithine/citrulline translocation).
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location. Although the source Reactome event concerns disease variants
+      that fail to translocate, the localization to the inner membrane is a correct
+      statement about the wild-type protein.
+- term:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9956519
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-traceable assignment of the core L-ornithine transmembrane transporter
+      activity.
+    action: ACCEPT
+    reason: &gt;-
+      Duplicates the well-supported core molecular function. Correct level of specificity.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Sequence-similarity (ISS) transfer of mitochondrial inner membrane location from
+      the S. cerevisiae ortholog ORT1/Q12375.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location; concordant with UniProt and electronic annotations and with
+      the multi-pass SLC25 topology.
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: EXP
+  original_reference_id: PMID:10369256
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental localization of ORNT1 to the mitochondrial membrane in the original
+      disease-gene study.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported mitochondrial membrane localization. The term is correct
+      though more general than the inner-membrane call; retained as a true and
+      experimentally grounded parent.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: mutations in a gene encoding a mitochondrial ornithine transporter
+- term:
+    id: GO:0043858
+    label: arginine:ornithine antiporter activity
+  evidence_type: EXP
+  original_reference_id: PMID:12807890
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimentally demonstrated arginine/ornithine antiport by reconstituted, purified
+      ORNT1 (ORC1). This is a specific antiport activity of the carrier and corresponds to
+      the UniProt/Rhea reaction L-arginine(out) + L-ornithine(in) = L-arginine(in) +
+      L-ornithine(out) (RHEA:34991).
+    action: ACCEPT
+    reason: &gt;-
+      Directly measured for reconstituted ORNT1 and matches the GO term direction
+      (arginine(out) + ornithine(in) = arginine(in) + ornithine(out)). It represents a
+      real, specific antiport function of the carrier. The physiologically dominant
+      exchange is ornithine/citrulline, but arginine:ornithine antiport is a genuine
+      biochemical activity and captures the carrier antiport mechanism more precisely than
+      generic antiporter activity.
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial-proteome study detecting ORNT1 in the mitochondrion.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the well-established mitochondrial localization, though less specific
+      than the experimentally supported inner-membrane location and derived from a
+      high-throughput proteomic dataset. Retained as a correct but corroborative,
+      non-core localization annotation.
+- term:
+    id: GO:0015189
+    label: L-lysine transmembrane transporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:12807890
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay of reconstituted ORNT1 showed transport of L-lysine, reflecting the
+      carrier broad basic-amino-acid specificity (UniProt Rhea reaction L-ornithine(out) +
+      L-lysine(in) = L-ornithine(in) + L-lysine(out), RHEA:70799).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally demonstrated in the reconstituted system (do not remove an IDA
+      activity). However, lysine is a lower-affinity substrate than ornithine (Km 0.8 vs
+      0.22 mM) and lysine transport is not the physiological role of the carrier; the
+      urea-cycle-relevant function is ornithine/citrulline exchange. Marked non-core to
+      reflect the broad in vitro specificity rather than the primary biological function.
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:0015297
+    label: antiporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:12807890
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct demonstration that ORNT1 transports basic amino acids by an exchange
+      (antiport) mechanism in reconstituted proteoliposomes.
+    action: ACCEPT
+    reason: &gt;-
+      Correct, experimentally grounded description of the antiport mechanism, although
+      general. Retained as a true parent of the specific antiport activities; the more
+      informative specific term is GO:0043858 (arginine:ornithine antiporter).
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:0061459
+    label: L-arginine transmembrane transporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:12807890
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay of reconstituted ORNT1 showed transport of L-arginine, reflecting the
+      carrier broad basic-amino-acid specificity (UniProt Rhea reaction RHEA:34991).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally demonstrated (do not remove an IDA activity). Arginine is a
+      lower-affinity substrate than ornithine (Km 1.58 vs 0.22 mM) and arginine transport
+      is not the carrier principal physiological role, which is ornithine/citrulline
+      exchange in the urea cycle. Marked non-core to reflect the broad in vitro
+      specificity.
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:1903401
+    label: L-lysine transmembrane transport
+  evidence_type: IDA
+  original_reference_id: PMID:12807890
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Biological-process counterpart of the demonstrated L-lysine transport activity by
+      reconstituted ORNT1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported but non-core; a manifestation of the carrier broad
+      basic-amino-acid specificity rather than its urea-cycle role.
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:1903826
+    label: L-arginine transmembrane transport
+  evidence_type: IDA
+  original_reference_id: PMID:12807890
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Biological-process counterpart of the demonstrated L-arginine transport activity by
+      reconstituted ORNT1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported but non-core; reflects broad basic-amino-acid specificity,
+      not the primary urea-cycle function.
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:10369256
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental localization of ORNT1 to the mitochondrion in the original
+      disease-gene identification study.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported mitochondrial localization, consistent with the more
+      specific inner-membrane location. Retained as a correct parent, non-core relative
+      to the specific mitochondrial inner membrane location.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: mutations in a gene encoding a mitochondrial ornithine transporter
+- term:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  evidence_type: EXP
+  original_reference_id: PMID:12807890
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental demonstration (reconstituted, purified ORNT1) of L-ornithine transport,
+      establishing the core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Directly measured core molecular function; ornithine is the highest-affinity
+      substrate (Km 0.22 mM). This is the defining activity of the carrier.
+    supported_by:
+    - reference_id: PMID:12807890
+      supporting_text: &gt;-
+        Both transport L-isomers of ornithine, lysine, arginine, and citrulline by
+        exchange and by unidirectional mechanisms, and they are inactivated by the same
+        inhibitors.
+- term:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  evidence_type: EXP
+  original_reference_id: PMID:12948741
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental support for L-ornithine transporter activity in the study
+      characterizing ORNT2 and confirming the ornithine-transport function shared with
+      ORNT1 (functional rescue of ornithine metabolism in HHH patient fibroblasts).
+    action: ACCEPT
+    reason: &gt;-
+      Reinforces the core molecular function of the ORNT ornithine carriers. The paper
+      demonstrates the ornithine-transport function that ORNT1 provides in the urea cycle
+      and that ORNT2 can partially replace.
+    supported_by:
+    - reference_id: PMID:12948741
+      supporting_text: &gt;-
+        When ORNT2 is overexpressed transiently in cultured fibroblasts from HHH patients,
+        it rescues the deficient ornithine metabolism in these cells.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70634
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-traceable assignment of mitochondrial inner membrane location, from the
+      reaction describing cytosolic/mitochondrial ornithine-citrulline exchange.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location, concordant with all other localization annotations.
+- term:
+    id: GO:0000050
+    label: urea cycle
+  evidence_type: TAS
+  original_reference_id: PMID:10369256
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated (TAS) involvement of ORNT1 in the urea cycle, from the disease-gene
+      identification study.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process. ORNT1 connects the cytosolic and matrix reactions of the
+      urea cycle; its deficiency causes the urea-cycle disorder HHH syndrome.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: &gt;-
+        ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and
+        is defective in HHH syndrome.
+- term:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  evidence_type: TAS
+  original_reference_id: PMID:10369256
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Author-stated (TAS) L-ornithine transporter activity for ORNT1 in the disease-gene
+      study.
+    action: ACCEPT
+    reason: Duplicates the well-supported core molecular function.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: mutations in a gene encoding a mitochondrial ornithine transporter
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: TAS
+  original_reference_id: PMID:10369256
+  qualifier: located_in
+  review:
+    summary: Author-stated (TAS) mitochondrial inner membrane location for ORNT1.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location, consistent with experimental and electronic annotations.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: transport ornithine across the mitochondrial inner membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:10369256
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Author-stated (TAS) generic membrane location, superseded by the specific
+      mitochondrial inner membrane annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Not incorrect (ORNT1 is a multi-pass membrane protein), but GO:0016020 is
+      uninformative given the well-established mitochondrial inner membrane localization.
+      It is a legacy general term that adds no biological information beyond the specific
+      inner-membrane annotations.
+- term:
+    id: GO:1990575
+    label: mitochondrial L-ornithine transmembrane transport
+  evidence_type: TAS
+  original_reference_id: PMID:10369256
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated (TAS) biological process of L-ornithine transport across the
+      mitochondrial membrane.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, concordant with the IBA assignment and the urea-cycle role.
+    supported_by:
+    - reference_id: PMID:10369256
+      supporting_text: transport ornithine across the mitochondrial inner membrane
+core_functions:
+- description: &gt;-
+    Ornithine/citrulline antiport across the inner mitochondrial membrane that couples the
+    cytosolic and matrix halves of the urea cycle, importing cytosolic L-ornithine into
+    the matrix in exchange for exporting matrix L-citrulline.
+  molecular_function:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0000050
+    label: urea cycle
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:12807890
+    supporting_text: &gt;-
+      Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange
+      and by unidirectional mechanisms, and they are inactivated by the same inhibitors.
+  - reference_id: PMID:10369256
+    supporting_text: &gt;-
+      ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is
+      defective in HHH syndrome.
+- description: &gt;-
+    Transmembrane movement of L-ornithine across the mitochondrial inner membrane, the
+    transport process that ORNT1 mediates.
+  molecular_function:
+    id: GO:0000064
+    label: L-ornithine transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:1990575
+    label: mitochondrial L-ornithine transmembrane transport
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:10369256
+    supporting_text: &gt;-
+      ORNT1 expression restores ornithine metabolism in fibroblasts from patients with
+      hyperammonaemia-hyperornithinaemia-homocitrullinuria (HHH) syndrome.
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10369256
+  title: Hyperornithinaemia-hyperammonaemia-homocitrullinuria syndrome is caused by
+    mutations in a gene encoding a mitochondrial ornithine transporter.
+  findings:
+  - statement: &gt;-
+      Identified ORNT1 (SLC25A15) by orthology to fungal mitochondrial ornithine carriers,
+      showed it restores ornithine metabolism in HHH patient fibroblasts, and established
+      that its mutations cause HHH syndrome.
+    supporting_text: &gt;-
+      ORNT1 encodes the mitochondrial ornithine transporter involved in UC function and is
+      defective in HHH syndrome.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified original disease-gene study establishing ORNT1 as the mitochondrial
+      ornithine transporter and its role in the urea cycle and HHH syndrome. Cached record
+      is abstract-only.
+- id: PMID:12807890
+  title: The mitochondrial ornithine transporter. Bacterial expression, reconstitution,
+    functional characterization, and tissue distribution of two human isoforms.
+  findings:
+  - statement: &gt;-
+      Reconstituted, purified ORNT1 (ORC1) transports L-ornithine, L-lysine, L-arginine
+      and L-citrulline by exchange and unidirectional mechanisms; ORNT2 (ORC2) has broader
+      specificity; both are most highly expressed in liver.
+    supporting_text: &gt;-
+      Both transport L-isomers of ornithine, lysine, arginine, and citrulline by exchange
+      and by unidirectional mechanisms, and they are inactivated by the same inhibitors.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified biochemical characterization of purified, reconstituted human
+      ORNT1/ORNT2, establishing substrate specificity (ornithine highest affinity) and
+      antiport mechanism. Cached record is abstract-only.
+- id: PMID:12948741
+  title: &#39;Cloning and characterization of human ORNT2: a second mitochondrial ornithine
+    transporter that can rescue a defective ORNT1 in patients with the hyperornithinemia-hyperammonemia-homocitrullinuria
+    syndrome, a urea cycle disorder.&#39;
+  findings:
+  - statement: &gt;-
+      ORNT2 (SLC25A2) is a paralog ~88% identical to ORNT1 that targets to mitochondria
+      and rescues deficient ornithine metabolism in HHH patient fibroblasts, explaining
+      partial functional redundancy.
+    supporting_text: &gt;-
+      When ORNT2 is overexpressed transiently in cultured fibroblasts from HHH patients,
+      it rescues the deficient ornithine metabolism in these cells.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; primarily characterizes the paralog ORNT2 but confirms the shared
+      ornithine-transport function relevant to ORNT1. Abstract-only.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings:
+  - statement: &gt;-
+      High-throughput mitochondrial-proteome study detecting SLC25A15 in the mitochondrion.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput proteomic detection supporting mitochondrial localization;
+      corroborative rather than functionally decisive.
+- id: PMID:22262851
+  title: Substrate specificity of the two mitochondrial ornithine carriers can be
+    swapped by single mutation in substrate binding site.
+  findings:
+  - statement: &gt;-
+      Mutagenesis of substrate-binding residues (R179, E180, W224) in ORNT1 shifts
+      relative ornithine versus arginine/lysine transport, defining the
+      substrate-specificity determinants of the carrier.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt-cited mechanistic study of ORNT1 substrate binding; supports the
+      ornithine-carrier function and its broad basic-amino-acid specificity. Not cached;
+      cited from the UniProt record (FUNCTION and MUTAGEN features).
+- id: Reactome:R-HSA-70634
+  title: ornithine (cytosolic) + citrulline (mitochondrial) =&gt; ornithine (mitochondrial)
+    + citrulline (cytosolic)
+  findings: []
+- id: Reactome:R-HSA-70635
+  title: Urea cycle
+  findings: []
+- id: Reactome:R-HSA-9956519
+  title: SLC25A15 variants don&#39;t translocate ornithine and citrulline
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/AAD3/AAD3-ai-review.html
+++ b/genes/yeast/AAD3/AAD3-ai-review.html
@@ -1,0 +1,2542 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AAD3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AAD3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P25612" target="_blank" class="term-link">
+                        P25612
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "AAD3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P25612" data-a="DESCRIPTION: AAD3 (systematic name YCR107W) is a Saccharomyces ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>AAD3 (systematic name YCR107W) is a Saccharomyces cerevisiae open reading frame encoding a 363-residue, full-length member of the aldo/keto reductase (AKR) superfamily (Pfam PF00248; aldo/keto reductase 2 subfamily). It is one of a set of paralogous &#34;aryl-alcohol dehydrogenase&#34; (AAD) genes (AAD3, AAD4, AAD6, AAD10, AAD14, AAD15, AAD16), most residing in subtelomeric regions, that were identified by sequence similarity to the NADP(+)-dependent aryl-alcohol dehydrogenase of the lignin-degrading white-rot fungus Phanerochaete chrysosporium. Despite the family name, no enzymatic activity or substrate has been experimentally demonstrated for the AAD3 gene product itself, and combined deletion of all seven yeast AAD genes produces no defect in aromatic-aldehyde reduction, indicating the family is functionally redundant or dispensable under standard laboratory conditions. AAD3 is thus best described as a putative NADP(H)-dependent oxidoreductase of the AKR fold whose physiological substrate and biological role remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0047681" target="_blank" class="term-link">
+                                    GO:0047681
+                                </a>
+                            </span>
+                            <span class="term-label">aryl-alcohol dehydrogenase (NADP+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P25612" data-a="GO:0047681" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA machine-learning rule) assignment of the specific molecular function &#34;aryl-alcohol dehydrogenase (NADP+) activity&#34; to AAD3. AAD3 is a full-length AKR-fold protein (Pfam PF00248), so a broad NADP(H)-dependent oxidoreductase potential is defensible, but the SPECIFIC aryl-alcohol dehydrogenase activity has never been demonstrated for the AAD3 gene product and is contradicted at the family level by the absence of any aryl-aldehyde phenotype in the seven-gene deletant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The specific aryl-alcohol dehydrogenase (NADP+) activity is a homology-driven over-annotation. The AAD family name derives entirely from similarity to the P. chrysosporium aryl-alcohol dehydrogenase (a lignin-degrading enzyme), yet combined deletion of all seven yeast AAD genes causes no defect in aromatic aldehyde reduction, and no in vitro activity or substrate has been reported for AAD3. The honest grounded statement is superfamily-level NADP(H)-dependent oxidoreductase (AKR) potential, not a defined aryl-alcohol dehydrogenase. Marked as over-annotated rather than removed because an AKR oxidoreductase capability is plausible and the term is not strictly impossible.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">GO_REF:0000117</span>
+
+                                    &middot; ARBA machine-learning rule (family AKR / aryl-alcohol dehydrogenase)
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Rule assigns a specific family activity from AKR/AAD sequence features; the child term overstates specificity for a paralog with no demonstrated activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link">
+                                        PMID:10572264
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">None of the knock-out strains revealed any mutant phenotype when tested for the degradation of aromatic aldehydes using both spectrophotometry and high performance liquid chromatography (HPLC).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006081" target="_blank" class="term-link">
+                                    GO:0006081
+                                </a>
+                            </span>
+                            <span class="term-label">aldehyde metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10572264
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Disruption of seven hypothetical aryl alcohol dehydrogenase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P25612" data-a="GO:0006081" data-r="PMID:10572264" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS assignment of the broad biological process &#34;aldehyde metabolic process&#34; to AAD3, inferred by sequence similarity (with/from UniProtKB:Q01752, the P. chrysosporium aryl-alcohol dehydrogenase). Aldehyde metabolism is the plausible generic process associated with the AKR fold, but it is unproven for AAD3 and the deletion data show no aldehyde-related phenotype for the yeast AAD genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a broad, low-confidence homology inference. The parent process &#34;aldehyde metabolic process&#34; is general enough that it remains a defensible, if unverified, contextual annotation for an AKR-fold protein, so it is retained as non-core rather than removed. It is explicitly NOT a core function: no substrate, activity, or phenotype ties AAD3 to aldehyde metabolism in vivo. The ISS source is a distant fungal paralog (Q01752), and combined deletion of all seven yeast AAD genes gave no aromatic-aldehyde phenotype.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE WEAK OR INFERRED</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">SOURCE EVIDENCE WEAK</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q01752</span>
+
+                                    &middot; Aryl-alcohol dehydrogenase [NADP(+)], Phanerodontia chrysosporium
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Donor is a functional lignin-degradation enzyme from a distantly related white-rot fungus; sequence similarity supports superfamily/process context only, not a demonstrated aldehyde-metabolism role for yeast AAD3.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link">
+                                        PMID:10572264
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">By in silicio analysis, we have discovered that there are seven open reading frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD) of the lignin-degrading fungus Phanerochaete chrysosporium.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0047681" target="_blank" class="term-link">
+                                    GO:0047681
+                                </a>
+                            </span>
+                            <span class="term-label">aryl-alcohol dehydrogenase (NADP+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10572264
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Disruption of seven hypothetical aryl alcohol dehydrogenase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P25612" data-a="GO:0047681" data-r="PMID:10572264" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS assignment of the specific &#34;aryl-alcohol dehydrogenase (NADP+) activity&#34; to AAD3, inferred by sequence similarity to the P. chrysosporium AAD (UniProtKB:Q01752). This is the same specific-activity over-annotation as the IEA line, transferred from a distant fungal enzyme. The deletion phenotype in the source paper argues directly against a demonstrable aryl-aldehyde activity for the yeast AAD genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The specific aryl-alcohol dehydrogenase activity is not supported for the AAD3 gene product: it rests only on homology to a lignin-degrading fungal enzyme, and the seven-gene S. cerevisiae AAD deletant shows no aromatic-aldehyde phenotype, with no in vitro activity ever reported. The defensible generalization is a superfamily-level NADP(H)-dependent oxidoreductase (AKR) function with unknown substrate. Not removed, because the ISS is a curator inference and an AKR oxidoreductase capability is biologically plausible; marked as over-annotated and paired with a proposed broader replacement term.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q01752</span>
+
+                                    &middot; Aryl-alcohol dehydrogenase [NADP(+)], Phanerodontia chrysosporium
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Functional donor is a white-rot fungal lignin enzyme; the specific aryl-alcohol activity does not safely transfer to a yeast subtelomeric paralog with no demonstrated activity and a family-wide null phenotype.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016616" target="_blank" class="term-link">
+                                    oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link">
+                                        PMID:10572264
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">None of the knock-out strains revealed any mutant phenotype when tested for the degradation of aromatic aldehydes using both spectrophotometry and high performance liquid chromatography (HPLC).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P25612" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component annotation with the ND (no biological data available) evidence code, the standard GO placeholder used when no localization data exist for the gene product. AAD3 has no experimentally determined subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the conventional ND root-term placeholder recording the absence of localization data, consistent with GO_REF:0000015. It is correct to retain as-is; it makes no substantive functional claim.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016616" target="_blank" class="term-link">
+                                    GO:0016616
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10572264
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Disruption of seven hypothetical aryl alcohol dehydrogenase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P25612" data-a="GO:0016616" data-r="PMID:10572264" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed generalized molecular function for AAD3: a superfamily-level NADP(H)-dependent oxidoreductase acting on CH-OH groups, replacing the over-specific &#34;aryl-alcohol dehydrogenase (NADP+) activity&#34;. This is the most specific activity that can be responsibly assigned from AKR-fold membership without demonstrated substrate specificity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> AAD3 is a full-length aldo/keto reductase (Pfam PF00248) with the AKR fold and NADP(H)-cofactor-associated regions, supporting a general NADP(H)-linked CH-OH oxidoreductase capability. Because no substrate or activity has been demonstrated for AAD3, this broad parent term is the appropriate, non-over-committing molecular function; it is offered as the replacement for the two over-specific aryl-alcohol-dehydrogenase annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link">
+                                        PMID:10572264
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">By in silicio analysis, we have discovered that there are seven open reading frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD) of the lignin-degrading fungus Phanerochaete chrysosporium.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Putative NADP(H)-dependent oxidoreductase of the aldo/keto reductase (AKR) superfamily. AAD3 is a full-length AKR-fold protein (Pfam PF00248), so a general NADP(H)-linked CH-OH oxidoreductase capability is the most specific molecular function that can be responsibly assigned. The physiological substrate and product are undetermined; the family &#34;aryl-alcohol dehydrogenase&#34; designation is a homology label from a fungal enzyme and is not supported by activity or phenotype data for AAD3. No biological process or subcellular location is established.</h3>
+                <span class="vote-buttons" data-g="P25612" data-a="FUNCTION: Putative NADP(H)-dependent oxidoreductase of the a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016616" target="_blank" class="term-link">
+                            oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link">
+                                PMID:10572264
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">None of the knock-out strains revealed any mutant phenotype when tested for the degradation of aromatic aldehydes using both spectrophotometry and high performance liquid chromatography (HPLC).</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10572264" target="_blank" class="term-link">
+                            PMID:10572264
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Disruption of seven hypothetical aryl alcohol dehydrogenase genes from Saccharomyces cerevisiae and construction of a multiple knock-out strain.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The seven S. cerevisiae AAD ORFs were identified in silico by high sequence similarity to the aryl-alcohol dehydrogenase of the lignin-degrading fungus Phanerochaete chrysosporium, and were named/annotated as putative aryl-alcohol dehydrogenases on that homology basis.</div>
+
+                        <div class="finding-text">"By in silicio analysis, we have discovered that there are seven open reading frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD) of the lignin-degrading fungus Phanerochaete chrysosporium."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion of the AAD genes, singly and in combination up to a septuple deletant, produced no detectable defect in aromatic-aldehyde reduction, arguing against a demonstrable, non-redundant aryl-alcohol dehydrogenase role for these genes (including AAD3) under the conditions tested.</div>
+
+                        <div class="finding-text">"None of the knock-out strains revealed any mutant phenotype when tested for the degradation of aromatic aldehydes using both spectrophotometry and high performance liquid chromatography (HPLC)."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does purified AAD3 protein have measurable NADPH-dependent reductase activity toward any aromatic aldehyde, aliphatic aldehyde, or reactive carbonyl, and if so what is its preferred substrate?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25612" data-a="Q: Does purified AAD3 protein have measurable NADPH-d..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is AAD3 expressed under any physiological condition (e.g. specific stress, stationary phase, or carbon source), and does it have any non-redundant phenotype distinct from the other AAD paralogs?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25612" data-a="Q: Is AAD3 expressed under any physiological conditio..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant AAD3 and assay NADPH-dependent reduction of a substrate panel (benzaldehyde, anisaldehyde, veratraldehyde, methylglyoxal, and other reactive carbonyls), determining kcat/Km; in parallel, model or determine the structure to confirm whether the AKR catalytic tetrad and cofactor pocket are intact and correctly positioned.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AAD3 is a functional but promiscuous NADP(H)-dependent aldehyde/carbonyl reductase whose in vivo role is masked by redundancy with other AAD/AKR enzymes.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzyme kinetics / structural analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25612" data-a="EXPERIMENT: Express and purify recombinant AAD3 and assay NADP..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform condition-dependent phenotyping of aad3-null and AAD-family multiple-null strains under oxidative/carbonyl stress and aromatic-aldehyde challenge, coupled with AAD3 transcript/protein expression profiling, to detect any non-redundant requirement.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AAD3 contributes to a condition-specific carbonyl/aromatic-compound stress response that is not detectable under standard growth.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / stress phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25612" data-a="EXPERIMENT: Perform condition-dependent phenotyping of aad3-nu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether the AAD3 gene product is a catalytically active enzyme at all, and if so, what reaction it catalyzes. No in vitro activity, no substrate, and no kinetic parameters have been reported for AAD3 specifically; its EC number remains 1.1.1.- (unassigned within oxidoreductases acting on CH-OH donors).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established: AAD3 is a full-length (363 aa) open reading frame adopting the aldo/keto reductase fold (Pfam PF00248; PANTHER PTHR43364:SF2), i.e. it has the structural scaffold and NADP(H)-cofactor-associated regions of the AKR superfamily. What is NOT established: any measured catalytic activity, physiological substrate, or product for the AAD3 protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> AAD3 is a canonical &#34;dark&#34; paralog: named by homology to a functional enzyme but never characterized. Determining whether it is an active promiscuous reductase, a conditionally functional enzyme, or a degenerate relic is prerequisite to any correct molecular-function annotation and to understanding why the AAD family expanded in Saccharomyces.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Heterologous expression and purification of AAD3 followed by NADPH-dependent reductase/oxidase assays across a panel of aromatic and aliphatic aldehydes, ketones, and reactive carbonyls; structural or homology-model verification of an intact, correctly positioned AKR catalytic tetrad (Asp/Tyr/Lys/His) and cofactor pocket to distinguish an active enzyme from a fold-retaining pseudoenzyme.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"None of the knock-out strains revealed any mutant phenotype when tested for the degradation of aromatic aldehydes using both spectrophotometry and high performance liquid chromatography (HPLC)."</em> — PMID:10572264</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role of AAD3 in S. cerevisiae — the pathway or physiological process (if any) it participates in, and the condition under which it is expressed or required — is undetermined. The aryl-alcohol/lignin context inherited from the Phanerochaete chrysosporium enzyme does not obviously apply, since budding yeast is not a lignin degrader.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established: combined deletion of all seven yeast AAD genes (including AAD3) causes no defect in aromatic-aldehyde reduction, no change in ergosterol/phospholipid profiles, and no mating or sporulation defect, indicating AAD3 is dispensable and functionally redundant with respect to those tested phenotypes. What is NOT established: any condition-specific role, inducing signal, or non-redundant contribution of AAD3.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without a defined biological process, AAD3 cannot be placed in a pathway or GO-CAM, and its retention in the genome (versus loss) is unexplained. Clarifying the condition(s) under which AAD3 matters would convert a homology label into testable biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Condition-dependent phenotyping of aad3 single and AAD-family multiple mutants (oxidative/carbonyl stress, aromatic-compound challenge, stationary phase, varied carbon/nitrogen sources), combined with AAD3 expression profiling, to detect any non-redundant, condition-specific requirement.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Specific tests for changes in the ergosterol and phospholipids profiles did not reveal any mutant phenotype and mating and sporulation efficiencies were not affected in the septuple deletant."</em> — PMID:10572264</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Why the AAD (aryl-alcohol dehydrogenase) gene family expanded to multiple, largely subtelomeric paralogs in Saccharomyces cerevisiae — and whether individual members such as AAD3 are maintained by selection, are subfunctionalized, or are degenerate duplicates — is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established: S. cerevisiae carries multiple AAD paralogs (AAD3, AAD4, AAD6, AAD10, AAD14, AAD15, AAD16) defined by similarity to a single fungal enzyme, and the AAD3 ORF is intact and full-length (not a truncated fragment). What is NOT established: the selective/evolutionary force behind the expansion, or the functional status (active vs. relic) of each paralog including AAD3.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> AAD family expansion is a model case of subtelomeric gene-family proliferation of uncertain adaptive value; resolving it informs both AAD3 annotation and broader questions about how yeast subtelomeres generate and retain paralogs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Comparative genomics across Saccharomyces and related yeasts (synteny, dN/dS, presence/absence, pseudogenization signatures) together with per-paralog biochemical characterization to determine which AAD members are under purifying selection and functionally distinct.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"By in silicio analysis, we have discovered that there are seven open reading frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD) of the lignin-degrading fungus Phanerochaete chrysosporium."</em> — PMID:10572264</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AAD3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P25612" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="aad3-ycr107w-s-cerevisiae-curation-notes">AAD3 (YCR107W) — S. cerevisiae — Curation Notes</h1>
+<p>Journal of research and reasoning for the AI GO-annotation review. Provenance recorded inline.</p>
+<h2 id="deep-research-status-provenance">Deep research status (provenance)</h2>
+<p>Automated deep research was attempted but did not produce a report:<br />
+- <code>just deep-research-falcon yeast AAD3 --fallback perplexity-lite</code>: falcon timed out at 600s;<br />
+  perplexity-lite fallback returned HTTP 401 "insufficient_quota" (billing/quota exhausted).<br />
+- Retry <code>just deep-research-falcon yeast AAD3</code>: falcon timed out again (SIGTERM at the 600s cap).</p>
+<p>No <code>-deep-research-{provider}.md</code> file was fabricated (per repo policy). The review is instead<br />
+grounded in the primary sources actually available: the UniProt record (P25612), the QuickGO GOA<br />
+export, the cached Delneri et al. 1999 abstract (PMID:10572264), and the InterPro/PANTHER family<br />
+metadata (PTHR43364), plus the inline sequence/domain analysis recorded below. This documentation<br />
+serves in place of a deep-research report.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li><strong>Gene</strong>: AAD3 (SGD standard name); systematic name <strong>YCR107W</strong> (chromosome III).</li>
+<li><strong>UniProt</strong>: P25612 (AAD3_YEAST), Reviewed/Swiss-Prot.</li>
+<li><strong>Length / MW</strong>: 363 aa; 40911 Da. CHAIN 1..363 (full-length; no signal peptide, no reported fragment/truncation).</li>
+<li><strong>Name meaning</strong>: "Putative aryl-alcohol dehydrogenase AAD3"; EC=1.1.1.- (partial/unassigned).</li>
+<li><strong>Family (UniProt SIMILARITY)</strong>: "Belongs to the aldo/keto reductase family. Aldo/keto reductase 2 subfamily." (ECO:0000305 = curator inference from sequence).</li>
+<li><strong>Domain</strong>: Pfam PF00248 (Aldo_ket_red), full-length match; Gene3D 3.20.20.100 (NADP-dependent oxidoreductase domain); SUPFAM SSF51430 (NAD(P)-linked oxidoreductase); CDD cd19147 (AKR_AKR9A3_9B1-4); InterPro IPR050523 (AKR_Detox_Biosynth), IPR023210, IPR036812.</li>
+<li><strong>PANTHER</strong>: PTHR43364 ("NADH-SPECIFIC METHYLGLYOXAL REDUCTASE-RELATED" / family name "Aldo/Keto Reductase Detoxification and Biosynthesis") and subfamily PTHR43364:SF2 ("ARYL-ALCOHOL DEHYDROGENASE AAD10-RELATED").</li>
+<li><strong>PE (protein existence)</strong>: PE=3, "Inferred from homology" — i.e. no protein-level or transcript-level experimental evidence recorded in UniProt for AAD3 itself.</li>
+</ul>
+<h2 id="the-aad-gene-family-in-s-cerevisiae-important-separate-aad3-from-paralogs">The AAD gene family in S. cerevisiae (important — separate AAD3 from paralogs)</h2>
+<p>The AAD (Aryl-Alcohol Dehydrogenase) genes are a family of paralogous ORFs in S. cerevisiae,<br />
+most located in subtelomeric regions. Members include AAD3 (YCR107W), AAD4 (YDL243C),<br />
+AAD6 (YFL056C), AAD10 (YJR155W), AAD14 (YNL331C), AAD15 (YOL165C), AAD16 (YFL057C).<br />
+They were identified by in-silico similarity to a <em>bona fide</em> fungal enzyme, and none has a<br />
+demonstrated enzymatic activity or loss-of-function phenotype in S. cerevisiae. Evidence for<br />
+AAD3-specific function must therefore be distinguished carefully from family-level statements.</p>
+<h2 id="known-evidence-supported">KNOWN (evidence-supported)</h2>
+<ol>
+<li>
+<p><strong>AAD3 is a member of the aldo/keto reductase (AKR) superfamily.</strong> Sequence/domain evidence:<br />
+   Pfam PF00248 covers the full 363-aa ORF; AKR fold assignments (Gene3D, SUPFAM, CDD, InterPro<br />
+   IPR050523). This is solid at the level of <em>fold/superfamily membership</em>, not specific catalysis.<br />
+   [UniProt P25612 DR lines: Pfam PF00248; Gene3D 3.20.20.100; SUPFAM SSF51430; InterPro IPR050523]</p>
+</li>
+<li>
+<p><strong>The AAD family was defined by similarity to the <em>Phanerochaete chrysosporium</em> aryl-alcohol<br />
+   dehydrogenase (AAD), a lignin-degradation enzyme.</strong> The ISS annotations on AAD3 use<br />
+<code>with/from = UniProtKB:Q01752</code>, which is the <em>P. chrysosporium</em> AAD (a white-rot fungus enzyme),<br />
+   NOT a yeast protein. [PANTHER PTHR43364-entries.csv: "Q01752 ... Phanerodontia chrysosporium ...<br />
+   Aryl-alcohol dehydrogenase [NADP(+)]"] [PMID:10572264 abstract: "seven open reading frames (ORFs)<br />
+   in Saccharomyces cerevisiae whose protein products show a high degree of amino acid sequence<br />
+   similarity to the aryl alcohol dehydrogenase (AAD) of the lignin-degrading fungus Phanerochaete<br />
+   chrysosporium"].</p>
+</li>
+<li>
+<p><strong>Deletion of the seven yeast AAD genes (including AAD3) produced NO aryl-aldehyde-degradation<br />
+   phenotype.</strong> [PMID:10572264 abstract: "None of the knock-out strains revealed any mutant phenotype<br />
+   when tested for the degradation of aromatic aldehydes using both spectrophotometry and high<br />
+   performance liquid chromatography (HPLC)."] Ergosterol/phospholipid profiles, mating and<br />
+   sporulation were also unaffected in the septuple deletant. Note: the stationary-phase aryl-alcohol<br />
+   dehydrogenase activity observed in wild-type yeast [same abstract] was NOT abolished by deleting<br />
+   all seven AAD genes, implying the measured cellular AAD activity is contributed by other (non-AAD)<br />
+   enzymes, and that the AAD genes are functionally redundant or silent under the conditions tested.</p>
+</li>
+</ol>
+<h2 id="not-known-open-knowledge-gaps">NOT known / open (knowledge gaps)</h2>
+<ul>
+<li>Whether AAD3 encodes a catalytically active enzyme at all. No in vitro activity, no substrate,<br />
+  and no kcat/Km have ever been reported for the AAD3 gene product specifically. EC is 1.1.1.- .</li>
+<li>The physiological substrate and biological role (if any). The "aryl-alcohol dehydrogenase" name is<br />
+  purely a homology transfer from the <em>P. chrysosporium</em> enzyme; S. cerevisiae is not a lignin<br />
+  degrader, so the ancestral aryl-alcohol/lignin-related context does not obviously apply.</li>
+<li>Subcellular localization is unassigned (GOA has an ND <code>is_active_in cellular_component</code> root<br />
+  annotation, GO_REF:0000015).</li>
+<li>Whether AAD3 is a functional gene, a conditionally-expressed paralog, or a degenerate/relic<br />
+  subtelomeric duplicate. The AAD family expansion sits in subtelomeric regions that are hotspots<br />
+  for gene duplication, rapid evolution, and pseudogenization.</li>
+</ul>
+<h2 id="domain-truncation-reasoning-inline-bioinformatics">Domain / truncation reasoning (inline bioinformatics)</h2>
+<p>I inspected the UniProt sequence directly (no sub-agent).</p>
+<ul>
+<li><strong>Full length, not truncated</strong>: FT CHAIN 1..363 spans the whole sequence; MW 40911 is typical of a<br />
+  complete ~360-aa AKR (AKRs are ~320-360 aa). There is no <code>FT ... FRAGMENT</code>, no premature-stop<br />
+  evidence, and the Pfam PF00248 match covers the full ORF. So AAD3 is NOT a truncated ORF/relic at<br />
+  the sequence level; it is an intact reading frame.</li>
+<li><strong>AKR fold features present</strong>: the N-terminal glycine-containing cofactor-loop region is present<br />
+  (<code>...PLILGEV...</code> around residues 29-34), the AKR core His/Trp region is present<br />
+  (<code>...DILYVHWWDY...</code> around residues 143-152, containing His147 and the conserved Trp pair), and a<br />
+  C-terminal NADP-binding-loop-like region is present (<code>...AYVRSKA...</code> around 294-300). These are<br />
+  consistent with a foldable AKR domain.</li>
+<li><strong>BUT</strong>: presence of the fold and generic catalytic-type residues does NOT establish a specific,<br />
+  physiologically relevant catalytic activity. AKR-fold proteins are notoriously promiscuous and<br />
+  many paralogs are pseudo-/orphan enzymes. Given (a) no experimental activity for AAD3,<br />
+  (b) the ISS is transferred from a distant fungal enzyme, and (c) the loss-of-phenotype on<br />
+  septuple deletion, a <em>specific</em> "aryl-alcohol dehydrogenase (NADP+) activity" (GO:0047681)<br />
+  assignment for AAD3 is an over-annotation. The defensible statement is superfamily-level<br />
+  oxidoreductase/AKR membership, with substrate unknown.</li>
+<li>I did not have a residue-level MSA against a curated AKR catalytic tetrad reference in the cache,<br />
+  so I deliberately do NOT claim the catalytic tetrad is "intact and competent" or "degenerate" —<br />
+  I claim only that the ORF is full-length and adopts an AKR fold, and that specific activity is<br />
+  unproven. This keeps the review honest.</li>
+</ul>
+<h2 id="annotation-by-annotation-reasoning">Annotation-by-annotation reasoning</h2>
+<p>GOA (AAD3-goa.tsv) has 4 annotations:</p>
+<ol>
+<li>
+<p><code>GO:0047681 aryl-alcohol dehydrogenase (NADP+) activity</code> / IEA / GO_REF:0000117 (ARBA machine rule).<br />
+   Over-annotation: an electronic rule assigning a <em>specific</em> activity to a putative enzyme with no<br />
+   demonstrated activity and a full-family loss-of-phenotype. → MARK_AS_OVER_ANNOTATED<br />
+   (propagation_review IEA rule; the correct grounded statement is superfamily-level AKR/oxidoreductase).</p>
+</li>
+<li>
+<p><code>GO:0006081 aldehyde metabolic process</code> / ISS / PMID:10572264, with Q01752.<br />
+   ISS from the <em>P. chrysosporium</em> AAD. Family-level; not demonstrated for AAD3. Aldehyde metabolism<br />
+   is the plausible superfamily-level process but is unproven for AAD3 and the deletion had no aldehyde<br />
+   phenotype. → KEEP_AS_NON_CORE (retain as a plausible, unverified process-level annotation; do not<br />
+   elevate to core). Consider MARK_AS_OVER_ANNOTATED — but the parent process is broad enough that it<br />
+   is defensible as a low-confidence homology inference; keep non-core with caveat.</p>
+</li>
+<li>
+<p><code>GO:0047681 aryl-alcohol dehydrogenase (NADP+) activity</code> / ISS / PMID:10572264, with Q01752.<br />
+   Same specific-activity over-annotation as (1), but via ISS from the fungal enzyme. The deletion<br />
+   phenotype directly argues against a demonstrable aryl-aldehyde activity for the yeast AAD genes.<br />
+   → MARK_AS_OVER_ANNOTATED; propose generalization to superfamily-level oxidoreductase in the review<br />
+   rationale. Do NOT REMOVE (defer: it is a curator ISS, and superfamily context is real).</p>
+</li>
+<li>
+<p><code>GO:0005575 cellular_component</code> (root) / ND / GO_REF:0000015.<br />
+   Root "no data" placeholder. Standard. → ACCEPT (keep as-is; it is the GO ND convention for<br />
+   unknown localization).</p>
+</li>
+</ol>
+<h2 id="term-id-notes">Term-id notes</h2>
+<ul>
+<li>existing_annotations ids are from GOA and are trusted (not rewritten).</li>
+<li>For core_functions I will use only well-supported author-checked ids. Candidate broader MF:<br />
+  GO:0016616 "oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor"<br />
+  (verified via OLS) — this is the honest superfamily-level activity I can defend from fold + family.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P25612
+gene_symbol: AAD3
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  AAD3 (systematic name YCR107W) is a Saccharomyces cerevisiae open reading frame
+  encoding a 363-residue, full-length member of the aldo/keto reductase (AKR)
+  superfamily (Pfam PF00248; aldo/keto reductase 2 subfamily). It is one of a set
+  of paralogous &#34;aryl-alcohol dehydrogenase&#34; (AAD) genes (AAD3, AAD4, AAD6, AAD10,
+  AAD14, AAD15, AAD16), most residing in subtelomeric regions, that were identified
+  by sequence similarity to the NADP(+)-dependent aryl-alcohol dehydrogenase of the
+  lignin-degrading white-rot fungus Phanerochaete chrysosporium. Despite the family
+  name, no enzymatic activity or substrate has been experimentally demonstrated for
+  the AAD3 gene product itself, and combined deletion of all seven yeast AAD genes
+  produces no defect in aromatic-aldehyde reduction, indicating the family is
+  functionally redundant or dispensable under standard laboratory conditions. AAD3
+  is thus best described as a putative NADP(H)-dependent oxidoreductase of the AKR
+  fold whose physiological substrate and biological role remain undetermined.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:10572264
+  title: Disruption of seven hypothetical aryl alcohol dehydrogenase genes from Saccharomyces
+    cerevisiae and construction of a multiple knock-out strain.
+  findings:
+  - statement: &gt;-
+      The seven S. cerevisiae AAD ORFs were identified in silico by high sequence
+      similarity to the aryl-alcohol dehydrogenase of the lignin-degrading fungus
+      Phanerochaete chrysosporium, and were named/annotated as putative aryl-alcohol
+      dehydrogenases on that homology basis.
+    supporting_text: &gt;-
+      By in silicio analysis, we have discovered that there are seven open reading
+      frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high
+      degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD)
+      of the lignin-degrading fungus Phanerochaete chrysosporium.
+  - statement: &gt;-
+      Deletion of the AAD genes, singly and in combination up to a septuple deletant,
+      produced no detectable defect in aromatic-aldehyde reduction, arguing against a
+      demonstrable, non-redundant aryl-alcohol dehydrogenase role for these genes
+      (including AAD3) under the conditions tested.
+    supporting_text: &gt;-
+      None of the knock-out strains revealed any mutant phenotype when tested for the
+      degradation of aromatic aldehydes using both spectrophotometry and high
+      performance liquid chromatography (HPLC).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Delneri et al., Yeast 1999) that explicitly
+      constructs and phenotypes deletions of the seven S. cerevisiae AAD genes,
+      including AAD3/YCR107W. Cached record is abstract-only (full_text_available:
+      false), but the abstract itself directly supports (a) the homology-based origin
+      of the AAD annotations and (b) the absence of an aryl-aldehyde-degradation
+      phenotype in the AAD deletants. This is the source of the ISS annotations on
+      AAD3, and it is the strongest available evidence bearing on AAD3 function.
+existing_annotations:
+- term:
+    id: GO:0047681
+    label: aryl-alcohol dehydrogenase (NADP+) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (ARBA machine-learning rule) assignment of the specific molecular
+      function &#34;aryl-alcohol dehydrogenase (NADP+) activity&#34; to AAD3. AAD3 is a
+      full-length AKR-fold protein (Pfam PF00248), so a broad NADP(H)-dependent
+      oxidoreductase potential is defensible, but the SPECIFIC aryl-alcohol
+      dehydrogenase activity has never been demonstrated for the AAD3 gene product and
+      is contradicted at the family level by the absence of any aryl-aldehyde
+      phenotype in the seven-gene deletant.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The specific aryl-alcohol dehydrogenase (NADP+) activity is a homology-driven
+      over-annotation. The AAD family name derives entirely from similarity to the
+      P. chrysosporium aryl-alcohol dehydrogenase (a lignin-degrading enzyme), yet
+      combined deletion of all seven yeast AAD genes causes no defect in aromatic
+      aldehyde reduction, and no in vitro activity or substrate has been reported for
+      AAD3. The honest grounded statement is superfamily-level NADP(H)-dependent
+      oxidoreductase (AKR) potential, not a defined aryl-alcohol dehydrogenase. Marked
+      as over-annotated rather than removed because an AKR oxidoreductase capability is
+      plausible and the term is not strictly impossible.
+    supported_by:
+    - reference_id: PMID:10572264
+      supporting_text: &gt;-
+        None of the knock-out strains revealed any mutant phenotype when tested for the
+        degradation of aromatic aldehydes using both spectrophotometry and high
+        performance liquid chromatography (HPLC).
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: GO_REF:0000117
+        source_label: ARBA machine-learning rule (family AKR / aryl-alcohol dehydrogenase)
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          Rule assigns a specific family activity from AKR/AAD sequence features; the
+          child term overstates specificity for a paralog with no demonstrated activity.
+- term:
+    id: GO:0006081
+    label: aldehyde metabolic process
+  evidence_type: ISS
+  original_reference_id: PMID:10572264
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS assignment of the broad biological process &#34;aldehyde metabolic process&#34; to
+      AAD3, inferred by sequence similarity (with/from UniProtKB:Q01752, the
+      P. chrysosporium aryl-alcohol dehydrogenase). Aldehyde metabolism is the
+      plausible generic process associated with the AKR fold, but it is unproven for
+      AAD3 and the deletion data show no aldehyde-related phenotype for the yeast AAD
+      genes.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a broad, low-confidence homology inference. The parent process &#34;aldehyde
+      metabolic process&#34; is general enough that it remains a defensible, if
+      unverified, contextual annotation for an AKR-fold protein, so it is retained as
+      non-core rather than removed. It is explicitly NOT a core function: no substrate,
+      activity, or phenotype ties AAD3 to aldehyde metabolism in vivo. The ISS source
+      is a distant fungal paralog (Q01752), and combined deletion of all seven yeast
+      AAD genes gave no aromatic-aldehyde phenotype.
+    supported_by:
+    - reference_id: PMID:10572264
+      supporting_text: &gt;-
+        By in silicio analysis, we have discovered that there are seven open reading
+        frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high
+        degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD)
+        of the lignin-degrading fungus Phanerochaete chrysosporium.
+    propagation_review:
+      root_cause: SOURCE_WEAK_OR_INFERRED
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - SOURCE_EVIDENCE_WEAK
+      source_entities:
+      - source_id: UniProtKB:Q01752
+        source_label: Aryl-alcohol dehydrogenase [NADP(+)], Phanerodontia chrysosporium
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Donor is a functional lignin-degradation enzyme from a distantly related
+          white-rot fungus; sequence similarity supports superfamily/process context
+          only, not a demonstrated aldehyde-metabolism role for yeast AAD3.
+- term:
+    id: GO:0047681
+    label: aryl-alcohol dehydrogenase (NADP+) activity
+  evidence_type: ISS
+  original_reference_id: PMID:10572264
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISS assignment of the specific &#34;aryl-alcohol dehydrogenase (NADP+) activity&#34; to
+      AAD3, inferred by sequence similarity to the P. chrysosporium AAD
+      (UniProtKB:Q01752). This is the same specific-activity over-annotation as the
+      IEA line, transferred from a distant fungal enzyme. The deletion phenotype in
+      the source paper argues directly against a demonstrable aryl-aldehyde activity
+      for the yeast AAD genes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The specific aryl-alcohol dehydrogenase activity is not supported for the AAD3
+      gene product: it rests only on homology to a lignin-degrading fungal enzyme, and
+      the seven-gene S. cerevisiae AAD deletant shows no aromatic-aldehyde phenotype,
+      with no in vitro activity ever reported. The defensible generalization is a
+      superfamily-level NADP(H)-dependent oxidoreductase (AKR) function with unknown
+      substrate. Not removed, because the ISS is a curator inference and an AKR
+      oxidoreductase capability is biologically plausible; marked as over-annotated
+      and paired with a proposed broader replacement term.
+    proposed_replacement_terms:
+    - id: GO:0016616
+      label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP
+        as acceptor
+    supported_by:
+    - reference_id: PMID:10572264
+      supporting_text: &gt;-
+        None of the knock-out strains revealed any mutant phenotype when tested for the
+        degradation of aromatic aldehydes using both spectrophotometry and high
+        performance liquid chromatography (HPLC).
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:Q01752
+        source_label: Aryl-alcohol dehydrogenase [NADP(+)], Phanerodontia chrysosporium
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Functional donor is a white-rot fungal lignin enzyme; the specific aryl-alcohol
+          activity does not safely transfer to a yeast subtelomeric paralog with no
+          demonstrated activity and a family-wide null phenotype.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component annotation with the ND (no biological data available)
+      evidence code, the standard GO placeholder used when no localization data exist
+      for the gene product. AAD3 has no experimentally determined subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      This is the conventional ND root-term placeholder recording the absence of
+      localization data, consistent with GO_REF:0000015. It is correct to retain as-is;
+      it makes no substantive functional claim.
+- term:
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP
+      as acceptor
+  evidence_type: ISS
+  original_reference_id: PMID:10572264
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed generalized molecular function for AAD3: a superfamily-level
+      NADP(H)-dependent oxidoreductase acting on CH-OH groups, replacing the
+      over-specific &#34;aryl-alcohol dehydrogenase (NADP+) activity&#34;. This is the most
+      specific activity that can be responsibly assigned from AKR-fold membership
+      without demonstrated substrate specificity.
+    action: NEW
+    reason: &gt;-
+      AAD3 is a full-length aldo/keto reductase (Pfam PF00248) with the AKR fold and
+      NADP(H)-cofactor-associated regions, supporting a general NADP(H)-linked CH-OH
+      oxidoreductase capability. Because no substrate or activity has been demonstrated
+      for AAD3, this broad parent term is the appropriate, non-over-committing molecular
+      function; it is offered as the replacement for the two over-specific
+      aryl-alcohol-dehydrogenase annotations.
+    supported_by:
+    - reference_id: PMID:10572264
+      supporting_text: &gt;-
+        By in silicio analysis, we have discovered that there are seven open reading
+        frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high
+        degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD)
+        of the lignin-degrading fungus Phanerochaete chrysosporium.
+core_functions:
+- description: &gt;-
+    Putative NADP(H)-dependent oxidoreductase of the aldo/keto reductase (AKR)
+    superfamily. AAD3 is a full-length AKR-fold protein (Pfam PF00248), so a general
+    NADP(H)-linked CH-OH oxidoreductase capability is the most specific molecular
+    function that can be responsibly assigned. The physiological substrate and product
+    are undetermined; the family &#34;aryl-alcohol dehydrogenase&#34; designation is a homology
+    label from a fungal enzyme and is not supported by activity or phenotype data for
+    AAD3. No biological process or subcellular location is established.
+  supported_by:
+  - reference_id: PMID:10572264
+    supporting_text: &gt;-
+      None of the knock-out strains revealed any mutant phenotype when tested for the
+      degradation of aromatic aldehydes using both spectrophotometry and high
+      performance liquid chromatography (HPLC).
+  molecular_function:
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP
+      as acceptor
+knowledge_gaps:
+- gap_statement: &gt;-
+    It is unknown whether the AAD3 gene product is a catalytically active enzyme at
+    all, and if so, what reaction it catalyzes. No in vitro activity, no substrate,
+    and no kinetic parameters have been reported for AAD3 specifically; its EC number
+    remains 1.1.1.- (unassigned within oxidoreductases acting on CH-OH donors).
+  boundary: &gt;-
+    What is established: AAD3 is a full-length (363 aa) open reading frame adopting the
+    aldo/keto reductase fold (Pfam PF00248; PANTHER PTHR43364:SF2), i.e. it has the
+    structural scaffold and NADP(H)-cofactor-associated regions of the AKR superfamily.
+    What is NOT established: any measured catalytic activity, physiological substrate,
+    or product for the AAD3 protein.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    AAD3 is a canonical &#34;dark&#34; paralog: named by homology to a functional enzyme but
+    never characterized. Determining whether it is an active promiscuous reductase, a
+    conditionally functional enzyme, or a degenerate relic is prerequisite to any
+    correct molecular-function annotation and to understanding why the AAD family
+    expanded in Saccharomyces.
+  resolution: &gt;-
+    Heterologous expression and purification of AAD3 followed by NADPH-dependent
+    reductase/oxidase assays across a panel of aromatic and aliphatic aldehydes,
+    ketones, and reactive carbonyls; structural or homology-model verification of an
+    intact, correctly positioned AKR catalytic tetrad (Asp/Tyr/Lys/His) and cofactor
+    pocket to distinguish an active enzyme from a fold-retaining pseudoenzyme.
+  provenance:
+  - reference_id: PMID:10572264
+    supporting_text: &gt;-
+      None of the knock-out strains revealed any mutant phenotype when tested for the
+      degradation of aromatic aldehydes using both spectrophotometry and high
+      performance liquid chromatography (HPLC).
+- gap_statement: &gt;-
+    The biological role of AAD3 in S. cerevisiae — the pathway or physiological
+    process (if any) it participates in, and the condition under which it is expressed
+    or required — is undetermined. The aryl-alcohol/lignin context inherited from the
+    Phanerochaete chrysosporium enzyme does not obviously apply, since budding yeast is
+    not a lignin degrader.
+  boundary: &gt;-
+    What is established: combined deletion of all seven yeast AAD genes (including
+    AAD3) causes no defect in aromatic-aldehyde reduction, no change in
+    ergosterol/phospholipid profiles, and no mating or sporulation defect, indicating
+    AAD3 is dispensable and functionally redundant with respect to those tested
+    phenotypes. What is NOT established: any condition-specific role, inducing signal,
+    or non-redundant contribution of AAD3.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Without a defined biological process, AAD3 cannot be placed in a pathway or
+    GO-CAM, and its retention in the genome (versus loss) is unexplained. Clarifying
+    the condition(s) under which AAD3 matters would convert a homology label into
+    testable biology.
+  resolution: &gt;-
+    Condition-dependent phenotyping of aad3 single and AAD-family multiple mutants
+    (oxidative/carbonyl stress, aromatic-compound challenge, stationary phase, varied
+    carbon/nitrogen sources), combined with AAD3 expression profiling, to detect any
+    non-redundant, condition-specific requirement.
+  provenance:
+  - reference_id: PMID:10572264
+    supporting_text: &gt;-
+      Specific tests for changes in the ergosterol and phospholipids profiles did not
+      reveal any mutant phenotype and mating and sporulation efficiencies were not
+      affected in the septuple deletant.
+- gap_statement: &gt;-
+    Why the AAD (aryl-alcohol dehydrogenase) gene family expanded to multiple,
+    largely subtelomeric paralogs in Saccharomyces cerevisiae — and whether individual
+    members such as AAD3 are maintained by selection, are subfunctionalized, or are
+    degenerate duplicates — is unknown.
+  boundary: &gt;-
+    What is established: S. cerevisiae carries multiple AAD paralogs (AAD3, AAD4,
+    AAD6, AAD10, AAD14, AAD15, AAD16) defined by similarity to a single fungal enzyme,
+    and the AAD3 ORF is intact and full-length (not a truncated fragment). What is NOT
+    established: the selective/evolutionary force behind the expansion, or the
+    functional status (active vs. relic) of each paralog including AAD3.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    AAD family expansion is a model case of subtelomeric gene-family proliferation of
+    uncertain adaptive value; resolving it informs both AAD3 annotation and broader
+    questions about how yeast subtelomeres generate and retain paralogs.
+  resolution: &gt;-
+    Comparative genomics across Saccharomyces and related yeasts (synteny, dN/dS,
+    presence/absence, pseudogenization signatures) together with per-paralog
+    biochemical characterization to determine which AAD members are under purifying
+    selection and functionally distinct.
+  provenance:
+  - reference_id: PMID:10572264
+    supporting_text: &gt;-
+      By in silicio analysis, we have discovered that there are seven open reading
+      frames (ORFs) in Saccharomyces cerevisiae whose protein products show a high
+      degree of amino acid sequence similarity to the aryl alcohol dehydrogenase (AAD)
+      of the lignin-degrading fungus Phanerochaete chrysosporium.
+suggested_questions:
+- question: &gt;-
+    Does purified AAD3 protein have measurable NADPH-dependent reductase activity
+    toward any aromatic aldehyde, aliphatic aldehyde, or reactive carbonyl, and if so
+    what is its preferred substrate?
+- question: &gt;-
+    Is AAD3 expressed under any physiological condition (e.g. specific stress,
+    stationary phase, or carbon source), and does it have any non-redundant phenotype
+    distinct from the other AAD paralogs?
+suggested_experiments:
+- hypothesis: &gt;-
+    AAD3 is a functional but promiscuous NADP(H)-dependent aldehyde/carbonyl reductase
+    whose in vivo role is masked by redundancy with other AAD/AKR enzymes.
+  description: &gt;-
+    Express and purify recombinant AAD3 and assay NADPH-dependent reduction of a
+    substrate panel (benzaldehyde, anisaldehyde, veratraldehyde, methylglyoxal, and
+    other reactive carbonyls), determining kcat/Km; in parallel, model or determine the
+    structure to confirm whether the AKR catalytic tetrad and cofactor pocket are
+    intact and correctly positioned.
+  experiment_type: enzyme kinetics / structural analysis
+- hypothesis: &gt;-
+    AAD3 contributes to a condition-specific carbonyl/aromatic-compound stress response
+    that is not detectable under standard growth.
+  description: &gt;-
+    Perform condition-dependent phenotyping of aad3-null and AAD-family multiple-null
+    strains under oxidative/carbonyl stress and aromatic-aldehyde challenge, coupled
+    with AAD3 transcript/protein expression profiling, to detect any non-redundant
+    requirement.
+  experiment_type: genetics / stress phenotyping
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/AIM6/AIM6-ai-review.html
+++ b/genes/yeast/AIM6/AIM6-ai-review.html
@@ -1,0 +1,2058 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AIM6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AIM6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q07716" target="_blank" class="term-link">
+                        Q07716
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "AIM6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q07716" data-a="DESCRIPTION: AIM6 (YDL237W) is an uncharacterized protein of th..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>AIM6 (YDL237W) is an uncharacterized protein of the budding yeast Saccharomyces cerevisiae whose molecular function and subcellular location are not established. It is a 390-residue protein synthesized with a predicted N-terminal signal peptide (residues 1-17), suggesting entry into the secretory pathway, and the bulk of the mature protein adopts the PLC-like phosphodiesterase TIM (beta/alpha)8-barrel fold shared by phosphoinositide-specific phospholipase C and glycerophosphodiester phosphodiesterase enzymes. It defines its own narrow sequence family (the AIM6 family) within a divergent, uncharacterized branch of this phosphodiesterase-like superfamily, and no catalytic activity, substrate, or physiological reaction has been demonstrated for it. The only experimental phenotype reported is that deletion impairs respiratory (non-fermentable-carbon) growth and alters mitochondrial transmission, the observation from which the gene took its name (Altered Inheritance of Mitochondria); whether this reflects a direct or an indirect role in mitochondrial function is unresolved. The gene is non-essential and is conserved among fungi.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
+                                    GO:0006629
+                                </a>
+                            </span>
+                            <span class="term-label">lipid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q07716" data-a="GO:0006629" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic InterPro2GO annotation transferred from the PLC-like phosphodiesterase superfamily match (IPR017946). Phosphoinositide-specific phospholipase C acts on membrane lipids, but AIM6 belongs to a divergent, uncharacterized subgroup of the fold with no demonstrated lipid substrate or lipid-related activity, and InterPro itself states its function is unclear.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This over-extrapolates the lipid role of characterized PI-PLC enzymes to a divergent uncharacterized domain. There is no experimental evidence that AIM6 participates in lipid metabolism; the phosphodiesterase-like superfamily also contains glycerophosphodiester phosphodiesterases and many non-lipid activities, so &#34;lipid metabolic process&#34; is an unsupported specialization from a fold-only match. Not a confident biological process for this gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008081" target="_blank" class="term-link">
+                                    GO:0008081
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoric diester hydrolase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q07716" data-a="GO:0008081" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic InterPro2GO annotation from the PLC-like phosphodiesterase TIM-barrel superfamily match (IPR017946 / IPR039559, CDD cd08577 &#34;PI-PLCc_GDPD_SF_unchar3&#34;). The mature protein does adopt this catalytic fold and retains some conserved His/Asp residues consistent with it, so the annotation is not demonstrably wrong; however the assignment is a distant, fold-level prediction from a subgroup that CDD and InterPro explicitly label uncharacterized, with no demonstrated activity, substrate, or assay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Keep awareness of the fold-based phosphodiesterase prediction, but it should not be treated as an established molecular function. It rests solely on membership in a divergent, uncharacterized branch of the PI-PLC/GDPD superfamily; no catalytic activity or substrate has ever been shown for AIM6. This is the central molecular-function knowledge gap for the gene (see knowledge_gaps), not a curated core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07716" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD records the molecular function as ND (no biological data available). This correctly states that no experimentally supported molecular function is known for AIM6; the only molecular-function claim in GOA is the fold-based IEA phosphodiesterase prediction above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Appropriate use of the root term with ND to signal that AIM6&#39;s molecular function is genuinely unknown. Consistent with SGD&#39;s summary that the protein&#39;s biological role and cellular location are unknown.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07716" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD records the cellular component as ND (no biological data available). UniProt provides no subcellular-location statement; the only localization-relevant feature is a predicted N-terminal signal peptide implying secretory-pathway entry, which is not sufficient to assign a compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct use of the root term with ND: AIM6&#39;s localization is unresolved. The predicted signal peptide and the indirect nature of the mitochondrial deletion phenotype mean a specific compartment cannot be asserted.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07716" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD records the biological process as ND (no biological data available). The one experimental handle is that deletion impairs respiratory growth / alters mitochondrial transmission (PMID:19300474), but the screen authors caution this may be indirect, so a specific biological process is not assignable with confidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct use of the root term with ND. While the AIM screen phenotype hints at a role connected to mitochondrial biogenesis/respiration, the effect may be indirect and no mechanism is known, so no specific BP term is warranted. The unknown biological role is captured in knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19300474" target="_blank" class="term-link">
+                            PMID:19300474
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Computationally driven, quantitative experiments discover genes required for mitochondrial biogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A quantitative petite-frequency screen identified ~100 previously uncharacterized proteins (the AIM series) whose deletion alters mitochondrial biogenesis/inheritance in S. cerevisiae; AIM6/YDL237W was named and scored in this study (per-gene data in the paper&#39;s Table S2).</div>
+
+                        <div class="finding-text">"we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and inheritance in Saccharomyces cerevisiae"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The authors caution that such deletion phenotypes need not reflect a direct intramitochondrial molecular role, since non-mitochondrial proteins can regulate biogenesis and some mutants may affect biogenesis indirectly.</div>
+
+                        <div class="finding-text">"raise the possibility that these mutants are somehow indirectly affecting biogenesis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the AIM6 PLC-like phosphodiesterase-fold domain have any catalytic activity in vitro, and if so, on what substrate (a phosphoinositide, a glycerophosphodiester, a cyclic phosphate, or another phosphodiester)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q07716" data-a="Q: Does the AIM6 PLC-like phosphodiesterase-fold doma..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Where does AIM6 localize? Is the predicted N-terminal signal peptide cleaved and does the protein enter the secretory pathway (ER/Golgi/cell surface/vacuole), which would argue that its respiratory phenotype is indirect rather than a direct mitochondrial role?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q07716" data-a="Q: Where does AIM6 localize? Is the predicted N-termi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the respiratory-growth / altered-mitochondrial-transmission phenotype of aim6-delta a direct consequence of AIM6 activity, or an indirect/pleiotropic effect (e.g. via lipid or secretory-pathway homeostasis)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q07716" data-a="Q: Is the respiratory-growth / altered-mitochondrial-..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant mature AIM6 (residues 18-390) and assay phosphodiesterase activity against a panel of candidate substrates (phosphoinositides, glycerophosphodiesters such as glycerophosphocholine, cyclic nucleotides, and generic bis-p-nitrophenyl phosphate) with and without divalent cations; test predicted catalytic-residue point mutants (e.g. the His118/His120 pair) to establish whether the retained fold is enzymatically functional or a pseudoenzyme.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The AIM6 PLC-like domain is a catalytically active phosphodiesterase acting on a specific phosphodiester substrate.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro enzyme assay / structure-function mutagenesis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q07716" data-a="EXPERIMENT: Purify recombinant mature AIM6 (residues 18-390) a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine AIM6 subcellular localization by tagging the endogenous locus (C-terminal fluorescent tag, and separately an internal tag preserving the signal peptide) and by subcellular fractionation / signal-peptide cleavage assays, to test whether AIM6 is secreted/ER-Golgi resident versus mitochondrial.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AIM6 enters the secretory pathway and is not a resident mitochondrial protein, implying its respiratory phenotype is indirect.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: fluorescence microscopy / subcellular fractionation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q07716" data-a="EXPERIMENT: Determine AIM6 subcellular localization by tagging..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Characterize aim6-delta with quantitative respiratory-growth and petite-frequency assays, lipidomic profiling, and epistasis / synthetic-genetic-array analysis against mitochondrial- biogenesis and lipid/secretory-pathway mutants to place AIM6 in a functional module and distinguish a direct from an indirect mitochondrial role.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The aim6-delta respiratory phenotype reports a defined pathway that can be identified by genetic and physiological profiling.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: quantitative genetics / metabolic profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q07716" data-a="EXPERIMENT: Characterize aim6-delta with quantitative respirat..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of AIM6 is unknown. Although the mature protein adopts the PLC-like phosphodiesterase (PI-PLC/GDPD-type) TIM-barrel fold, it is undetermined whether AIM6 has any catalytic activity at all, and if so what its substrate and reaction are. No enzymatic activity, substrate, or partner has ever been measured for it.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> AIM6 is a verified, non-essential, expressed 390-aa protein (protein-level evidence) with a predicted N-terminal signal peptide (1-17). Its C-terminal domain (~residues 115-385) matches the PLC-like phosphodiesterase TIM-barrel superfamily (IPR017946) and an AIM6-specific PI-PLC-like catalytic-domain entry (IPR039559) built on CDD cd08577, a group explicitly labelled &#34;uncharacterized.&#34; Some conserved His/Asp residues consistent with the fold are retained. The only functional label in GOA beyond root/ND terms is the fold-based IEA phosphodiesterase prediction.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> AIM6 is a conserved fungal protein that defines its own family within a divergent branch of the ubiquitous phosphoinositide-phospholipase-C / glycerophosphodiester-phosphodiesterase superfamily. Establishing whether it is an active phosphodiesterase (and on what substrate) or a pseudoenzyme would assign a first molecular function to a member of the fungal unknome and clarify a poorly explored corner of a large, biomedically important enzyme fold.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro phosphodiesterase assays on purified AIM6 against a substrate panel, with catalytic-residue mutagenesis to test whether the fold is functional; structural determination of the domain to inspect the active-site geometry.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"68 genes with no previously characterized cellular role"</em> — PMID:19300474</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role of AIM6 and the mechanism behind its deletion phenotype are unknown. It is unresolved whether AIM6 acts directly in mitochondrial biogenesis/respiration or whether the respiratory-growth defect of the deletion is an indirect consequence of some other cellular activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The one experimental phenotype is that aim6-delta impairs respiratory (non-fermentable-carbon) growth and alters mitochondrial transmission (the basis of the AIM name), reported in the quantitative petite-frequency screen of PMID:19300474. That study explicitly cautions that many genes with such phenotypes are not mitochondrial and may affect biogenesis indirectly. AIM6&#39;s localization is unknown, and its predicted signal peptide points toward the secretory pathway rather than the mitochondrion.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning AIM6 to a specific pathway would explain a reproducible respiratory-growth phenotype in a model eukaryote and determine whether it is a genuine (if unusual, secretory-pathway-linked) contributor to mitochondrial function or an indirect effector — a distinction the original screen flagged as generally unresolved for its hits.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Determine AIM6 localization; run epistasis / synthetic-genetic and metabolic (lipidomic) profiling of aim6-delta against mitochondrial-biogenesis and lipid/secretory-pathway mutants to place AIM6 in a functional module and test direct vs indirect models.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"raise the possibility that these mutants are somehow indirectly affecting biogenesis"</em> — PMID:19300474</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AIM6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q07716" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="aim6-ydl237w-curation-notes">AIM6 (YDL237W) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> AIM6.</p>
+<h2 id="identity-verified-from-uniprot-record">Identity (verified from UniProt record)</h2>
+<ul>
+<li>UniProt: <strong>Q07716</strong> (AIM6_YEAST), reviewed, 390 aa, PE=1 (evidence at protein level).</li>
+<li>SGD systematic name: <strong>YDL237W</strong>; standard name <strong>AIM6</strong>; SGD:S000002396.</li>
+<li>Name: "Altered inheritance of mitochondria protein 6" (UniProt) / "Altered Inheritance rate of Mitochondria" (SGD). The AIM series was named in the mitochondrial-biogenesis screen of <a href="https://pubmed.ncbi.nlm.nih.gov/19300474">PMID:19300474</a>.</li>
+<li>Flags: <strong>Precursor</strong>; predicted N-terminal <strong>signal peptide 1–17</strong> (ECO:0000255), mature chain 18–390 (PRO_0000242484). Keyword: Signal.</li>
+<li>Family: "Belongs to the AIM6 family" (a UniProt family essentially defined by this protein and close fungal orthologs, not a characterized enzyme family).</li>
+</ul>
+<h2 id="domain-fold-reasoning-done-inline-from-uniprot-dr-lines-interpro-api">Domain / fold reasoning (done inline from UniProt DR lines + InterPro API)</h2>
+<p>InterPro domain matches for Q07716 (from InterPro REST API):<br />
+- <strong>IPR017946</strong> homologous_superfamily — "PLC-like phosphodiesterase, TIM beta/alpha-barrel domain superfamily", residues <strong>117–385</strong>.<br />
+- <strong>IPR039559</strong> domain — "Altered inheritance of mitochondria protein 6, PI-PLC-like catalytic domain", residues <strong>115–382</strong>.<br />
+- <strong>IPR051236</strong> family — "Histone acetyltransferase RTT109-like", residues 80–387.<br />
+- CDD: <strong>cd08577</strong> = "PI-PLCc_GDPD_SF_unchar3" ("<strong>Uncharacterized</strong> hypothetical proteins similar to the catalytic domains of Phosphoinositide-specific phospholipase and Glycerophosphodiester phosphodiesterases").<br />
+- SUPFAM: SSF51695 (PLC-like phosphodiesterases). PANTHER: PTHR31571 "ALTERED INHERITANCE OF MITOCHONDRIA PROTEIN 6".</p>
+<p>Interpretation:<br />
+- The mature protein is essentially one domain adopting the <strong>PLC-like phosphodiesterase TIM (β/α)8-barrel fold</strong> — the fold shared by phosphoinositide-specific phospholipase C (PI-PLC) and glycerophosphodiester phosphodiesterases (GDPD). This is the structural basis for the IEA MF annotation GO:0008081 "phosphoric diester hydrolase activity".<br />
+- <strong>InterPro itself states "The function of Aim6 is not clear"</strong>, and the CDD source group is explicitly labelled "uncharacterized". So the phosphodiesterase activity is a <strong>fold-level homology prediction only</strong>, from a divergent, uncharacterized subgroup — not an experimentally established activity, and the substrate/specificity is unknown.<br />
+- The IPR051236 "Histone acetyltransferase RTT109-like" family match is a <strong>noisy/over-broad PANTHER grouping</strong>; it does NOT imply AIM6 is a histone acetyltransferase (RTT109 is nuclear; AIM6 carries a secretory signal peptide, incompatible with a nucleosomal HAT). Do not annotate to acetyltransferase on this basis.</p>
+<p>Inline check of catalytic residues (script over the sequence): the catalytic-domain region carries conserved His/Asp residues consistent with the fold, notably an <strong>"HSHND" motif at H118-S119-H120-N121-D122</strong> (GDPD/PLC-superfamily catalytic-type residues sit at the N-terminal end of the barrel), plus H156 (GHNEAY), H313/H318 (HCGSDHWK), H343 (GAHAL). So catalytic machinery is at least partially retained at the fold level — enough that the phosphodiesterase prediction cannot be confidently <em>refuted</em> as a dead pseudoenzyme, but there is no positive evidence for any catalytic activity, substrate, or the "lipid metabolic process" leap.</p>
+<h2 id="what-is-known-experimental">What is KNOWN (experimental)</h2>
+<ul>
+<li><strong>Disruption phenotype: impairs respiratory growth</strong> (UniProt CC, ECO:0000269|PubMed:19300474). AIM6/YDL237W was one of the previously uncharacterized ORFs whose deletion gave a mitochondrial-biogenesis/petite phenotype in the Hess et al. quantitative screen. Note: the per-gene datum sits in that paper's Table S2 (not in the cached full text); the cached full text establishes the <strong>screen and its phenotype interpretations</strong> but does not name YDL237W/AIM6 in the running text.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/19300474" title="we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and inheritance in Saccharomyces cerevisiae">PMID:19300474</a></li>
+<li>The screen explicitly cautions the phenotype does not prove a direct mitochondrial molecular role: <a href="https://pubmed.ncbi.nlm.nih.gov/19300474" title="many proteins not localized to mitochondria are vital for regulating mitochondrial function and biogenesis">PMID:19300474</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/19300474" title="raise the possibility that these mutants are somehow indirectly affecting biogenesis">PMID:19300474</a>.</li>
+<li>SGD locus summary (web, 2026): <strong>"Protein whose biological role and cellular location are unknown."</strong> Verified ORF, non-essential. Additional deletion phenotypes catalogued at SGD (from various high-throughput datasets): inability to grow on glycerol, increased competitive fitness on fermentable medium, altered heat-stress survival, decreased H2S production with excess cysteine — all HTP, none establishing a molecular function.</li>
+<li>Protein-level evidence (PE=1): detected by mass spectrometry (<a href="https://pubmed.ncbi.nlm.nih.gov/29897761">PMID:29897761</a>, proteogenomics of S. cerevisiae) and present in abundance datasets (~6,000 molecules/cell per SGD). Confirms the protein exists and is expressed; says nothing about function.</li>
+</ul>
+<h2 id="what-is-not-known">What is NOT known</h2>
+<ul>
+<li><strong>Molecular function</strong>: unknown. Only a fold-based PI-PLC/GDPD-like phosphodiesterase <em>prediction</em> (IEA). No demonstrated catalytic activity, no substrate, no assay. The specific claim "phosphoric <em>diester</em> hydrolase" and the "lipid metabolic process" inference (borrowing PI-PLC's lipid substrate) are unsupported over-reaches from the divergent fold.</li>
+<li><strong>Cellular localization</strong>: unknown/unresolved. UniProt gives no subcellular-location CC. There is a predicted N-terminal signal peptide (suggesting entry into the secretory pathway / a non-cytosolic destination), which is hard to reconcile with a direct intramitochondrial role — so the mitochondrial phenotype is plausibly indirect. SGD: "cellular location ... unknown."</li>
+<li><strong>Biological role / mechanism behind the AIM screen phenotype</strong>: unknown. The petite/respiratory phenotype places AIM6 loss upstream of normal respiratory competence, but whether this is a direct role in mitochondrial biogenesis or an indirect/pleiotropic effect (e.g. via a secretory-pathway or lipid-related activity) is undetermined.</li>
+</ul>
+<h2 id="annotation-plan">Annotation plan</h2>
+<p>GOA has 5 annotations:<br />
+1. GO:0006629 lipid metabolic process — IEA (InterPro, IPR017946). MARK_AS_OVER_ANNOTATED: extrapolates PI-PLC's lipid role to a divergent uncharacterized domain; no evidence AIM6 acts on lipids.<br />
+2. GO:0008081 phosphoric diester hydrolase activity — IEA (InterPro, IPR017946). UNDECIDED/MARK_AS_OVER_ANNOTATED: fold-level prediction from an "uncharacterized" CDD group; retain awareness but not as a confident core function.<br />
+3. GO:0003674 molecular_function — ND (SGD). ACCEPT (root/ND placeholder; correctly signals unknown MF).<br />
+4. GO:0005575 cellular_component — ND (SGD). ACCEPT (root/ND placeholder).<br />
+5. GO:0008150 biological_process — ND (SGD). ACCEPT (root/ND placeholder).</p>
+<p>core_functions: minimal/none with confidence (dark gene). knowledge_gaps is the primary deliverable.</p>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>Falcon deep research was attempted twice (<code>just deep-research-falcon yeast AIM6</code>) and both attempts<br />
+failed: first attempt timed out after 600s (Edison/falcon endpoint) and the perplexity-lite fallback<br />
+returned HTTP 401 (quota exceeded); retry disconnected (RemoteProtocolError, exit 143). No<br />
+<code>AIM6-deep-research-*.md</code> file was produced, and per project policy I did NOT fabricate one. This<br />
+review is therefore grounded in: the UniProt record (Q07716), the GOA TSV, the cached full text of<br />
+PMID:19300474 (verbatim-quoted), and manually verified public resources (SGD locus page, InterPro<br />
+IPR039559 / IPR017946 REST API, CDD cd08577, PANTHER PTHR31571). All non-PMID assertions are recorded<br />
+here with their source.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q07716
+gene_symbol: AIM6
+product_type: PROTEIN
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  AIM6 (YDL237W) is an uncharacterized protein of the budding yeast Saccharomyces cerevisiae
+  whose molecular function and subcellular location are not established. It is a 390-residue
+  protein synthesized with a predicted N-terminal signal peptide (residues 1-17), suggesting
+  entry into the secretory pathway, and the bulk of the mature protein adopts the PLC-like
+  phosphodiesterase TIM (beta/alpha)8-barrel fold shared by phosphoinositide-specific
+  phospholipase C and glycerophosphodiester phosphodiesterase enzymes. It defines its own
+  narrow sequence family (the AIM6 family) within a divergent, uncharacterized branch of this
+  phosphodiesterase-like superfamily, and no catalytic activity, substrate, or physiological
+  reaction has been demonstrated for it. The only experimental phenotype reported is that
+  deletion impairs respiratory (non-fermentable-carbon) growth and alters mitochondrial
+  transmission, the observation from which the gene took its name (Altered Inheritance of
+  Mitochondria); whether this reflects a direct or an indirect role in mitochondrial function
+  is unresolved. The gene is non-essential and is conserved among fungi.
+
+references:
+- id: PMID:19300474
+  title: &#34;Computationally driven, quantitative experiments discover genes required for mitochondrial biogenesis.&#34;
+  findings:
+  - statement: &gt;-
+      A quantitative petite-frequency screen identified ~100 previously uncharacterized proteins
+      (the AIM series) whose deletion alters mitochondrial biogenesis/inheritance in S. cerevisiae;
+      AIM6/YDL237W was named and scored in this study (per-gene data in the paper&#39;s Table S2).
+    supporting_text: &gt;-
+      we have identified 100 proteins whose deficiency alters mitochondrial biogenesis and inheritance in Saccharomyces cerevisiae
+  - statement: &gt;-
+      The authors caution that such deletion phenotypes need not reflect a direct intramitochondrial
+      molecular role, since non-mitochondrial proteins can regulate biogenesis and some mutants may
+      affect biogenesis indirectly.
+    supporting_text: &gt;-
+      raise the possibility that these mutants are somehow indirectly affecting biogenesis
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified (PMC2648979). This is the source of the AIM6 name and of the sole
+      experimental datum for the gene (deletion impairs respiratory growth / alters mitochondrial
+      transmission), which UniProt cites as the DISRUPTION PHENOTYPE. The cached full text
+      establishes the screen and its interpretive caveats but does not name YDL237W/AIM6 in the
+      running text (the per-gene call is in supplementary Table S2), so quotes here are anchored to
+      the screen-level findings and caveats, not to a gene-specific sentence.
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard InterPro2GO electronic-annotation reference. The two IEA terms it supports
+      (GO:0008081, GO:0006629) both derive from the PLC-like phosphodiesterase superfamily match
+      (IPR017946); they are fold-level predictions from a divergent, uncharacterized subgroup, not
+      evidence of demonstrated activity.
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard SGD ND (no biological data available) reference; correctly used to record that
+      AIM6&#39;s molecular function, biological process, and cellular component are unknown.
+
+existing_annotations:
+- term:
+    id: GO:0006629
+    label: lipid metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic InterPro2GO annotation transferred from the PLC-like phosphodiesterase superfamily
+      match (IPR017946). Phosphoinositide-specific phospholipase C acts on membrane lipids, but AIM6
+      belongs to a divergent, uncharacterized subgroup of the fold with no demonstrated lipid
+      substrate or lipid-related activity, and InterPro itself states its function is unclear.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This over-extrapolates the lipid role of characterized PI-PLC enzymes to a divergent
+      uncharacterized domain. There is no experimental evidence that AIM6 participates in lipid
+      metabolism; the phosphodiesterase-like superfamily also contains glycerophosphodiester
+      phosphodiesterases and many non-lipid activities, so &#34;lipid metabolic process&#34; is an
+      unsupported specialization from a fold-only match. Not a confident biological process for
+      this gene.
+- term:
+    id: GO:0008081
+    label: phosphoric diester hydrolase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic InterPro2GO annotation from the PLC-like phosphodiesterase TIM-barrel superfamily
+      match (IPR017946 / IPR039559, CDD cd08577 &#34;PI-PLCc_GDPD_SF_unchar3&#34;). The mature protein does
+      adopt this catalytic fold and retains some conserved His/Asp residues consistent with it, so
+      the annotation is not demonstrably wrong; however the assignment is a distant, fold-level
+      prediction from a subgroup that CDD and InterPro explicitly label uncharacterized, with no
+      demonstrated activity, substrate, or assay.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Keep awareness of the fold-based phosphodiesterase prediction, but it should not be treated as
+      an established molecular function. It rests solely on membership in a divergent, uncharacterized
+      branch of the PI-PLC/GDPD superfamily; no catalytic activity or substrate has ever been shown
+      for AIM6. This is the central molecular-function knowledge gap for the gene (see knowledge_gaps),
+      not a curated core function.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      SGD records the molecular function as ND (no biological data available). This correctly states
+      that no experimentally supported molecular function is known for AIM6; the only molecular-function
+      claim in GOA is the fold-based IEA phosphodiesterase prediction above.
+    action: ACCEPT
+    reason: &gt;-
+      Appropriate use of the root term with ND to signal that AIM6&#39;s molecular function is genuinely
+      unknown. Consistent with SGD&#39;s summary that the protein&#39;s biological role and cellular location
+      are unknown.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      SGD records the cellular component as ND (no biological data available). UniProt provides no
+      subcellular-location statement; the only localization-relevant feature is a predicted N-terminal
+      signal peptide implying secretory-pathway entry, which is not sufficient to assign a compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Correct use of the root term with ND: AIM6&#39;s localization is unresolved. The predicted signal
+      peptide and the indirect nature of the mitochondrial deletion phenotype mean a specific
+      compartment cannot be asserted.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      SGD records the biological process as ND (no biological data available). The one experimental
+      handle is that deletion impairs respiratory growth / alters mitochondrial transmission
+      (PMID:19300474), but the screen authors caution this may be indirect, so a specific biological
+      process is not assignable with confidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct use of the root term with ND. While the AIM screen phenotype hints at a role connected
+      to mitochondrial biogenesis/respiration, the effect may be indirect and no mechanism is known,
+      so no specific BP term is warranted. The unknown biological role is captured in knowledge_gaps.
+
+core_functions: []
+
+proposed_new_terms: []
+
+suggested_questions:
+- question: &gt;-
+    Does the AIM6 PLC-like phosphodiesterase-fold domain have any catalytic activity in vitro, and
+    if so, on what substrate (a phosphoinositide, a glycerophosphodiester, a cyclic phosphate, or
+    another phosphodiester)?
+- question: &gt;-
+    Where does AIM6 localize? Is the predicted N-terminal signal peptide cleaved and does the protein
+    enter the secretory pathway (ER/Golgi/cell surface/vacuole), which would argue that its respiratory
+    phenotype is indirect rather than a direct mitochondrial role?
+- question: &gt;-
+    Is the respiratory-growth / altered-mitochondrial-transmission phenotype of aim6-delta a direct
+    consequence of AIM6 activity, or an indirect/pleiotropic effect (e.g. via lipid or
+    secretory-pathway homeostasis)?
+
+suggested_experiments:
+- hypothesis: &gt;-
+    The AIM6 PLC-like domain is a catalytically active phosphodiesterase acting on a specific
+    phosphodiester substrate.
+  description: &gt;-
+    Purify recombinant mature AIM6 (residues 18-390) and assay phosphodiesterase activity against a
+    panel of candidate substrates (phosphoinositides, glycerophosphodiesters such as
+    glycerophosphocholine, cyclic nucleotides, and generic bis-p-nitrophenyl phosphate) with and
+    without divalent cations; test predicted catalytic-residue point mutants (e.g. the His118/His120
+    pair) to establish whether the retained fold is enzymatically functional or a pseudoenzyme.
+  experiment_type: in vitro enzyme assay / structure-function mutagenesis
+- hypothesis: &gt;-
+    AIM6 enters the secretory pathway and is not a resident mitochondrial protein, implying its
+    respiratory phenotype is indirect.
+  description: &gt;-
+    Determine AIM6 subcellular localization by tagging the endogenous locus (C-terminal fluorescent
+    tag, and separately an internal tag preserving the signal peptide) and by subcellular
+    fractionation / signal-peptide cleavage assays, to test whether AIM6 is secreted/ER-Golgi
+    resident versus mitochondrial.
+  experiment_type: fluorescence microscopy / subcellular fractionation
+- hypothesis: &gt;-
+    The aim6-delta respiratory phenotype reports a defined pathway that can be identified by genetic
+    and physiological profiling.
+  description: &gt;-
+    Characterize aim6-delta with quantitative respiratory-growth and petite-frequency assays,
+    lipidomic profiling, and epistasis / synthetic-genetic-array analysis against mitochondrial-
+    biogenesis and lipid/secretory-pathway mutants to place AIM6 in a functional module and
+    distinguish a direct from an indirect mitochondrial role.
+  experiment_type: quantitative genetics / metabolic profiling
+
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of AIM6 is unknown. Although the mature protein adopts the PLC-like
+    phosphodiesterase (PI-PLC/GDPD-type) TIM-barrel fold, it is undetermined whether AIM6 has any
+    catalytic activity at all, and if so what its substrate and reaction are. No enzymatic activity,
+    substrate, or partner has ever been measured for it.
+  boundary: &gt;-
+    AIM6 is a verified, non-essential, expressed 390-aa protein (protein-level evidence) with a
+    predicted N-terminal signal peptide (1-17). Its C-terminal domain (~residues 115-385) matches the
+    PLC-like phosphodiesterase TIM-barrel superfamily (IPR017946) and an AIM6-specific PI-PLC-like
+    catalytic-domain entry (IPR039559) built on CDD cd08577, a group explicitly labelled
+    &#34;uncharacterized.&#34; Some conserved His/Asp residues consistent with the fold are retained. The
+    only functional label in GOA beyond root/ND terms is the fold-based IEA phosphodiesterase
+    prediction.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    AIM6 is a conserved fungal protein that defines its own family within a divergent branch of the
+    ubiquitous phosphoinositide-phospholipase-C / glycerophosphodiester-phosphodiesterase
+    superfamily. Establishing whether it is an active phosphodiesterase (and on what substrate) or a
+    pseudoenzyme would assign a first molecular function to a member of the fungal unknome and
+    clarify a poorly explored corner of a large, biomedically important enzyme fold.
+  resolution: &gt;-
+    In vitro phosphodiesterase assays on purified AIM6 against a substrate panel, with
+    catalytic-residue mutagenesis to test whether the fold is functional; structural determination of
+    the domain to inspect the active-site geometry.
+  provenance:
+    - reference_id: PMID:19300474
+      supporting_text: &gt;-
+        68 genes with no previously characterized cellular role
+- gap_statement: &gt;-
+    The biological role of AIM6 and the mechanism behind its deletion phenotype are unknown. It is
+    unresolved whether AIM6 acts directly in mitochondrial biogenesis/respiration or whether the
+    respiratory-growth defect of the deletion is an indirect consequence of some other cellular
+    activity.
+  boundary: &gt;-
+    The one experimental phenotype is that aim6-delta impairs respiratory (non-fermentable-carbon)
+    growth and alters mitochondrial transmission (the basis of the AIM name), reported in the
+    quantitative petite-frequency screen of PMID:19300474. That study explicitly cautions that many
+    genes with such phenotypes are not mitochondrial and may affect biogenesis indirectly. AIM6&#39;s
+    localization is unknown, and its predicted signal peptide points toward the secretory pathway
+    rather than the mitochondrion.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning AIM6 to a specific pathway would explain a reproducible respiratory-growth phenotype
+    in a model eukaryote and determine whether it is a genuine (if unusual, secretory-pathway-linked)
+    contributor to mitochondrial function or an indirect effector — a distinction the original
+    screen flagged as generally unresolved for its hits.
+  resolution: &gt;-
+    Determine AIM6 localization; run epistasis / synthetic-genetic and metabolic (lipidomic)
+    profiling of aim6-delta against mitochondrial-biogenesis and lipid/secretory-pathway mutants to
+    place AIM6 in a functional module and test direct vs indirect models.
+  provenance:
+    - reference_id: PMID:19300474
+      supporting_text: &gt;-
+        raise the possibility that these mutants are somehow indirectly affecting biogenesis
+
+status: COMPLETE
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/AVT2/AVT2-ai-review.html
+++ b/genes/yeast/AVT2/AVT2-ai-review.html
@@ -1,0 +1,2982 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AVT2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AVT2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P39981" target="_blank" class="term-link">
+                        P39981
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "AVT2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P39981" data-a="DESCRIPTION: AVT2 (YEL064C) is a 480-residue polytopic integral..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>AVT2 (YEL064C) is a 480-residue polytopic integral membrane protein of budding yeast, one of seven paralogous AVT proteins (AVT1-7) belonging to the amino acid/auxin permease (AAAP) superfamily (TCDB 2.A.18; Pfam Aa_trans PF01490; InterPro IPR013057; PANTHER PTHR22950), the same solute-carrier clan (SLC32/SLC36/SLC38-like) as the neuronal vesicular GABA/glycine transporters. It has nine predicted transmembrane helices and a disordered cytoplasmic N-terminus, and its fold is that of an amino acid transmembrane transporter. Unlike several of its paralogs, AVT2 has no experimentally demonstrated transported substrate, transport direction, or driving force: in the founding biochemical survey of the family, transport activity was demonstrated for AVT1 (vacuolar uptake of large neutral amino acids) and for AVT3, AVT4 and AVT6 (vacuolar amino acid efflux), whereas AVT2 was not among the members with measurable activity. AVT2 has been directly localized to the endoplasmic reticulum, while the vacuolar-membrane localization typical of the family is inferred rather than directly shown for this paralog. Its physiological role remains undetermined and its null mutant is viable.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015179" target="_blank" class="term-link">
+                                    GO:0015179
+                                </a>
+                            </span>
+                            <span class="term-label">L-amino acid transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0015179" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic amino-acid transmembrane transporter molecular function assigned by phylogenetic (IBA) inference across the AAAP/AVT tree. This is the most specific molecular function that can be defended for AVT2: the Aa_trans (PF01490 / AAAP; PANTHER PTHR22950) fold with nine predicted TM helices supports amino-acid transporter activity, but AVT2 has no demonstrated substrate and no demonstrated transport direction, so it must stay at this generic level. A more specific term (particular substrate, or uptake vs. efflux) is not supported: the paralogs split between uptake (AVT1) and efflux (AVT3/AVT4/AVT6) of different amino-acid classes, so paralogy does not pin AVT2&#39;s specificity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The AAAP/Aa_trans transporter fold justifies a generic amino-acid transmembrane transporter molecular function; no substrate or direction is assignable for AVT2 (it was among the AVT members with no demonstrated transport activity), so the annotation should remain generic and must not be specialized.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Seven genes in Saccharomyces cerevisiae are predicted to code for membrane-spanning proteins (designated AVT1-7) that are related to the neuronal gamma-aminobutyric acid-glycine vesicular transporters.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003333" target="_blank" class="term-link">
+                                    GO:0003333
+                                </a>
+                            </span>
+                            <span class="term-label">amino acid transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0003333" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic amino-acid transmembrane transport biological process, assigned by phylogenetic inference and consistent with the transporter fold and the demonstrated function of the AVT family. The specific amino-acid substrate and the direction of transport for AVT2 are unknown, so the annotation is kept at this generic BP level rather than specialized to a particular vacuolar uptake or efflux process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A generic amino-acid transmembrane transport process is the appropriate biological-process annotation for a member of a demonstrated amino-acid transporter family whose own substrate and direction are undetermined; specializing it would over-annotate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have now demonstrated that four of these proteins mediate amino acid transport in vacuoles.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902475" target="_blank" class="term-link">
+                                    GO:1902475
+                                </a>
+                            </span>
+                            <span class="term-label">L-alpha-amino acid transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:1902475" data-r="GO_REF:0000108" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Amino-acid transmembrane transport biological process reached automatically by inter-ontology (logical) inference from the GO:0015179 L-amino acid transmembrane transporter molecular function. It is consistent with the IBA-supported generic transport process above and with the transporter fold; the specific substrate and direction remain unknown, so it is retained at this generic level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Auto-derived, internally consistent generic amino-acid transport process; correct at this generality for a fold-confirmed amino-acid transporter of undetermined specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This function is consistent with the role of the vacuole in protein degradation, whereby accumulated amino acids are exported to the cytosol.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11274162
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A family of yeast proteins mediating bidirectional vacuolar ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0005783" data-r="PMID:11274162" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) localization of AVT2 to the endoplasmic reticulum, curated by SGD from the founding AVT-family paper. This is the only experimentally determined localization for AVT2 specifically and is accepted as the authoritative cellular-component call. It is notable that this differs from the vacuole-membrane localization typical of the family and inferred by UniProt from the same paper (see the vacuolar membrane annotation), leaving the in-vivo site of action of AVT2 an open question.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) localization curated from the primary paper; per curation guidance a direct-assay curator call is not overruled from an abstract-only cache. This is the core, directly demonstrated localization for AVT2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A family of yeast proteins mediating bidirectional vacuolar amino acid transport.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) endoplasmic-reticulum localization. It agrees with, and independently corroborates, the same ER compartment established for AVT2 by direct assay (the IDA annotation from PMID:11274162). Accepted as consistent with the experimentally determined localization; the IDA remains the primary, directly grounded evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Points to the same ER compartment that is experimentally demonstrated for AVT2 by direct assay (IDA, PMID:11274162); the phylogenetic call is concordant with that evidence and is accepted as corroborating rather than contradicting it.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A family of yeast proteins mediating bidirectional vacuolar amino acid transport.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad membrane localization from phylogenetic inference. Correct and consistent with the experimentally supported multi-pass topology (nine predicted TM helices); retained as a general, non-core localization statement, since the more informative compartment identity (ER by IDA, vacuole membrane by UniProt) is captured by the specific annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> AVT2 is unambiguously an integral multi-pass membrane protein, so the generic membrane term is directly supported and correct; it is broad but accurate for a polytopic transporter.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Seven genes in Saccharomyces cerevisiae are predicted to code for membrane-spanning proteins (designated AVT1-7)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005774" target="_blank" class="term-link">
+                                    GO:0005774
+                                </a>
+                            </span>
+                            <span class="term-label">vacuolar membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0005774" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Vacuolar-membrane localization from the UniProt Subcellular Location mapping (SL-0271). In the UniProt record this location is attributed to the same primary paper (PubMed:11274162) as the AVT2-specific ER localization curated by SGD, so the two databases interpret the same study differently: the family is canonically tonoplast/vacuolar, but AVT2 was directly observed in the ER. This annotation is retained as a plausible, family-consistent location but is not treated as an established core fact, because it conflicts with the direct-assay ER localization. Whether AVT2 acts at the vacuole membrane, is ER-resident, or is a vacuolar transporter caught in the secretory pathway is an open question.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Family-expected/UniProt-mapped location that conflicts with the AVT2-specific ER IDA; retained as plausible but non-core rather than removed, since the underlying subcellular location mapping is not overruled and the ER-vs-vacuole question is genuinely unresolved.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                        PMID:11274162
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A family of yeast proteins mediating bidirectional vacuolar amino acid transport.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function placeholder (No Data) assigned by SGD. It is superseded by the generic but informative L-amino acid transmembrane transporter activity (GO:0015179) annotation already present from the IBA route, so the uninformative root term should be removed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder that is now redundant: the molecular-function aspect is already covered, more informatively, by the GO:0015179 transporter activity annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P39981" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process placeholder (No Data) assigned by SGD. It is superseded by the generic amino-acid transmembrane transport (GO:0003333) biological-process annotation already present, so the uninformative root term should be removed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root-term placeholder that is now redundant: the biological-process aspect is already covered by the GO:0003333 amino acid transmembrane transport annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>AVT2 is a nine-transmembrane-helix integral membrane protein of the amino acid/auxin permease (AAAP; Aa_trans PF01490 / InterPro IPR013057 / PANTHER PTHR22950) superfamily and one of the seven yeast AVT paralogs related to the vesicular GABA/glycine transporters. Its fold supports a generic amino-acid transmembrane transporter activity, but no substrate, no transport direction, and no driving force have been demonstrated for AVT2: in the biochemical survey that established the family&#39;s function, activity was shown for AVT1 (uptake) and AVT3/AVT4/AVT6 (efflux) but not for AVT2. It has been directly localized to the endoplasmic reticulum.</h3>
+                <span class="vote-buttons" data-g="P39981" data-a="FUNCTION: AVT2 is a nine-transmembrane-helix integral membra..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015179" target="_blank" class="term-link">
+                            L-amino acid transmembrane transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                endoplasmic reticulum
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                                PMID:11274162
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Seven genes in Saccharomyces cerevisiae are predicted to code for membrane-spanning proteins (designated AVT1-7) that are related to the neuronal gamma-aminobutyric acid-glycine vesicular transporters.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11274162" target="_blank" class="term-link">
+                            PMID:11274162
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A family of yeast proteins mediating bidirectional vacuolar amino acid transport.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Seven S. cerevisiae genes (AVT1-7) encode membrane-spanning proteins related to the neuronal GABA-glycine vesicular transporters; four (AVT1, AVT3, AVT4, AVT6) were demonstrated to mediate vacuolar amino acid transport (AVT1 imports large neutral amino acids; AVT3/AVT4 export large neutral amino acids; AVT6 exports Asp/Glu). AVT2 was not among the members with demonstrated activity. AVT2 is directly localized (by SGD IDA from this paper) to the endoplasmic reticulum, whereas UniProt maps it (from the same paper) to the vacuole membrane.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What amino acid(s) does AVT2 transport, and in which direction (vacuolar uptake or efflux), given that it was inactive in the assay that characterized AVT1/AVT3/AVT4/AVT6?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39981" data-a="Q: What amino acid(s) does AVT2 transport, and in whi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does AVT2 function at the endoplasmic reticulum (where it was directly localized) or at the vacuole membrane (as expected for the family and mapped by UniProt), and is its localization conditional?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39981" data-a="Q: Does AVT2 function at the endoplasmic reticulum (w..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are the seven AVT paralogs functionally redundant, and does AVT2 have any dedicated phenotype under conditions (e.g. nitrogen starvation, autophagy) that stress vacuolar amino-acid flux?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39981" data-a="Q: Are the seven AVT paralogs functionally redundant,..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform substrate- and direction-resolved transport assays of AVT2 (uptake and efflux, with and without a proton gradient/ATP) in isolated vacuoles/vesicles or a heterologous system, mirroring the assays used to characterize AVT1/AVT3/AVT4/AVT6.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AVT2 transports a specific amino acid or amino-acid class in a defined direction; its previous apparent inactivity reflects assay conditions (e.g. wrong substrate, mislocalization, or a requirement for a partner/condition) rather than a genuine lack of transport capability.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P39981" data-a="EXPERIMENT: Perform substrate- and direction-resolved transpor..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the subcellular localization of endogenously tagged AVT2 by high-resolution imaging and fractionation, co-stained with ER and vacuole-membrane markers, across growth conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AVT2 localizes at least partly to the ER rather than exclusively to the vacuole membrane, and its distribution changes with growth/nutrient condition.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P39981" data-a="EXPERIMENT: Determine the subcellular localization of endogeno..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct combinatorial avt single and multiple deletions (including avt2) and phenotype them for vacuolar amino-acid pools and growth under nitrogen limitation, autophagy induction, and diverse amino-acid conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AVT2 is partially redundant with other AVT paralogs and contributes to vacuolar amino-acid homeostasis only in combination with, or under conditions that stress, the rest of the family.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P39981" data-a="EXPERIMENT: Construct combinatorial avt single and multiple de..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate, transport direction, driving force, and biological role of AVT2 are all undetermined. It is one of the functionally dark members of the yeast AVT family: a bona fide amino-acid-transporter-fold protein with no demonstrated cargo, no assigned transport direction, and no dedicated loss-of-function phenotype (the null is viable).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established: AVT2 is a nine-TM AAAP/Aa_trans (PF01490) amino-acid-transporter-fold protein, a paralog of the demonstrated vacuolar amino-acid transporters AVT1/AVT3/AVT4/AVT6. What is excluded/unknown: in the family&#39;s founding biochemical survey only four of the seven AVT proteins (AVT1, AVT3, AVT4, AVT6) had measurable transport activity, and AVT2 was not among them, so no substrate or direction is established for AVT2. The paralogs are functionally split between uptake and efflux of different amino-acid classes, so paralogy does not resolve AVT2&#39;s function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> AVT2 is a conserved AVT-family transporter that has remained functionally unassigned since the family was described; closing this gap would remove a dark node from yeast vacuolar/amino-acid transport biology and clarify whether the AVT paralogs are redundant or specialized.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct transport assays (substrate screens and uptake/efflux/driving-force measurements) of AVT2 in isolated vacuoles or a heterologous expression system; comparative metabolomics and combinatorial avt deletions (with and without AVT1/AVT3/AVT4/AVT5/AVT6/AVT7) to resolve redundancy and any AVT2-specific phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We have now demonstrated that four of these proteins mediate amino acid transport in vacuoles."</em> — PMID:11274162</li>
+
+                <li><em>"One protein, AVT1, is required for the vacuolar uptake of large neutral amino acids"</em> — PMID:11274162</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The in-vivo compartment where AVT2 acts is unresolved. AVT2 has been directly localized to the endoplasmic reticulum, yet the family is canonically vacuolar (tonoplast) and UniProt maps AVT2 to the vacuole membrane. It is unknown whether AVT2 is a genuine ER-resident transporter, an ER-retained (e.g. unassembled/regulated) family member, or a vacuolar transporter observed in the secretory pathway.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: an experimental (IDA) localization of AVT2 to the endoplasmic reticulum, and a UniProt Subcellular Location mapping to the vacuole membrane; both are attributed to the same primary study. Unknown: which localization reflects AVT2&#39;s site of function, and whether its localization is conditional or regulated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The compartment where a transporter resides constrains its possible substrates and biological role; the ER-versus-vacuole ambiguity is a barrier to interpreting AVT2&#39;s function and to deciding whether the family-level vacuolar-transport annotations apply to this paralog.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> High-resolution live-cell imaging of endogenously tagged AVT2 with ER and vacuole-membrane markers under multiple growth conditions; subcellular fractionation and, if warranted, mutational analysis of putative ER-retention/trafficking signals.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"A family of yeast proteins mediating bidirectional vacuolar amino acid transport."</em> — PMID:11274162</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AVT2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P39981" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Research Report: AVT2 (YEL064C) — Vacuolar Amino Acid Transporter 2 in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">23 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:44:57.948940</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="AVT2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="AVT2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-avt2-yel064c-vacuolar-amino-acid-transporter-2-in-saccharomyces-cerevisiae">Research Report: AVT2 (YEL064C) — Vacuolar Amino Acid Transporter 2 in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>AVT2 (systematic name YEL064C; UniProt P39981) encodes a predicted 480-amino-acid integral membrane protein in the budding yeast <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein belongs to the amino acid/polyamine transporter 2 family (also referred to as the amino acid/auxin permease [AAAP] superfamily) and contains the AA_transpt_TM domain (IPR013057; PF01490) (russnak2001afamilyof pages 8-8, kawanokawada2018transportofamino pages 2-3). AVT2 is one of seven members (AVT1–AVT7) of the AVT family in <em>S. cerevisiae</em>, which are predicted to be membrane-spanning proteins related to the neuronal vesicular inhibitory amino acid transporter (VIAAT/VGAT) family, including the <em>C. elegans</em> UNC-47 protein (russnak2001afamilyof pages 1-1, russnak2001afamilyof pages 1-3).</p>
+<h2 id="2-the-avt-family-context">2. The AVT Family Context</h2>
+<p>The AVT family was identified and functionally characterized by Russnak, Konczal, and McIntire (2001) in a landmark study demonstrating that four of the seven family members mediate bidirectional amino acid transport across the vacuolar membrane (russnak2001afamilyof pages 1-1). The family subdivides phylogenetically into four branches: AVT1, AVT2, AVT3/AVT4, and AVT5/AVT6/AVT7 (russnak2001afamilyof pages 4-6). Functionally characterized members include:</p>
+<ul>
+<li><strong>AVT1</strong>: Mediates vacuolar uptake (import) of large neutral amino acids, including glutamine, asparagine, isoleucine, leucine, and tyrosine, as well as histidine (russnak2001afamilyof pages 1-1, kawanokawada2018transportofamino pages 2-3).</li>
+<li><strong>AVT3 and AVT4</strong>: Function synergistically in the export of neutral amino acids from the vacuole to the cytosol, with AVT4 also recognizing basic amino acids (russnak2001afamilyof pages 1-1, kawanokawada2018transportofamino pages 2-3).</li>
+<li><strong>AVT6</strong>: Responsible for the efflux of acidic amino acids (aspartate and glutamate), with recent evidence suggesting it may also export neutral amino acids redundantly with Avt3/Avt4/Avt7 (russnak2001afamilyof pages 1-1, nakajo2026significanceofamino pages 1-7).</li>
+<li><strong>AVT7</strong>: Partially characterized; exports proline and glutamine from vacuoles, and may have bidirectional transport activity depending on metabolic conditions (bianchi2019regulationofamino pages 9-10, nishida2016vacuolaraminoacid pages 6-7).</li>
+</ul>
+<p>The family members share conserved structural features with approximately 9–11 predicted transmembrane domains, and transport activity for characterized members is driven by the proton electrochemical gradient maintained by the vacuolar H⁺-ATPase (V-ATPase) (russnak2001afamilyof pages 4-6, kawanokawada2018transportofamino pages 2-3).</p>
+<p>The following table summarizes the functional status of all AVT family members:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Systematic name</th>
+<th style="text-align: right;">Protein size (aa)</th>
+<th>Known substrates</th>
+<th>Transport direction</th>
+<th>Functional status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AVT1</td>
+<td>YJR001W</td>
+<td style="text-align: right;">602</td>
+<td>Gln, Asn, Ile, Leu, Tyr, His</td>
+<td>Import (cyt→vac)</td>
+<td>Characterized (russnak2001afamilyof pages 8-8, kawanokawada2018transportofamino pages 2-3, bianchi2019regulationofamino pages 9-10)</td>
+</tr>
+<tr>
+<td>AVT2</td>
+<td>YEL064C</td>
+<td style="text-align: right;">480</td>
+<td>Unknown</td>
+<td>Unknown</td>
+<td>Uncharacterized (russnak2001afamilyof pages 8-8, bianchi2019regulationofamino pages 9-10)</td>
+</tr>
+<tr>
+<td>AVT3</td>
+<td>YKL146W</td>
+<td style="text-align: right;">692</td>
+<td>Neutral amino acids: Gln, Asn, Ile, Leu, Tyr</td>
+<td>Export (vac→cyt)</td>
+<td>Characterized (russnak2001afamilyof pages 8-8, russnak2001afamilyof pages 1-1, bianchi2019regulationofamino pages 9-10)</td>
+</tr>
+<tr>
+<td>AVT4</td>
+<td>YNL101W</td>
+<td style="text-align: right;">713</td>
+<td>Neutral amino acids; also His, Lys, Arg</td>
+<td>Export (vac→cyt)</td>
+<td>Characterized (russnak2001afamilyof pages 8-8, kawanokawada2018transportofamino pages 2-3, bianchi2019regulationofamino pages 9-10)</td>
+</tr>
+<tr>
+<td>AVT5</td>
+<td>YBL089W</td>
+<td style="text-align: right;">509</td>
+<td>Unknown</td>
+<td>Unknown</td>
+<td>Uncharacterized (russnak2001afamilyof pages 8-8, bianchi2019regulationofamino pages 9-10)</td>
+</tr>
+<tr>
+<td>AVT6</td>
+<td>YER119C</td>
+<td style="text-align: right;">448</td>
+<td>Asp, Glu; recent evidence suggests additional neutral amino acids</td>
+<td>Export (vac→cyt)</td>
+<td>Characterized (russnak2001afamilyof pages 8-8, russnak2001afamilyof pages 1-1, nakajo2026significanceofamino pages 1-7)</td>
+</tr>
+<tr>
+<td>AVT7</td>
+<td>YIL088C</td>
+<td style="text-align: right;">490</td>
+<td>Pro, Gln</td>
+<td>Export / likely bidirectional depending on condition</td>
+<td>Partially characterized (bianchi2019regulationofamino pages 9-10, nishida2016vacuolaraminoacid pages 6-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the seven S. cerevisiae AVT-family transporters, including systematic identifiers, protein lengths, known substrates, transport direction, and degree of functional characterization. It is useful for placing AVT2 in family context and highlighting that AVT2 remains one of the least characterized members.</em></p>
+<h2 id="3-avt2-function-and-substrate-specificity">3. AVT2 Function and Substrate Specificity</h2>
+<p><strong>AVT2 remains one of the least characterized members of the AVT family.</strong> Despite extensive functional analysis using purified vacuolar membrane vesicles and radiolabeled amino acid transport assays, no vacuolar amino acid transport role has been assigned to AVT2 (russnak2001afamilyof pages 8-8). The substrates, direction of transport, and mechanism of action for AVT2 are all listed as "unknown" in the literature spanning from the original 2001 study through the most recent reviews (parzych2019vacuolarhydrolysisand pages 9-11, sekito2008novelfamiliesof pages 3-5, kawanokawada2018transportofamino pages 2-3, russnak2001afamilyof pages 8-8).</p>
+<p>Russnak et al. (2001) explicitly noted that they were unable to detect any amino acid transport function for AVT2 under their standard assay conditions, which tested a panel of neutral, acidic, and basic amino acids (russnak2001afamilyof pages 8-8). The authors suggested that AVT2 may transport other organic compounds or may require additional cofactors not included in standard experimental conditions (russnak2001afamilyof pages 8-8). A comprehensive review by Bianchi et al. (2019) confirmed that "no activity has been observed for two of the predicted family members, Avt2 and Avt5" (bianchi2019regulationofamino pages 9-10).</p>
+<p>Similarly, when Nishida et al. (2016) examined the effects of AVT gene deletions on proline distribution, single deletion of <em>AVT2</em> did not clearly alter the subcellular localization of proline (nishida2016vacuolaraminoacid pages 6-7). This contrasts with the clear effects of deleting <em>AVT1</em> (reduced vacuolar proline) or <em>AVT3</em> (increased vacuolar proline) (nishida2016vacuolaraminoacid pages 6-7).</p>
+<p>The key finding from the original characterization is summarized below:</p>
+<blockquote>
+<p>“In the original functional analysis of the <em>S. cerevisiae</em> AVT family, AVT2 (YEL064C) emerged as an outlier: sequence comparisons placed it closer to the mammalian system N transporter SN1/NAT1 than to the better-characterized yeast AVT uptake/export branches, yet no vacuolar amino acid transport activity could be assigned to AVT2 under the assay conditions used. AVT2-HA did not show the vacuolar staining pattern seen for AVT1, AVT4, or AVT6; instead, it produced punctate staining reminiscent of endoplasmic reticulum-resident proteins. The authors therefore concluded that AVT2 might function in a different cellular region, while also cautioning that the tagged protein could have been mislocalized; alternatively, AVT2 may transport other organic solutes or require additional cofactors absent from the standard transport assays.” (russnak2001afamilyof pages 8-8)</p>
+</blockquote>
+<p><em>Blockquote: This blockquote condenses the main conclusion about AVT2 from Russnak et al. 2001: despite family membership and homology to mammalian transporters, AVT2 remained functionally unassigned and showed uncertain, possibly ER-like localization.</em></p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>The subcellular localization of AVT2 is uncertain and may not be exclusively vacuolar. In indirect immunofluorescence experiments using HA-tagged AVT2, the staining pattern was "punctate staining reminiscent of proteins that reside in the endoplasmic reticulum," which was distinctly different from the vacuolar membrane staining observed for AVT1-HA, AVT4-HA, and AVT6-HA (all of which showed patterns indistinguishable from the vacuolar ATPase subunit VMA2) (russnak2001afamilyof pages 8-8). The authors cautioned that this localization pattern could potentially represent misfolded derivatized (HA-tagged) molecules retained in the ER, but the result raises the possibility that AVT2 may function at the ER or at other intracellular membranes rather than exclusively at the vacuole (russnak2001afamilyof pages 8-8).</p>
+<p>Notably, at the amino acid sequence level, Avt1 and Avt2 do not cluster with any of the other Avt members in phylogenetic analysis, suggesting a distinct evolutionary trajectory within the family (bianchi2019regulationofamino pages 9-10).</p>
+<h2 id="5-evolutionary-relationships-and-bioinformatic-inferences">5. Evolutionary Relationships and Bioinformatic Inferences</h2>
+<p>AVT2 is more closely related to the mammalian system N transporter SN1/NAT1 than to the other AVT family members (russnak2001afamilyof pages 8-8). SN1/NAT1 is a plasma membrane glutamine/histidine transporter that resides on mammalian cell surfaces and requires Na⁺ cotransport in addition to a pH gradient for function (russnak2001afamilyof pages 8-8). This homology to SN1/NAT1 provides a potential clue to AVT2's substrate specificity: it may preferentially transport glutamine and/or histidine, though this has not been experimentally confirmed.</p>
+<p>The broader AVT family belongs to the AAAP (amino acid/auxin permease) superfamily, which is phylogenetically related to the mammalian SLC32 family (VGAT/VIAAT vesicular GABA/glycine transporters), the SLC36 family (proton-coupled amino acid transporters, including LYAAT-1), and plant amino acid/auxin permeases (kawanokawada2018transportofamino pages 2-3, sekito2008novelfamiliesof pages 2-3, russnak2001afamilyof pages 1-3). The AVT proteins share varying degrees of sequence identity with each other: AVT5 and AVT6 share 52% identity, AVT3 and AVT4 share 38% identity, and AVT7 shares 35% identity with AVT5, while UNC-47 and VGAT share 35% identity (russnak2001afamilyof pages 1-3).</p>
+<h2 id="6-transcriptional-regulation">6. Transcriptional Regulation</h2>
+<p>Although AVT2 function is unknown, its transcription is regulated in a manner consistent with a role in amino acid homeostasis. Nishida et al. (2016) identified all seven <em>AVT</em> genes (including <em>AVT2</em>) as novel proline-responsive genes: mRNA levels of all <em>AVT</em> genes were significantly elevated 1–5 hours after the addition of exogenous proline, with increases ranging from 1.5-fold to 5-fold depending on the gene (nishida2016vacuolaraminoacid pages 3-6). The transcriptional changes of the <em>AVT</em> genes were significantly greater than those of all other genes tested (p &lt; 10⁻¹⁵) (nishida2016vacuolaraminoacid pages 3-6). This co-regulation with the other AVT family members supports the hypothesis that AVT2 participates in vacuolar amino acid homeostasis, even though its specific transport function remains undetectable under standard assay conditions.</p>
+<p>Notably, the <em>AVT</em> gene promoters do not contain typical Put3-recognition sites (the proline-dependent transcriptional activator), and the <em>cis</em> and <em>trans</em> elements responsible for proline-dependent induction of AVT genes remain to be identified (nishida2016vacuolaraminoacid pages 3-6). Additionally, AVT2 has been suggested as a candidate for transport of S-adenosylmethionine (AdoMet) across the vacuolar membrane, based on its potential for vacuolar amino acid-related transport (chan2003regulationofsadenosylmethionine pages 5-6), though this has not been experimentally validated.</p>
+<h2 id="7-relationship-to-autophagy-and-nitrogen-starvation">7. Relationship to Autophagy and Nitrogen Starvation</h2>
+<p>The vacuolar amino acid transport system in which AVT2 participates (by family membership) plays a critical role in autophagy-mediated amino acid recycling. During nitrogen starvation, autophagy delivers bulk cytoplasmic proteins to the vacuole for degradation, and the resulting amino acids must be exported back to the cytosol for reuse in protein synthesis and cell survival (yang2006atg22recyclesamino pages 1-2, yang2006atg22recyclesamino pages 6-7). The related transporter Atg22, together with Avt3 and Avt4, functions as partially redundant vacuolar amino acid effluxers that are essential for recycling leucine, isoleucine, and tyrosine from the vacuole during starvation (yang2006atg22recyclesamino pages 1-2, yang2006atg22recyclesamino pages 5-6).</p>
+<p>However, AVT2 is conspicuously absent from the functionally important transporters in this context. In the most recent study by Nakajo et al. (2026), which comprehensively examined vacuolar amino acid recycling using an <em>avt3Δ avt4Δ avt6Δ avt7Δ</em> quadruple mutant, AVT2 was not included among the vacuolar amino acid exporters (nakajo2026significanceofamino pages 1-7). This quadruple mutant showed reduced protein synthesis under nitrogen starvation and impaired sporulation, phenocopying autophagy-defective mutants (nakajo2026significanceofamino pages 1-7). The exclusion of AVT2 from this analysis underscores the current consensus that AVT2 does not have a detectable role in vacuolar amino acid efflux.</p>
+<h2 id="8-summary-and-current-status">8. Summary and Current Status</h2>
+<p>AVT2 (YEL064C) encodes a predicted membrane-spanning amino acid transporter of the AAAP superfamily in <em>S. cerevisiae</em>. Despite its classification as a "vacuolar amino acid transporter" based on family membership and domain architecture, AVT2 remains functionally uncharacterized after more than two decades of research on the AVT family. Key unresolved questions include:</p>
+<ol>
+<li><strong>Substrate identity</strong>: No amino acid or other organic solute has been identified as a substrate for AVT2 transport activity.</li>
+<li><strong>True subcellular localization</strong>: Preliminary immunofluorescence suggests ER-like rather than vacuolar localization, but this finding requires validation with additional approaches.</li>
+<li><strong>Transport direction</strong>: Whether AVT2 mediates import, export, or bidirectional transport is unknown.</li>
+<li><strong>Mechanism</strong>: Whether AVT2 functions as an H⁺/amino acid antiporter (like AVT1) or operates by another mechanism is undetermined.</li>
+</ol>
+<p>The closest mammalian homolog, SN1/NAT1 (a system N glutamine/histidine transporter), provides an evolutionary clue suggesting possible glutamine or histidine transport activity. AVT2 transcription is co-regulated with other AVT family members in response to proline, supporting a role in amino acid homeostasis. However, the protein may require specific cofactors, operate under specific physiological conditions, or transport non-amino acid organic solutes that have not been tested. Future studies employing reconstituted proteoliposome assays, broader substrate screening, or high-resolution localization approaches may be needed to finally assign a function to this enigmatic transporter.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(russnak2001afamilyof pages 8-8): Roland Russnak, David Konczal, and Steven L. McIntire. A family of yeast proteins mediating bidirectional vacuolar amino acid transport*. The Journal of Biological Chemistry, 276:23849-23857, Jun 2001. URL: https://doi.org/10.1074/jbc.m008028200, doi:10.1074/jbc.m008028200. This article has 223 citations.</p>
+</li>
+<li>
+<p>(kawanokawada2018transportofamino pages 2-3): Miyuki Kawano-Kawada, Yoshimi Kakinuma, and Takayuki Sekito. Transport of amino acids across the vacuolar membrane of yeast: its mechanism and physiological role. Biological &amp; pharmaceutical bulletin, 41 10:1496-1501, Oct 2018. URL: https://doi.org/10.1248/bpb.b18-00165, doi:10.1248/bpb.b18-00165. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(russnak2001afamilyof pages 1-1): Roland Russnak, David Konczal, and Steven L. McIntire. A family of yeast proteins mediating bidirectional vacuolar amino acid transport*. The Journal of Biological Chemistry, 276:23849-23857, Jun 2001. URL: https://doi.org/10.1074/jbc.m008028200, doi:10.1074/jbc.m008028200. This article has 223 citations.</p>
+</li>
+<li>
+<p>(russnak2001afamilyof pages 1-3): Roland Russnak, David Konczal, and Steven L. McIntire. A family of yeast proteins mediating bidirectional vacuolar amino acid transport*. The Journal of Biological Chemistry, 276:23849-23857, Jun 2001. URL: https://doi.org/10.1074/jbc.m008028200, doi:10.1074/jbc.m008028200. This article has 223 citations.</p>
+</li>
+<li>
+<p>(russnak2001afamilyof pages 4-6): Roland Russnak, David Konczal, and Steven L. McIntire. A family of yeast proteins mediating bidirectional vacuolar amino acid transport*. The Journal of Biological Chemistry, 276:23849-23857, Jun 2001. URL: https://doi.org/10.1074/jbc.m008028200, doi:10.1074/jbc.m008028200. This article has 223 citations.</p>
+</li>
+<li>
+<p>(nakajo2026significanceofamino pages 1-7): Haruto Nakajo, Takayuki Sekito, Ryogo Okamura, Shiori Nakagawa, Nodoka Hamada, Yusuke Yamamoto, Wakaba Yagi, Natsumi Ozaka, Takumi Kimura, Soshi Abe, Naoko Sugimoto, Koichi Akiyama, and Miyuki Kawano-Kawada. Significance of amino acid recycling from vacuoles for viability and sporulation of yeast cells under starvation conditions. Scientific Reports, Mar 2026. URL: https://doi.org/10.1038/s41598-026-42129-3, doi:10.1038/s41598-026-42129-3. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bianchi2019regulationofamino pages 9-10): Frans Bianchi, Joury S. van’t Klooster, Stephanie J. Ruiz, and Bert Poolman. Regulation of amino acid transport in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, Nov 2019. URL: https://doi.org/10.1128/mmbr.00024-19, doi:10.1128/mmbr.00024-19. This article has 171 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nishida2016vacuolaraminoacid pages 6-7): Ikuhisa Nishida, Daisuke Watanabe, Ariunzaya Tsolmonbaatar, Tomohiro Kaino, Iwao Ohtsu, and Hiroshi Takagi. Vacuolar amino acid transporters upregulated by exogenous proline and involved in cellular localization of proline in saccharomyces cerevisiae. The Journal of general and applied microbiology, 62 3:132-9, May 2016. URL: https://doi.org/10.2323/jgam.2016.01.005, doi:10.2323/jgam.2016.01.005. This article has 36 citations.</p>
+</li>
+<li>
+<p>(parzych2019vacuolarhydrolysisand pages 9-11): Katherine R. Parzych and Daniel J. Klionsky. Vacuolar hydrolysis and efflux: current knowledge and unanswered questions. Autophagy, 15:212-227, Nov 2019. URL: https://doi.org/10.1080/15548627.2018.1545821, doi:10.1080/15548627.2018.1545821. This article has 56 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sekito2008novelfamiliesof pages 3-5): Takayuki Sekito, Yuki Fujiki, Yoshinori Ohsumi, and Yoshimi Kakinuma. Novel families of vacuolar amino acid transporters. IUBMB Life, 60:519-525, Aug 2008. URL: https://doi.org/10.1002/iub.92, doi:10.1002/iub.92. This article has 74 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sekito2008novelfamiliesof pages 2-3): Takayuki Sekito, Yuki Fujiki, Yoshinori Ohsumi, and Yoshimi Kakinuma. Novel families of vacuolar amino acid transporters. IUBMB Life, 60:519-525, Aug 2008. URL: https://doi.org/10.1002/iub.92, doi:10.1002/iub.92. This article has 74 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nishida2016vacuolaraminoacid pages 3-6): Ikuhisa Nishida, Daisuke Watanabe, Ariunzaya Tsolmonbaatar, Tomohiro Kaino, Iwao Ohtsu, and Hiroshi Takagi. Vacuolar amino acid transporters upregulated by exogenous proline and involved in cellular localization of proline in saccharomyces cerevisiae. The Journal of general and applied microbiology, 62 3:132-9, May 2016. URL: https://doi.org/10.2323/jgam.2016.01.005, doi:10.2323/jgam.2016.01.005. This article has 36 citations.</p>
+</li>
+<li>
+<p>(chan2003regulationofsadenosylmethionine pages 5-6): Sherwin Y. Chan and Dean R. Appling. Regulation of s-adenosylmethionine levels in saccharomyces cerevisiae*. Journal of Biological Chemistry, 278:43051-43059, Oct 2003. URL: https://doi.org/10.1074/jbc.m308696200, doi:10.1074/jbc.m308696200. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2006atg22recyclesamino pages 1-2): Zhifen Yang, Ju Huang, Jiefei Geng, Usha Nair, and Daniel J. Klionsky. Atg22 recycles amino acids to link the degradative and recycling functions of autophagy. Molecular biology of the cell, 17 12:5094-104, Dec 2006. URL: https://doi.org/10.1091/mbc.e06-06-0479, doi:10.1091/mbc.e06-06-0479. This article has 403 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2006atg22recyclesamino pages 6-7): Zhifen Yang, Ju Huang, Jiefei Geng, Usha Nair, and Daniel J. Klionsky. Atg22 recycles amino acids to link the degradative and recycling functions of autophagy. Molecular biology of the cell, 17 12:5094-104, Dec 2006. URL: https://doi.org/10.1091/mbc.e06-06-0479, doi:10.1091/mbc.e06-06-0479. This article has 403 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2006atg22recyclesamino pages 5-6): Zhifen Yang, Ju Huang, Jiefei Geng, Usha Nair, and Daniel J. Klionsky. Atg22 recycles amino acids to link the degradative and recycling functions of autophagy. Molecular biology of the cell, 17 12:5094-104, Dec 2006. URL: https://doi.org/10.1091/mbc.e06-06-0479, doi:10.1091/mbc.e06-06-0479. This article has 403 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="AVT2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="AVT2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>russnak2001afamilyof pages 1-1</li>
+<li>russnak2001afamilyof pages 4-6</li>
+<li>russnak2001afamilyof pages 8-8</li>
+<li>bianchi2019regulationofamino pages 9-10</li>
+<li>nishida2016vacuolaraminoacid pages 6-7</li>
+<li>russnak2001afamilyof pages 1-3</li>
+<li>nishida2016vacuolaraminoacid pages 3-6</li>
+<li>chan2003regulationofsadenosylmethionine pages 5-6</li>
+<li>nakajo2026significanceofamino pages 1-7</li>
+<li>kawanokawada2018transportofamino pages 2-3</li>
+<li>parzych2019vacuolarhydrolysisand pages 9-11</li>
+<li>sekito2008novelfamiliesof pages 3-5</li>
+<li>sekito2008novelfamiliesof pages 2-3</li>
+<li>AAAP</li>
+<li>https://doi.org/10.1074/jbc.m008028200,</li>
+<li>https://doi.org/10.1248/bpb.b18-00165,</li>
+<li>https://doi.org/10.1038/s41598-026-42129-3,</li>
+<li>https://doi.org/10.1128/mmbr.00024-19,</li>
+<li>https://doi.org/10.2323/jgam.2016.01.005,</li>
+<li>https://doi.org/10.1080/15548627.2018.1545821,</li>
+<li>https://doi.org/10.1002/iub.92,</li>
+<li>https://doi.org/10.1074/jbc.m308696200,</li>
+<li>https://doi.org/10.1091/mbc.e06-06-0479,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AVT2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P39981" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="avt2-yel064c-p39981-review-notes">AVT2 (YEL064C / P39981) review notes</h1>
+<p>Journal of the AI GO-annotation review for <em>S. cerevisiae</em> AVT2. Provenance is recorded inline<br />
+as <code>[PMID:xxxxx "verbatim text"]</code> or <code>[SGD/UniProt ...]</code>.</p>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li>UniProt: <strong>P39981</strong> = <code>AVT2_YEAST</code>; systematic name <strong>YEL064C</strong>; SGD:S000000790.<br />
+  480 aa, 53.3 kDa. [UniProt P39981 record; SGD locus S000000790]</li>
+<li>Standard name <strong>AVT2</strong> = "Amino acid Vacuolar Transport 2". Protein name in UniProt:<br />
+  "Vacuolar amino acid transporter 2".</li>
+<li>Family (multiple concordant sources):</li>
+<li>UniProt SIMILARITY: "Belongs to the amino acid/polyamine transporter 2 family." (ECO:0000305)</li>
+<li>TCDB <strong>2.A.18.6.20</strong> = the Amino Acid/Auxin Permease (<strong>AAAP</strong>) family.</li>
+<li>Pfam <strong>PF01490</strong> (Aa_trans); InterPro <strong>IPR013057</strong> (Amino acid transporter, transmembrane domain).</li>
+<li>PANTHER <strong>PTHR22950</strong> "AMINO ACID TRANSPORTER", subfamily <strong>PTHR22950:SF458</strong><br />
+    "SODIUM-COUPLED NEUTRAL AMINO ACID TRANSPORTER 11-RELATED" (i.e. SLC38/SNAT-like clan).</li>
+<li>eggNOG KOG1305; OrthoDB 28208at2759.<br />
+  This is the SLC32/SLC36/SLC38 ("amino acid/auxin permease", AAAP) superfamily — the same<br />
+  clan Russnak et al. described as "related to the neuronal GABA-glycine vesicular transporters"<br />
+  (the vesicular inhibitory amino acid transporter VGAT/SLC32 is in this clan).</li>
+<li><strong>9 predicted TM helices</strong> (UniProt FT TRANSMEM, ECO:0000255): 72-92, 95-115, 145-165,<br />
+  214-234, 263-283, 297-317, 338-358, 394-414, 447-467. N-terminal ~48 aa disordered/cytoplasmic<br />
+  (REGION 21-48 Disordered, polar-residue biased). So a bona fide polytopic integral membrane<br />
+  transporter fold.</li>
+</ul>
+<p>NOTE on the "PQ-loop" descriptor in the task brief: the actual UniProt/InterPro/Pfam evidence<br />
+assigns AVT2 to the <strong>Aa_trans (PF01490 / AAAP / SLC38-SNAT-like)</strong> clan, NOT the PQ-loop<br />
+(SLC36-PAT/LamB / cystinosin, PF04193) family. I ground the review on the AAAP/Aa_trans<br />
+assignment that is actually in the record.</p>
+<h2 id="the-avt-family-avt1-7-what-is-known-and-what-is-avt2-specific">The AVT family (AVT1-7) — what is known, and what is AVT2-specific</h2>
+<p>The founding paper is Russnak, Konczal &amp; McIntire 2001, J Biol Chem<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11274162" title="A family of yeast proteins mediating bidirectional vacuolar amino acid transport">PMID:11274162</a>.<br />
+<code>full_text_available: false</code> in our cache — <strong>abstract only</strong>. Abstract states:</p>
+<ul>
+<li>"Seven genes in Saccharomyces cerevisiae are predicted to code for membrane-spanning proteins<br />
+  (designated AVT1-7) that are related to the neuronal gamma-aminobutyric acid-glycine vesicular<br />
+  transporters." <a href="https://pubmed.ncbi.nlm.nih.gov/11274162">PMID:11274162</a></li>
+<li>"We have now demonstrated that <strong>four</strong> of these proteins mediate amino acid transport in<br />
+  vacuoles." <a href="https://pubmed.ncbi.nlm.nih.gov/11274162">PMID:11274162</a></li>
+<li>The four with demonstrated activity are named explicitly:</li>
+<li><strong>AVT1</strong> — vacuolar <strong>uptake</strong> of large neutral amino acids (Tyr, Gln, Asn, Ile, Leu);<br />
+    ATP-dependent, abolished by nigericin (pH-gradient driven). <a href="https://pubmed.ncbi.nlm.nih.gov/11274162">PMID:11274162</a></li>
+<li><strong>AVT3, AVT4</strong> — <strong>efflux</strong> of Tyr/large neutral amino acids from the vacuole (system-h-like).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11274162">PMID:11274162</a></li>
+<li><strong>AVT6</strong> — <strong>efflux</strong> of aspartate and glutamate; ATP-dependent, nigericin-sensitive.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11274162">PMID:11274162</a></li>
+<li><strong>AVT2, AVT5, AVT7 are NOT among the four</strong> with demonstrated transport in that paper — i.e.<br />
+  no substrate or direction was demonstrated for AVT2. This is the AVT2-specific gap.</li>
+</ul>
+<p>Secondary literature confirms AVT2 remained functionally uncharacterized:<br />
+- Regulation-of-amino-acid-transport review (Bianchi/Van Belle/... 2019, MMBR) and other<br />
+  reviews describe AVT2/AVT5 as members with <strong>no observed transport activity</strong>. (WebSearch of<br />
+  the MMBR review text: "No activity has been observed for two of the predicted family members,<br />
+  Avt2 and Avt5.") — I did not cite this verbatim in the YAML because I could not fetch the full<br />
+  MMBR text into the publications cache; recorded here as background only.</p>
+<h2 id="go-annotations-in-goa-9-total-from-avt2-goatsv-quickgo">GO annotations in GOA (9 total; from AVT2-goa.tsv / QuickGO)</h2>
+<p>MF:<br />
+- GO:0003674 molecular_function — <strong>ND</strong>, GO_REF:0000015 (SGD root placeholder)<br />
+- GO:0015179 L-amino acid transmembrane transporter activity — <strong>IBA</strong>, GO_REF:0000033<br />
+BP:<br />
+- GO:0003333 amino acid transmembrane transport — <strong>IBA</strong>, GO_REF:0000033<br />
+- GO:1902475 L-alpha-amino acid transmembrane transport — <strong>IEA</strong>, GO_REF:0000108 (inferred from<br />
+  the GO:0015179 MF via inter-ontology "logical inference" link)<br />
+- GO:0008150 biological_process — <strong>ND</strong>, GO_REF:0000015 (SGD root placeholder)<br />
+CC:<br />
+- GO:0005783 endoplasmic reticulum — <strong>IDA</strong>, <strong>PMID:11274162</strong> (SGD; direct assay)<br />
+- GO:0005783 endoplasmic reticulum — <strong>IBA</strong>, GO_REF:0000033 (GO_Central phylogenetic)<br />
+- GO:0016020 membrane — <strong>IBA</strong>, GO_REF:0000033<br />
+- GO:0005774 vacuolar membrane — <strong>IEA</strong>, GO_REF:0000044 (UniProtKB SubCell SL-0271)</p>
+<h3 id="localization-er-idasgd-vs-vacuole-membrane-uniprot-subcell-family-expectation">Localization: ER (IDA/SGD) vs vacuole membrane (UniProt SubCell / family expectation)</h3>
+<p>There is a genuine, notable discrepancy:<br />
+- <strong>SGD IDA (GO:0005783 ER)</strong> from PMID:11274162 — direct-assay localization to the ER.<br />
+  The abstract is about <em>vacuolar</em> transport of the family, but the SGD curator read the full<br />
+  text and assigned AVT2 specifically to the ER. Per project rules I do NOT overrule an<br />
+  experimental (IDA) curator call from the abstract-only cache → ACCEPT.<br />
+- <strong>UniProt SubCell (GO:0005774 vacuole membrane, IEA)</strong> — SL-0271, cites the same PMID:11274162<br />
+  as the source of "Vacuole membrane; Multi-pass membrane protein". So UniProt and SGD read the<br />
+  same paper differently (family-expected vacuole vs. observed ER). AVT family members are<br />
+  canonically tonoplast/vacuolar; AVT2 may localize to the ER (possibly ER-retained /<br />
+  not trafficked to the vacuole), which is itself a hint that AVT2 is atypical. This is a real<br />
+  knowledge gap (where does AVT2 actually act?).</p>
+<h2 id="domain-based-reasoning-for-the-molecular-function">Domain-based reasoning for the molecular function</h2>
+<ul>
+<li>The Aa_trans (PF01490 / AAAP / SLC38-SNAT-like) fold with 9 TM helices strongly supports a<br />
+<strong>generic amino acid transmembrane transporter</strong> activity — this is domain-defensible.</li>
+<li>BUT no substrate and no direction (uptake vs efflux, and driving force) has been demonstrated<br />
+  for AVT2 specifically. Its paralogs split into uptake (AVT1) and efflux (AVT3/4/6) with<br />
+  different substrate classes, so paralogy does <strong>not</strong> pin AVT2's substrate/direction.</li>
+<li>Therefore: keep MF at the generic amino-acid-transporter level (GO:0015179 L-amino acid<br />
+  transmembrane transporter activity is a reasonable IBA-supported generic MF; a <em>specific</em><br />
+  substrate/direction would be over-annotation).</li>
+</ul>
+<h2 id="review-decisions-summary">Review decisions (summary)</h2>
+<ul>
+<li>GO:0015179 L-amino acid transmembrane transporter activity (IBA) — <strong>ACCEPT</strong> as the<br />
+  defensible generic MF (family fold; substrate unknown → do not specialize).</li>
+<li>GO:0003333 amino acid transmembrane transport (IBA) — <strong>ACCEPT</strong> generic BP.</li>
+<li>GO:1902475 L-alpha-amino acid transmembrane transport (IEA, inter-ontology) — <strong>ACCEPT</strong><br />
+  (consistent, generic; auto-derived from the MF).</li>
+<li>GO:0005783 ER (IDA, PMID:11274162) — <strong>ACCEPT</strong> (direct experimental localization; core CC).</li>
+<li>GO:0005783 ER (IBA) — <strong>KEEP_AS_NON_CORE</strong> (phylogenetic duplicate of the IDA; the IDA is the<br />
+  authoritative one).</li>
+<li>GO:0016020 membrane (IBA) — <strong>ACCEPT</strong> (correct, generic; it is an integral membrane protein).</li>
+<li>GO:0005774 vacuolar membrane (IEA, SubCell) — <strong>KEEP_AS_NON_CORE</strong> (family-expected/UniProt<br />
+  location; conflicts with the ER IDA, so retained as plausible-but-not-core rather than removed —<br />
+  cannot overrule either the SubCell mapping or note the unresolved ER-vs-vacuole question).</li>
+<li>GO:0003674 molecular_function (ND) — <strong>REMOVE</strong> (root placeholder, now superseded by GO:0015179).</li>
+<li>GO:0008150 biological_process (ND) — <strong>REMOVE</strong> (root placeholder, superseded by GO:0003333).</li>
+</ul>
+<h2 id="knowledge-gaps-primary-deliverable-this-is-a-dark-gene">Knowledge gaps (primary deliverable — this is a dark gene)</h2>
+<ol>
+<li><strong>Transported substrate + direction unknown</strong> for AVT2. Family fold ⇒ amino acid transporter,<br />
+   but no substrate/direction/driving-force demonstrated (unlike AVT1 uptake; AVT3/4/6 efflux).</li>
+<li><strong>In-vivo localization unresolved</strong>: IDA places it in the ER, but UniProt/family expectation is<br />
+   the vacuole membrane — is AVT2 an ER-resident, an ER-retained mis-folded/unassembled member, or<br />
+   a vacuolar transporter caught in transit?</li>
+<li><strong>Physiological role / redundancy</strong> with the AVT family: no dedicated phenotype; deletion is<br />
+   viable. Is AVT2 redundant with AVT1/3/4/5/6/7 or specialized/silent?</li>
+<li>No demonstrated activity in the one biochemical survey that assayed the whole family<br />
+   (only 4/7 members scored positive; AVT2 was among the 3 negatives).<br />
+</content><br />
+</invoke></li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P39981
+gene_symbol: AVT2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  AVT2 (YEL064C) is a 480-residue polytopic integral membrane protein of budding yeast, one of
+  seven paralogous AVT proteins (AVT1-7) belonging to the amino acid/auxin permease (AAAP)
+  superfamily (TCDB 2.A.18; Pfam Aa_trans PF01490; InterPro IPR013057; PANTHER PTHR22950), the
+  same solute-carrier clan (SLC32/SLC36/SLC38-like) as the neuronal vesicular GABA/glycine
+  transporters. It has nine predicted transmembrane helices and a disordered cytoplasmic
+  N-terminus, and its fold is that of an amino acid transmembrane transporter. Unlike several of
+  its paralogs, AVT2 has no experimentally demonstrated transported substrate, transport
+  direction, or driving force: in the founding biochemical survey of the family, transport
+  activity was demonstrated for AVT1 (vacuolar uptake of large neutral amino acids) and for
+  AVT3, AVT4 and AVT6 (vacuolar amino acid efflux), whereas AVT2 was not among the members with
+  measurable activity. AVT2 has been directly localized to the endoplasmic reticulum, while the
+  vacuolar-membrane localization typical of the family is inferred rather than directly shown for
+  this paralog. Its physiological role remains undetermined and its null mutant is viable.
+existing_annotations:
+- term:
+    id: GO:0015179
+    label: L-amino acid transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic amino-acid transmembrane transporter molecular function assigned by phylogenetic
+      (IBA) inference across the AAAP/AVT tree. This is the most specific molecular function that
+      can be defended for AVT2: the Aa_trans (PF01490 / AAAP; PANTHER PTHR22950) fold with nine
+      predicted TM helices supports amino-acid transporter activity, but AVT2 has no demonstrated
+      substrate and no demonstrated transport direction, so it must stay at this generic level.
+      A more specific term (particular substrate, or uptake vs. efflux) is not supported: the
+      paralogs split between uptake (AVT1) and efflux (AVT3/AVT4/AVT6) of different amino-acid
+      classes, so paralogy does not pin AVT2&#39;s specificity.
+    action: ACCEPT
+    reason: &gt;-
+      The AAAP/Aa_trans transporter fold justifies a generic amino-acid transmembrane
+      transporter molecular function; no substrate or direction is assignable for AVT2 (it was
+      among the AVT members with no demonstrated transport activity), so the annotation should
+      remain generic and must not be specialized.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        Seven genes in Saccharomyces cerevisiae are predicted to code for
+        membrane-spanning proteins (designated AVT1-7) that are related to the neuronal
+        gamma-aminobutyric acid-glycine vesicular transporters.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0003333
+    label: amino acid transmembrane transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Generic amino-acid transmembrane transport biological process, assigned by phylogenetic
+      inference and consistent with the transporter fold and the demonstrated function of the
+      AVT family. The specific amino-acid substrate and the direction of transport for AVT2 are
+      unknown, so the annotation is kept at this generic BP level rather than specialized to a
+      particular vacuolar uptake or efflux process.
+    action: ACCEPT
+    reason: &gt;-
+      A generic amino-acid transmembrane transport process is the appropriate biological-process
+      annotation for a member of a demonstrated amino-acid transporter family whose own substrate
+      and direction are undetermined; specializing it would over-annotate.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        We have now demonstrated
+        that four of these proteins mediate amino acid transport in vacuoles.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:1902475
+    label: L-alpha-amino acid transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Amino-acid transmembrane transport biological process reached automatically by
+      inter-ontology (logical) inference from the GO:0015179 L-amino acid transmembrane
+      transporter molecular function. It is consistent with the IBA-supported generic transport
+      process above and with the transporter fold; the specific substrate and direction remain
+      unknown, so it is retained at this generic level.
+    action: ACCEPT
+    reason: &gt;-
+      Auto-derived, internally consistent generic amino-acid transport process; correct at this
+      generality for a fold-confirmed amino-acid transporter of undetermined specificity.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        This function is consistent
+        with the role of the vacuole in protein degradation, whereby accumulated amino
+        acids are exported to the cytosol.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: PMID:11274162
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct-assay (IDA) localization of AVT2 to the endoplasmic reticulum, curated by SGD from
+      the founding AVT-family paper. This is the only experimentally determined localization for
+      AVT2 specifically and is accepted as the authoritative cellular-component call. It is
+      notable that this differs from the vacuole-membrane localization typical of the family and
+      inferred by UniProt from the same paper (see the vacuolar membrane annotation), leaving the
+      in-vivo site of action of AVT2 an open question.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental (IDA) localization curated from the primary paper; per curation guidance a
+      direct-assay curator call is not overruled from an abstract-only cache. This is the core,
+      directly demonstrated localization for AVT2.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        A family of yeast proteins mediating bidirectional vacuolar amino acid
+        transport.
+      reference_section_type: TITLE
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) endoplasmic-reticulum localization. It agrees with, and independently
+      corroborates, the same ER compartment established for AVT2 by direct assay (the IDA
+      annotation from PMID:11274162). Accepted as consistent with the experimentally determined
+      localization; the IDA remains the primary, directly grounded evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Points to the same ER compartment that is experimentally demonstrated for AVT2 by direct
+      assay (IDA, PMID:11274162); the phylogenetic call is concordant with that evidence and is
+      accepted as corroborating rather than contradicting it.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        A family of yeast proteins mediating bidirectional vacuolar amino acid
+        transport.
+      reference_section_type: TITLE
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Broad membrane localization from phylogenetic inference. Correct and consistent with the
+      experimentally supported multi-pass topology (nine predicted TM helices); retained as a
+      general, non-core localization statement, since the more informative compartment identity
+      (ER by IDA, vacuole membrane by UniProt) is captured by the specific annotations.
+    action: ACCEPT
+    reason: &gt;-
+      AVT2 is unambiguously an integral multi-pass membrane protein, so the generic membrane term
+      is directly supported and correct; it is broad but accurate for a polytopic transporter.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        Seven genes in Saccharomyces cerevisiae are predicted to code for
+        membrane-spanning proteins (designated AVT1-7)
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005774
+    label: vacuolar membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Vacuolar-membrane localization from the UniProt Subcellular Location mapping (SL-0271). In
+      the UniProt record this location is attributed to the same primary paper (PubMed:11274162)
+      as the AVT2-specific ER localization curated by SGD, so the two databases interpret the same
+      study differently: the family is canonically tonoplast/vacuolar, but AVT2 was directly
+      observed in the ER. This annotation is retained as a plausible, family-consistent location
+      but is not treated as an established core fact, because it conflicts with the direct-assay
+      ER localization. Whether AVT2 acts at the vacuole membrane, is ER-resident, or is a vacuolar
+      transporter caught in the secretory pathway is an open question.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Family-expected/UniProt-mapped location that conflicts with the AVT2-specific ER IDA;
+      retained as plausible but non-core rather than removed, since the underlying subcellular
+      location mapping is not overruled and the ER-vs-vacuole question is genuinely unresolved.
+    supported_by:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        A family of yeast proteins mediating bidirectional vacuolar amino acid
+        transport.
+      reference_section_type: TITLE
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function placeholder (No Data) assigned by SGD. It is superseded by the
+      generic but informative L-amino acid transmembrane transporter activity (GO:0015179)
+      annotation already present from the IBA route, so the uninformative root term should be
+      removed.
+    action: REMOVE
+    reason: &gt;-
+      ND root-term placeholder that is now redundant: the molecular-function aspect is already
+      covered, more informatively, by the GO:0015179 transporter activity annotation.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process placeholder (No Data) assigned by SGD. It is superseded by the
+      generic amino-acid transmembrane transport (GO:0003333) biological-process annotation
+      already present, so the uninformative root term should be removed.
+    action: REMOVE
+    reason: &gt;-
+      ND root-term placeholder that is now redundant: the biological-process aspect is already
+      covered by the GO:0003333 amino acid transmembrane transport annotation.
+core_functions:
+- description: &gt;-
+    AVT2 is a nine-transmembrane-helix integral membrane protein of the amino acid/auxin permease
+    (AAAP; Aa_trans PF01490 / InterPro IPR013057 / PANTHER PTHR22950) superfamily and one of the
+    seven yeast AVT paralogs related to the vesicular GABA/glycine transporters. Its fold supports
+    a generic amino-acid transmembrane transporter activity, but no substrate, no transport
+    direction, and no driving force have been demonstrated for AVT2: in the biochemical survey
+    that established the family&#39;s function, activity was shown for AVT1 (uptake) and AVT3/AVT4/AVT6
+    (efflux) but not for AVT2. It has been directly localized to the endoplasmic reticulum.
+  molecular_function:
+    id: GO:0015179
+    label: L-amino acid transmembrane transporter activity
+  locations:
+  - id: GO:0005783
+    label: endoplasmic reticulum
+  supported_by:
+  - reference_id: PMID:11274162
+    supporting_text: &gt;-
+      Seven genes in Saccharomyces cerevisiae are predicted to code for
+      membrane-spanning proteins (designated AVT1-7) that are related to the neuronal
+      gamma-aminobutyric acid-glycine vesicular transporters.
+    reference_section_type: ABSTRACT
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The transported substrate, transport direction (vacuolar uptake vs. efflux), and driving
+      force of AVT2 are unknown, so no molecular function more specific than the generic
+      &#34;L-amino acid transmembrane transporter activity&#34; can be assigned. In the founding
+      biochemical survey of the family, AVT2 was not among the members (AVT1, AVT3, AVT4, AVT6)
+      for which transport activity was demonstrated.
+    boundary: &gt;-
+      AVT2 is a confirmed polytopic AAAP/Aa_trans amino-acid-transporter-fold protein (nine
+      predicted TM helices) and a paralog of transporters with demonstrated, but divergent,
+      specificities (AVT1 imports large neutral amino acids; AVT6 exports Asp/Glu; AVT3/AVT4
+      export large neutral amino acids), so a substrate cannot be inferred from paralogy.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Without a substrate and direction, AVT2 cannot be placed in a specific transport pathway
+      and its molecular function stays at an uninformative generic level; identifying its cargo
+      is the rate-limiting step for annotating this dark AVT-family transporter.
+    resolution: &gt;-
+      Substrate- and direction-resolved transport assays of AVT2 in isolated vacuoles/vesicles or
+      a heterologous system (as was done for AVT1/AVT3/AVT4/AVT6), plus metabolomic profiling of
+      avt2 loss- and gain-of-function strains.
+    provenance:
+    - reference_id: PMID:11274162
+      supporting_text: &gt;-
+        We have now demonstrated
+        that four of these proteins mediate amino acid transport in vacuoles.
+      reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The physiological substrate, transport direction, driving force, and biological role of AVT2
+    are all undetermined. It is one of the functionally dark members of the yeast AVT family: a
+    bona fide amino-acid-transporter-fold protein with no demonstrated cargo, no assigned
+    transport direction, and no dedicated loss-of-function phenotype (the null is viable).
+  boundary: &gt;-
+    What is established: AVT2 is a nine-TM AAAP/Aa_trans (PF01490) amino-acid-transporter-fold
+    protein, a paralog of the demonstrated vacuolar amino-acid transporters AVT1/AVT3/AVT4/AVT6.
+    What is excluded/unknown: in the family&#39;s founding biochemical survey only four of the seven
+    AVT proteins (AVT1, AVT3, AVT4, AVT6) had measurable transport activity, and AVT2 was not
+    among them, so no substrate or direction is established for AVT2. The paralogs are functionally
+    split between uptake and efflux of different amino-acid classes, so paralogy does not resolve
+    AVT2&#39;s function.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    AVT2 is a conserved AVT-family transporter that has remained functionally unassigned since the
+    family was described; closing this gap would remove a dark node from yeast vacuolar/amino-acid
+    transport biology and clarify whether the AVT paralogs are redundant or specialized.
+  resolution: &gt;-
+    Direct transport assays (substrate screens and uptake/efflux/driving-force measurements) of
+    AVT2 in isolated vacuoles or a heterologous expression system; comparative metabolomics and
+    combinatorial avt deletions (with and without AVT1/AVT3/AVT4/AVT5/AVT6/AVT7) to resolve
+    redundancy and any AVT2-specific phenotype.
+  provenance:
+  - reference_id: PMID:11274162
+    supporting_text: &gt;-
+      We have now demonstrated
+      that four of these proteins mediate amino acid transport in vacuoles.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:11274162
+    supporting_text: &gt;-
+      One
+      protein, AVT1, is required for the vacuolar uptake of large neutral amino acids
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The in-vivo compartment where AVT2 acts is unresolved. AVT2 has been directly localized to the
+    endoplasmic reticulum, yet the family is canonically vacuolar (tonoplast) and UniProt maps
+    AVT2 to the vacuole membrane. It is unknown whether AVT2 is a genuine ER-resident transporter,
+    an ER-retained (e.g. unassembled/regulated) family member, or a vacuolar transporter observed
+    in the secretory pathway.
+  boundary: &gt;-
+    Established: an experimental (IDA) localization of AVT2 to the endoplasmic reticulum, and a
+    UniProt Subcellular Location mapping to the vacuole membrane; both are attributed to the same
+    primary study. Unknown: which localization reflects AVT2&#39;s site of function, and whether its
+    localization is conditional or regulated.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    The compartment where a transporter resides constrains its possible substrates and biological
+    role; the ER-versus-vacuole ambiguity is a barrier to interpreting AVT2&#39;s function and to
+    deciding whether the family-level vacuolar-transport annotations apply to this paralog.
+  resolution: &gt;-
+    High-resolution live-cell imaging of endogenously tagged AVT2 with ER and vacuole-membrane
+    markers under multiple growth conditions; subcellular fractionation and, if warranted,
+    mutational analysis of putative ER-retention/trafficking signals.
+  provenance:
+  - reference_id: PMID:11274162
+    supporting_text: &gt;-
+      A family of yeast proteins mediating bidirectional vacuolar amino acid
+      transport.
+    reference_section_type: TITLE
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What amino acid(s) does AVT2 transport, and in which direction (vacuolar uptake or efflux),
+    given that it was inactive in the assay that characterized AVT1/AVT3/AVT4/AVT6?
+- question: &gt;-
+    Does AVT2 function at the endoplasmic reticulum (where it was directly localized) or at the
+    vacuole membrane (as expected for the family and mapped by UniProt), and is its localization
+    conditional?
+- question: &gt;-
+    Are the seven AVT paralogs functionally redundant, and does AVT2 have any dedicated
+    phenotype under conditions (e.g. nitrogen starvation, autophagy) that stress vacuolar
+    amino-acid flux?
+suggested_experiments:
+- description: &gt;-
+    Perform substrate- and direction-resolved transport assays of AVT2 (uptake and efflux, with
+    and without a proton gradient/ATP) in isolated vacuoles/vesicles or a heterologous system,
+    mirroring the assays used to characterize AVT1/AVT3/AVT4/AVT6.
+  hypothesis: &gt;-
+    AVT2 transports a specific amino acid or amino-acid class in a defined direction; its previous
+    apparent inactivity reflects assay conditions (e.g. wrong substrate, mislocalization, or a
+    requirement for a partner/condition) rather than a genuine lack of transport capability.
+- description: &gt;-
+    Determine the subcellular localization of endogenously tagged AVT2 by high-resolution imaging
+    and fractionation, co-stained with ER and vacuole-membrane markers, across growth conditions.
+  hypothesis: &gt;-
+    AVT2 localizes at least partly to the ER rather than exclusively to the vacuole membrane, and
+    its distribution changes with growth/nutrient condition.
+- description: &gt;-
+    Construct combinatorial avt single and multiple deletions (including avt2) and phenotype them
+    for vacuolar amino-acid pools and growth under nitrogen limitation, autophagy induction, and
+    diverse amino-acid conditions.
+  hypothesis: &gt;-
+    AVT2 is partially redundant with other AVT paralogs and contributes to vacuolar amino-acid
+    homeostasis only in combination with, or under conditions that stress, the rest of the family.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: PMID:11274162
+  title: A family of yeast proteins mediating bidirectional vacuolar amino acid transport.
+  findings:
+  - statement: &gt;-
+      Seven S. cerevisiae genes (AVT1-7) encode membrane-spanning proteins related to the
+      neuronal GABA-glycine vesicular transporters; four (AVT1, AVT3, AVT4, AVT6) were
+      demonstrated to mediate vacuolar amino acid transport (AVT1 imports large neutral amino
+      acids; AVT3/AVT4 export large neutral amino acids; AVT6 exports Asp/Glu). AVT2 was not among
+      the members with demonstrated activity. AVT2 is directly localized (by SGD IDA from this
+      paper) to the endoplasmic reticulum, whereas UniProt maps it (from the same paper) to the
+      vacuole membrane.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Russnak, Konczal &amp; McIntire 2001, J Biol Chem 276:23849-57). This is the
+      founding paper for the AVT family and the source of both the AVT2 ER localization (SGD IDA)
+      and the UniProt vacuole-membrane call. Cache is abstract-only (full_text_available: false);
+      every supporting_text quote used is a verbatim substring of the cached title/abstract. The
+      load-bearing negative point for AVT2 is that only four of seven AVT proteins had
+      demonstrated activity and AVT2 is not named among them.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/BIT2/BIT2-ai-review.html
+++ b/genes/yeast/BIT2/BIT2-ai-review.html
@@ -1,0 +1,2476 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BIT2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>BIT2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P38346" target="_blank" class="term-link">
+                        P38346
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "BIT2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P38346" data-a="DESCRIPTION: BIT2 (systematic name YBR270C) is an accessory sub..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>BIT2 (systematic name YBR270C) is an accessory subunit of TOR complex 2 (TORC2), the rapamycin-insensitive TOR-kinase complex of budding yeast. TORC2 is built around the Tor2 Ser/Thr protein kinase together with Lst8, Avo1, Avo2, Avo3/Tsc11, and one of the two paralogous accessory subunits Bit61 or Bit2, and it signals to the AGC-family kinases Ypk1/Ypk2 to control plasma-membrane homeostasis, sphingolipid metabolism, and actin cytoskeleton organization during polarized growth. BIT2 belongs to the Bit61/PRR5 family (Pfam HbrB), whose members are the fungal Bit61/Bit2 and the metazoan PRR5/PRR5L (Protor-1/Protor-2) accessory subunits of TORC2/mTORC2; these proteins have no known catalytic activity and act as regulatory/scaffolding subunits. BIT2 physically associates with the TORC2 subunit Tsc11 and with the TORC2 downstream effectors Slm1 and Slm2. It arose from the whole-genome duplication as the paralog of BIT61, with which it is largely interchangeable within TORC2; bit2 null mutants are viable, consistent with functional redundancy between the two paralogs. The specific, BIT2-distinct molecular contribution to TORC2 has not been experimentally defined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007163" target="_blank" class="term-link">
+                                    GO:0007163
+                                </a>
+                            </span>
+                            <span class="term-label">establishment or maintenance of cell polarity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0007163" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) participation in establishment/maintenance of cell polarity. TORC2 signaling, via Slm1/Slm2 and the Ypk1/Ypk2 kinases, does regulate the actin cytoskeleton and polarized growth, so a family-level link to cell polarity is biologically reasonable. However, this is a downstream, process-level inference and there is no BIT2-specific experimental evidence for a direct role in cell polarity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as a plausible IBA process annotation propagated across the Bit61/PRR5 family, but treat it as non-core: it reflects the broad downstream output of TORC2 signaling rather than a demonstrated, BIT2-specific function. The core, better-supported process annotation for BIT2 is TORC2 signaling (GO:0038203).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019887" target="_blank" class="term-link">
+                                    GO:0019887
+                                </a>
+                            </span>
+                            <span class="term-label">protein kinase regulator activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0019887" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) molecular function. As an accessory subunit of the Tor2-kinase-containing TORC2, BIT2 plausibly contributes to modulating the complex&#39;s protein-kinase activity, and this is the least uninformative molecular-function term available for the family. However, there is no experimental demonstration that BIT2 itself enables (independently has) protein kinase regulator activity; the Bit61/PRR5 (HbrB) domain has no catalytic motifs and the paralog family members are non-catalytic accessory subunits.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Keep as an IBA family molecular-function annotation but mark non-core: BIT2 does not independently &#34;enable&#34; kinase regulation; any such activity is a property it contributes to as part of TORC2. This is captured more accurately in core_functions as contributes_to_molecular_function (protein kinase regulator activity) alongside TORC2 membership. This annotation is the locus of the gene&#39;s molecular-function knowledge gap (see knowledge_gaps).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031932" target="_blank" class="term-link">
+                                    GO:0031932
+                                </a>
+                            </span>
+                            <span class="term-label">TORC2 complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0031932" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) membership of the TORC2 complex, consistent with the whole Bit61/Bit2/PRR5/Protor family being TORC2/mTORC2 accessory subunits. This is corroborated by the experimental IDA row (below) and by the TORC2 subunit inventory in the cryo-EM literature.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TORC2 complex membership is the best-supported, core annotation for BIT2, supported by both phylogenetic inference and direct experimental data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29170376" target="_blank" class="term-link">
+                                        PMID:29170376
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038203" target="_blank" class="term-link">
+                                    GO:0038203
+                                </a>
+                            </span>
+                            <span class="term-label">TORC2 signaling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0038203" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) participation in TORC2 signaling, following directly from TORC2 complex membership. TORC2 signaling to the Ypk1/Ypk2 AGC kinases and the Slm1/Slm2 effectors is the pathway in which BIT2 acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological-process annotation for BIT2: as a TORC2 subunit it is involved in TORC2 signaling. Well-supported both phylogenetically and by the experimental IC row.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031932" target="_blank" class="term-link">
+                                    GO:0031932
+                                </a>
+                            </span>
+                            <span class="term-label">TORC2 complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15689497" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15689497
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The pleckstrin homology domain proteins Slm1 and Slm2 are re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0031932" data-r="PMID:15689497" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) evidence, assigned by SGD, for BIT2 as part of the TORC2 complex. The cached copy of PMID:15689497 is abstract-only and its abstract foregrounds the paralog Bit61 binding Slm1/Slm2/Avo2; the BIT2-specific complex-membership data are in the full text/figures that the SGD curator read. Per curation policy, the experimental annotation is retained and not downgraded on the basis of the abstract naming the paralog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the experimental anchor for BIT2&#39;s core function (TORC2 complex membership). Defer to the SGD curator, who had access to the full text; do not REMOVE or weaken an IDA annotation merely because the abstract-only cache emphasizes the paralog Bit61.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15689497" target="_blank" class="term-link">
+                                        PMID:15689497
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Slm1 and Slm2 physically interact with Avo2 and Bit61, two components of the TORC2 signaling complex, which mediates Tor2 signaling to the actin cytoskeleton.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038203" target="_blank" class="term-link">
+                                    GO:0038203
+                                </a>
+                            </span>
+                            <span class="term-label">TORC2 signaling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15689497" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15689497
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The pleckstrin homology domain proteins Slm1 and Slm2 are re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0038203" data-r="PMID:15689497" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator-inferred (IC) participation in TORC2 signaling, derived from the experimental TORC2 complex membership (GO:0031932). A subunit of TORC2 necessarily participates in TORC2 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Sound IC annotation logically entailed by the experimental complex-membership evidence; a core biological-process annotation for BIT2.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38346" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with the No-Data (ND) evidence code, correctly reflecting that no specific molecular function has been experimentally determined for BIT2. The Bit61/PRR5 (HbrB) domain has no catalytic activity, and BIT2 acts as an accessory subunit whose distinct biochemical contribution to TORC2 is undefined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND annotation is an honest and appropriate reflection of BIT2&#39;s molecular-function knowledge gap (see knowledge_gaps), not a curation defect. It should be retained until a specific BIT2 molecular activity is demonstrated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>BIT2 is an accessory (non-catalytic) subunit of TOR complex 2 (TORC2) that participates in TORC2 signaling. TORC2 comprises the Tor2 protein kinase with Lst8, Avo1, Avo2, Avo3/Tsc11 and one of the paralogous accessory subunits Bit61 or Bit2. BIT2&#39;s own biochemical activity is undefined; consistent with its Bit61/PRR5 (HbrB) family and its metazoan PRR5/Protor orthologs, it functions as a regulatory/scaffolding subunit that contributes to the complex&#39;s kinase-regulatory output rather than independently enabling a catalytic activity.</h3>
+                <span class="vote-buttons" data-g="P38346" data-a="FUNCTION: BIT2 is an accessory (non-catalytic) subunit of TO..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038203" target="_blank" class="term-link">
+                                TORC2 signaling
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031932" target="_blank" class="term-link">
+                            TORC2 complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29170376" target="_blank" class="term-link">
+                                PMID:29170376
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15689497" target="_blank" class="term-link">
+                                PMID:15689497
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Slm1 and Slm2 physically interact with Avo2 and Bit61, two components of the TORC2 signaling complex, which mediates Tor2 signaling to the actin cytoskeleton.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15689497" target="_blank" class="term-link">
+                            PMID:15689497
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The pleckstrin homology domain proteins Slm1 and Slm2 are required for actin cytoskeleton organization in yeast and bind phosphatidylinositol-4,5-bisphosphate and TORC2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11283351" target="_blank" class="term-link">
+                            PMID:11283351
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A comprehensive two-hybrid analysis to explore the yeast protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29170376" target="_blank" class="term-link">
+                            PMID:29170376
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cryo-EM structure of Saccharomyces cerevisiae target of rapamycin complex 2.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does BIT2 make any non-redundant contribution to TORC2 relative to its paralog BIT61 (e.g. condition-specific incorporation, differential expression, or a distinct effector bias), or are the two paralogs fully interchangeable within TORC2?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38346" data-a="Q: Does BIT2 make any non-redundant contribution to T..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the biochemical role of the BIT2 accessory subunit within TORC2 — does it modulate Tor2 kinase activity, substrate (Ypk1/Ypk2) or effector (Slm1/Slm2) selection, complex assembly/stability, or TORC2 membrane localization?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38346" data-a="Q: What is the biochemical role of the BIT2 accessory..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Assay Tor2 kinase activity toward Ypk1/Ypk2 and TORC2 complex integrity in wild-type, bit2-delta, bit61-delta, and bit2-delta bit61-delta strains, to determine whether either paralog is required for TORC2 activity/assembly and whether they are functionally redundant.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: BIT2 and BIT61 are largely redundant accessory subunits; loss of both, but not either alone, measurably impairs TORC2 kinase output or complex stability.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic and biochemical (in vitro kinase assay; co-purification)</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38346" data-a="EXPERIMENT: Assay Tor2 kinase activity toward Ypk1/Ypk2 and TO..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify TORC2 via tagged BIT2 (rather than Bit61) and determine its structure and effector (Slm1/Slm2) contacts, to test whether BIT2-containing TORC2 differs architecturally or in effector engagement from Bit61-containing TORC2.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: BIT2-containing TORC2 occupies the same accessory-subunit position (Avo3-associated edge) as Bit61-containing TORC2, with comparable effector contacts.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification and cryo-EM / crosslinking-MS</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38346" data-a="EXPERIMENT: Purify TORC2 via tagged BIT2 (rather than Bit61) a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity labeling (BioID/TurboID) with tagged BIT2 in yeast to map its proximal interactome within and beyond TORC2, distinguishing an accessory-scaffold role from a dedicated effector-recruiting role.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The BIT2 proximal interactome is dominated by TORC2 subunits and Slm1/Slm2, consistent with an accessory/scaffolding function rather than an independent enzymatic activity.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: proximity-labeling proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38346" data-a="EXPERIMENT: Proximity labeling (BioID/TurboID) with tagged BIT..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> BIT2&#39;s specific molecular function within TORC2 is unknown. No experiment defines a BIT2-specific biochemical activity, and its molecular_function is annotated ND. It is undetermined whether BIT2 regulates Tor2 kinase activity, effector/substrate selection, complex assembly, or localization.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> BIT2 is an experimentally confirmed subunit of TORC2 (IDA) and thereby participates in TORC2 signaling; it associates with Tsc11 and the effectors Slm1/Slm2 (UniProt SUBUNIT, from PMID:11283351 and PMID:15689497). It belongs to the Bit61/PRR5 (HbrB) family, whose members (fungal Bit61/Bit2; metazoan PRR5/PRR5L = Protor-1/Protor-2) are non-catalytic accessory subunits of TORC2/mTORC2. The sequence has no catalytic motif.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning the molecular role of each TORC2 accessory subunit is required to understand how this master regulator of membrane and actin homeostasis is tuned. The absence of a GO term for an &#34;accessory/regulatory subunit of a kinase complex&#34; is why the well-defined complex membership still leaves BIT2 MF-dark.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical dissection of BIT2&#39;s contribution to TORC2 (kinase assays, effector-engagement and assembly assays with bit2 alleles); development of an ontology term for accessory kinase-complex subunit activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2)."</em> — PMID:29170376</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> BIT2&#39;s non-redundant function relative to its whole-genome-duplication paralog BIT61 is unknown. TORC2 contains &#34;Bit61 or its paralog Bit2&#34;, but whether the two are fully interchangeable or have distinct, condition-specific roles has not been established, and no bit2-delta bit61-delta double-mutant phenotype is reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> BIT2 and BIT61 are paralogs arising from the yeast whole-genome duplication; both are accessory subunits of TORC2 and both single-gene deletions are viable. The cryo-EM TORC2 structure was solved from Bit61-containing complexes purified from a bit2-delta strain, so the two paralogs can substitute for one another in the complex.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing redundant from specialized paralog function determines whether BIT2 merits a distinct functional annotation and whether TORC2 output can be differentially tuned via subunit choice.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Comparative phenotyping and TORC2 activity assays across bit2-delta, bit61-delta and the double mutant under diverse stresses; measurement of paralog-specific expression and condition-dependent incorporation into TORC2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2)."</em> — PMID:29170376</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(BIT2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38346" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="bit2-ybr270c-curation-notes">BIT2 (YBR270C) curation notes</h1>
+<p>Journal-style working notes for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> BIT2.<br />
+Provenance is recorded inline as <code>[PMID:xxxx "verbatim supporting text"]</code> or <code>[source "..."]</code>.<br />
+BIT2-specific evidence is kept strictly separate from evidence about its paralog BIT61.</p>
+<h2 id="identity-from-uniprot-p38346-sgd-s000000474">Identity (from UniProt P38346 / SGD S000000474)</h2>
+<ul>
+<li>UniProt: <strong>P38346</strong>, entry name <code>BIT2_YEAST</code>, 545 aa, 61.2 kDa.</li>
+<li>RecName: "Probable target of rapamycin complex 2 subunit BIT2" (Short: "TORC2 subunit BIT2");<br />
+  AltName "Binding partner of TOR2 protein 2".</li>
+<li>Systematic name: <strong>YBR270C</strong> (chromosome II); ORF name YBR1738; SGD:S000000474; GeneID 852573.</li>
+<li>Evidence at protein level (PE1). Reference proteome UP000002311.</li>
+<li>Sequence note: the protein is largely low-complexity; UniProt annotates two disordered regions<br />
+  (residues 1–24 and 78–166) with polar-residue compositional bias (MobiDB-lite). The globular<br />
+  portion is C-terminal (roughly residues ~170–545), which is where the Pfam HbrB match lies.</li>
+</ul>
+<h2 id="family-domain-inline-domain-analysis-of-the-uniprot-record">Family / domain (inline domain analysis of the UniProt record)</h2>
+<ul>
+<li><strong>Pfam PF08539 (HbrB)</strong>, <strong>InterPro IPR013745 (Bit61/PRR5)</strong>, <strong>PANTHER PTHR32428</strong><br />
+  ("TARGET OF RAPAMYCIN COMPLEX 2 SUBUNIT BIT61-RELATED"), subfamily <strong>PTHR32428:SF2</strong>.</li>
+<li>PANTHER family members (<code>interpro/panther/PTHR32428/PTHR32428-entries.csv</code>) place BIT2 in the<br />
+  same SF2 subfamily as:</li>
+<li><em>S. cerevisiae</em> <strong>BIT61</strong> (P47041) — the WGD paralog (also SF2);</li>
+<li><em>S. pombe</em> <strong>bit61</strong> (O74547) and SPAC6B12.03c (O14208);</li>
+<li>and the mammalian/vertebrate orthologs are the <strong>PRR5 / PRR5L</strong> proteins (Proline-rich<br />
+    protein 5 / 5-like; SF3/SF4), i.e. <strong>Protor-1 / Protor-2</strong>, the accessory regulatory<br />
+    subunits of <strong>mTORC2</strong>.<br />
+  So the whole family is the fungal Bit61/Bit2 ↔ metazoan PRR5/Protor lineage of <strong>TORC2/mTORC2<br />
+  accessory subunits</strong>. This orthology is the strongest grounding for "TORC2 subunit".</li>
+<li>The HbrB/Bit61-PRR5 domain has no known catalytic activity; PRR5/Protor are described as<br />
+  accessory/regulatory (non-catalytic) subunits. There is no nucleotide-binding, kinase, or other<br />
+  enzymatic motif in the sequence. Consistent with an <strong>accessory/scaffolding subunit</strong>, not an<br />
+  enzyme. This underlies the MF-dark call below.</li>
+</ul>
+<h2 id="known-about-bit2-specifically-bit2-not-bit61">KNOWN about BIT2 specifically (BIT2, not BIT61)</h2>
+<ol>
+<li><strong>BIT2 is a subunit of TORC2</strong> (part of the TOR complex 2).</li>
+<li>GOA: <code>GO:0031932 TORC2 complex</code>, <strong>IDA</strong>, PMID:15689497, assigned by SGD (part_of). This is the<br />
+     experimental anchor for complex membership.</li>
+<li>The TORC2 subunit inventory in the cryo-EM paper explicitly names BIT2 as an alternative<br />
+     paralog subunit: <a href="https://pubmed.ncbi.nlm.nih.gov/29170376" title="TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL),      Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or      Protor2).">PMID:29170376</a>. NOTE: TORC2 contains <strong>Bit61 <em>or</em> Bit2</strong> — the two paralogs are alternative,<br />
+     largely interchangeable accessory subunits of the same complex.</li>
+<li><strong>BIT2 physically interacts with TORC2 components / effectors.</strong></li>
+<li>UniProt SUBUNIT: "Interacts with the target of rapamycin complex 2 (TORC2) subunit TSC11 and<br />
+     the TORC2 effectors SLM1 and SLM2." {ECO:0000269|PubMed:11283351, ECO:0000269|PubMed:15689497}.</li>
+<li>These are the physical-interaction data (Ito et al. 2001 genome-wide two-hybrid PMID:11283351;<br />
+     Fadri et al. 2005 PMID:15689497) that place BIT2 in the TORC2/Slm1-Slm2 interaction network.</li>
+<li>CAUTION: PMID:15689497 is cached <strong>abstract-only</strong> (<code>full_text_available: false</code>); its abstract<br />
+     foregrounds <strong>Slm1/Slm2 binding Avo2 and Bit61</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/15689497" title="Slm1 and Slm2 physically      interact with Avo2 and Bit61, two components of the TORC2 signaling complex">PMID:15689497</a>. The BIT2 IDA to<br />
+     TORC2 complex is attributed by the SGD curator to this paper, so the BIT2-specific data are in<br />
+     the full text / figures that I cannot see. Per project rules I do NOT remove or downgrade the<br />
+     experimental IDA on the basis that the abstract names the paralog.</li>
+<li><strong>Non-essential; viable null.</strong> <em>bit2Δ</em> is viable in S288C; high-throughput phenotyping reports<br />
+   decreased resistance to oxidative stress and to a farnesyltransferase inhibitor (SGD phenotype<br />
+   summary, high-throughput screens) [https://yeastgenome.org/locus/S000000474]. No strong,<br />
+   specific single-mutant growth phenotype is documented, consistent with paralog redundancy with<br />
+   BIT61.</li>
+</ol>
+<h2 id="known-about-the-paralog-bit61-kept-separate-do-not-attribute-to-bit2">KNOWN about the paralog BIT61 (kept separate — do NOT attribute to BIT2)</h2>
+<ul>
+<li>The <strong>cryo-EM TORC2 structure was solved from TORC2 purified via Bit61-TAP in a <em>bit2Δ</em> strain</strong>;<br />
+  the structural placement ("Finger2", the acute angle of the rhombohedron, contact with Avo3) is<br />
+  therefore for <strong>Bit61, not BIT2</strong>: <a href="https://pubmed.ncbi.nlm.nih.gov/29170376" title="TORC2 was prepared through pull-down of   TAP-tagged Bit61 from yeast extracts lacking Bit2">PMID:29170376</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/29170376" title="despite the fact that we   purified TORC2 via tagged Bit61 from cells lacking Bit2, the density for the Bit61 subunit is not   well-defined, and beyond a general localization to Finger2, we cannot conclude more.">PMID:29170376</a>. I will NOT<br />
+  cite the Finger2/edge placement as BIT2 evidence — only the general "Bit61 or its paralog Bit2 is<br />
+  a TORC2 subunit" statement is BIT2-applicable.</li>
+<li>BIT61 (YJL058C, P47041) has its own SGD phenotypes (decreased competitive fitness on minimal/SC<br />
+  media, decreased resistance to acid pH, elevated chromosome loss) — these are BIT61, not BIT2.</li>
+</ul>
+<h2 id="not-known-about-bit2-the-knowledge-gaps">NOT known about BIT2 (the knowledge gaps)</h2>
+<ol>
+<li><strong>BIT2's specific molecular activity within TORC2 is undefined.</strong> The Bit61/PRR5 (HbrB) domain<br />
+   has no catalytic activity; BIT2 is an accessory/regulatory subunit whose molecular contribution<br />
+   (does it modulate substrate selection? complex stability? localization? effector, e.g. Slm1/Slm2,<br />
+   engagement?) has not been demonstrated for BIT2 specifically. GOA already flags this: the SGD MF<br />
+   annotation is <code>GO:0003674 molecular_function</code> <strong>ND</strong> (no data).</li>
+<li><strong>BIT2's non-redundant function vs BIT61 is unknown.</strong> TORC2 contains "Bit61 or its paralog Bit2";<br />
+   whether the two paralogs are functionally distinct (differential expression, condition-specific<br />
+   incorporation, distinct effector bias) or fully redundant is not established. No <em>bit2Δ bit61Δ</em><br />
+   double-mutant phenotype is annotated at SGD.</li>
+<li><strong>No strong single-mutant loss-of-function phenotype</strong> pins down a BIT2-specific biological role;<br />
+   the reported phenotypes are high-throughput sensitivities (oxidative stress; farnesyltransferase<br />
+   inhibitor), not a mechanistic assignment.</li>
+</ol>
+<h2 id="goa-annotations-to-review-7-rows-in-bit2-goatsv">GOA annotations to review (7 rows in BIT2-goa.tsv)</h2>
+<ol>
+<li><code>GO:0007163 establishment or maintenance of cell polarity</code> — IBA (GO_REF:0000033), involved_in.<br />
+   Phylogenetic (IBA). TORC2/Slm-actin axis does regulate polarized growth/actin, so this is<br />
+   plausible at the family level but is a downstream/process-level inference, not BIT2-specific<br />
+   experimental data. → KEEP_AS_NON_CORE (family/process-level, not core BIT2 activity).</li>
+<li><code>GO:0019887 protein kinase regulator activity</code> — IBA (GO_REF:0000033), enables. IBA-projected MF.<br />
+   BIT2 as a TORC2 accessory subunit plausibly contributes to regulating the Tor2 kinase, but there<br />
+   is no BIT2 experimental MF; "regulator of the kinase" via being part of the complex is the family<br />
+   rationale. This is the least uninformative MF available. → KEEP_AS_NON_CORE (IBA family MF; not an<br />
+   independently demonstrated BIT2 activity; better captured as contributes_to at the complex level).</li>
+<li><code>GO:0031932 TORC2 complex</code> — IBA (GO_REF:0000033), part_of. → ACCEPT (redundant with the IDA row<br />
+   but phylogenetically well-supported; core).</li>
+<li><code>GO:0038203 TORC2 signaling</code> — IBA (GO_REF:0000033), involved_in. → ACCEPT/KEEP (core BP; TORC2<br />
+   membership implies participation in TORC2 signaling).</li>
+<li><code>GO:0031932 TORC2 complex</code> — <strong>IDA</strong>, PMID:15689497, part_of. → ACCEPT (experimental anchor;<br />
+   core). Defer to SGD curator; do not REMOVE despite abstract-only cache foregrounding Bit61.</li>
+<li><code>GO:0038203 TORC2 signaling</code> — <strong>IC</strong> (inferred from GO:0031932 complex membership),<br />
+   PMID:15689497, involved_in. → ACCEPT (IC directly from the experimental complex membership; core).</li>
+<li><code>GO:0003674 molecular_function</code> — <strong>ND</strong> (GO_REF:0000015), enables. Root MF, no data. → ACCEPT/KEEP<br />
+   (honestly reflects that BIT2's specific MF is undetermined — the MF-dark gap; this is the correct<br />
+   use of ND, not a defect).</li>
+</ol>
+<h2 id="core-function-synthesis">Core function synthesis</h2>
+<ul>
+<li><strong>Core:</strong> BIT2 is an accessory (non-catalytic) subunit of TORC2, the rapamycin-insensitive TOR<br />
+  complex 2 (Tor2, Lst8, Avo1, Avo2, Avo3/Tsc11, and Bit61-or-Bit2). It participates in TORC2<br />
+  signaling. Membership is experimental (IDA) and phylogenetically supported (IBA); orthology to<br />
+  metazoan PRR5/Protor (accessory mTORC2 subunits) corroborates an accessory/regulatory role.</li>
+<li><strong>MF:</strong> best expressed as <em>contributes_to</em> a TORC2/kinase-regulatory activity rather than an<br />
+  independently enabled activity; BIT2's own biochemical activity is unknown (MF-dark).</li>
+<li>Because BIT2 is one of two interchangeable paralog subunits, its individual functional weight is<br />
+  intrinsically hard to pin down (redundancy with BIT61).</li>
+</ul>
+<h2 id="deep-research-provider-status">Deep-research provider status</h2>
+<p>Automated deep research was attempted twice via <code>just deep-research-falcon yeast BIT2
+--fallback perplexity-lite</code>. Both attempts failed: the falcon provider timed out/was killed<br />
+(exit 143/144) and the perplexity-lite fallback returned HTTP 401 (API quota exceeded). No<br />
+<code>-deep-research-{provider}.md</code> file was produced, and none was fabricated. This review is<br />
+therefore grounded directly in the UniProt record (P38346), the GOA TSV, the cached primary<br />
+literature (PMID:15689497, PMID:11283351, PMID:29170376), the PANTHER/InterPro family record<br />
+(PTHR32428 / IPR013745 / PF08539), and the SGD locus page — all cited with provenance above.</p>
+<h2 id="references-gathered-cached">References gathered / cached</h2>
+<ul>
+<li>PMID:15689497 — Fadri et al. 2005, Mol Biol Cell (abstract-only cache). IDA anchor for TORC2<br />
+  complex membership; SLM1/SLM2 interaction. relevance HIGH.</li>
+<li>PMID:11283351 — Ito et al. 2001, PNAS (full text cached; genome-wide two-hybrid). Physical<br />
+  interaction data underlying the TSC11/SLM1/SLM2 interactions in UniProt SUBUNIT. relevance MEDIUM<br />
+  (systematic screen; BIT2 data in supplementary interaction tables, not discussed in body text).</li>
+<li>PMID:29170376 — Karuppasamy et al. 2017, Nat Commun (full text cached). Cryo-EM TORC2 structure.<br />
+  Establishes the "Bit61 or its paralog Bit2" subunit inventory (BIT2-applicable). CAUTION: all<br />
+  structural placement is for Bit61 (purified from <em>bit2Δ</em>), NOT BIT2. relevance MEDIUM.</li>
+<li>SGD locus page S000000474 — phenotype/paralog summary (viable null; oxidative-stress &amp;<br />
+  farnesyltransferase-inhibitor sensitivities; WGD paralog BIT61).</li>
+<li>GO_REF:0000015 (ND policy), GO_REF:0000033 (phylogenetic IBA) — method references.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P38346
+gene_symbol: BIT2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  BIT2 (systematic name YBR270C) is an accessory subunit of TOR complex 2 (TORC2),
+  the rapamycin-insensitive TOR-kinase complex of budding yeast. TORC2 is built
+  around the Tor2 Ser/Thr protein kinase together with Lst8, Avo1, Avo2, Avo3/Tsc11,
+  and one of the two paralogous accessory subunits Bit61 or Bit2, and it signals to
+  the AGC-family kinases Ypk1/Ypk2 to control plasma-membrane homeostasis, sphingolipid
+  metabolism, and actin cytoskeleton organization during polarized growth. BIT2 belongs
+  to the Bit61/PRR5 family (Pfam HbrB), whose members are the fungal Bit61/Bit2 and the
+  metazoan PRR5/PRR5L (Protor-1/Protor-2) accessory subunits of TORC2/mTORC2; these
+  proteins have no known catalytic activity and act as regulatory/scaffolding subunits.
+  BIT2 physically associates with the TORC2 subunit Tsc11 and with the TORC2 downstream
+  effectors Slm1 and Slm2. It arose from the whole-genome duplication as the paralog of
+  BIT61, with which it is largely interchangeable within TORC2; bit2 null mutants are
+  viable, consistent with functional redundancy between the two paralogs. The specific,
+  BIT2-distinct molecular contribution to TORC2 has not been experimentally defined.
+existing_annotations:
+- term:
+    id: GO:0007163
+    label: establishment or maintenance of cell polarity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) participation in establishment/maintenance of cell
+      polarity. TORC2 signaling, via Slm1/Slm2 and the Ypk1/Ypk2 kinases, does regulate the
+      actin cytoskeleton and polarized growth, so a family-level link to cell polarity is
+      biologically reasonable. However, this is a downstream, process-level inference and
+      there is no BIT2-specific experimental evidence for a direct role in cell polarity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retain as a plausible IBA process annotation propagated across the Bit61/PRR5 family,
+      but treat it as non-core: it reflects the broad downstream output of TORC2 signaling
+      rather than a demonstrated, BIT2-specific function. The core, better-supported process
+      annotation for BIT2 is TORC2 signaling (GO:0038203).
+- term:
+    id: GO:0019887
+    label: protein kinase regulator activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) molecular function. As an accessory subunit of the
+      Tor2-kinase-containing TORC2, BIT2 plausibly contributes to modulating the complex&#39;s
+      protein-kinase activity, and this is the least uninformative molecular-function term
+      available for the family. However, there is no experimental demonstration that BIT2
+      itself enables (independently has) protein kinase regulator activity; the Bit61/PRR5
+      (HbrB) domain has no catalytic motifs and the paralog family members are non-catalytic
+      accessory subunits.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Keep as an IBA family molecular-function annotation but mark non-core: BIT2 does not
+      independently &#34;enable&#34; kinase regulation; any such activity is a property it
+      contributes to as part of TORC2. This is captured more accurately in core_functions as
+      contributes_to_molecular_function (protein kinase regulator activity) alongside TORC2
+      membership. This annotation is the locus of the gene&#39;s molecular-function knowledge gap
+      (see knowledge_gaps).
+- term:
+    id: GO:0031932
+    label: TORC2 complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) membership of the TORC2 complex, consistent with the
+      whole Bit61/Bit2/PRR5/Protor family being TORC2/mTORC2 accessory subunits. This is
+      corroborated by the experimental IDA row (below) and by the TORC2 subunit inventory in
+      the cryo-EM literature.
+    action: ACCEPT
+    reason: &gt;-
+      TORC2 complex membership is the best-supported, core annotation for BIT2, supported by
+      both phylogenetic inference and direct experimental data.
+    supported_by:
+    - reference_id: PMID:29170376
+      supporting_text: &gt;-
+        TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).
+- term:
+    id: GO:0038203
+    label: TORC2 signaling
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) participation in TORC2 signaling, following directly
+      from TORC2 complex membership. TORC2 signaling to the Ypk1/Ypk2 AGC kinases and the
+      Slm1/Slm2 effectors is the pathway in which BIT2 acts.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological-process annotation for BIT2: as a TORC2 subunit it is involved in TORC2
+      signaling. Well-supported both phylogenetically and by the experimental IC row.
+- term:
+    id: GO:0031932
+    label: TORC2 complex
+  evidence_type: IDA
+  original_reference_id: PMID:15689497
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) evidence, assigned by SGD, for BIT2 as part of the TORC2
+      complex. The cached copy of PMID:15689497 is abstract-only and its abstract foregrounds
+      the paralog Bit61 binding Slm1/Slm2/Avo2; the BIT2-specific complex-membership data are
+      in the full text/figures that the SGD curator read. Per curation policy, the
+      experimental annotation is retained and not downgraded on the basis of the abstract
+      naming the paralog.
+    action: ACCEPT
+    reason: &gt;-
+      This is the experimental anchor for BIT2&#39;s core function (TORC2 complex membership).
+      Defer to the SGD curator, who had access to the full text; do not REMOVE or weaken an
+      IDA annotation merely because the abstract-only cache emphasizes the paralog Bit61.
+    supported_by:
+    - reference_id: PMID:15689497
+      supporting_text: &gt;-
+        Slm1 and Slm2 physically interact with Avo2 and Bit61, two components of the TORC2 signaling complex, which mediates Tor2 signaling to the actin cytoskeleton.
+- term:
+    id: GO:0038203
+    label: TORC2 signaling
+  evidence_type: IC
+  original_reference_id: PMID:15689497
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Curator-inferred (IC) participation in TORC2 signaling, derived from the experimental
+      TORC2 complex membership (GO:0031932). A subunit of TORC2 necessarily participates in
+      TORC2 signaling.
+    action: ACCEPT
+    reason: &gt;-
+      Sound IC annotation logically entailed by the experimental complex-membership evidence;
+      a core biological-process annotation for BIT2.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function term with the No-Data (ND) evidence code, correctly reflecting
+      that no specific molecular function has been experimentally determined for BIT2. The
+      Bit61/PRR5 (HbrB) domain has no catalytic activity, and BIT2 acts as an accessory
+      subunit whose distinct biochemical contribution to TORC2 is undefined.
+    action: ACCEPT
+    reason: &gt;-
+      The ND annotation is an honest and appropriate reflection of BIT2&#39;s molecular-function
+      knowledge gap (see knowledge_gaps), not a curation defect. It should be retained until a
+      specific BIT2 molecular activity is demonstrated.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: PMID:15689497
+  title: The pleckstrin homology domain proteins Slm1 and Slm2 are required for actin
+    cytoskeleton organization in yeast and bind phosphatidylinositol-4,5-bisphosphate
+    and TORC2.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMID verified against PubMed (Fadri et al., Mol Biol Cell 2005). Cached copy is
+      abstract-only (full_text_available: false). The abstract establishes Slm1/Slm2
+      interaction with TORC2 components (Avo2, Bit61) and the TORC2-&gt;actin axis; the
+      BIT2-specific TORC2-complex IDA that SGD attributes to this paper rests on full-text
+      data not present in the cached abstract. Cited correctly by SGD; supports the
+      TORC2-membership and TORC2-signaling annotations for BIT2.
+- id: PMID:11283351
+  title: A comprehensive two-hybrid analysis to explore the yeast protein interactome.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMID verified against PubMed (Ito et al., PNAS 2001). Genome-wide two-hybrid screen;
+      the BIT2 interactions with Tsc11, Slm1 and Slm2 cited in the UniProt SUBUNIT section
+      derive from this systematic dataset (interaction tables), not from BIT2-focused prose.
+      Provides supporting physical-interaction context for BIT2&#39;s place in the TORC2/Slm
+      network; corroborating rather than function-defining.
+- id: PMID:29170376
+  title: Cryo-EM structure of Saccharomyces cerevisiae target of rapamycin complex 2.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMID verified against PubMed (Karuppasamy et al., Nat Commun 2017). Establishes the
+      TORC2 subunit inventory including the phrase &#34;Bit61 or its paralog Bit2&#34; (BIT2-applicable,
+      cited verbatim for complex membership). IMPORTANT: all structural placement in this paper
+      is for Bit61, because the authors purified TORC2 by protein-A affinity purification of
+      Bit61-TAP from a Bit2 knockout strain (paraphrased); the Finger2/edge localization is NOT
+      attributed to BIT2 here. Used only for the general subunit-membership statement.
+core_functions:
+- description: &gt;-
+    BIT2 is an accessory (non-catalytic) subunit of TOR complex 2 (TORC2) that participates
+    in TORC2 signaling. TORC2 comprises the Tor2 protein kinase with Lst8, Avo1, Avo2,
+    Avo3/Tsc11 and one of the paralogous accessory subunits Bit61 or Bit2. BIT2&#39;s own
+    biochemical activity is undefined; consistent with its Bit61/PRR5 (HbrB) family and its
+    metazoan PRR5/Protor orthologs, it functions as a regulatory/scaffolding subunit that
+    contributes to the complex&#39;s kinase-regulatory output rather than independently enabling
+    a catalytic activity.
+  contributes_to_molecular_function:
+    id: GO:0019887
+    label: protein kinase regulator activity
+  directly_involved_in:
+  - id: GO:0038203
+    label: TORC2 signaling
+  in_complex:
+    id: GO:0031932
+    label: TORC2 complex
+  supported_by:
+  - reference_id: PMID:29170376
+    supporting_text: &gt;-
+      TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).
+  - reference_id: PMID:15689497
+    supporting_text: &gt;-
+      Slm1 and Slm2 physically interact with Avo2 and Bit61, two components of the TORC2 signaling complex, which mediates Tor2 signaling to the actin cytoskeleton.
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The specific, BIT2-distinct molecular activity within TORC2 is undetermined. It is not
+      known whether BIT2 modulates Tor2 kinase activity, substrate/effector (e.g. Slm1/Slm2,
+      Ypk1/Ypk2) selection, complex assembly/stability, or subcellular targeting, nor whether
+      it has any activity beyond that of an interchangeable accessory subunit.
+    boundary: &gt;-
+      BIT2 is experimentally established as part of the TORC2 complex (IDA) and, as such,
+      participates in TORC2 signaling; it associates with the TORC2 subunit Tsc11 and the
+      effectors Slm1/Slm2. It belongs to the Bit61/PRR5 (HbrB) family of non-catalytic
+      accessory subunits (metazoan orthologs PRR5/PRR5L / Protor-1/Protor-2). No catalytic
+      or nucleotide-binding motif is present in the sequence.
+    gap_kind:
+    - BIOLOGY
+    - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      TORC2 is a master regulator of plasma-membrane homeostasis, sphingolipid metabolism and
+      the actin cytoskeleton; understanding what each accessory subunit contributes is needed
+      to explain how TORC2 output is tuned. GO currently offers no molecular-function term for
+      &#34;accessory/regulatory subunit of a protein kinase complex&#34;, so even a well-defined
+      accessory role reads as MF-dark and the SGD annotation is molecular_function ND.
+    resolution: &gt;-
+      Separation-of-function and interaction-mapping experiments (e.g. bit2 point/deletion
+      alleles assayed for Tor2 kinase activity toward Ypk1/Ypk2, TORC2 assembly, and Slm1/Slm2
+      engagement); a dedicated MF term for accessory kinase-complex subunit activity.
+    provenance:
+    - reference_id: PMID:29170376
+      supporting_text: &gt;-
+        TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).
+      reference_section_type: INTRODUCTION
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does BIT2 make any non-redundant contribution to TORC2 relative to its paralog BIT61
+    (e.g. condition-specific incorporation, differential expression, or a distinct effector
+    bias), or are the two paralogs fully interchangeable within TORC2?
+- question: &gt;-
+    What is the biochemical role of the BIT2 accessory subunit within TORC2 — does it modulate
+    Tor2 kinase activity, substrate (Ypk1/Ypk2) or effector (Slm1/Slm2) selection, complex
+    assembly/stability, or TORC2 membrane localization?
+suggested_experiments:
+- description: &gt;-
+    Assay Tor2 kinase activity toward Ypk1/Ypk2 and TORC2 complex integrity in wild-type,
+    bit2-delta, bit61-delta, and bit2-delta bit61-delta strains, to determine whether either
+    paralog is required for TORC2 activity/assembly and whether they are functionally
+    redundant.
+  hypothesis: &gt;-
+    BIT2 and BIT61 are largely redundant accessory subunits; loss of both, but not either
+    alone, measurably impairs TORC2 kinase output or complex stability.
+  experiment_type: genetic and biochemical (in vitro kinase assay; co-purification)
+- description: &gt;-
+    Purify TORC2 via tagged BIT2 (rather than Bit61) and determine its structure and effector
+    (Slm1/Slm2) contacts, to test whether BIT2-containing TORC2 differs architecturally or in
+    effector engagement from Bit61-containing TORC2.
+  hypothesis: &gt;-
+    BIT2-containing TORC2 occupies the same accessory-subunit position (Avo3-associated edge)
+    as Bit61-containing TORC2, with comparable effector contacts.
+  experiment_type: affinity purification and cryo-EM / crosslinking-MS
+- description: &gt;-
+    Proximity labeling (BioID/TurboID) with tagged BIT2 in yeast to map its proximal
+    interactome within and beyond TORC2, distinguishing an accessory-scaffold role from a
+    dedicated effector-recruiting role.
+  hypothesis: &gt;-
+    The BIT2 proximal interactome is dominated by TORC2 subunits and Slm1/Slm2, consistent
+    with an accessory/scaffolding function rather than an independent enzymatic activity.
+  experiment_type: proximity-labeling proteomics
+knowledge_gaps:
+- gap_statement: &gt;-
+    BIT2&#39;s specific molecular function within TORC2 is unknown. No experiment defines a
+    BIT2-specific biochemical activity, and its molecular_function is annotated ND. It is
+    undetermined whether BIT2 regulates Tor2 kinase activity, effector/substrate selection,
+    complex assembly, or localization.
+  boundary: &gt;-
+    BIT2 is an experimentally confirmed subunit of TORC2 (IDA) and thereby participates in
+    TORC2 signaling; it associates with Tsc11 and the effectors Slm1/Slm2 (UniProt SUBUNIT,
+    from PMID:11283351 and PMID:15689497). It belongs to the Bit61/PRR5 (HbrB) family, whose
+    members (fungal Bit61/Bit2; metazoan PRR5/PRR5L = Protor-1/Protor-2) are non-catalytic
+    accessory subunits of TORC2/mTORC2. The sequence has no catalytic motif.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning the molecular role of each TORC2 accessory subunit is required to understand how
+    this master regulator of membrane and actin homeostasis is tuned. The absence of a GO term
+    for an &#34;accessory/regulatory subunit of a kinase complex&#34; is why the well-defined complex
+    membership still leaves BIT2 MF-dark.
+  resolution: &gt;-
+    Biochemical dissection of BIT2&#39;s contribution to TORC2 (kinase assays, effector-engagement
+    and assembly assays with bit2 alleles); development of an ontology term for accessory
+    kinase-complex subunit activity.
+  provenance:
+  - reference_id: PMID:29170376
+    supporting_text: &gt;-
+      TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).
+    reference_section_type: INTRODUCTION
+- gap_statement: &gt;-
+    BIT2&#39;s non-redundant function relative to its whole-genome-duplication paralog BIT61 is
+    unknown. TORC2 contains &#34;Bit61 or its paralog Bit2&#34;, but whether the two are fully
+    interchangeable or have distinct, condition-specific roles has not been established, and no
+    bit2-delta bit61-delta double-mutant phenotype is reported.
+  boundary: &gt;-
+    BIT2 and BIT61 are paralogs arising from the yeast whole-genome duplication; both are
+    accessory subunits of TORC2 and both single-gene deletions are viable. The cryo-EM TORC2
+    structure was solved from Bit61-containing complexes purified from a bit2-delta strain, so
+    the two paralogs can substitute for one another in the complex.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Distinguishing redundant from specialized paralog function determines whether BIT2 merits a
+    distinct functional annotation and whether TORC2 output can be differentially tuned via
+    subunit choice.
+  resolution: &gt;-
+    Comparative phenotyping and TORC2 activity assays across bit2-delta, bit61-delta and the
+    double mutant under diverse stresses; measurement of paralog-specific expression and
+    condition-dependent incorporation into TORC2.
+  provenance:
+  - reference_id: PMID:29170376
+    supporting_text: &gt;-
+      TORC2 (mTORC2) is composed of Tor2 (mTOR), Lst8 (mLst8/GβL), Avo1 (hSin1), Avo2 (no ortholog), Avo3 (Rictor) and Bit61 or its paralog Bit2 (Protor1 or Protor2).
+    reference_section_type: INTRODUCTION
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/CAF120/CAF120-ai-review.html
+++ b/genes/yeast/CAF120/CAF120-ai-review.html
@@ -1,0 +1,3288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CAF120 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CAF120</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P53836" target="_blank" class="term-link">
+                        P53836
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CAF120";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P53836" data-a="DESCRIPTION: CAF120 (systematic name YNL278W) is a large (1060-..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CAF120 (systematic name YNL278W) is a large (1060-residue, ~118 kDa), non-essential Saccharomyces cerevisiae protein whose molecular function is essentially uncharacterized. It was originally identified as a &#34;CCR4-associated factor&#34; of 120 kDa (hence its name) and is reported to associate with the CCR4-NOT complex, the conserved machinery that combines a nuclear transcription-regulatory role with the cytoplasmic major mRNA deadenylase activity; however, CAF120 is not enumerated among the canonical CCR4-NOT core subunits and no gene-specific molecular activity has been demonstrated for it. Its only recognized folded domain is a divergent pleckstrin-homology (PH) domain near the N-terminus (a member, with its paralog SKG3, of the Skg3/CAF120-like PH subfamily); the remaining ~85% of the protein is largely intrinsically disordered and low-complexity. The protein localizes to the cytoplasm, nucleus, and the bud neck, and it relocalizes under DNA-damaging stress. It is a substrate of the cyclin-dependent kinase Cdk1 and is multiply phosphorylated on serine residues. CAF120 has a whole-genome-duplication paralog, SKG3 (YHR133C), which is likewise poorly characterized. In meiosis, CAF120 has been identified as a metaphase-I-enriched interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover machinery and acts as a regulator of meiotic crossing-over: its deletion reproducibly reduces crossover frequency, although the molecular mechanism by which it contributes to crossover formation is not yet established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004672" target="_blank" class="term-link">
+                                    GO:0004672
+                                </a>
+                            </span>
+                            <span class="term-label">protein kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0004672" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred (IBA) protein kinase activity propagated within PANTHER family PTN001969686. The reference members driving the inference are Arabidopsis MAP kinase kinase kinase loci (AT1G05100, AT3G50310, AT4G26890 in the WITH/FROM field), which are bona fide kinase-domain proteins. CAF120 has NO protein kinase domain: its only Pfam/ InterPro-recognized folded module is a PH domain (residues 75-204; PF00169/PF25381, IPR058155), with the rest of the protein intrinsically disordered. This is a family over-propagation in which a shared accessory PH module drew a non-kinase yeast protein into a plant-MAP3K-dominated cluster, causing it to inherit a catalytic activity it does not possess. Biologically indefensible.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CAF120 lacks any protein kinase domain (UniProt/InterPro/Pfam show only a PH domain plus disordered regions); the IBA kinase activity is over-propagated from kinase-domain Arabidopsis MAP3K family members via a shared PH module and has no gene-specific support.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001969686</span>
+
+                                    &middot; PANTHER family node driving the IBA transfer
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Family clustering appears PH-domain-driven; the kinase MF comes from the plant MAP3K members, not from CAF120, which has no kinase domain.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">AGI_LocusCode:AT1G05100</span>
+
+                                    &middot; Arabidopsis MAP kinase kinase kinase
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Bona fide kinase-domain protein; activity does not transfer to non-kinase CAF120.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">AGI_LocusCode:AT3G50310</span>
+
+                                    &middot; Arabidopsis MAP kinase kinase kinase (MKKK20)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Kinase-domain reference member; not applicable to CAF120.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
+                                    GO:0007165
+                                </a>
+                            </span>
+                            <span class="term-label">signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0007165" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred (IBA) signal transduction from the same PANTHER family (PTN001969686), with the same Arabidopsis MAP3K reference set (AT1G05100, AT2G32510, AT3G50310) in the WITH/FROM field. &#34;Signal transduction&#34; is the generic process that the kinase-domain plant members carry; it was inherited by CAF120 through the same PH-domain- driven mis-clustering that produced the erroneous kinase-activity call. There is no experimental or domain-based evidence that CAF120 acts in a signaling cascade.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated from kinase-containing plant MAP3K family members; CAF120 has no kinase domain and no evidence of participation in a signaling pathway. Removing alongside the linked kinase-activity IBA that generated it.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001969686</span>
+
+                                    &middot; PANTHER family node driving the IBA transfer
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Same PH-domain-driven family cluster; &#34;signal transduction&#34; is the generic BP of the plant MAP3K members and does not apply to the non-kinase CAF120.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">AGI_LocusCode:AT1G05100</span>
+
+                                    &middot; Arabidopsis MAP kinase kinase kinase
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Signaling role is kinase-cascade-dependent; not transferable to CAF120.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation derived from the UniProtKB-SubCell mapping (SL-0191), which is in turn backed by the experimental subcellular-location record in UniProt (Nucleus; ECO:0000269|PubMed:14562095, the Huh 2003 GFP localization atlas). Consistent with the multi-compartment (cytoplasm/nucleus/bud neck) localization of the protein. Correct but broad, and not the core function of this dark gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Evidence-backed subcellular location (via SubCell mapping from a GFP-atlas experimental record), but a general localization term rather than a molecular function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProtKB-SubCell mapping (SL-0086), backed by the experimental UniProt subcellular-location record (Cytoplasm; ECO:0000269|PubMed:14562095). A correct but very general location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct high-level cytoplasmic localization derived from an experimentally-backed SubCell mapping; general and non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005935" target="_blank" class="term-link">
+                                    GO:0005935
+                                </a>
+                            </span>
+                            <span class="term-label">cellular bud neck</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0005935" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProtKB-SubCell mapping (SL-0029), backed by the experimental UniProt record (Bud neck; ECO:0000269|PubMed:14562095). This duplicates the more direct IDA bud-neck annotation below (PMID:25028499) and is subsumed by it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct bud-neck localization, consistent with (and subsumed by) the direct-assay bud-neck annotation (GO:0005935, IDA, PMID:25028499); accepted for consistency with that annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level &#34;molecular function unknown&#34; placeholder (ND). This honestly reflects the dark-gene status of CAF120: despite the PH domain and CCR4-NOT association, no specific molecular activity (catalytic, binding, adapter, or scaffold) has been experimentally demonstrated, and GO/SGD do not assign it one. Appropriate to retain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No defensible molecular function can be assigned; the ND annotation correctly records that the molecular function is unknown.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level &#34;biological process unknown&#34; placeholder (ND) reflecting the state of GOA at the time of annotation. Since then, a meiotic role has been reported (CAF120 is a metaphase-I-enriched MutLgamma-Exo1 interactor whose deletion reduces crossover frequency; PMID:31351878), which is captured as a proposed NEW annotation below (GO:0010520). The ND is retained as-is (it is a trusted GOA record and this review does not rewrite GOA ids), but it no longer reflects the best available knowledge of the gene&#39;s biological role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GOA-sourced ND placeholder correctly recording that GOA holds no specific biological process; complemented (not contradicted) by the proposed meiotic-crossover-regulation annotation below (GO:0010520; PMID:31351878).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005935" target="_blank" class="term-link">
+                                    GO:0005935
+                                </a>
+                            </span>
+                            <span class="term-label">cellular bud neck</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25028499" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25028499
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteome-wide remodeling of protein location and function by...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0005935" data-r="PMID:25028499" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) localization of Caf120 to the cellular bud neck, from a high-resolution cellular-imaging study of proteome-wide, condition-dependent protein localization. The same study reports that Caf120 changes subcellular location under DNA-damaging conditions. This is the best-supported experimental annotation for the gene and is consistent with the UniProt bud-neck subcellular-location record (from the Huh 2003 GFP atlas).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported direct-assay localization to the bud neck; the strongest experimental annotation available for this otherwise uncharacterized protein.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010520" target="_blank" class="term-link">
+                                    GO:0010520
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of reciprocal meiotic recombination</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31351878" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31351878
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Network Rewiring of Homologous Recombination Enzymes during ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P53836" data-a="GO:0010520" data-r="PMID:31351878" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation. A proteomic and genetic dissection of the recombination- intermediate-processing enzymes found that CAF120 is a meiosis-specific (metaphase-I- enriched) interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover machinery, and that deletion of CAF120 reproducibly reduces meiotic crossover frequency (genetic distance at the CEN8-THR1 interval), placing it among the identified regulators of crossing-over. This is a specific, experimentally-supported biological role for an otherwise dark gene. The general &#34;regulation of reciprocal meiotic recombination&#34; term (GO:0010520) is chosen rather than a directional (positive/negative) child because the authors explicitly flag the molecular mechanism as uncharacterized (&#34;interesting candidates for further functional analyses&#34;).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not present in current GOA, but supported by direct genetic evidence (reproducible reduction in crossover frequency in caf120-null meiosis) plus a meiosis-specific physical association with the MutLgamma-Exo1 crossover machinery (PMID:31351878). Conservatively annotated to the general regulation term because the direction/mechanism is not resolved.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31351878" target="_blank" class="term-link">
+                                        PMID:31351878
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Rtk1, Caf120, and Chd1 as regulators of crossing-over</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31351878" target="_blank" class="term-link">
+                                        PMID:31351878
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">chd1Δ, rtk1Δ, and caf120Δ</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>No specific molecular function can be positively assigned to CAF120. The only experimentally solid statement about the gene product is its localization: it is a cytoplasmic and nuclear protein that concentrates at the cellular bud neck and relocalizes under DNA-damaging stress. It carries a single recognized folded domain — a divergent pleckstrin-homology (PH) domain (Skg3/CAF120-like PH subfamily) — embedded in a largely disordered protein, and it is a substrate of the cyclin-dependent kinase Cdk1. Although it is named as a CCR4-associated factor and is reported to associate with the CCR4-NOT complex, it is not enumerated among the canonical CCR4-NOT core subunits and no complex-level or independent molecular activity has been demonstrated for it.</h3>
+                <span class="vote-buttons" data-g="P53836" data-a="FUNCTION: No specific molecular function can be positively a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005935" target="_blank" class="term-link">
+                                cellular bud neck
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25028499" target="_blank" class="term-link">
+                                PMID:25028499
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">under DNA-damaging conditions, Tsr1, Caf120, Dip5, Skg6, Lte1, and</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CAF120 acts as a regulator of meiotic crossing-over. It is a meiosis-specific, metaphase-I- enriched interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover-forming machinery, and its deletion reproducibly reduces meiotic crossover frequency. This is the only specific biological process for which CAF120 has direct experimental support; consistent with the protein&#39;s lack of any catalytic domain (only a divergent PH module), its contribution is presumed to be a non-catalytic regulatory/scaffolding role, but the molecular mechanism is not established.</h3>
+                <span class="vote-buttons" data-g="P53836" data-a="FUNCTION: CAF120 acts as a regulator of meiotic crossing-ove..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010520" target="_blank" class="term-link">
+                                regulation of reciprocal meiotic recombination
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31351878" target="_blank" class="term-link">
+                                PMID:31351878
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Rtk1, Caf120, and Chd1 as regulators of crossing-over</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31351878" target="_blank" class="term-link">
+                                PMID:31351878
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">chd1Δ, rtk1Δ, and caf120Δ</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25028499" target="_blank" class="term-link">
+                            PMID:25028499
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteome-wide remodeling of protein location and function by stress.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11733989" target="_blank" class="term-link">
+                            PMID:11733989
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Purification and characterization of the 1.0 MDa CCR4-NOT complex identifies two novel components of the complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31351878" target="_blank" class="term-link">
+                            PMID:31351878
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Network Rewiring of Homologous Recombination Enzymes during Mitotic Proliferation and Meiosis.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the divergent PH domain of CAF120 bind a phosphoinositide, a protein partner, or neither, and does this binding determine its localization to the bud neck?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="Q: Does the divergent PH domain of CAF120 bind a phos..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is CAF120 a stable stoichiometric subunit of the CCR4-NOT complex or a transient associated factor, and does it contribute measurably to CCR4-NOT mRNA-deadenylase or transcriptional activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="Q: Is CAF120 a stable stoichiometric subunit of the C..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are CAF120 and its whole-genome-duplication paralog SKG3 functionally redundant, and does a double deletion reveal a phenotype masked in the single mutants?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="Q: Are CAF120 and its whole-genome-duplication paralo..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> By what molecular mechanism does CAF120 promote meiotic crossover formation — does it act on recruitment, stability, or activity of the MutLgamma-Exo1 machinery at recombination intermediates, and is this role connected to its CCR4-NOT association or PH domain?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Joao Matos</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="Q: By what molecular mechanism does CAF120 promote me..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify the recombinant CAF120 PH domain (and full-length protein) and assay phosphoinositide binding by lipid-strip and liposome-flotation assays; in parallel, perform affinity-purification / proximity-labeling (e.g. BioID or TurboID) from yeast to identify protein interactors, and test whether mutating the predicted ligand-binding surface disrupts bud-neck localization of a GFP fusion.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The CAF120 PH domain targets the protein to a specific membrane/lipid or protein partner at the bud neck.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical and cell-biological interaction mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="EXPERIMENT: Express and purify the recombinant CAF120 PH domai..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform quantitative affinity purification of tagged core CCR4-NOT subunits (e.g. NOT1, CCR4) with stoichiometry measurement to determine whether CAF120 co-purifies stably; and measure global and reporter-specific mRNA poly(A) tail lengths / deadenylation kinetics and reporter transcription in caf120-null versus wild-type cells.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CAF120 is only transiently/substoichiometrically associated with CCR4-NOT and does not materially affect complex activity.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: quantitative interaction proteomics and mRNA-turnover assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="EXPERIMENT: Perform quantitative affinity purification of tagg..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct caf120 skg3 single and double deletion strains and profile them for growth, budding/cytokinesis morphology, stress (including DNA-damage) sensitivity, and amino-acid metabolism, looking for synthetic phenotypes absent from the single mutants.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CAF120 and SKG3 are functionally redundant paralogs.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic redundancy / synthetic phenotype analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="EXPERIMENT: Construct caf120 skg3 single and double deletion s..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Dissect the CAF120-MutLgamma-Exo1 relationship in meiosis: map the meiosis-specific interaction interface (co-IP / crosslinking-MS of tagged Caf120 with Mlh1/Mlh3/Exo1), test whether caf120Δ alters MutLgamma-Exo1 chromatin recruitment or joint-molecule resolution (physical recombination assays, ChIP), and determine epistasis of caf120Δ with mlh3Δ/exo1Δ for crossover frequency and spore viability.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CAF120 promotes meiotic crossovers by modulating the MutLgamma-Exo1 crossover machinery.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: meiotic recombination mechanism / genetic-interaction analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53836" data-a="EXPERIMENT: Dissect the CAF120-MutLgamma-Exo1 relationship in ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of CAF120 is unknown. No catalytic, nucleic-acid-binding, adapter, or scaffolding activity has been demonstrated, and the ligand and role of its divergent N-terminal PH domain (Skg3/CAF120-like PH subfamily) are undetermined — it is not known whether this PH domain binds phosphoinositides (as canonical PH domains do), a protein partner, or acts as a non-binding structural module.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that CAF120 is a 1060-residue, ~118 kDa non-essential protein whose only recognized folded domain is a PH domain (residues 75-204; Pfam PF00169/PF25381, InterPro IPR058155 Skg3/CAF120-like PH), with the remainder largely intrinsically disordered and low-complexity. It localizes to the cytoplasm, nucleus, and bud neck, is a Cdk1 phosphosubstrate, is expressed at ~1380 molecules/cell in log phase, and has a whole-genome-duplication paralog, SKG3. GO and SGD record its molecular function as unknown (ND).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> CAF120 is a conserved-fold, phospho-regulated protein that sits at the interface of two heavily-studied systems (the CCR4-NOT machinery and the bud-neck cytokinesis apparatus) yet has no assigned mechanism. Determining what its PH domain binds would likely reveal both its molecular activity and where it acts, and would clarify whether the electronic kinase/ signaling annotations it currently inherits are truly spurious.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of the recombinant PH domain (phosphoinositide-strip / liposome binding, and pulldown/proximity proteomics for protein ligands); structural determination of the PH domain to assess whether its ligand-binding pocket is competent; and identification of interaction partners of the full-length protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"condition-specific subcellular locations, biological processes, and"</em> — PMID:25028499</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unresolved whether CAF120 is a bona fide, stable core subunit of the CCR4-NOT complex or merely a transient / substoichiometric associated factor, and — if it does associate — whether it makes any functional contribution to CCR4-NOT-dependent mRNA deadenylation/ turnover or transcriptional regulation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> CAF120 is named &#34;CCR4-associated factor 120 kDa&#34;, and UniProt lists it as a subunit of the 1.0 MDa CCR4-NOT core complex interacting with NOT1, attributing this to the 2001 complex- purification study. However, that study&#39;s own report of the 1.0 MDa complex composition names CCR4, CAF1, NOT1-5 and the two newly identified proteins CAF40 and CAF130, and the GO ontology&#39;s definition of the Saccharomyces &#34;CCR4-NOT core complex&#34; (GO:0030015) enumerates Ccr4p, Caf1p, Caf40p, Caf130p and Not1-5p — CAF120 is absent from both lists. Correspondingly, GOA carries no CCR4-NOT complex (GO:0030014/GO:0030015) annotation for CAF120, and SGD/GO record its biological process as unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether CAF120 is a real CCR4-NOT subunit or an associated factor determines whether it can legitimately inherit any CCR4-NOT function and shapes how this dark gene should be curated. The discrepancy between the gene&#39;s name / UniProt subunit statement and the canonical complex composition (in the primary paper and in GO) is exactly the kind of unresolved association that should not be propagated as fact without confirmation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Quantitative interaction proteomics (e.g. affinity purification with stoichiometry determination, or reciprocal tagging of core subunits) to test stable versus transient CCR4-NOT association; and functional assays (mRNA deadenylation / poly(A) tail length, reporter-gene transcription) in caf120-null versus wild-type cells to test any contribution to CCR4-NOT activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The 1.0 MDa complex was found to contain CCR4, CAF1, NOT1-5 and two"</em> — PMID:11733989</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular mechanism by which CAF120 promotes meiotic crossing-over is unknown: it is not established how (or whether directly) CAF120 acts on the MutLgamma-Exo1 crossover machinery, what its meiosis-specific binding is to within that network, or why loss of CAF120 lowers crossover frequency.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established (by affinity-proteomics plus a genetic crossover assay) that CAF120 is a metaphase-I-enriched interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover machinery and that caf120-null meiosis shows a reproducible reduction in crossover frequency, so CAF120 is a bona fide regulator of crossing-over. However, the study characterized the mechanism only for a co-identified factor (Chd1, via its DNA-binding activity) and explicitly left CAF120 (and Rtk1) as candidates for further functional analysis; CAF120 has no catalytic domain, so any contribution is presumed non-catalytic/regulatory but is otherwise undefined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the one sharp mechanistic hole in an otherwise newly-illuminated function: CAF120 is now known to matter for crossover formation, but the causal step it controls is undefined. Closing it would convert a &#34;regulator of crossing-over&#34; statement into a mechanistic model and would clarify whether CAF120&#39;s role is exerted through, or independently of, its reported CCR4-NOT / PH-domain-mediated interactions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Mechanistic dissection of the CAF120-MutLgamma-Exo1 relationship: mapping the meiosis- specific interaction interface, testing whether CAF120 affects MutLgamma-Exo1 recruitment, stability, or nuclease activity at recombination intermediates, and epistasis of caf120 with mlh1/mlh3/exo1 in crossover assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Rtk1 and Caf120 are interesting candidates for further functional analyses"</em> — PMID:31351878</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role and physiological significance of CAF120&#39;s bud-neck localization and of its DNA-damage-induced relocalization are unknown, as is the basis of its subtle deletion phenotypes (reduced competitive fitness, altered free amino-acid profile, stress sensitivity) and its functional relationship to (or redundancy with) its paralog SKG3.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> CAF120 is experimentally localized to the bud neck (IDA) in addition to the cytoplasm and nucleus, and it changes subcellular location under DNA-damaging conditions. Its deletion is viable, with only diffuse high-throughput phenotypes reported, and it has a WGD paralog, SKG3, that is itself uncharacterized. No process-level mechanism connects these observations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Bud-neck enrichment and stress-triggered relocalization hint at a cytokinesis- and/or stress-response-related role, but without a mechanism these remain descriptive. Testing whether CAF120 and SKG3 are functionally redundant is essential, because paralog redundancy is a common reason a single-gene deletion shows only subtle phenotypes and would explain the gene&#39;s apparent dispensability.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotypic analysis of caf120 skg3 double mutants (and stress/DNA-damage challenges) for synthetic defects in growth, budding/cytokinesis and stress survival; live-cell imaging of the relocalization dynamics; and genetic-interaction / co-expression profiling to place the gene in a pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"under DNA-damaging conditions, Tsr1, Caf120, Dip5, Skg6, Lte1, and"</em> — PMID:25028499</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CAF120-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53836" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: CAF120 (YNL278W) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:28:33.177349</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="CAF120-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-caf120-ynl278w-in-saccharomyces-cerevisiae">Comprehensive Research Report: CAF120 (YNL278W) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>CAF120 (systematic name YNL278W) encodes a 120 kDa CCR4-associated factor in <em>Saccharomyces cerevisiae</em> (baker's yeast). The protein was originally identified by its physical association with the CCR4 protein, the major cytoplasmic mRNA deadenylase in yeast (goldstrohm2007pufproteinmediateddeadenylation pages 1-2). CAF120 is a member of the CAF120 protein family and contains Pleckstrin Homology (PH)-like domains (InterPro: IPR011993, IPR001849, IPR058155), which typically function as protein-protein or protein-lipid interaction modules. It is important to note that CAF120 is distinct from Caf130, another yeast-specific CCR4-associated factor that is consistently listed as a core subunit of the CCR4-NOT complex.</p>
+<p>The key properties of CAF120 are summarized in the following table:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Protein name</td>
+<td>CCR4-NOT transcriptional complex subunit CAF120; also described as a 120 kDa CCR4-associated factor (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, hagkarim2020theregulatoryproperties pages 1-3)</td>
+</tr>
+<tr>
+<td>Gene name</td>
+<td><strong>CAF120</strong> (goldstrohm2007pufproteinmediateddeadenylation pages 1-2)</td>
+</tr>
+<tr>
+<td>Systematic name</td>
+<td><strong>YNL278W</strong> (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, kim2018globalanalysisof pages 75-77)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Saccharomyces cerevisiae</em> (baker’s yeast; strain S288C/background strains used in cited studies) (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, philipp2019networkrewiringof pages 1-3)</td>
+</tr>
+<tr>
+<td>Molecular weight</td>
+<td>~120 kDa by nomenclature/original factor description; exact mass not established in the cited papers here (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, hagkarim2020theregulatoryproperties pages 1-3)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>Contains PH/PH-like domains per UniProt/domain annotations supplied in the research prompt; consistent with a likely non-catalytic scaffolding or interaction role, but no primary structural study for yeast Caf120 was identified here (supported functionally by lack of known catalytic activity) (philipp2019networkrewiringof pages 7-8, hagkarim2020theregulatoryproperties pages 1-3)</td>
+</tr>
+<tr>
+<td>Known functions</td>
+<td>Non-catalytic CCR4-associated factor linked to the broader CCR4-NOT gene-expression machinery; not required for HO mRNA deadenylation in the tested assay, but contributes to normal meiotic crossover frequency, implicating it in meiotic recombination/crossover control (goldstrohm2007pufproteinmediateddeadenylation pages 2-3, philipp2019networkrewiringof pages 7-8)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Detected at the <strong>cytoplasm, bud neck, and bud</strong> in a proteome-scale localization/homomerization study (kim2018globalanalysisof pages 75-77)</td>
+</tr>
+<tr>
+<td>Deletion phenotype</td>
+<td><strong>caf120Δ</strong> showed <strong>no apparent effect on HO mRNA poly(A) tail length/deadenylation</strong> in the Mpt5p/HO assay; in contrast, <strong>caf120Δ reduced meiotic genetic distance/crossover frequency</strong> in the CEN8-THR1 interval assay (goldstrohm2007pufproteinmediateddeadenylation pages 2-3, philipp2019networkrewiringof pages 7-8)</td>
+</tr>
+<tr>
+<td>Key interactors / pathway context</td>
+<td>Functionally associated with the <strong>CCR4-NOT/CCR4-Pop2-Not</strong> complex context in mRNA regulation; genetically/functionally linked to the <strong>MutLγ-Exo1 meiotic crossover pathway</strong>, where Caf120 emerged from a screen of metaphase I-enriched interactors affecting crossover formation (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, philipp2019networkrewiringof pages 7-8, philipp2019networkrewiringof pages 8-9)</td>
+</tr>
+<tr>
+<td>Essential gene?</td>
+<td><strong>Non-essential</strong> under standard laboratory conditions; viable deletion strains were used in both deadenylation and meiotic crossover studies (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, philipp2019networkrewiringof pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main curated properties of yeast CAF120/YNL278W, including identity, localization, pathway context, and experimentally observed deletion phenotypes. It is useful as a compact reference because the literature on this specific protein is limited and dispersed across CCR4-NOT and meiosis studies.</em></p>
+<h2 id="2-relationship-to-the-ccr4-not-complex">2. Relationship to the CCR4-NOT Complex</h2>
+<p>The CCR4-NOT complex is a highly conserved, multisubunit assembly central to the regulation of eukaryotic gene expression. In <em>S. cerevisiae</em>, the complex was originally identified through genetic screens for transcription regulators and was later shown to carry the major cytoplasmic mRNA deadenylase activity (miller2012ccr4notcomplexthe pages 1-2, collart2016theccr4‐notcomplex pages 1-2). The nine core subunits of the yeast CCR4-NOT complex are: Not1 (the scaffold), Not2, Not3, Not4, Not5, Caf1 (Pop2), Ccr4, Caf40, and Caf130 (caulier2025theccr4–notcomplex pages 2-3, hagkarim2020theregulatoryproperties pages 1-3, chapat2014novelrolesof pages 1-2, collart2017theccr4notcomplex pages 1-4). These are organized into functional modules—a deadenylase module (Ccr4 and Caf1), a ubiquitination module (Not4), the NOT module (Not2-Not3-Not5), the Caf40 module, and a fifth module comprising Caf130—all docked onto the Not1 scaffold protein (collart2017theccr4notcomplex pages 1-4).</p>
+<p>CAF120 is not consistently listed among these nine canonical core subunits. Rather, it appears to be an associated or peripheral factor of the CCR4-NOT complex. The original biochemical purification of Ccr4-containing complexes identified several CCR4-associated factors, including Caf1, Caf40, Caf130, and CAF120, as proteins that co-purify with Ccr4 (goldstrohm2007pufproteinmediateddeadenylation pages 1-2). The larger (~1.9 MDa) version of the complex may additionally contain a combination of factors such as Dhh1, Dbf2, Caf4, Caf16, and Btt1, beyond the ~1.0 MDa core (miller2012ccr4notcomplexthe pages 1-2, bartlam2010thestructuralbasis pages 1-3). The precise stoichiometric relationship of CAF120 to the core complex remains poorly defined.</p>
+<h2 id="3-molecular-function">3. Molecular Function</h2>
+<p>CAF120 has no known enzymatic activity. It does not possess deadenylase, ubiquitin ligase, or any other catalytic function. Its PH-like domains are characteristic of scaffold or adaptor proteins that mediate protein-protein interactions. This structural architecture suggests that CAF120 functions as a non-catalytic, structural or regulatory component within the broader CCR4-NOT interaction network.</p>
+<h3 id="31-dispensability-for-mrna-deadenylation">3.1 Dispensability for mRNA Deadenylation</h3>
+<p>Direct experimental testing of CAF120's role in mRNA deadenylation has been performed. Goldstrohm et al. (2007) examined the deadenylation of HO mRNA—a well-characterized target of PUF protein-mediated poly(A) tail shortening—in a panel of deletion strains lacking various CCR4-NOT complex components. Deletion of CAF120 (caf120Δ) had no apparent effect on HO mRNA poly(A) tail length, in contrast to the severe deadenylation defects observed in ccr4Δ and pop2Δ strains (goldstrohm2007pufproteinmediateddeadenylation pages 2-3). This result was consistent across multiple non-essential subunits: deletions of Caf130, Not3, and Not4 also did not significantly affect HO deadenylation (goldstrohm2007pufproteinmediateddeadenylation pages 2-3). Thus, CAF120 is dispensable for at least one well-characterized deadenylation pathway.</p>
+<h3 id="32-role-in-meiotic-crossing-over">3.2 Role in Meiotic Crossing-Over</h3>
+<p>Perhaps the most striking functional finding for CAF120 emerged from a large-scale proteomic and genetic study of homologous recombination enzymes by Wild et al. (2019). This study used affinity purification–mass spectrometry to characterize the interaction network of seven recombination intermediate processing enzymes (RIPEs) during mitotic proliferation and meiosis in <em>S. cerevisiae</em> (philipp2019networkrewiringof pages 1-3). CAF120 was identified as a metaphase I-enriched interactor of the MutLγ-Exo1 complex—the endonuclease system responsible for generating the majority of meiotic crossovers (philipp2019networkrewiringof pages 7-8).</p>
+<p>A functional screen of metaphase I-enriched interactors revealed that deletion of CAF120 (caf120Δ) caused a reproducible reduction in genetic distance at the CEN8-THR1 interval, a standard measure of crossover frequency (philipp2019networkrewiringof pages 7-8). This phenotype was milder than that observed for chd1Δ, which showed a crossover defect comparable to deletion of core crossover genes (MLH1, MLH3, or EXO1), but it nonetheless demonstrated a functional role for CAF120 in meiotic recombination (philipp2019networkrewiringof pages 7-8). The molecular mechanism by which CAF120 contributes to crossover formation remains unknown, but its identification as a context-specific interactor of the MutLγ-Exo1 pathway suggests it may serve a scaffolding or regulatory role during the resolution of meiotic recombination intermediates.</p>
+<h3 id="33-self-interaction-homomerization">3.3 Self-Interaction (Homomerization)</h3>
+<p>A global analysis of protein homomerization in <em>S. cerevisiae</em> detected CAF120 as a protein capable of self-interaction (kim2018globalanalysisof pages 75-77). This capacity for homomerization may be relevant to its scaffolding function, potentially allowing multimerization-dependent assembly of protein complexes.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>In a proteome-wide study of protein homomerization and localization, CAF120 was detected in the cytoplasm, at the bud neck, and in the bud (kim2018globalanalysisof pages 75-77). This predominantly cytoplasmic localization is consistent with the known primary localization of the CCR4-NOT complex. The parent CCR4-NOT complex has been detected in both the cytoplasm and the nucleus (collart2016theccr4‐notcomplex pages 2-4, chapat2014novelrolesof pages 5-6). In yeast, CCR4-NOT components are present in the cytoplasm where they carry out mRNA deadenylation, and in processing bodies (P-bodies) which are cytoplasmic granules involved in mRNA decay and storage (chapat2014novelrolesof pages 5-6). The complex also has nuclear functions including roles in transcription regulation, mRNA export, and nuclear RNA quality control (miller2012ccr4notcomplexthe pages 1-2, miller2012ccr4notcomplexthe pages 11-12, miller2012ccr4notcomplexthe pages 9-11). During the cell cycle, the complex shows dynamic redistribution: it concentrates in the nucleus during G1 phase and redistributes to the cytoplasm during S phase (hagkarim2020theregulatoryproperties pages 14-16). Recent comprehensive reviews, however, emphasize that the best-supported functions of the CCR4-NOT complex are cytoplasmic—deadenylation, mRNA decay, and translational control—while direct evidence for nuclear transcriptional roles has been more elusive (caulier2025theccr4–notcomplex pages 7-8).</p>
+<h2 id="5-biochemical-pathways">5. Biochemical Pathways</h2>
+<h3 id="51-mrna-metabolism-pathway">5.1 mRNA Metabolism Pathway</h3>
+<p>CAF120 is embedded within the broader CCR4-NOT complex, which is the major eukaryotic deadenylase complex responsible for shortening poly(A) tails on mRNAs (collart2016theccr4‐notcomplex pages 1-2, caulier2025theccr4–notcomplex pages 1-2). This complex regulates gene expression at multiple levels: transcription initiation and elongation, mRNA quality control and export, translational control, co-translational quality control, and mRNA decay (collart2016theccr4‐notcomplex pages 1-2, collart2017theccr4notcomplex pages 1-4). Although CAF120 itself is not required for the deadenylation reaction, its association with the complex places it within this central mRNA metabolism machinery.</p>
+<h3 id="52-meiotic-recombination-pathway">5.2 Meiotic Recombination Pathway</h3>
+<p>CAF120 participates in the MutLγ-Exo1 meiotic crossover pathway (philipp2019networkrewiringof pages 1-3, philipp2019networkrewiringof pages 7-8). During meiosis, recombination intermediates (joint molecules containing Holliday junctions) are resolved by structure-selective nucleases and the MutLγ-Exo1 endonuclease to generate crossovers. The MutLγ complex (Mlh1-Mlh3) works with Exo1 to produce the majority of meiotic crossovers. CAF120 was identified as a meiosis-specific (metaphase I-enriched) component of this pathway's interaction network, and its deletion reduces crossover frequency (philipp2019networkrewiringof pages 7-8).</p>
+<h2 id="6-domain-architecture-and-evolutionary-context">6. Domain Architecture and Evolutionary Context</h2>
+<p>CAF120 contains PH (Pleckstrin Homology) and PH-like domains, belonging to the PH-like domain superfamily (IPR011993) and specifically to the Skg3/CAF120-like PH family (IPR058155). PH domains are versatile protein-protein and protein-lipid interaction modules found in diverse signaling and scaffold proteins. In the context of CAF120, these domains are likely to mediate its association with other proteins, potentially including components of the CCR4-NOT complex or the meiotic recombination machinery.</p>
+<p>CAF120 is a member of the CAF120 family (per UniProt classification), which appears to be restricted to fungi. The protein has no obvious orthologs in metazoan organisms (caulier2025theccr4–notcomplex pages 2-3), paralleling the situation with Caf130, another yeast-specific CCR4-NOT associated factor that lacks identifiable homologs outside of yeast. The recent comprehensive review by Caulier et al. (2025) confirms that the CCR4-NOT complex composition varies across organisms, with a universally conserved core enriched by lineage-specific subunits such as Caf130 in <em>S. cerevisiae</em> (caulier2025theccr4–notcomplex pages 1-2, caulier2025theccr4–notcomplex pages 2-3).</p>
+<h2 id="7-gene-essentiality-and-phenotypic-effects">7. Gene Essentiality and Phenotypic Effects</h2>
+<p>CAF120 is a non-essential gene under standard laboratory conditions. Viable deletion strains have been constructed and used in multiple studies (goldstrohm2007pufproteinmediateddeadenylation pages 1-2, philipp2019networkrewiringof pages 7-8). The deletion of CAF120 does not display any readily identifiable growth phenotype on standard media, consistent with the observation that deletion of Caf40 or Caf130 similarly does not display obvious growth defects (collart2016theccr4‐notcomplex pages 2-4). However, mild sensitivity or resistance changes to various conditions may exist, as documented in the Saccharomyces Genome Database (collart2016theccr4‐notcomplex pages 2-4). The most notable phenotype of caf120Δ is the reduction in meiotic crossover frequency (philipp2019networkrewiringof pages 7-8).</p>
+<h2 id="8-recent-developments">8. Recent Developments</h2>
+<p>Recent studies on the CCR4-NOT complex (2023–2025) have focused primarily on the roles of core subunits in co-translational quality control, codon optimality-dependent mRNA decay, and ribosome-associated functions. A landmark study by Zhu et al. (2024) revealed that specific tRNAs in the ribosomal P-site recruit the CCR4-NOT complex via CNOT3/Not5, directly linking translation efficiency to mRNA stability. Collart et al. (2024) reviewed the expanding roles of the CCR4-NOT complex in co-translational processes, including protein folding and organelle targeting. A comprehensive 2025 review by Caulier et al. in <em>Nucleic Acids Research</em> provided an updated evolutionary perspective on CCR4-NOT complex composition and function (caulier2025theccr4–notcomplex pages 1-2). However, no recent studies have specifically addressed the function or structure of CAF120 itself, leaving this protein as one of the less characterized components of the broader CCR4-NOT interaction network.</p>
+<h2 id="9-conclusions-and-knowledge-gaps">9. Conclusions and Knowledge Gaps</h2>
+<p>CAF120/YNL278W is a poorly characterized, non-catalytic, PH domain-containing protein associated with the CCR4-NOT complex in <em>S. cerevisiae</em>. While it was originally identified as a CCR4-associated factor, it is not required for the canonical deadenylation function of the complex. Its most clearly defined biological role is in meiotic crossing-over, where it contributes to normal crossover frequency through the MutLγ-Exo1 pathway. Its PH-like domains suggest a scaffolding or adapter function, potentially bridging protein-protein interactions within the CCR4-NOT complex or between the complex and other cellular machinery. Significant knowledge gaps remain regarding: (1) the precise structural basis for CAF120's interaction with the CCR4-NOT complex and its docking site on Not1; (2) the molecular mechanism by which it promotes meiotic crossover formation; (3) whether it has additional condition-specific functions beyond deadenylation and meiosis; and (4) the functional significance of its homomerization capacity and cytoplasmic/bud neck localization.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(goldstrohm2007pufproteinmediateddeadenylation pages 1-2): Aaron C. Goldstrohm, Daniel J. Seay, Brad A. Hook, and Marvin Wickens. Puf protein-mediated deadenylation is catalyzed by ccr4p*. Journal of Biological Chemistry, 282:109-114, Jan 2007. URL: https://doi.org/10.1074/jbc.m609413200, doi:10.1074/jbc.m609413200. This article has 217 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hagkarim2020theregulatoryproperties pages 1-3): Nafiseh Chalabi Hagkarim and Roger J. Grand. The regulatory properties of the ccr4–not complex. Cells, 9:2379, Oct 2020. URL: https://doi.org/10.3390/cells9112379, doi:10.3390/cells9112379. This article has 88 citations.</p>
+</li>
+<li>
+<p>(kim2018globalanalysisof pages 75-77): Yeonsoo Kim, J. Jung, C. Pack, and W. Huh. Global analysis of protein homomerization in saccharomyces cerevisiae. Genome Research, 29:135-145, Apr 2018. URL: https://doi.org/10.1101/gr.231860.117, doi:10.1101/gr.231860.117. This article has 14 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(philipp2019networkrewiringof pages 1-3): Philipp Wild, Aitor Susperregui, Ilaria Piazza, Christian Dörig, Ashwini Oke, Meret Arter, Miyuki Yamaguchi, Alexander T. Hilditch, Karla Vuina, Ki Choi Chan, Tatiana Gromova, James E. Haber, Jennifer C. Fung, Paola Picotti, and Joao Matos. Network rewiring of homologous recombination enzymes during mitotic proliferation and meiosis. Molecular Cell, 75:859-874.e4, Aug 2019. URL: https://doi.org/10.1016/j.molcel.2019.06.022, doi:10.1016/j.molcel.2019.06.022. This article has 62 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(philipp2019networkrewiringof pages 7-8): Philipp Wild, Aitor Susperregui, Ilaria Piazza, Christian Dörig, Ashwini Oke, Meret Arter, Miyuki Yamaguchi, Alexander T. Hilditch, Karla Vuina, Ki Choi Chan, Tatiana Gromova, James E. Haber, Jennifer C. Fung, Paola Picotti, and Joao Matos. Network rewiring of homologous recombination enzymes during mitotic proliferation and meiosis. Molecular Cell, 75:859-874.e4, Aug 2019. URL: https://doi.org/10.1016/j.molcel.2019.06.022, doi:10.1016/j.molcel.2019.06.022. This article has 62 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(goldstrohm2007pufproteinmediateddeadenylation pages 2-3): Aaron C. Goldstrohm, Daniel J. Seay, Brad A. Hook, and Marvin Wickens. Puf protein-mediated deadenylation is catalyzed by ccr4p*. Journal of Biological Chemistry, 282:109-114, Jan 2007. URL: https://doi.org/10.1074/jbc.m609413200, doi:10.1074/jbc.m609413200. This article has 217 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(philipp2019networkrewiringof pages 8-9): Philipp Wild, Aitor Susperregui, Ilaria Piazza, Christian Dörig, Ashwini Oke, Meret Arter, Miyuki Yamaguchi, Alexander T. Hilditch, Karla Vuina, Ki Choi Chan, Tatiana Gromova, James E. Haber, Jennifer C. Fung, Paola Picotti, and Joao Matos. Network rewiring of homologous recombination enzymes during mitotic proliferation and meiosis. Molecular Cell, 75:859-874.e4, Aug 2019. URL: https://doi.org/10.1016/j.molcel.2019.06.022, doi:10.1016/j.molcel.2019.06.022. This article has 62 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(miller2012ccr4notcomplexthe pages 1-2): Jason E. Miller and Joseph C. Reese. Ccr4-not complex: the control freak of eukaryotic cells. Critical Reviews in Biochemistry and Molecular Biology, 47:315-333, Jun 2012. URL: https://doi.org/10.3109/10409238.2012.667214, doi:10.3109/10409238.2012.667214. This article has 222 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(collart2016theccr4‐notcomplex pages 1-2): Martine A. Collart. The ccr4‐not complex is a key regulator of eukaryotic gene expression. Wiley Interdisciplinary Reviews. RNA, 7:438-454, Jan 2016. URL: https://doi.org/10.1002/wrna.1332, doi:10.1002/wrna.1332. This article has 446 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caulier2025theccr4–notcomplex pages 2-3): Guillaume Caulier, Joseph Siblini, Lina Sène, Fabienne Mauxion, and Bertrand Séraphin. The ccr4–not complex: a multifaceted sensor of molecular signals instructing eukaryotic mrna translation and stability. Nucleic Acids Research, Nov 2025. URL: https://doi.org/10.1093/nar/gkaf1401, doi:10.1093/nar/gkaf1401. This article has 8 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chapat2014novelrolesof pages 1-2): Clément Chapat and Laura Corbo. Novel roles of the ccr4–not complex. Wiley Interdisciplinary Reviews: RNA, 5:883-901, Nov 2014. URL: https://doi.org/10.1002/wrna.1254, doi:10.1002/wrna.1254. This article has 33 citations.</p>
+</li>
+<li>
+<p>(collart2017theccr4notcomplex pages 1-4): Martine A. Collart and Olesya O. Panasenko. The ccr4-not complex: architecture and structural insights. Sub-cellular biochemistry, 83:349-379, Jan 2017. URL: https://doi.org/10.1007/978-3-319-46503-6_13, doi:10.1007/978-3-319-46503-6_13. This article has 77 citations.</p>
+</li>
+<li>
+<p>(bartlam2010thestructuralbasis pages 1-3): Mark Bartlam and Tadashi Yamamoto. The structural basis for deadenylation by the ccr4-not complex. Protein &amp; Cell, 1:443-452, Jun 2010. URL: https://doi.org/10.1007/s13238-010-0060-8, doi:10.1007/s13238-010-0060-8. This article has 99 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(collart2016theccr4‐notcomplex pages 2-4): Martine A. Collart. The ccr4‐not complex is a key regulator of eukaryotic gene expression. Wiley Interdisciplinary Reviews. RNA, 7:438-454, Jan 2016. URL: https://doi.org/10.1002/wrna.1332, doi:10.1002/wrna.1332. This article has 446 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chapat2014novelrolesof pages 5-6): Clément Chapat and Laura Corbo. Novel roles of the ccr4–not complex. Wiley Interdisciplinary Reviews: RNA, 5:883-901, Nov 2014. URL: https://doi.org/10.1002/wrna.1254, doi:10.1002/wrna.1254. This article has 33 citations.</p>
+</li>
+<li>
+<p>(miller2012ccr4notcomplexthe pages 11-12): Jason E. Miller and Joseph C. Reese. Ccr4-not complex: the control freak of eukaryotic cells. Critical Reviews in Biochemistry and Molecular Biology, 47:315-333, Jun 2012. URL: https://doi.org/10.3109/10409238.2012.667214, doi:10.3109/10409238.2012.667214. This article has 222 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(miller2012ccr4notcomplexthe pages 9-11): Jason E. Miller and Joseph C. Reese. Ccr4-not complex: the control freak of eukaryotic cells. Critical Reviews in Biochemistry and Molecular Biology, 47:315-333, Jun 2012. URL: https://doi.org/10.3109/10409238.2012.667214, doi:10.3109/10409238.2012.667214. This article has 222 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hagkarim2020theregulatoryproperties pages 14-16): Nafiseh Chalabi Hagkarim and Roger J. Grand. The regulatory properties of the ccr4–not complex. Cells, 9:2379, Oct 2020. URL: https://doi.org/10.3390/cells9112379, doi:10.3390/cells9112379. This article has 88 citations.</p>
+</li>
+<li>
+<p>(caulier2025theccr4–notcomplex pages 7-8): Guillaume Caulier, Joseph Siblini, Lina Sène, Fabienne Mauxion, and Bertrand Séraphin. The ccr4–not complex: a multifaceted sensor of molecular signals instructing eukaryotic mrna translation and stability. Nucleic Acids Research, Nov 2025. URL: https://doi.org/10.1093/nar/gkaf1401, doi:10.1093/nar/gkaf1401. This article has 8 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caulier2025theccr4–notcomplex pages 1-2): Guillaume Caulier, Joseph Siblini, Lina Sène, Fabienne Mauxion, and Bertrand Séraphin. The ccr4–not complex: a multifaceted sensor of molecular signals instructing eukaryotic mrna translation and stability. Nucleic Acids Research, Nov 2025. URL: https://doi.org/10.1093/nar/gkaf1401, doi:10.1093/nar/gkaf1401. This article has 8 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="CAF120-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>goldstrohm2007pufproteinmediateddeadenylation pages 1-2</li>
+<li>kim2018globalanalysisof pages 75-77</li>
+<li>goldstrohm2007pufproteinmediateddeadenylation pages 2-3</li>
+<li>philipp2019networkrewiringof pages 1-3</li>
+<li>philipp2019networkrewiringof pages 7-8</li>
+<li>chapat2014novelrolesof pages 5-6</li>
+<li>hagkarim2020theregulatoryproperties pages 14-16</li>
+<li>hagkarim2020theregulatoryproperties pages 1-3</li>
+<li>philipp2019networkrewiringof pages 8-9</li>
+<li>chapat2014novelrolesof pages 1-2</li>
+<li>bartlam2010thestructuralbasis pages 1-3</li>
+<li>https://doi.org/10.1074/jbc.m609413200,</li>
+<li>https://doi.org/10.3390/cells9112379,</li>
+<li>https://doi.org/10.1101/gr.231860.117,</li>
+<li>https://doi.org/10.1016/j.molcel.2019.06.022,</li>
+<li>https://doi.org/10.3109/10409238.2012.667214,</li>
+<li>https://doi.org/10.1002/wrna.1332,</li>
+<li>https://doi.org/10.1093/nar/gkaf1401,</li>
+<li>https://doi.org/10.1002/wrna.1254,</li>
+<li>https://doi.org/10.1007/978-3-319-46503-6_13,</li>
+<li>https://doi.org/10.1007/s13238-010-0060-8,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CAF120-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53836" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="caf120-ynl278w-p53836-curation-notes">CAF120 (YNL278W / P53836) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> CAF120.<br />
+CAF120 is an <strong>understudied ("dark") gene</strong>: it is named as a CCR4-associated factor and<br />
+is reported to be associated with the CCR4-NOT complex, but its own molecular function and<br />
+biological role are essentially uncharacterized. The primary deliverable of this review is<br />
+therefore an honest <code>knowledge_gaps</code> section plus conservatively-reasoned <code>description</code> /<br />
+<code>core_functions</code> grounded in domain content, orthology and the sparse literature — never<br />
+invented function.</p>
+<h2 id="identity-verified-from-uniprot-record">Identity (verified from UniProt record)</h2>
+<ul>
+<li>UniProt: <strong>P53836</strong> (CA120_YEAST); systematic name <strong>YNL278W</strong>; ORF N0610; SGD:S000005222.</li>
+<li>Standard name <strong>CAF120</strong> = "CCR4-Associated Factor 120" / "120 kDa CCR4-associated factor".</li>
+<li>1060 aa, 118 kDa, non-essential.</li>
+<li>Present with 1380 molecules/cell in log-phase SD medium<br />
+  [UniProt MISCELLANEOUS, ECO:0000269|PubMed:14562106].</li>
+</ul>
+<h2 id="domain-family-architecture-read-inline-from-caf120-uniprottxt">Domain / family architecture (read inline from CAF120-uniprot.txt)</h2>
+<ul>
+<li>Single recognized folded domain: a <strong>PH (pleckstrin-homology) domain</strong>, residues 75–204<br />
+  (PROSITE PS50003; Pfam PF00169 "PH" and PF25381 "PH_26"; SMART SM00233; Gene3D 2.30.29.30;<br />
+  SUPFAM SSF50729). InterPro <strong>IPR058155 "Skg3/CAF120-like_PH"</strong> — i.e. CAF120 defines,<br />
+  together with its paralog SKG3, a <em>specialized/divergent</em> PH-domain subfamily.</li>
+<li>The rest of the protein (≈residues 205–1060) is largely <strong>intrinsically disordered</strong>:<br />
+  MobiDB-lite disordered regions 465–589, 801–942, 955–1060, with low-complexity / polar /<br />
+  basic-acidic biased composition. No catalytic, nucleic-acid-binding, or other functional<br />
+  domain is annotated.</li>
+<li><strong>No protein kinase domain</strong> is present (no PF00069 / Pkinase; the only Pfam hits are the<br />
+  two PH models). This is decisive for judging the IBA "protein kinase activity" annotation<br />
+  (see below).</li>
+<li>Heavily phosphorylated: MOD_RES phosphoserines at S491, S510, S518, S538, S556, S871, S885;<br />
+  S556 and others are <strong>Cdk1 (Cdc28) substrate sites</strong> [ECO:0007744|PubMed:19779198 "Global<br />
+  analysis of Cdk1 substrate phosphorylation sites"]. So CAF120 is a substrate of cell-cycle<br />
+  kinases, not itself a kinase.</li>
+<li><strong>Paralog SKG3 (YHR133C)</strong> arose from the whole-genome duplication (SGD homology; shared<br />
+  IPR058155 PH family). SKG3 is likewise poorly characterized.</li>
+</ul>
+<h2 id="ccr4-not-association-nuanced-do-not-overstate">CCR4-NOT association — nuanced, do not overstate</h2>
+<ul>
+<li>UniProt FUNCTION/SUBUNIT (ECO:0000269|PubMed:11733989): describes CAF120 as a "component of<br />
+  the CCR4-NOT core complex … Subunit of the 1.0 MDa CCR4-NOT core complex that contains CCR4,<br />
+  CAF1, CAF120, NOT1, NOT2, NOT3, NOT4, NOT5, CAF40 and CAF130. In the complex interacts with<br />
+  NOT1." The generic CCR4-NOT FUNCTION text on the UniProt entry is the standard boilerplate<br />
+  for the complex (nuclear general transcription factor / cytoplasmic mRNA deadenylase), NOT a<br />
+  gene-specific experimental result for CAF120.</li>
+<li>BUT: the <strong>cached PMID:11733989 abstract</strong> ("Purification and characterization of the 1.0 MDa<br />
+  CCR4-NOT complex identifies two novel components") lists the identified 1.0 MDa components as<br />
+  "CCR4, CAF1, NOT1-5 and two new proteins, <strong>CAF40 and CAF130</strong>" — the abstract does <strong>not</strong><br />
+  name CAF120 <a href="https://pubmed.ncbi.nlm.nih.gov/11733989" title="The 1.0 MDa complex was found to contain CCR4, CAF1, NOT1-5 and   two new proteins, CAF40 and CAF130.">PMID:11733989</a>. The full text is not in our cache (full_text_available:<br />
+  false), so I cannot confirm what the paper says about CAF120 specifically.</li>
+<li>Critically, the <strong>GO ontology's own definition of GO:0030015 "CCR4-NOT core complex"</strong><br />
+  enumerates the Saccharomyces core subunits as "Ccr4p, Caf1p, Caf40p, Caf130p, Not1p, Not2p,<br />
+  Not3p, Not4p, and Not5p" — <strong>CAF120 is not listed</strong> [GO:0030015 definition, verified via OLS].</li>
+<li>Consistent with this, <strong>GOA has NO CCR4-NOT complex annotation for CAF120</strong> (no GO:0030014/<br />
+  GO:0030015 in the goa.tsv), and SGD lists CAF120's molecular function and biological process<br />
+  as <strong>unknown (ND)</strong> [SGD locus S000005222; ND annotations GO:0003674 / GO:0008150,<br />
+  GO_REF:0000015].</li>
+<li>Interpretation: CAF120 is a <em>CCR4-associated factor</em> (hence the name) that co-purifies with<br />
+  or associates with CCR4-NOT, but its status as a stable/canonical core subunit is not<br />
+  established in GO/SGD and cannot be verified from the cached abstract. I therefore do NOT<br />
+  assert a CCR4-NOT core-complex membership as a confident core_function; I record it as a<br />
+  key knowledge gap and (at most) a KEEP_AS_NON_CORE / candidate association, not fabricated<br />
+  MF.</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li><strong>Bud neck</strong>: IDA, GO:0005935 <a href="https://pubmed.ncbi.nlm.nih.gov/25028499">PMID:25028499</a>. Also captured in UniProt SUBCELLULAR LOCATION<br />
+  (Bud neck; ECO:0000269|PubMed:14562095, the Huh 2003 GFP localization atlas). Well supported.</li>
+<li><strong>Cytoplasm</strong> and <strong>Nucleus</strong>: UniProt SUBCELLULAR LOCATION (ECO:0000269|PubMed:14562095);<br />
+  GOA has these as IEA GO_REF:0000044 (UniProtKB-SubCell mapping SL-0086 cytoplasm, SL-0191<br />
+  nucleus). Reasonable, evidence-backed subcellular locations.</li>
+<li>PMID:25028499 (Lee et al. 2014, "Proteome-wide remodeling of protein location and function by<br />
+  stress"; abstract-only in cache) reports that under <strong>DNA-damaging conditions</strong> Caf120 (among<br />
+  Tsr1, Dip5, Skg6, Lte1, Nnf2) <strong>changes subcellular location</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/25028499" title="under   DNA-damaging conditions, Tsr1, Caf120, Dip5, Skg6, Lte1, and Nnf2 change subcellular   location">PMID:25028499</a>. This is a condition-dependent relocalization observation, consistent with the<br />
+  multi-compartment (cytoplasm/nucleus/bud neck) steady-state localization.</li>
+</ul>
+<h2 id="phenotypes-sgd-background-context-not-directly-annotatable-here">Phenotypes (SGD, background context — not directly annotatable here)</h2>
+<p>caf120Δ null: decreased competitive fitness in minimal medium; altered free amino-acid profile;<br />
+elevated cell-surface metal reductase activity; decreased vegetative &amp; anaerobic growth;<br />
+abnormal vacuolar morphology; increased stress sensitivity [SGD locus S000005222, phenotype<br />
+summary]. These are diffuse, mostly high-throughput phenotypes and do not pin down a specific<br />
+molecular function — consistent with the "dark gene" status.</p>
+<h2 id="annotation-by-annotation-reasoning-goa">Annotation-by-annotation reasoning (GOA)</h2>
+<ol>
+<li><strong>GO:0004672 protein kinase activity — IBA (GO_REF:0000033)</strong> — from PANTHER family<br />
+   PTN001969686, with reference members = Arabidopsis MAP3K loci <strong>AT1G05100, AT3G50310,<br />
+   AT4G26890</strong> (WITH/FROM). CAF120 has <strong>no protein kinase domain</strong> (only the PH domain). This<br />
+   is a family over-propagation: a shared accessory PH module pulled a non-kinase yeast protein<br />
+   into a plant-MAP3K-dominated PANTHER cluster, inheriting the kinase MF from the kinase-domain<br />
+   members. Biologically indefensible → <strong>REMOVE</strong>.</li>
+<li><strong>GO:0007165 signal transduction — IBA (GO_REF:0000033)</strong> — same PANTHER family<br />
+   (PTN001969686), same Arabidopsis MAP3K reference set. "Signal transduction" is the generic<br />
+   BP the plant MAP3Ks carry. No evidence CAF120 acts in a signaling cascade; inherited via the<br />
+   same over-propagation. → <strong>REMOVE</strong> (over-annotation; no gene-specific support).</li>
+<li><strong>GO:0005634 nucleus — IEA (GO_REF:0000044, SL-0191)</strong> — UniProtKB-SubCell mapping backed by<br />
+   PubMed:14562095 (GFP atlas). Reasonable subcellular location. → <strong>KEEP_AS_NON_CORE</strong>.</li>
+<li><strong>GO:0005737 cytoplasm — IEA (GO_REF:0000044, SL-0086)</strong> — same GFP-atlas backing. Broad but<br />
+   correct location. → <strong>KEEP_AS_NON_CORE</strong>.</li>
+<li><strong>GO:0005935 cellular bud neck — IEA (GO_REF:0000044, SL-0029)</strong> — redundant with the IDA<br />
+   below but derived from the SubCell mapping. → <strong>KEEP_AS_NON_CORE</strong> (subsumed by the IDA).</li>
+<li><strong>GO:0003674 molecular_function — ND (GO_REF:0000015)</strong> — root "unknown MF" placeholder.<br />
+   Honest reflection of the dark-gene state; the ND is appropriate given no defensible MF. →<br />
+<strong>ACCEPT</strong> (it correctly records that MF is unknown).</li>
+<li><strong>GO:0008150 biological_process — ND (GO_REF:0000015)</strong> — root "unknown BP" placeholder.<br />
+   Same rationale. → <strong>ACCEPT</strong>.</li>
+<li><strong>GO:0005935 cellular bud neck — IDA (PMID:25028499)</strong> — direct-assay localization to the<br />
+   bud neck. Well supported (and consistent with the Huh GFP atlas). → <strong>ACCEPT</strong> (best-supported<br />
+   experimental annotation).</li>
+</ol>
+<h2 id="what-is-known-vs-not-known">What is KNOWN vs NOT known</h2>
+<p>KNOWN:<br />
+- Subcellular localization: cytoplasm, nucleus, and bud neck (GFP atlas + IDA); relocalizes<br />
+  under DNA-damage stress.<br />
+- Has a divergent PH domain (Skg3/CAF120-like PH family, IPR058155); is a Cdk1 phosphosubstrate.<br />
+- Co-purifies with / is associated with the CCR4-NOT machinery (named "CCR4-associated factor";<br />
+  UniProt SUBUNIT), though not enumerated as a GO/SGD core subunit.<br />
+- Has a WGD paralog SKG3 (YHR133C), also uncharacterized.</p>
+<p>NOT known (knowledge gaps):<br />
+- Molecular function: no demonstrated catalytic, binding, adapter, or scaffold activity. The PH<br />
+  domain's ligand (phosphoinositide? protein? — divergent family) is unknown.<br />
+- Biological role: whether it functionally contributes to CCR4-NOT mRNA deadenylation/turnover<br />
+  or transcriptional regulation, or acts independently at the bud neck, is unresolved.<br />
+- Whether it is a bona fide stable CCR4-NOT core subunit vs a transient/substoichiometric<br />
+  associated factor.<br />
+- Physiological meaning of bud-neck localization (cytokinesis/budding role?) and of the<br />
+  DNA-damage-induced relocalization.<br />
+- Functional relationship to / redundancy with paralog SKG3.</p>
+<h2 id="update-post-merge-from-falcon-deep-research-independent-verification-meiotic-crossover-role">UPDATE (post-merge, from falcon deep research + independent verification): meiotic crossover role</h2>
+<p>The falcon deep-research report (CAF120-deep-research-falcon.md, 21 citations) surfaced a<br />
+specific, previously-missed functional finding, which I then verified independently against the<br />
+primary paper (NOT taking falcon's word for it):</p>
+<ul>
+<li><strong>CAF120 is a regulator of meiotic crossing-over.</strong> Wild et al. 2019 (Mol Cell; PMID:31351878;<br />
+  DOI 10.1016/j.molcel.2019.06.022; full text cached) affinity-purified the recombination-<br />
+  intermediate-processing enzymes across mitosis and meiosis and found CAF120 as a meiosis-<br />
+  specific (metaphase-I-enriched) interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover<br />
+  machinery. A functional screen showed caf120Δ reproducibly REDUCES crossover frequency:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31351878" title="Rtk1, Caf120, and Chd1 as regulators of crossing-over">PMID:31351878</a> and<br />
+  [PMID:31351878 "chd1Δ, rtk1Δ, and caf120Δ" (the 3 of 5 mutants with reduced genetic distance)].</li>
+<li>The authors characterized the MECHANISM only for the co-identified factor Chd1 (via DNA<br />
+  binding), and explicitly leave CAF120 as unresolved:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31351878" title="Rtk1 and Caf120 are interesting candidates for further functional analyses">PMID:31351878</a>.</li>
+<li>Verified independently via PubMed/abstract (PMID:31351878) and WebSearch — the abstract states<br />
+  the same. This is a genuine experimental role, so CAF120 is NOT wholly dark; it is MF-dark with<br />
+  one now-known BP (meiotic crossover regulation) whose mechanism is a residual sub-gap.</li>
+</ul>
+<p>Actions taken: added NEW annotation GO:0010520 (regulation of reciprocal meiotic recombination,<br />
+IMP, PMID:31351878); added a meiotic core_function; added a RESIDUAL_SUBGAP knowledge gap for the<br />
+unknown mechanism; updated description. All supporting_text verbatim-verified against the cached<br />
+full text.</p>
+<p>Note on falcon's other claims: falcon also cited Goldstrohm 2007 (JBC; PUF/Ccr4 deadenylation)<br />
+as testing caf120Δ with NO effect on HO mRNA deadenylation, and Kim 2018 (Genome Res; homomer-<br />
+ization) for self-interaction + cytoplasm/bud/bud-neck localization. These are plausible but I<br />
+did NOT independently verify the caf120-specific data in those papers, so I did not add them as<br />
+annotations (only the crossover finding, which I verified, was incorporated).</p>
+<h2 id="provenance-summary-of-key-references">Provenance summary of key references</h2>
+<ul>
+<li>PMID:11733989 — CCR4-NOT 1.0 MDa complex purification (abstract-only in cache; names CAF40/<br />
+  CAF130 as new components; UniProt attributes CAF120 subunit status to it).</li>
+<li>PMID:14562095 — Huh 2003 GFP localization atlas (source of cytoplasm/nucleus/bud-neck SubCell).</li>
+<li>PMID:14562106 — Ghaemmaghami 2003 protein abundance (1380 molecules/cell).</li>
+<li>PMID:19779198 — Holt 2009 Cdk1 substrate phosphosites (CAF120 is a Cdk1 substrate).</li>
+<li>PMID:17287358 — Chi 2007 phosphoproteome (additional phosphosites).</li>
+<li>PMID:25028499 — Lee 2014 stress-induced relocalization; source of the bud-neck IDA<br />
+  (abstract-only in cache).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P53836
+gene_symbol: CAF120
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  CAF120 (systematic name YNL278W) is a large (1060-residue, ~118 kDa), non-essential
+  Saccharomyces cerevisiae protein whose molecular function is essentially uncharacterized.
+  It was originally identified as a &#34;CCR4-associated factor&#34; of 120 kDa (hence its name) and
+  is reported to associate with the CCR4-NOT complex, the conserved machinery that combines a
+  nuclear transcription-regulatory role with the cytoplasmic major mRNA deadenylase activity;
+  however, CAF120 is not enumerated among the canonical CCR4-NOT core subunits and no
+  gene-specific molecular activity has been demonstrated for it. Its only recognized folded
+  domain is a divergent pleckstrin-homology (PH) domain near the N-terminus (a member, with
+  its paralog SKG3, of the Skg3/CAF120-like PH subfamily); the remaining ~85% of the protein
+  is largely intrinsically disordered and low-complexity. The protein localizes to the
+  cytoplasm, nucleus, and the bud neck, and it relocalizes under DNA-damaging stress. It is a
+  substrate of the cyclin-dependent kinase Cdk1 and is multiply phosphorylated on serine
+  residues. CAF120 has a whole-genome-duplication paralog, SKG3 (YHR133C), which is likewise
+  poorly characterized. In meiosis, CAF120 has been identified as a metaphase-I-enriched
+  interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover machinery and acts as a regulator of
+  meiotic crossing-over: its deletion reproducibly reduces crossover frequency, although the
+  molecular mechanism by which it contributes to crossover formation is not yet established.
+existing_annotations:
+- term:
+    id: GO:0004672
+    label: protein kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred (IBA) protein kinase activity propagated within PANTHER family
+      PTN001969686. The reference members driving the inference are Arabidopsis MAP kinase
+      kinase kinase loci (AT1G05100, AT3G50310, AT4G26890 in the WITH/FROM field), which are
+      bona fide kinase-domain proteins. CAF120 has NO protein kinase domain: its only Pfam/
+      InterPro-recognized folded module is a PH domain (residues 75-204; PF00169/PF25381,
+      IPR058155), with the rest of the protein intrinsically disordered. This is a family
+      over-propagation in which a shared accessory PH module drew a non-kinase yeast protein
+      into a plant-MAP3K-dominated cluster, causing it to inherit a catalytic activity it does
+      not possess. Biologically indefensible.
+    action: REMOVE
+    reason: &gt;-
+      CAF120 lacks any protein kinase domain (UniProt/InterPro/Pfam show only a PH domain plus
+      disordered regions); the IBA kinase activity is over-propagated from kinase-domain
+      Arabidopsis MAP3K family members via a shared PH module and has no gene-specific support.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN001969686
+        source_label: PANTHER family node driving the IBA transfer
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Family clustering appears PH-domain-driven; the kinase MF comes from the plant
+          MAP3K members, not from CAF120, which has no kinase domain.
+      - source_id: AGI_LocusCode:AT1G05100
+        source_label: Arabidopsis MAP kinase kinase kinase
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Bona fide kinase-domain protein; activity does not transfer to non-kinase CAF120.
+      - source_id: AGI_LocusCode:AT3G50310
+        source_label: Arabidopsis MAP kinase kinase kinase (MKKK20)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Kinase-domain reference member; not applicable to CAF120.
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred (IBA) signal transduction from the same PANTHER family
+      (PTN001969686), with the same Arabidopsis MAP3K reference set (AT1G05100, AT2G32510,
+      AT3G50310) in the WITH/FROM field. &#34;Signal transduction&#34; is the generic process that the
+      kinase-domain plant members carry; it was inherited by CAF120 through the same PH-domain-
+      driven mis-clustering that produced the erroneous kinase-activity call. There is no
+      experimental or domain-based evidence that CAF120 acts in a signaling cascade.
+    action: REMOVE
+    reason: &gt;-
+      Over-propagated from kinase-containing plant MAP3K family members; CAF120 has no kinase
+      domain and no evidence of participation in a signaling pathway. Removing alongside the
+      linked kinase-activity IBA that generated it.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN001969686
+        source_label: PANTHER family node driving the IBA transfer
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Same PH-domain-driven family cluster; &#34;signal transduction&#34; is the generic BP of the
+          plant MAP3K members and does not apply to the non-kinase CAF120.
+      - source_id: AGI_LocusCode:AT1G05100
+        source_label: Arabidopsis MAP kinase kinase kinase
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Signaling role is kinase-cascade-dependent; not transferable to CAF120.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation derived from the UniProtKB-SubCell mapping (SL-0191), which is in
+      turn backed by the experimental subcellular-location record in UniProt (Nucleus;
+      ECO:0000269|PubMed:14562095, the Huh 2003 GFP localization atlas). Consistent with the
+      multi-compartment (cytoplasm/nucleus/bud neck) localization of the protein. Correct but
+      broad, and not the core function of this dark gene.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Evidence-backed subcellular location (via SubCell mapping from a GFP-atlas experimental
+      record), but a general localization term rather than a molecular function; retain as
+      non-core.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation from the UniProtKB-SubCell mapping (SL-0086), backed by the
+      experimental UniProt subcellular-location record (Cytoplasm; ECO:0000269|PubMed:14562095).
+      A correct but very general location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct high-level cytoplasmic localization derived from an experimentally-backed SubCell
+      mapping; general and non-core.
+- term:
+    id: GO:0005935
+    label: cellular bud neck
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation from the UniProtKB-SubCell mapping (SL-0029), backed by the
+      experimental UniProt record (Bud neck; ECO:0000269|PubMed:14562095). This duplicates the
+      more direct IDA bud-neck annotation below (PMID:25028499) and is subsumed by it.
+    action: ACCEPT
+    reason: &gt;-
+      Correct bud-neck localization, consistent with (and subsumed by) the direct-assay bud-neck
+      annotation (GO:0005935, IDA, PMID:25028499); accepted for consistency with that annotation.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root-level &#34;molecular function unknown&#34; placeholder (ND). This honestly reflects the
+      dark-gene status of CAF120: despite the PH domain and CCR4-NOT association, no specific
+      molecular activity (catalytic, binding, adapter, or scaffold) has been experimentally
+      demonstrated, and GO/SGD do not assign it one. Appropriate to retain.
+    action: ACCEPT
+    reason: &gt;-
+      No defensible molecular function can be assigned; the ND annotation correctly records
+      that the molecular function is unknown.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root-level &#34;biological process unknown&#34; placeholder (ND) reflecting the state of GOA at
+      the time of annotation. Since then, a meiotic role has been reported (CAF120 is a
+      metaphase-I-enriched MutLgamma-Exo1 interactor whose deletion reduces crossover frequency;
+      PMID:31351878), which is captured as a proposed NEW annotation below (GO:0010520). The ND
+      is retained as-is (it is a trusted GOA record and this review does not rewrite GOA ids),
+      but it no longer reflects the best available knowledge of the gene&#39;s biological role.
+    action: ACCEPT
+    reason: &gt;-
+      GOA-sourced ND placeholder correctly recording that GOA holds no specific biological
+      process; complemented (not contradicted) by the proposed meiotic-crossover-regulation
+      annotation below (GO:0010520; PMID:31351878).
+- term:
+    id: GO:0005935
+    label: cellular bud neck
+  evidence_type: IDA
+  original_reference_id: PMID:25028499
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct-assay (IDA) localization of Caf120 to the cellular bud neck, from a high-resolution
+      cellular-imaging study of proteome-wide, condition-dependent protein localization. The
+      same study reports that Caf120 changes subcellular location under DNA-damaging conditions.
+      This is the best-supported experimental annotation for the gene and is consistent with the
+      UniProt bud-neck subcellular-location record (from the Huh 2003 GFP atlas).
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported direct-assay localization to the bud neck; the strongest experimental
+      annotation available for this otherwise uncharacterized protein.
+- term:
+    id: GO:0010520
+    label: regulation of reciprocal meiotic recombination
+  evidence_type: IMP
+  original_reference_id: PMID:31351878
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation. A proteomic and genetic dissection of the recombination-
+      intermediate-processing enzymes found that CAF120 is a meiosis-specific (metaphase-I-
+      enriched) interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover machinery, and that
+      deletion of CAF120 reproducibly reduces meiotic crossover frequency (genetic distance at
+      the CEN8-THR1 interval), placing it among the identified regulators of crossing-over. This
+      is a specific, experimentally-supported biological role for an otherwise dark gene. The
+      general &#34;regulation of reciprocal meiotic recombination&#34; term (GO:0010520) is chosen
+      rather than a directional (positive/negative) child because the authors explicitly flag
+      the molecular mechanism as uncharacterized (&#34;interesting candidates for further functional
+      analyses&#34;).
+    action: NEW
+    reason: &gt;-
+      Not present in current GOA, but supported by direct genetic evidence (reproducible
+      reduction in crossover frequency in caf120-null meiosis) plus a meiosis-specific physical
+      association with the MutLgamma-Exo1 crossover machinery (PMID:31351878). Conservatively
+      annotated to the general regulation term because the direction/mechanism is not resolved.
+    supported_by:
+    - reference_id: PMID:31351878
+      supporting_text: &#34;Rtk1, Caf120, and Chd1 as regulators of crossing-over&#34;
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:31351878
+      supporting_text: &#34;chd1Δ, rtk1Δ, and caf120Δ&#34;
+      reference_section_type: RESULTS
+core_functions:
+- description: &gt;-
+    No specific molecular function can be positively assigned to CAF120. The only
+    experimentally solid statement about the gene product is its localization: it is a
+    cytoplasmic and nuclear protein that concentrates at the cellular bud neck and relocalizes
+    under DNA-damaging stress. It carries a single recognized folded domain — a divergent
+    pleckstrin-homology (PH) domain (Skg3/CAF120-like PH subfamily) — embedded in a largely
+    disordered protein, and it is a substrate of the cyclin-dependent kinase Cdk1. Although it
+    is named as a CCR4-associated factor and is reported to associate with the CCR4-NOT complex,
+    it is not enumerated among the canonical CCR4-NOT core subunits and no complex-level or
+    independent molecular activity has been demonstrated for it.
+  supported_by:
+  - reference_id: PMID:25028499
+    supporting_text: &#34;under DNA-damaging conditions, Tsr1, Caf120, Dip5, Skg6, Lte1, and&#34;
+    reference_section_type: ABSTRACT
+  locations:
+  - id: GO:0005935
+    label: cellular bud neck
+- description: &gt;-
+    CAF120 acts as a regulator of meiotic crossing-over. It is a meiosis-specific, metaphase-I-
+    enriched interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover-forming machinery, and its
+    deletion reproducibly reduces meiotic crossover frequency. This is the only specific
+    biological process for which CAF120 has direct experimental support; consistent with the
+    protein&#39;s lack of any catalytic domain (only a divergent PH module), its contribution is
+    presumed to be a non-catalytic regulatory/scaffolding role, but the molecular mechanism is
+    not established.
+  supported_by:
+  - reference_id: PMID:31351878
+    supporting_text: &#34;Rtk1, Caf120, and Chd1 as regulators of crossing-over&#34;
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:31351878
+    supporting_text: &#34;chd1Δ, rtk1Δ, and caf120Δ&#34;
+    reference_section_type: RESULTS
+  directly_involved_in:
+  - id: GO:0010520
+    label: regulation of reciprocal meiotic recombination
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of CAF120 is unknown. No catalytic, nucleic-acid-binding, adapter,
+    or scaffolding activity has been demonstrated, and the ligand and role of its divergent
+    N-terminal PH domain (Skg3/CAF120-like PH subfamily) are undetermined — it is not known
+    whether this PH domain binds phosphoinositides (as canonical PH domains do), a protein
+    partner, or acts as a non-binding structural module.
+  boundary: &gt;-
+    It is firmly established that CAF120 is a 1060-residue, ~118 kDa non-essential protein
+    whose only recognized folded domain is a PH domain (residues 75-204; Pfam PF00169/PF25381,
+    InterPro IPR058155 Skg3/CAF120-like PH), with the remainder largely intrinsically
+    disordered and low-complexity. It localizes to the cytoplasm, nucleus, and bud neck, is a
+    Cdk1 phosphosubstrate, is expressed at ~1380 molecules/cell in log phase, and has a
+    whole-genome-duplication paralog, SKG3. GO and SGD record its molecular function as unknown
+    (ND).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    CAF120 is a conserved-fold, phospho-regulated protein that sits at the interface of two
+    heavily-studied systems (the CCR4-NOT machinery and the bud-neck cytokinesis apparatus) yet
+    has no assigned mechanism. Determining what its PH domain binds would likely reveal both its
+    molecular activity and where it acts, and would clarify whether the electronic kinase/
+    signaling annotations it currently inherits are truly spurious.
+  resolution: &gt;-
+    Biochemical characterization of the recombinant PH domain (phosphoinositide-strip / liposome
+    binding, and pulldown/proximity proteomics for protein ligands); structural determination of
+    the PH domain to assess whether its ligand-binding pocket is competent; and identification of
+    interaction partners of the full-length protein.
+  provenance:
+  - reference_id: PMID:25028499
+    supporting_text: &#34;condition-specific subcellular locations, biological processes, and&#34;
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    It is unresolved whether CAF120 is a bona fide, stable core subunit of the CCR4-NOT complex
+    or merely a transient / substoichiometric associated factor, and — if it does associate —
+    whether it makes any functional contribution to CCR4-NOT-dependent mRNA deadenylation/
+    turnover or transcriptional regulation.
+  boundary: &gt;-
+    CAF120 is named &#34;CCR4-associated factor 120 kDa&#34;, and UniProt lists it as a subunit of the
+    1.0 MDa CCR4-NOT core complex interacting with NOT1, attributing this to the 2001 complex-
+    purification study. However, that study&#39;s own report of the 1.0 MDa complex composition
+    names CCR4, CAF1, NOT1-5 and the two newly identified proteins CAF40 and CAF130, and the
+    GO ontology&#39;s definition of the Saccharomyces &#34;CCR4-NOT core complex&#34; (GO:0030015)
+    enumerates Ccr4p, Caf1p, Caf40p, Caf130p and Not1-5p — CAF120 is absent from both lists.
+    Correspondingly, GOA carries no CCR4-NOT complex (GO:0030014/GO:0030015) annotation for
+    CAF120, and SGD/GO record its biological process as unknown.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether CAF120 is a real CCR4-NOT subunit or an associated factor determines whether it can
+    legitimately inherit any CCR4-NOT function and shapes how this dark gene should be curated.
+    The discrepancy between the gene&#39;s name / UniProt subunit statement and the canonical
+    complex composition (in the primary paper and in GO) is exactly the kind of unresolved
+    association that should not be propagated as fact without confirmation.
+  resolution: &gt;-
+    Quantitative interaction proteomics (e.g. affinity purification with stoichiometry
+    determination, or reciprocal tagging of core subunits) to test stable versus transient
+    CCR4-NOT association; and functional assays (mRNA deadenylation / poly(A) tail length,
+    reporter-gene transcription) in caf120-null versus wild-type cells to test any contribution
+    to CCR4-NOT activity.
+  provenance:
+  - reference_id: PMID:11733989
+    supporting_text: &#34;The 1.0 MDa complex was found to contain CCR4, CAF1, NOT1-5 and two&#34;
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The molecular mechanism by which CAF120 promotes meiotic crossing-over is unknown: it is not
+    established how (or whether directly) CAF120 acts on the MutLgamma-Exo1 crossover machinery,
+    what its meiosis-specific binding is to within that network, or why loss of CAF120 lowers
+    crossover frequency.
+  boundary: &gt;-
+    It is established (by affinity-proteomics plus a genetic crossover assay) that CAF120 is a
+    metaphase-I-enriched interactor of the MutLgamma (Mlh1-Mlh3)-Exo1 crossover machinery and
+    that caf120-null meiosis shows a reproducible reduction in crossover frequency, so CAF120 is
+    a bona fide regulator of crossing-over. However, the study characterized the mechanism only
+    for a co-identified factor (Chd1, via its DNA-binding activity) and explicitly left CAF120
+    (and Rtk1) as candidates for further functional analysis; CAF120 has no catalytic domain, so
+    any contribution is presumed non-catalytic/regulatory but is otherwise undefined.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    This is the one sharp mechanistic hole in an otherwise newly-illuminated function: CAF120 is
+    now known to matter for crossover formation, but the causal step it controls is undefined.
+    Closing it would convert a &#34;regulator of crossing-over&#34; statement into a mechanistic model
+    and would clarify whether CAF120&#39;s role is exerted through, or independently of, its reported
+    CCR4-NOT / PH-domain-mediated interactions.
+  resolution: &gt;-
+    Mechanistic dissection of the CAF120-MutLgamma-Exo1 relationship: mapping the meiosis-
+    specific interaction interface, testing whether CAF120 affects MutLgamma-Exo1 recruitment,
+    stability, or nuclease activity at recombination intermediates, and epistasis of caf120 with
+    mlh1/mlh3/exo1 in crossover assays.
+  provenance:
+  - reference_id: PMID:31351878
+    supporting_text: &#34;Rtk1 and Caf120 are interesting candidates for further functional analyses&#34;
+    reference_section_type: DISCUSSION
+- gap_statement: &gt;-
+    The biological role and physiological significance of CAF120&#39;s bud-neck localization and of
+    its DNA-damage-induced relocalization are unknown, as is the basis of its subtle deletion
+    phenotypes (reduced competitive fitness, altered free amino-acid profile, stress
+    sensitivity) and its functional relationship to (or redundancy with) its paralog SKG3.
+  boundary: &gt;-
+    CAF120 is experimentally localized to the bud neck (IDA) in addition to the cytoplasm and
+    nucleus, and it changes subcellular location under DNA-damaging conditions. Its deletion is
+    viable, with only diffuse high-throughput phenotypes reported, and it has a WGD paralog,
+    SKG3, that is itself uncharacterized. No process-level mechanism connects these observations.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Bud-neck enrichment and stress-triggered relocalization hint at a cytokinesis- and/or
+    stress-response-related role, but without a mechanism these remain descriptive. Testing
+    whether CAF120 and SKG3 are functionally redundant is essential, because paralog redundancy
+    is a common reason a single-gene deletion shows only subtle phenotypes and would explain the
+    gene&#39;s apparent dispensability.
+  resolution: &gt;-
+    Phenotypic analysis of caf120 skg3 double mutants (and stress/DNA-damage challenges) for
+    synthetic defects in growth, budding/cytokinesis and stress survival; live-cell imaging of
+    the relocalization dynamics; and genetic-interaction / co-expression profiling to place the
+    gene in a pathway.
+  provenance:
+  - reference_id: PMID:25028499
+    supporting_text: &#34;under DNA-damaging conditions, Tsr1, Caf120, Dip5, Skg6, Lte1, and&#34;
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Does the divergent PH domain of CAF120 bind a phosphoinositide, a protein partner, or
+    neither, and does this binding determine its localization to the bud neck?
+- question: &gt;-
+    Is CAF120 a stable stoichiometric subunit of the CCR4-NOT complex or a transient associated
+    factor, and does it contribute measurably to CCR4-NOT mRNA-deadenylase or transcriptional
+    activity?
+- question: &gt;-
+    Are CAF120 and its whole-genome-duplication paralog SKG3 functionally redundant, and does a
+    double deletion reveal a phenotype masked in the single mutants?
+- question: &gt;-
+    By what molecular mechanism does CAF120 promote meiotic crossover formation — does it act on
+    recruitment, stability, or activity of the MutLgamma-Exo1 machinery at recombination
+    intermediates, and is this role connected to its CCR4-NOT association or PH domain?
+  experts:
+  - Joao Matos
+suggested_experiments:
+- hypothesis: &gt;-
+    The CAF120 PH domain targets the protein to a specific membrane/lipid or protein partner at
+    the bud neck.
+  description: &gt;-
+    Express and purify the recombinant CAF120 PH domain (and full-length protein) and assay
+    phosphoinositide binding by lipid-strip and liposome-flotation assays; in parallel, perform
+    affinity-purification / proximity-labeling (e.g. BioID or TurboID) from yeast to identify
+    protein interactors, and test whether mutating the predicted ligand-binding surface disrupts
+    bud-neck localization of a GFP fusion.
+  experiment_type: biochemical and cell-biological interaction mapping
+- hypothesis: &gt;-
+    CAF120 is only transiently/substoichiometrically associated with CCR4-NOT and does not
+    materially affect complex activity.
+  description: &gt;-
+    Perform quantitative affinity purification of tagged core CCR4-NOT subunits (e.g. NOT1,
+    CCR4) with stoichiometry measurement to determine whether CAF120 co-purifies stably; and
+    measure global and reporter-specific mRNA poly(A) tail lengths / deadenylation kinetics and
+    reporter transcription in caf120-null versus wild-type cells.
+  experiment_type: quantitative interaction proteomics and mRNA-turnover assay
+- hypothesis: &gt;-
+    CAF120 and SKG3 are functionally redundant paralogs.
+  description: &gt;-
+    Construct caf120 skg3 single and double deletion strains and profile them for growth,
+    budding/cytokinesis morphology, stress (including DNA-damage) sensitivity, and amino-acid
+    metabolism, looking for synthetic phenotypes absent from the single mutants.
+  experiment_type: genetic redundancy / synthetic phenotype analysis
+- hypothesis: &gt;-
+    CAF120 promotes meiotic crossovers by modulating the MutLgamma-Exo1 crossover machinery.
+  description: &gt;-
+    Dissect the CAF120-MutLgamma-Exo1 relationship in meiosis: map the meiosis-specific
+    interaction interface (co-IP / crosslinking-MS of tagged Caf120 with Mlh1/Mlh3/Exo1), test
+    whether caf120Δ alters MutLgamma-Exo1 chromatin recruitment or joint-molecule resolution
+    (physical recombination assays, ChIP), and determine epistasis of caf120Δ with mlh3Δ/exo1Δ
+    for crossover frequency and spore viability.
+  experiment_type: meiotic recombination mechanism / genetic-interaction analysis
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: MISCITED
+    review_notes: &gt;-
+      The IBA pipeline (PANTHER family PTN001969686) propagated protein kinase activity and
+      signal transduction onto CAF120 from Arabidopsis MAP3K reference members that carry a
+      kinase domain CAF120 lacks; the inference is not applicable to this gene.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:25028499
+  title: Proteome-wide remodeling of protein location and function by stress.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Source of the direct-assay bud-neck localization annotation and the
+      report that Caf120 relocalizes under DNA-damaging conditions. Cached record is abstract-
+      only (full_text_available: false); the bud-neck IDA reflects the study&#39;s high-resolution
+      imaging.
+- id: PMID:11733989
+  title: Purification and characterization of the 1.0 MDa CCR4-NOT complex identifies two novel
+    components of the complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary characterization of the 1.0 MDa CCR4-NOT complex; UniProt cites it
+      for CAF120&#39;s subunit status, but the cached abstract names only CAF40 and CAF130 as the
+      newly identified components and lists the complex composition without CAF120. Full text not
+      in cache (abstract-only); used here to delimit the CCR4-NOT-membership knowledge gap, not
+      to assert core-subunit status.
+- id: PMID:31351878
+  title: Network Rewiring of Homologous Recombination Enzymes during Mitotic Proliferation and
+    Meiosis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PMID:31351878; Mol Cell 2019; DOI 10.1016/j.molcel.2019.06.022); full text
+      cached. Directly establishes a specific biological role for the otherwise dark CAF120: it
+      is a meiosis-specific (metaphase-I-enriched) interactor of the MutLgamma-Exo1 crossover
+      machinery, and caf120-null meiosis shows a reproducible reduction in crossover frequency,
+      placing CAF120 among the identified regulators of crossing-over. The authors explicitly
+      note the mechanism is uncharacterized (&#34;interesting candidates for further functional
+      analyses&#34;), supporting both the NEW GO:0010520 annotation and the residual mechanistic
+      knowledge gap.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/CPR4/CPR4-ai-review.html
+++ b/genes/yeast/CPR4/CPR4-ai-review.html
@@ -1,0 +1,3406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CPR4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CPR4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P25334" target="_blank" class="term-link">
+                        P25334
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CPR4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P25334" data-a="DESCRIPTION: CPR4 (systematic name YCR069W; originally cloned a..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CPR4 (systematic name YCR069W; originally cloned as SCC3) is one of eight cyclophilins in Saccharomyces cerevisiae and the founder of the &#34;cyclophilin C (CypC)&#34;-type secretory-pathway subgroup, with CPR8 as its closest paralog. It is a peptidyl-prolyl cis-trans isomerase (PPIase/rotamase, EC 5.2.1.8) of the cyclophilin family, catalyzing cis-trans isomerization of peptidyl-prolyl bonds, a rate-limiting step in protein folding. CPR4 has an unusual domain architecture among cyclophilins: an N-terminal cleavable signal peptide, a central cyclophilin PPIase domain (with a predicted N-glycosylation site), and a single C-terminal transmembrane helix. This dual topology (signal peptide plus C-terminal membrane anchor) is shared with Drosophila NinaA, a membrane-anchored secretory-pathway cyclophilin required for rhodopsin folding and transport, and places CPR4 in the endoplasmic reticulum / endomembrane system; systematic and review-level localization data assign it to the vacuole, consistent with a protein that transits the secretory pathway. CPR4 is non-essential. Its catalytic residues are conserved, but the tryptophan equivalent to human cyclophilin A W121 that lines the cyclosporin A binding pocket is not conserved, predicting atypical cyclosporin A binding. No physiological in vivo substrate or specific biological role has been established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
+                                    GO:0003755
+                                </a>
+                            </span>
+                            <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0003755" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of cyclophilin PPIase activity, the defining molecular function of the family and of CPR4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPR4 carries an intact cyclophilin-type PPIase domain (UniProt DOMAIN 55..225; Pfam PF00160; CDD cd00317) and the conserved cyclophilin catalytic/substrate-binding motifs are present and correctly positioned (inline sequence analysis, this review). PPIase is the well-supported core molecular function. This is the correct core MF term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" target="_blank" class="term-link">
+                                        PMID:1803821
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an open reading frame of 954 nucleotides with coding potential for a protein with high similarity to the ubiquitous cyclophilins which are both peptidyl-prolyl cis-trans isomerases and cyclosporin A-binding proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment to the endoplasmic reticulum, consistent with CPR4&#39;s N-terminal signal peptide and entry into the secretory pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPR4&#39;s signal peptide (UniProt SIGNAL 1..20) and C-terminal TM helix direct it into the ER / secretory pathway, so ER is a defensible localization. However, the more specific experimentally-supported steady-state localization for Cpr4 (and its paralog Cpr8) is the vacuole; the ER assignment reflects the transit compartment / family topology. Retained as a valid but non-core (localization, not molecular function) annotation; not contradicted.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" target="_blank" class="term-link">
+                                        PMID:15998457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are located in vacuoles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0006457" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment to protein folding, the general biological process associated with cyclophilin PPIase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein folding is the family-level process for cyclophilins (PPIase accelerates the rate-limiting proline-isomerization step of folding). This general BP is appropriate for CPR4 on homology grounds. No CPR4-specific in-vivo substrate or more specific process is known (see knowledge_gaps), so the general term is retained without further specialization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" target="_blank" class="term-link">
+                                        PMID:15998457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both de novo protein folding and the refolding processes following cellular membrane traffic necessitate isomerization to the cis form</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
+                                    GO:0003755
+                                </a>
+                            </span>
+                            <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0003755" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (InterPro/EC to GO) assignment of PPIase activity, redundant with the IBA and ISS PPIase annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro IPR002130 (cyclophilin-type PPIase domain) and EC 5.2.1.8 map to GO:0003755; CPR4 carries this domain with intact catalytic residues. Consistent with the core molecular function; a redundant but correct electronic confirmation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" target="_blank" class="term-link">
+                                        PMID:1803821
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">high similarity to the ubiquitous cyclophilins which are both peptidyl-prolyl cis-trans isomerases and cyclosporin A-binding proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (UniProt SubCell) assignment to membrane, based on the predicted C-terminal transmembrane helix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CPR4 has a single predicted C-terminal transmembrane helix (UniProt TRANSMEM 286..303), so membrane localization is supported. This is a general CC term; retained as a valid but non-core localization annotation. The specific membrane (ER/vacuolar endomembrane) is better captured by the ER and vacuole terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" target="_blank" class="term-link">
+                                        PMID:1803821
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the other one at the carboxyl end with a structure similar to a transmembrane helix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000324" target="_blank" class="term-link">
+                                    GO:0000324
+                                </a>
+                            </span>
+                            <span class="term-label">fungal-type vacuole</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26928762
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    One library to make them all: streamlining the creation of y...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0000324" data-r="PMID:26928762" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput microscopy (HDA) assignment of CPR4 to the fungal-type vacuole.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (HDA) localization from a systematic screen; concordant with the review-level statement that Cpr4 and its paralog Cpr8 are vacuolar. This is the most specific experimentally-supported steady-state localization for CPR4. Retained as a valid but non-core (localization) annotation. Note the source paper (PMID:26928762) is a genome-wide library/methods paper and does not discuss CPR4 individually; the vacuole is nonetheless supported independently by Wang &amp; Heitman 2005.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" target="_blank" class="term-link">
+                                        PMID:15998457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are located in vacuoles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
+                                    GO:0003755
+                                </a>
+                            </span>
+                            <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9371805" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9371805
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    All cyclophilins and FK506 binding proteins are, individuall...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0003755" data-r="PMID:9371805" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS) assignment of PPIase activity to CPR4, based on cyclophilin homology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ISS PPIase from SGD, consistent with the family assignment and CPR4&#39;s intact cyclophilin catalytic domain. Reinforces the core molecular function; correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9371805" target="_blank" class="term-link">
+                                        PMID:9371805
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cpr8, a homolog of the secretory pathway cyclophilin Cpr4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P25334" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process annotation with ND (no biological data), recording that no specific biological process has been experimentally determined for CPR4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This ND root annotation is an honest and correct statement of the current state of knowledge: despite the general protein-folding process inferred from homology, no CPR4-specific in-vivo biological role has been experimentally established (see knowledge_gaps). Root ND annotations are conventionally retained.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9371805" target="_blank" class="term-link">
+                                        PMID:9371805
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the physiological functions of these proteins are largely unknown</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CPR4 is a cyclophilin-type peptidyl-prolyl cis-trans isomerase (rotamase, EC 5.2.1.8) that catalyzes cis-trans isomerization of peptidyl-prolyl bonds; its catalytic residues are conserved, making PPIase activity its domain-defensible core molecular function.</h3>
+                <span class="vote-buttons" data-g="P25334" data-a="FUNCTION: CPR4 is a cyclophilin-type peptidyl-prolyl cis-tra..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
+                            peptidyl-prolyl cis-trans isomerase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000324" target="_blank" class="term-link">
+                                fungal-type vacuole
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                endoplasmic reticulum
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" target="_blank" class="term-link">
+                                PMID:1803821
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">high similarity to the ubiquitous cyclophilins which are both peptidyl-prolyl cis-trans isomerases and cyclosporin A-binding proteins</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CPR4 is a membrane-anchored cyclophilin of the secretory/endomembrane system: an N-terminal signal peptide plus a single C-terminal transmembrane helix embed it in the ER/vacuolar membrane, with the catalytic cyclophilin domain in the lumenal compartment. This dual topology matches Drosophila NinaA, motivating a hypothesized (not yet demonstrated) role as a substrate-specific foldase for secretory/membrane clients.</h3>
+                <span class="vote-buttons" data-g="P25334" data-a="FUNCTION: CPR4 is a membrane-anchored cyclophilin of the sec..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
+                            peptidyl-prolyl cis-trans isomerase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000324" target="_blank" class="term-link">
+                                fungal-type vacuole
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                endoplasmic reticulum
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" target="_blank" class="term-link">
+                                PMID:1803821
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Its putative protein product (Scc3) contains two hydrophobic cores, one at the amino terminal, 20 amino acids long, which could serve as a signal peptide, and the other one at the carboxyl end with a structure similar to a transmembrane helix</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" target="_blank" class="term-link">
+                                PMID:15998457
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are located in vacuoles</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" target="_blank" class="term-link">
+                            PMID:1803821
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The nucleotide sequence of a third cyclophilin-homologous gene from Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CPR4/SCC3 encodes a cyclophilin-homologous protein with two hydrophobic regions — an N-terminal signal peptide and a C-terminal transmembrane-like helix — making it a likely secretory or membrane protein.</div>
+
+                        <div class="finding-text">"Its putative protein product (Scc3) contains two hydrophobic cores, one at the amino terminal, 20 amino acids long, which could serve as a signal peptide, and the other one at the carboxyl end with a structure similar to a transmembrane helix."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The only cyclophilin with the same dual topology is Drosophila NinaA, a secretory-pathway transmembrane cyclophilin implicated in rhodopsin folding, suggesting an analogous foldase role for CPR4 on different, unidentified target proteins.</div>
+
+                        <div class="finding-text">"The only cyclophilin with similar structure to that of Scc3 is ninaA from Drosophila melanogaster, a transmembrane protein which seems to be implicated in the correct folding and/or intercalation of rhodopsin in the endoplasmic reticulum of the fly photoreceptors"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9371805" target="_blank" class="term-link">
+                            PMID:9371805
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">All cyclophilins and FK506 binding proteins are, individually and collectively, dispensable for viability in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CPR4 is the secretory-pathway cyclophilin of S. cerevisiae; CPR8 is its homolog. None of the eight yeast cyclophilins is essential, and a strain lacking all 12 immunophilins is viable, with little evidence of functional overlap.</div>
+
+                        <div class="finding-text">"Cpr8, a homolog of the secretory pathway cyclophilin Cpr4"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The physiological functions of yeast immunophilins are largely unknown; each is proposed to act on a small set of unique, as-yet-unidentified partner proteins.</div>
+
+                        <div class="finding-text">"the physiological functions of these proteins are largely unknown"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" target="_blank" class="term-link">
+                            PMID:15998457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cyclophilins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cpr4 and Cpr8 each contain a single cyclophilin-like domain plus a long N-terminal signal peptide and are localized to vacuoles.</div>
+
+                        <div class="finding-text">"Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are located in vacuoles"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">None of the eight individual yeast cyclophilins is essential, and an octuple mutant lacking all eight is viable with little or no evidence of functional redundancy.</div>
+
+                        <div class="finding-text">"an octuplet mutant lacking all eight cyclophilins was viable and that there was little or no evidence for functional redundancy"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Drosophila NinaA, the structural analog of Cpr4, is an ortholog of mammalian CypC and is crucial for folding of rhodopsin isoforms.</div>
+
+                        <div class="finding-text">"NinaA (an ortholog of mammal CypC), is crucial for the folding of rhodopsin isoforms"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15353296" target="_blank" class="term-link">
+                            PMID:15353296
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Prolyl isomerases in yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Comprehensive review of the S. cerevisiae prolyl isomerase repertoire (cyclophilins, FKBPs, parvulins), providing family-level context for Cpr4 among Cpr1-Cpr8.</div>
+
+                        <div class="finding-text">"Prolyl isomerases in yeast."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                            PMID:26928762
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide N-terminal GFP tagging (SWAT) of endomembrane proteins assigned many proteins to the ER, punctate structures and the vacuole; CPR4 received its high-throughput vacuole localization from this class of systematic screen.</div>
+
+                        <div class="finding-text">"most new localization assignments were to the ER, punctate structures and vacuole"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CPR4/CPR4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CPR4 (Edison Scientific Literature)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The tryptophan equivalent to human cyclophilin A W121 (a key cyclosporin A contact) is replaced by glutamate in CPR4/Scc3, predicting reduced cyclosporin A binding while leaving catalytic PPIase features intact.</div>
+
+                        <div class="finding-text">"the conserved cyclophilin residue equivalent to W121, important for cyclosporin A binding in other cyclophilins, is replaced by glutamate in Scc3/CPR4"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">No direct biochemical measurement of CPR4 PPIase catalytic activity, substrate specificity, or kinetics has been reported, and its precise cellular function is unresolved.</div>
+
+                        <div class="finding-text">"direct biochemical measurement of Cpr4&#39;s PPIase catalytic activity, substrate specificity, or kinetic parameters has not been reported"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which secretory, membrane, or vacuolar proteins are the physiological substrates/clients of CPR4, and does their folding or transport depend on CPR4 (analogous to NinaA and rhodopsin)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25334" data-a="Q: Which secretory, membrane, or vacuolar proteins ar..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does CPR4 have measurable PPIase activity in vitro, and is that catalytic activity (versus a catalysis-independent chaperone role) required for any in vivo function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25334" data-a="Q: Does CPR4 have measurable PPIase activity in vitro..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do CPR4 and CPR8 share clients or buffer each other, revealing a conditional phenotype in the cpr4 cpr8 double mutant that is absent from either single mutant?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25334" data-a="Q: Do CPR4 and CPR8 share clients or buffer each othe..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Identify CPR4-proximal proteins and candidate substrates by proximity labeling (BioID/TurboID or APEX2) on tagged CPR4 in the ER/vacuolar membrane, and by co-immunoprecipitation, then test whether candidate clients misfold, mislocalize, or are destabilized in a cpr4 deletion (optionally cpr4 cpr8 double deletion) under standard and ER-stress conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CPR4 is a membrane-anchored, substrate-specific foldase of the secretory pathway (NinaA analog) that assists folding/transport of a restricted set of secretory or vacuolar proteins.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25334" data-a="EXPERIMENT: Identify CPR4-proximal proteins and candidate subs..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant CPR4 (catalytic domain) and measure PPIase activity with a standard protease-coupled peptidyl-prolyl isomerization assay; determine cyclosporin A inhibition and compare to CPR1 (CypA-type). Test a catalytic-dead point mutant for loss of any cpr4-dependent phenotype to separate catalytic from chaperone roles.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CPR4 has cyclophilin PPIase catalytic activity but atypical (reduced) cyclosporin A binding owing to the non-conserved W121-equivalent residue.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25334" data-a="EXPERIMENT: Purify recombinant CPR4 (catalytic domain) and mea..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare growth, secretory-pathway integrity, and unfolded-protein-response activation across wild-type, cpr4, cpr8, and cpr4 cpr8 strains under tunicamycin, heat, and other proteostatic stresses; quantify CPR4 expression/induction under these conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CPR4 function is buffered by CPR8 and/or induced under ER/folding stress.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25334" data-a="EXPERIMENT: Compare growth, secretory-pathway integrity, and u..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No physiological in vivo substrate or client protein of CPR4 has been identified. It is unknown which secretory/membrane/vacuolar proteins (if any) require CPR4-catalyzed peptidyl-prolyl isomerization for their folding, assembly, or transport.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: CPR4 is a cyclophilin-family PPIase (EC 5.2.1.8) with an intact catalytic domain, a signal peptide, and a C-terminal transmembrane anchor, localizing to the ER/secretory pathway and vacuole. What is NOT established is any specific client protein or the reaction it performs on that client in vivo.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Cyclophilins act on restricted, unique partner sets rather than as general foldases; identifying CPR4&#39;s client(s) would convert a homology-level &#34;protein folding&#34; annotation into a specific, mechanistically meaningful biological role and test the NinaA-analogous foldase hypothesis in yeast.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"regulates a restricted number of unique partner proteins that remain to be identified"</em> — PMID:9371805</li>
+
+                <li><em>"the physiological functions of these proteins are largely unknown"</em> — PMID:9371805</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether CPR4 has measurable PPIase activity and whether that catalytic activity is required in vivo for any process. No direct biochemical measurement of CPR4 PPIase kinetics, substrate specificity, or catalysis-dependent phenotype has been reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: the cyclophilin catalytic residues are conserved in the CPR4 sequence, so catalytic competence is predicted. What is NOT established is any experimental enzyme measurement for the CPR4 protein or a catalysis-requiring phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Cyclophilins can act as chaperones independently of catalysis; distinguishing a catalytic from a catalysis-independent role for CPR4 is prerequisite to a mechanistic annotation.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"direct biochemical measurement of Cpr4&#39;s PPIase catalytic activity, substrate specificity, or kinetic parameters has not been reported"</em> — file:yeast/CPR4/CPR4-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The extent of functional redundancy between CPR4 and its closest paralog CPR8 (and other ER/secretory folding factors) is unknown. Viability data show non-essentiality but do not test substrate-level or conditional redundancy.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: CPR4 and CPR8 are paralogous vacuolar/secretory cyclophilins (same PANTHER subfamily SF568, CypC-type), and none of the eight yeast cyclophilins — nor an octuple mutant — is essential, with little evidence of functional redundancy at the level of viability. What is NOT established is whether CPR4 and CPR8 (or other folding factors) share clients or buffer one another under specific stresses.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Redundancy would explain the lack of a deletion phenotype and would guide combinatorial-mutant experiments needed to reveal the pathway CPR4 serves.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"an octuplet mutant lacking all eight cyclophilins was viable and that there was little or no evidence for functional redundancy"</em> — PMID:15998457</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether CPR4 binds cyclosporin A is untested and predicted to be atypical: the tryptophan equivalent to human cyclophilin A W121, which lines the cyclosporin A binding pocket, is not conserved in CPR4.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established (this review): the entire CPR4 cyclophilin domain contains no tryptophan, and the position homologous to human CypA W121 (in the motif TAKTE-W-LDGK) is not a Trp in CPR4; the deep-research synthesis independently reports a W121-to-glutamate substitution. What is NOT established is the actual cyclosporin A affinity/sensitivity of the CPR4 protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Cyclosporin A binding and PPIase catalysis are structurally separable in cyclophilins; a non-canonical CsA pocket would distinguish CPR4 pharmacologically from CypA-type cyclophilins and refine the family-propagated &#34;cyclosporin A binding&#34; inference for this protein.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the conserved cyclophilin residue equivalent to W121, important for cyclosporin A binding in other cyclophilins, is replaced by glutamate in Scc3/CPR4"</em> — file:yeast/CPR4/CPR4-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CPR4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P25334" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: CPR4 (YCR069W) — A Membrane-Associated Cyclophilin in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:18:17.903477</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="CPR4-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="CPR4-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-cpr4-ycr069w-a-membrane-associated-cyclophilin-in-saccharomyces-cerevisiae">Comprehensive Research Report: CPR4 (YCR069W) — A Membrane-Associated Cyclophilin in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>CPR4 (UniProt accession: P25334) encodes peptidyl-prolyl cis-trans isomerase CPR4, also designated CYP4, SCC3, YCR069W, or YCR69W/YCR70W. The gene is located on chromosome III of <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein belongs to the cyclophilin family of peptidyl-prolyl cis-trans isomerases (PPIases; EC 5.2.1.8), which catalyze the interconversion of cis and trans conformations of peptide bonds preceding proline residues in polypeptide chains (franco1991thenucleotidesequence pages 4-7, franco1991thenucleotidesequence pages 1-2).</p>
+<h2 id="2-protein-architecture-and-structural-features">2. Protein Architecture and Structural Features</h2>
+<p>The CPR4 gene was originally cloned and sequenced as SCC3 (for <em>S. cerevisiae</em> cyclophilin 3), described as the third cyclophilin-homologous gene identified in budding yeast. The open reading frame comprises 954 nucleotides encoding a polypeptide of 318 amino acids with a predicted molecular weight of approximately 33–36 kDa and an isoelectric point of 6.9 (franco1991thenucleotidesequence pages 4-7, franco1991thenucleotidesequence pages 1-2). The protein has three notable structural features:</p>
+<blockquote>
+<p>CPR4 (also CYP4, SCC3, YCR069W) in <em>Saccharomyces cerevisiae</em> encodes a cyclophilin-family peptidyl-prolyl cis-trans isomerase precursor of 318 amino acids (~33–36 kDa) that contains an N-terminal ~20 aa signal peptide, a central cyclophilin-like/PPIase domain, and a hydrophobic C-terminal membrane anchor; the original SCC3 cloning study concluded that these features make the protein secretory or, more likely, membrane-anchored. (franco1991thenucleotidesequence pages 4-7, franco1991thenucleotidesequence pages 2-4, franco1991thenucleotidesequence pages 1-2, pemberton2005identificationandcomparative pages 6-8)</p>
+<p>Sequence comparison showed that CPR4/Scc3 is unusual among yeast cyclophilins because it shares structural organization with <em>Drosophila</em> NinaA, including both a cleavable signal peptide and a C-terminal transmembrane segment, supporting the idea that CPR4 may act on folding or trafficking of proteins in the secretory pathway rather than functioning as a soluble cytosolic cyclophilin. (franco1991thenucleotidesequence pages 4-7, arevalorodriguez2004prolylisomerasesin pages 7-8, colley1991thecyclophilinhomolog pages 1-2, pemberton2005identificationandcomparative pages 11-13)</p>
+<p>Franco et al. also noted that the conserved cyclophilin residue equivalent to W121, important for cyclosporin A binding in other cyclophilins, is replaced by glutamate in Scc3/CPR4 (W121E-equivalent substitution), implying that cyclosporin binding may be reduced while leaving catalytic PPIase-related features more intact; however, CPR4-specific CsA sensitivity was not directly established. (franco1991thenucleotidesequence pages 4-7)</p>
+<p>Later yeast cyclophilin surveys placed Cpr4 among the eight <em>S. cerevisiae</em> cyclophilins and reported vacuolar localization, while comparative analyses also discussed ER/secretory-pathway association, heat-shock/tunicamycin inducibility, and a relationship to cyclophilin C-like proteins. Taken together, the best-supported model is that CPR4 is a membrane-associated secretory/vacuolar cyclophilin with conserved cyclophilin fold characteristics but an incompletely resolved precise cellular function. (arevalorodriguez2004prolylisomerasesin pages 7-8, arevalorodriguez2004prolylisomerasesin pages 4-6, wang2005thecyclophilins pages 2-3, wang2005thecyclophilins pages 3-4, pemberton2005identificationandcomparative pages 11-13)</p>
+</blockquote>
+<p><em>Blockquote: This blockquote condenses the main structural and localization evidence for yeast CPR4/Cpr4, including its precursor architecture, NinaA-like topology, and the key W121E-related inference about cyclosporin binding. It is useful as a quick-reference evidence summary for functional annotation.</em></p>
+<p><strong>N-terminal signal peptide.</strong> The first ~20 amino acids constitute a hydrophobic signal peptide with a predicted cleavage site between positions A20 and A21, consistent with entry into the secretory pathway (franco1991thenucleotidesequence pages 4-7, franco1991thenucleotidesequence pages 1-2).</p>
+<p><strong>Central cyclophilin-like PPIase domain.</strong> The core of the protein contains a cyclophilin-like domain (CLD), harboring the canonical PPIase fold (InterPro: IPR002130, IPR029000; Pfam: PF00160). Sequence alignment with other cyclophilins reveals conservation of key catalytic segments, particularly segment IV, which is implicated in PPIase activity (franco1991thenucleotidesequence pages 4-7, pemberton2005identificationandcomparative pages 6-8).</p>
+<p><strong>C-terminal transmembrane domain.</strong> Unlike the major cytosolic yeast cyclophilin Cpr1, Cpr4 contains a hydrophobic stretch of approximately 17 amino acids at the C-terminus that fits the characteristics of a transmembrane helix domain (franco1991thenucleotidesequence pages 4-7, arevalorodriguez2004prolylisomerasesin pages 7-8). The protein also contains a potential glycosylation site (S-A-T) (franco1991thenucleotidesequence pages 4-7). This combined topology — cleavable signal peptide plus C-terminal membrane anchor — suggests the protein is a type I integral membrane protein with its catalytic domain oriented on the luminal/exoplasmic face (franco1991thenucleotidesequence pages 4-7, franco1991thenucleotidesequence pages 1-2).</p>
+<h2 id="3-enzymatic-function">3. Enzymatic Function</h2>
+<p>As a cyclophilin-family member, Cpr4 is predicted to catalyze the cis-trans isomerization of peptidyl-prolyl bonds in substrate proteins (EC 5.2.1.8). This reaction accelerates the rate-limiting step of protein folding that involves proline-containing segments (franco1991thenucleotidesequence pages 1-2, arevalorodriguez2004prolylisomerasesin pages 2-4). The cyclophilin fold of Cpr4 is well conserved relative to other family members, including canonical segments associated with PPIase catalysis (franco1991thenucleotidesequence pages 4-7). However, direct biochemical measurement of Cpr4's PPIase catalytic activity, substrate specificity, or kinetic parameters has not been reported. The specific in vivo substrates of Cpr4 remain unknown, and its biological function is listed as "unknown" in comprehensive surveys of yeast prolyl isomerases (arevalorodriguez2004prolylisomerasesin pages 4-6).</p>
+<p>A notable sequence feature with functional implications is the substitution of the tryptophan residue at the position equivalent to W121 of human cyclophilin A. In human CypA, W121 is critical for cyclosporin A (CsA) binding: mutation to phenylalanine or alanine reduces CsA susceptibility by 75- to 200-fold while diminishing PPIase activity only 2- to 13-fold, demonstrating that CsA binding and PPIase catalytic function are structurally separable. In Cpr4/Scc3, this tryptophan is replaced by glutamic acid, suggesting that Cpr4 may exhibit reduced sensitivity to CsA, though this was not experimentally verified (franco1991thenucleotidesequence pages 4-7).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>The localization of Cpr4 has been addressed in multiple studies, with evidence pointing to the vacuole and the endoplasmic reticulum/secretory pathway:</p>
+<ul>
+<li>
+<p><strong>Vacuolar localization:</strong> Multiple comprehensive surveys of yeast prolyl isomerases consistently report Cpr4 as a vacuolar protein (arevalorodriguez2004prolylisomerasesin pages 4-6, wang2005thecyclophilins pages 2-3). Wang and Heitman (2005) described both Cpr4 and Cpr8 as vacuolar cyclophilins that share cyclophilin C (CypC) as their mammalian ortholog (wang2005thecyclophilins pages 2-3). Arévalo-Rodríguez et al. (2004) also noted that "recent reports indicate that Cpr4 localizes to the vacuole" (arevalorodriguez2004prolylisomerasesin pages 7-8).</p>
+</li>
+<li>
+<p><strong>ER and secretory pathway association:</strong> Pemberton and Kay (2005), in their comparative PPIase analysis, listed Cpr4 with a predicted ER localization based on its N-terminal signal sequence, and described it as functioning within the secretory pathway. They further noted that CPR4 expression is induced by heat shock and tunicamycin, the latter being an ER stress agent that induces the unfolded protein response (pemberton2005identificationandcomparative pages 6-8, pemberton2005identificationandcomparative pages 11-13).</p>
+</li>
+</ul>
+<p>These observations are not contradictory: membrane proteins with signal peptides transit through the ER en route to other compartments including the vacuole. The presence of both an N-terminal signal peptide and a C-terminal transmembrane domain indicates that Cpr4 enters the secretory pathway and is subsequently trafficked — likely reaching the vacuolar membrane as its final destination.</p>
+<h2 id="5-relationship-to-drosophila-ninaa-and-functional-inference">5. Relationship to <em>Drosophila</em> NinaA and Functional Inference</h2>
+<p>The most striking structural parallel to Cpr4 is with Drosophila NinaA (neither inactivation nor afterpotential A), an integral membrane cyclophilin essential for rhodopsin biosynthesis and transport. NinaA shares with Cpr4 the combined topology of an N-terminal cleavable signal peptide and a C-terminal transmembrane domain, along with a central cyclophilin catalytic domain (franco1991thenucleotidesequence pages 4-7, arevalorodriguez2004prolylisomerasesin pages 7-8, colley1991thecyclophilinhomolog pages 1-2). NinaA localizes to the ER and secretory vesicles, where it is required for the proper folding and ER-to-Golgi transport of Rh1 opsin (colley1991thecyclophilinhomolog pages 4-6, colley1991thecyclophilinhomolog pages 2-4, colley1991thecyclophilinhomolog pages 1-2). In NinaA mutants, Rh1 opsin accumulates in the ER in an unprocessed high-molecular-weight form, and dramatic ER membrane elaboration occurs (colley1991thecyclophilinhomolog pages 4-6). NinaA acts as a substrate-specific chaperone/foldase, exhibiting selectivity for Rh1 and Rh2 rhodopsin isoforms but not Rh3 or Rh4, and targets the N-terminal P37 proline residue (ferreira2012fromdrosophilato pages 6-8, colley1991thecyclophilinhomolog pages 2-4).</p>
+<p>The structural similarity between Cpr4 and NinaA led Franco et al. (1991) to propose that Cpr4 may serve an analogous function in yeast — acting as a membrane-anchored cyclophilin that assists in the folding or transport of specific membrane or secretory proteins — though with different target substrates, as yeast lacks rhodopsins (franco1991thenucleotidesequence pages 4-7, franco1991thenucleotidesequence pages 1-2). This remains the most compelling functional hypothesis for Cpr4, though it has not been experimentally validated.</p>
+<h2 id="6-context-within-the-yeast-cyclophilin-family">6. Context within the Yeast Cyclophilin Family</h2>
+<p><em>S. cerevisiae</em> encodes eight cyclophilins (Cpr1–Cpr8) distributed across multiple subcellular compartments. The following table summarizes their properties:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th style="text-align: right;">Approx. mass</th>
+<th>Subcellular localization</th>
+<th>Known function / distinguishing features</th>
+<th>Mammalian ortholog</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CPR1</td>
+<td style="text-align: right;">17 kDa</td>
+<td>Cytoplasm, nucleus</td>
+<td>Cyclosporin A receptor; interacts with Sin3-Rpd3 histone deacetylase complex (arevalorodriguez2004prolylisomerasesin pages 4-6, wang2005thecyclophilins pages 3-4)</td>
+<td>CypA (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td>CPR2</td>
+<td style="text-align: right;">20 kDa</td>
+<td>Secreted / secretory pathway</td>
+<td>Required for cell survival after heat shock (arevalorodriguez2004prolylisomerasesin pages 4-6, arevalorodriguez2004prolylisomerasesin pages 7-8)</td>
+<td>CypB (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td>CPR3</td>
+<td style="text-align: right;">20 kDa</td>
+<td>Mitochondria</td>
+<td>Supports mitochondrial function at high temperature; assists mitochondrial protein folding under stress (arevalorodriguez2004prolylisomerasesin pages 4-6, arevalorodriguez2004prolylisomerasesin pages 7-8)</td>
+<td>CypD (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td><strong>CPR4</strong></td>
+<td style="text-align: right;"><strong>33 kDa</strong></td>
+<td><strong>Vacuole; also reported/predicted in ER/secretory pathway</strong></td>
+<td><strong>Function remains unknown; cyclophilin-family PPIase domain; N-terminal signal peptide; C-terminal transmembrane domain(s); structurally similar to Drosophila NinaA; reported as induced by heat shock and tunicamycin</strong> (arevalorodriguez2004prolylisomerasesin pages 4-6, arevalorodriguez2004prolylisomerasesin pages 7-8, franco1991thenucleotidesequence pages 4-7, pemberton2005identificationandcomparative pages 11-13)</td>
+<td><strong>CypC</strong> (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td>CPR5</td>
+<td style="text-align: right;">23 kDa</td>
+<td>Endoplasmic reticulum</td>
+<td>Unknown function; secretory-pathway cyclophilin with HDEL retention signal (arevalorodriguez2004prolylisomerasesin pages 4-6, arevalorodriguez2004prolylisomerasesin pages 7-8)</td>
+<td>CypB (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td>CPR6</td>
+<td style="text-align: right;">45 kDa</td>
+<td>Cytoplasm</td>
+<td>Interacts with Hsp82/Hsp90; contains TPR domain; chaperone-associated cyclophilin (arevalorodriguez2004prolylisomerasesin pages 4-6, arevalorodriguez2004prolylisomerasesin pages 7-8)</td>
+<td>Cyp40 (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td>CPR7</td>
+<td style="text-align: right;">45 kDa</td>
+<td>Cytoplasm</td>
+<td>Interacts with Hsp90; contains TPR domain; required for normal growth (arevalorodriguez2004prolylisomerasesin pages 4-6, arevalorodriguez2004prolylisomerasesin pages 7-8)</td>
+<td>Cyp40 (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+<tr>
+<td>CPR8</td>
+<td style="text-align: right;">35 kDa</td>
+<td>Vacuole / membrane</td>
+<td>Unknown function; membrane-associated vacuolar cyclophilin (arevalorodriguez2004prolylisomerasesin pages 4-6, wang2005thecyclophilins pages 2-3, pemberton2005identificationandcomparative pages 11-13)</td>
+<td>CypC (wang2005thecyclophilins pages 2-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the eight Saccharomyces cerevisiae cyclophilins (CPR1-CPR8), including size, localization, functions, and ortholog assignments. CPR4 is highlighted because it is the target gene and has mixed localization/function evidence that is important for interpretation.</em></p>
+<p>A critical finding from genetic studies is that none of the eight yeast cyclophilins is essential for viability. An octuple mutant strain (Δcpr1 Δcpr2 Δcpr3 Δcpr4 Δcpr5 Δcpr6 Δcpr7 Δcpr8) lacking all eight cyclophilins is viable, with little evidence of functional redundancy among the family members (wang2005thecyclophilins pages 3-4, arevalorodriguez2004prolylisomerasesin pages 2-4). This indicates that whatever function Cpr4 performs, it is dispensable under standard laboratory growth conditions. The only essential yeast prolyl isomerase is the parvulin-family member Ess1 (arevalorodriguez2004prolylisomerasesin pages 2-4).</p>
+<p>Phylogenetic analyses place Cpr4 and Cpr8 on the same branch, both related to the cyclophilin C family (CypC orthologs), and distinct from the cyclophilin A (CypA/Cpr1) and cyclophilin B (CypB/Cpr2, Cpr5) lineages. The cyclophilin C orthologs appear to have evolved independently from one another and from the cyclophilin B orthologs, rather than sharing a distinct common ancestor (wang2005thecyclophilins pages 3-4, pemberton2005identificationandcomparative pages 10-11, pemberton2005identificationandcomparative pages 11-13).</p>
+<h2 id="7-gene-expression">7. Gene Expression</h2>
+<p>Northern blot analysis demonstrated that CPR4/SCC3 is constitutively expressed during exponential growth, producing an abundant ~1.2 kb transcript (franco1991thenucleotidesequence pages 4-7). The 5′ regulatory region contains a TATA box at position −135 and other promoter elements but lacks identifiable upstream activating sequences, consistent with constitutive expression (franco1991thenucleotidesequence pages 4-7). Independently, Pemberton and Kay (2005) reported that CPR4 is induced by heat shock and tunicamycin, suggesting regulation under ER-stress or protein-folding-stress conditions (pemberton2005identificationandcomparative pages 11-13).</p>
+<h2 id="8-summary-and-functional-annotation">8. Summary and Functional Annotation</h2>
+<p>Cpr4 is a membrane-anchored cyclophilin of the secretory/vacuolar pathway in <em>S. cerevisiae</em>. Based on its domain architecture, it is predicted to catalyze peptidyl-prolyl cis-trans isomerization (EC 5.2.1.8) of substrate proteins within the lumen of the ER, transport vesicles, or the vacuole. Its unique topology — with an N-terminal signal peptide and C-terminal transmembrane anchor — is shared with <em>Drosophila</em> NinaA, suggesting it may function as a chaperone-like PPIase that assists in the folding or intracellular transport of specific membrane or secretory proteins. However, the precise in vivo substrates and biological role of Cpr4 remain experimentally undefined. The protein is non-essential, as demonstrated by the viability of strains lacking all eight yeast cyclophilins. CPR4 is constitutively expressed and may be further upregulated under conditions of ER stress. The replacement of the canonical CsA-binding tryptophan with glutamic acid suggests that Cpr4 may have reduced cyclosporin A affinity compared to other cyclophilins, although this has not been directly tested.</p>
+<h2 id="key-references">Key References</h2>
+<ul>
+<li>Franco, L. et al. (1991). <em>Yeast</em>, 7:971–979. Original cloning and sequencing of SCC3/CPR4.</li>
+<li>Arévalo-Rodríguez, M. et al. (2004). <em>Frontiers in Bioscience</em>, 9:2420–2446. Comprehensive review of yeast prolyl isomerases.</li>
+<li>Wang, P. and Heitman, J. (2005). <em>Genome Biology</em>, 6:226. Review of the cyclophilin family.</li>
+<li>Pemberton, T.J. and Kay, J.E. (2005). <em>Comparative and Functional Genomics</em>, 6:277–300. Comparative PPIase repertoire analysis.</li>
+<li>Colley, N.J. et al. (1991). <em>Cell</em>, 67:255–263. NinaA cyclophilin function in the secretory pathway.</li>
+<li>Ferreira, P.A. and Orry, A. (2012). <em>Journal of Neurogenetics</em>, 26:132–143. Review of NinaA and cyclophilin roles.</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(franco1991thenucleotidesequence pages 4-7): L. Franco, A. Jiménez, J. Demolder, F. Molemans, W. Fiers, and R. Contreras. The nucleotide sequence of a third cyclophilin‐homologous gene from saccharomyces cerevisiae. Yeast, 7:971-979, Dec 1991. URL: https://doi.org/10.1002/yea.320070909, doi:10.1002/yea.320070909. This article has 44 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(franco1991thenucleotidesequence pages 1-2): L. Franco, A. Jiménez, J. Demolder, F. Molemans, W. Fiers, and R. Contreras. The nucleotide sequence of a third cyclophilin‐homologous gene from saccharomyces cerevisiae. Yeast, 7:971-979, Dec 1991. URL: https://doi.org/10.1002/yea.320070909, doi:10.1002/yea.320070909. This article has 44 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(franco1991thenucleotidesequence pages 2-4): L. Franco, A. Jiménez, J. Demolder, F. Molemans, W. Fiers, and R. Contreras. The nucleotide sequence of a third cyclophilin‐homologous gene from saccharomyces cerevisiae. Yeast, 7:971-979, Dec 1991. URL: https://doi.org/10.1002/yea.320070909, doi:10.1002/yea.320070909. This article has 44 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pemberton2005identificationandcomparative pages 6-8): Trevor J. Pemberton and John E. Kay. Identification and comparative analysis of the peptidyl-prolyl cis/trans isomerase repertoires of h. sapiens, d. melanogaster, c. elegans, s. cerevisiae and sz. pombe. Comparative and Functional Genomics, 6:277-300, Jul 2005. URL: https://doi.org/10.1002/cfg.482, doi:10.1002/cfg.482. This article has 74 citations.</p>
+</li>
+<li>
+<p>(arevalorodriguez2004prolylisomerasesin pages 7-8): M. Arévalo-Rodríguez, Xiaoyun Wu, S. Hanes, and J. Heitman. Prolyl isomerases in yeast. Frontiers in bioscience : a journal and virtual library, 9:2420-46, Sep 2004. URL: https://doi.org/10.2741/1405, doi:10.2741/1405. This article has 151 citations.</p>
+</li>
+<li>
+<p>(colley1991thecyclophilinhomolog pages 1-2): Nansi Jo Colley, Elizabeth K. Baker, Mark A. Stamnes, and Charles S. Zuker. The cyclophilin homolog ninaa is required in the secretory pathway. Cell, 67:255-263, Oct 1991. URL: https://doi.org/10.1016/0092-8674(91)90177-z, doi:10.1016/0092-8674(91)90177-z. This article has 405 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pemberton2005identificationandcomparative pages 11-13): Trevor J. Pemberton and John E. Kay. Identification and comparative analysis of the peptidyl-prolyl cis/trans isomerase repertoires of h. sapiens, d. melanogaster, c. elegans, s. cerevisiae and sz. pombe. Comparative and Functional Genomics, 6:277-300, Jul 2005. URL: https://doi.org/10.1002/cfg.482, doi:10.1002/cfg.482. This article has 74 citations.</p>
+</li>
+<li>
+<p>(arevalorodriguez2004prolylisomerasesin pages 4-6): M. Arévalo-Rodríguez, Xiaoyun Wu, S. Hanes, and J. Heitman. Prolyl isomerases in yeast. Frontiers in bioscience : a journal and virtual library, 9:2420-46, Sep 2004. URL: https://doi.org/10.2741/1405, doi:10.2741/1405. This article has 151 citations.</p>
+</li>
+<li>
+<p>(wang2005thecyclophilins pages 2-3): Ping Wang and Joseph Heitman. The cyclophilins. Genome Biology, 6:226-226, Jun 2005. URL: https://doi.org/10.1186/gb-2005-6-7-226, doi:10.1186/gb-2005-6-7-226. This article has 892 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2005thecyclophilins pages 3-4): Ping Wang and Joseph Heitman. The cyclophilins. Genome Biology, 6:226-226, Jun 2005. URL: https://doi.org/10.1186/gb-2005-6-7-226, doi:10.1186/gb-2005-6-7-226. This article has 892 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arevalorodriguez2004prolylisomerasesin pages 2-4): M. Arévalo-Rodríguez, Xiaoyun Wu, S. Hanes, and J. Heitman. Prolyl isomerases in yeast. Frontiers in bioscience : a journal and virtual library, 9:2420-46, Sep 2004. URL: https://doi.org/10.2741/1405, doi:10.2741/1405. This article has 151 citations.</p>
+</li>
+<li>
+<p>(colley1991thecyclophilinhomolog pages 4-6): Nansi Jo Colley, Elizabeth K. Baker, Mark A. Stamnes, and Charles S. Zuker. The cyclophilin homolog ninaa is required in the secretory pathway. Cell, 67:255-263, Oct 1991. URL: https://doi.org/10.1016/0092-8674(91)90177-z, doi:10.1016/0092-8674(91)90177-z. This article has 405 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(colley1991thecyclophilinhomolog pages 2-4): Nansi Jo Colley, Elizabeth K. Baker, Mark A. Stamnes, and Charles S. Zuker. The cyclophilin homolog ninaa is required in the secretory pathway. Cell, 67:255-263, Oct 1991. URL: https://doi.org/10.1016/0092-8674(91)90177-z, doi:10.1016/0092-8674(91)90177-z. This article has 405 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ferreira2012fromdrosophilato pages 6-8): Paulo A. Ferreira and Andrew Orry. From drosophila to humans: reflections on the roles of the prolyl isomerases and chaperones, cyclophilins, in cell function and disease. Journal of Neurogenetics, 26:132-143, Jun 2012. URL: https://doi.org/10.3109/01677063.2011.647143, doi:10.3109/01677063.2011.647143. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pemberton2005identificationandcomparative pages 10-11): Trevor J. Pemberton and John E. Kay. Identification and comparative analysis of the peptidyl-prolyl cis/trans isomerase repertoires of h. sapiens, d. melanogaster, c. elegans, s. cerevisiae and sz. pombe. Comparative and Functional Genomics, 6:277-300, Jul 2005. URL: https://doi.org/10.1002/cfg.482, doi:10.1002/cfg.482. This article has 74 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="CPR4-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="CPR4-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>franco1991thenucleotidesequence pages 4-7</li>
+<li>arevalorodriguez2004prolylisomerasesin pages 4-6</li>
+<li>wang2005thecyclophilins pages 2-3</li>
+<li>arevalorodriguez2004prolylisomerasesin pages 7-8</li>
+<li>colley1991thecyclophilinhomolog pages 4-6</li>
+<li>arevalorodriguez2004prolylisomerasesin pages 2-4</li>
+<li>pemberton2005identificationandcomparative pages 11-13</li>
+<li>franco1991thenucleotidesequence pages 1-2</li>
+<li>franco1991thenucleotidesequence pages 2-4</li>
+<li>pemberton2005identificationandcomparative pages 6-8</li>
+<li>colley1991thecyclophilinhomolog pages 1-2</li>
+<li>wang2005thecyclophilins pages 3-4</li>
+<li>colley1991thecyclophilinhomolog pages 2-4</li>
+<li>ferreira2012fromdrosophilato pages 6-8</li>
+<li>pemberton2005identificationandcomparative pages 10-11</li>
+<li>https://doi.org/10.1002/yea.320070909,</li>
+<li>https://doi.org/10.1002/cfg.482,</li>
+<li>https://doi.org/10.2741/1405,</li>
+<li>https://doi.org/10.1016/0092-8674(91</li>
+<li>https://doi.org/10.1186/gb-2005-6-7-226,</li>
+<li>https://doi.org/10.3109/01677063.2011.647143,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CPR4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P25334" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cpr4-s-cerevisiae-ycr069w-p25334-curation-notes">CPR4 (S. cerevisiae, YCR069W, P25334) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review. Inline provenance uses<br />
+<code>[PMID:xxxx "verbatim supporting text"]</code>.</p>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li>UniProt: <strong>P25334</strong> <code>CYPR_YEAST</code>, "Peptidyl-prolyl cis-trans isomerase CPR4",<br />
+  EC 5.2.1.8, AltName Rotamase, <strong>Flags: Precursor</strong> (has signal peptide).</li>
+<li>Gene: <strong>CPR4</strong>; Synonyms <strong>CYP4, SCC3</strong>; systematic name <strong>YCR069W</strong> (chromosome III).</li>
+<li>SGD: S000000665. PANTHER family PTHR11071 (Cyclophilin-type PPIase),<br />
+  subfamily <strong>PTHR11071:SF568 "PEPTIDYL-PROLYL CIS-TRANS ISOMERASE CPR4-RELATED"</strong>.</li>
+<li>Length 318 aa, MW 35.8 kDa.</li>
+<li>PE level: <code>PE 3: Inferred from homology</code> — UniProt has <strong>no direct experimental<br />
+  evidence</strong> for CPR4 protein existence/function; identity/function is homology-based.</li>
+<li>Originally cloned/sequenced as <strong>SCC3</strong> ("S. cerevisiae cyclophilin 3"), the third<br />
+  cyclophilin-homologous gene found in budding yeast [PMID:1803821, Franco et al. 1991].</li>
+</ul>
+<p>CPR4 is one of eight cyclophilins in S. cerevisiae (CPR1–CPR8). Its closest paralog is<br />
+<strong>CPR8</strong> (P53728, CYP8); both are the yeast "cyclophilin C (CypC)"-type / vacuolar cyclophilins<br />
+and share PANTHER subfamily SF568 (verified in<br />
+<code>interpro/panther/PTHR11071/PTHR11071-entries.csv</code>: both P25334/CPR4 and P53728/CPR8 map to<br />
+SF568 "CPR4-RELATED"). <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" title="Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are located in vacuoles">PMID:15998457</a>. Dolinski et al. describe Cpr8 as<br />
+"a homolog of the secretory pathway cyclophilin Cpr4" <a href="https://pubmed.ncbi.nlm.nih.gov/9371805">PMID:9371805</a>.</p>
+<h2 id="domain-architecture-verified-from-uniprot-ft-inline-sequence-analysis">Domain architecture (verified from UniProt FT + inline sequence analysis)</h2>
+<ul>
+<li><strong>SIGNAL 1..20</strong> (ECO:0000255) — N-terminal cleavable signal peptide → ER / secretory targeting.</li>
+<li><strong>CHAIN 21..318</strong> mature protein.</li>
+<li><strong>DOMAIN 55..225</strong> "PPIase cyclophilin-type" (PROSITE PRU00156).</li>
+<li><strong>TRANSMEM 286..303</strong> "Helical" (ECO:0000255) — a single C-terminal transmembrane helix.</li>
+<li><strong>CARBOHYD 166</strong> N-linked glycosylation site (ECO:0000255) → consistent with lumenal topology.</li>
+<li>Keywords: Glycoprotein; Isomerase; Membrane; Rotamase; Signal; Transmembrane; Transmembrane helix.</li>
+</ul>
+<p>Franco et al. 1991 described exactly this dual topology from sequence:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1803821" title="contains two hydrophobic cores, one at the amino terminal, 20 amino acids long, which could serve as a signal peptide, and the other one at the carboxyl end with a structure similar to a transmembrane helix">PMID:1803821</a> and concluded <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" title="Scc3 could be a secretory or, more likely, a transmembrane protein">PMID:1803821</a>. UniProt SUBCELLULAR LOCATION: "Membrane; Single-pass<br />
+membrane protein" (ECO:0000305, an inference, not experimental).</p>
+<h2 id="catalytic-residue-csa-pocket-analysis-inline-this-review">Catalytic-residue / CsA-pocket analysis (inline, this review)</h2>
+<p>I compared the CPR4 cyclophilin domain to human cyclophilin A (PPIA, P62937), whose<br />
+catalytic/CsA-contact residues are well established.</p>
+<p><strong>Catalytic core motifs are PRESENT and correctly positioned within the 55–225 domain:</strong><br />
+<code>NNFAML</code> (pos 82), <code>HTYSYR</code> (104), <code>GPFTVYGP</code> (132), <code>FGPD</code> (161), <code>GQITSG</code> (190), <code>RFLYFV</code> (219).<br />
+These correspond to conserved cyclophilin catalytic/substrate-binding elements → PPIase<br />
+catalytic machinery is intact → <strong>PPIase (GO:0003755) is domain-defensible</strong>.</p>
+<p><strong>NOTABLE DIVERGENCE — the conserved CsA-binding tryptophan is ABSENT.</strong><br />
+Human CypA has a single Trp, W121, in <code>FICTAKTE</code><strong>W</strong><code>LDGKHVV</code>; W121 lines the cyclosporin-A<br />
+pocket and is a key CsA contact. The homologous region in CPR4 is <code>IITTKAD</code><strong>GNE</strong><code>ELDGK</code> —<br />
+no Trp in the entire cyclophilin domain (the protein's only Trp is W2, in the signal peptide).<br />
+Whole-domain Trp count = 0. This is <strong>independently corroborated</strong> by Franco et al. as reported<br />
+in the deep-research synthesis: the W121-equivalent is replaced by glutamate in Scc3/CPR4<br />
+(a W121E-type substitution) [file:yeast/CPR4/CPR4-deep-research-falcon.md, citing Franco 1991].<br />
+Interpretation: CPR4 likely has <strong>reduced/altered cyclosporin-A binding</strong> relative to canonical<br />
+cyclophilins, even though the PPIase catalytic residues are conserved. In human CypA, W121→F/A<br />
+lowers CsA affinity 75–200-fold but PPIase activity only 2–13-fold, showing the two are<br />
+structurally separable. (This is a sequence-based prediction; CPR4 CsA binding is untested.)</p>
+<h2 id="ninaa-structural-parallel-functional-hypothesis-not-established-for-cpr4">NinaA structural parallel (functional hypothesis, not established for CPR4)</h2>
+<p>The only cyclophilin sharing CPR4's dual topology (N-terminal signal peptide + C-terminal TM +<br />
+central CLD) is <em>Drosophila</em> <strong>NinaA</strong>, a membrane-anchored, secretory-pathway cyclophilin<br />
+required for correct folding and ER→Golgi transport of rhodopsin. Franco 1991<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1803821" title="The only cyclophilin with similar structure to that of Scc3 is ninaA from Drosophila melanogaster, a transmembrane protein which seems to be implicated in the correct folding and/or intercalation of rhodopsin in the endoplasmic reticulum of the fly photoreceptors">PMID:1803821</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/1803821" title="the amino and the carboxy regions of Scc3 and ninaA share a significant level of homology, which suggests that they have a similar function, albeit for different target proteins">PMID:1803821</a>. NinaA is a CypC ortholog <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" title="A retina-specific cyclophilin of the fruit fly Drosophila melanogaster, NinaA (an ortholog of mammal CypC), is crucial for the folding of rhodopsin isoforms">PMID:15998457</a>. This motivates a hypothesis that CPR4 is a<br />
+membrane-anchored, substrate-specific foldase for secretory/membrane clients — but yeast has no<br />
+rhodopsins and CPR4's substrates are unknown.</p>
+<h2 id="what-is-known-vs-not-known-about-cpr4-specifically">What is KNOWN vs NOT known about CPR4 specifically</h2>
+<h3 id="known-or-well-supported">KNOWN (or well-supported)</h3>
+<ol>
+<li>CPR4 is a cyclophilin-family PPIase by sequence/homology (UniProt, PANTHER, InterPro,<br />
+   Pfam PF00160, CDD cd00317). Catalytic residues intact (this review). EC 5.2.1.8.</li>
+<li>Signal peptide + C-terminal TM helix → a <strong>secretory-pathway / ER, membrane</strong> cyclophilin<br />
+   [PMID:1803821; PMID:15998457]. Dolinski et al. call it "the secretory pathway cyclophilin<br />
+   Cpr4" <a href="https://pubmed.ncbi.nlm.nih.gov/9371805">PMID:9371805</a>.</li>
+<li>CPR4 is <strong>non-essential</strong>. None of the eight yeast cyclophilins (nor an octuple mutant) is<br />
+   essential; little/no functional redundancy [PMID:15998457 "none of the eight individual<br />
+   cyclophilins was found to be essential in S. cerevisiae"; "an octuplet mutant lacking all<br />
+   eight cyclophilins was viable and that there was little or no evidence for functional<br />
+   redundancy"]; corroborated for all 12 immunophilins in [PMID:9371805 "None of the eight<br />
+   cyclophilins or four FKBPs were essential"; "yeast mutants lacking all 12 immunophilins were<br />
+   viable"].</li>
+<li><strong>Localization</strong>: Wang &amp; Heitman 2005 place Cpr4 (and Cpr8) in <strong>vacuoles</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/15998457" title="Cpr4 and Cpr8 ... are located in vacuoles">PMID:15998457</a>. SGD HDA (systematic microscopy) also assigns<br />
+   the fungal-type vacuole (GO:0000324) [PMID:26928762 source dataset]. Family-level IBA instead<br />
+   assigns ER (GO:0005783)/cytoplasm. So localization data are partly discordant (vacuole vs ER);<br />
+   both are within the secretory/endomembrane system and not mutually exclusive for a protein<br />
+   that transits the ER en route to the vacuole. PMID:26928762 is a genome-wide library/methods<br />
+   paper and does not discuss CPR4 individually.</li>
+</ol>
+<h3 id="not-known-genuine-gaps">NOT known (genuine gaps)</h3>
+<ul>
+<li><strong>No physiological in-vivo substrate/client of CPR4 is known.</strong> Dolinski et al. conclude<br />
+  immunophilin physiological functions are "largely unknown" and that each "regulates a<br />
+  restricted number of unique partner proteins that remain to be identified"<br />
+  [PMID:9371805 "the physiological functions of these proteins are largely unknown";<br />
+  "regulates a restricted number of unique partner proteins that remain to be identified"].</li>
+<li><strong>Whether CPR4's PPIase activity is measured / required in vivo</strong> — no direct biochemical<br />
+  measurement of CPR4 PPIase kinetics or substrate specificity has been reported (deep research).</li>
+<li><strong>Redundancy with CPR8</strong> (its SF568 paralog) or with other ER/secretory folding factors —<br />
+  untested; viability data show little redundancy but substrate-level redundancy is unexplored.</li>
+<li><strong>CsA binding of CPR4 specifically</strong> — untested; predicted atypical (missing W121-equivalent).</li>
+<li><strong>The NinaA-analogous foldase hypothesis</strong> — plausible from topology/homology but never<br />
+  experimentally validated in yeast.</li>
+<li>No specific biological process is experimentally assigned; GOA carries an explicit ND<br />
+  "biological_process" root annotation (GO_REF:0000015).</li>
+</ul>
+<h2 id="annotation-by-annotation-plan-8-goa-rows">Annotation-by-annotation plan (8 GOA rows)</h2>
+<ol>
+<li>GO:0003755 PPIase, IBA (GO_REF:0000033), enables → <strong>ACCEPT</strong> (core MF; catalytic residues intact).</li>
+<li>GO:0005783 endoplasmic reticulum, IBA, is_active_in → <strong>KEEP_AS_NON_CORE</strong>: architecture<br />
+   (signal peptide + TM) supports secretory/ER; note vacuole is the more specific experimental call.</li>
+<li>GO:0006457 protein folding, IBA, involved_in → <strong>ACCEPT</strong> as general family-level BP; no<br />
+   CPR4-specific in-vivo process known → keep general.</li>
+<li>GO:0003755 PPIase, IEA (GO_REF:0000120 InterPro/EC), enables → <strong>ACCEPT</strong> (redundant MF confirmation).</li>
+<li>GO:0016020 membrane, IEA (GO_REF:0000044 SubCell), located_in → <strong>KEEP_AS_NON_CORE</strong>:<br />
+   C-terminal TM helix supports membrane; general term.</li>
+<li>GO:0000324 fungal-type vacuole, HDA (PMID:26928762), located_in → <strong>KEEP_AS_NON_CORE</strong><br />
+   (experimental localization; concordant with Wang&amp;Heitman vacuole; do not remove).</li>
+<li>GO:0003755 PPIase, ISS (PMID:9371805), enables → <strong>ACCEPT</strong> (ISS from a cyclophilin homolog; MF consistent).</li>
+<li>GO:0008150 biological_process (root), ND (GO_REF:0000015) → <strong>ACCEPT</strong> (honest "no specific BP known" placeholder).</li>
+</ol>
+<h2 id="references">References</h2>
+<ul>
+<li>PMID:1803821 — Franco et al. (1991) Yeast. Original SCC3/CPR4 cloning+sequence; dual topology;<br />
+  NinaA parallel. Abstract-only in cache. HIGH relevance (primary source for identity/topology).</li>
+<li>PMID:9371805 — Dolinski, Muir, Cardenas, Heitman (1997) PNAS. Immunophilin knockouts;<br />
+  non-essentiality; "unknown physiological function / unique partners." Abstract-only. HIGH.</li>
+<li>PMID:15998457 — Wang &amp; Heitman (2005) Genome Biology "The cyclophilins." Full text. Cpr4/Cpr8<br />
+  vacuolar localization; octuple-mutant viability; NinaA=CypC. HIGH (review, direct CPR4 statements).</li>
+<li>PMID:15353296 — Arévalo-Rodríguez et al. (2004) Front Biosci "Prolyl isomerases in yeast."<br />
+  Abstract-only. MEDIUM (review context).</li>
+<li>PMID:26928762 — Yofe et al. (2016) Nat Methods, SWAT. Source of HDA vacuole datapoint; does not<br />
+  discuss CPR4 individually. MEDIUM (localization datapoint).</li>
+<li>file:yeast/CPR4/CPR4-deep-research-falcon.md — Falcon deep research synthesis. Used for the<br />
+  W121E-equivalent corroboration and general synthesis; independently consistent with my<br />
+  UniProt/sequence analysis.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P25334
+gene_symbol: CPR4
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  CPR4 (systematic name YCR069W; originally cloned as SCC3) is one of eight cyclophilins in
+  Saccharomyces cerevisiae and the founder of the &#34;cyclophilin C (CypC)&#34;-type secretory-pathway
+  subgroup, with CPR8 as its closest paralog. It is a peptidyl-prolyl cis-trans isomerase
+  (PPIase/rotamase, EC 5.2.1.8) of the cyclophilin family, catalyzing cis-trans isomerization of
+  peptidyl-prolyl bonds, a rate-limiting step in protein folding. CPR4 has an unusual domain
+  architecture among cyclophilins: an N-terminal cleavable signal peptide, a central cyclophilin
+  PPIase domain (with a predicted N-glycosylation site), and a single C-terminal transmembrane
+  helix. This dual topology (signal peptide plus C-terminal membrane anchor) is shared with
+  Drosophila NinaA, a membrane-anchored secretory-pathway cyclophilin required for rhodopsin
+  folding and transport, and places CPR4 in the endoplasmic reticulum / endomembrane system;
+  systematic and review-level localization data assign it to the vacuole, consistent with a
+  protein that transits the secretory pathway. CPR4 is non-essential. Its catalytic residues are
+  conserved, but the tryptophan equivalent to human cyclophilin A W121 that lines the cyclosporin
+  A binding pocket is not conserved, predicting atypical cyclosporin A binding. No physiological
+  in vivo substrate or specific biological role has been established.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:1803821
+  title: The nucleotide sequence of a third cyclophilin-homologous gene from Saccharomyces
+    cerevisiae.
+  findings:
+  - statement: &gt;-
+      CPR4/SCC3 encodes a cyclophilin-homologous protein with two hydrophobic regions —
+      an N-terminal signal peptide and a C-terminal transmembrane-like helix — making it a
+      likely secretory or membrane protein.
+    supporting_text: &gt;-
+      Its putative protein product (Scc3) contains two hydrophobic cores, one at the amino
+      terminal, 20 amino acids long, which could serve as a signal peptide, and the other one at
+      the carboxyl end with a structure similar to a transmembrane helix.
+  - statement: &gt;-
+      The only cyclophilin with the same dual topology is Drosophila NinaA, a secretory-pathway
+      transmembrane cyclophilin implicated in rhodopsin folding, suggesting an analogous foldase
+      role for CPR4 on different, unidentified target proteins.
+    supporting_text: &gt;-
+      The only cyclophilin with similar structure to that of Scc3 is ninaA from Drosophila
+      melanogaster, a transmembrane protein which seems to be implicated in the correct folding
+      and/or intercalation of rhodopsin in the endoplasmic reticulum of the fly photoreceptors
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original cloning/sequencing paper for SCC3/CPR4 (P25334, YCR069W). PubMed-verified;
+      abstract-only in cache. Primary source for the signal-peptide + C-terminal TM topology and
+      the NinaA structural parallel. Consistent with the UniProt feature table.
+- id: PMID:9371805
+  title: All cyclophilins and FK506 binding proteins are, individually and collectively,
+    dispensable for viability in Saccharomyces cerevisiae.
+  findings:
+  - statement: &gt;-
+      CPR4 is the secretory-pathway cyclophilin of S. cerevisiae; CPR8 is its homolog. None of
+      the eight yeast cyclophilins is essential, and a strain lacking all 12 immunophilins is
+      viable, with little evidence of functional overlap.
+    supporting_text: &gt;-
+      Cpr8, a homolog of the secretory pathway cyclophilin Cpr4
+  - statement: &gt;-
+      The physiological functions of yeast immunophilins are largely unknown; each is proposed to
+      act on a small set of unique, as-yet-unidentified partner proteins.
+    supporting_text: &gt;-
+      the physiological functions of these proteins are largely unknown
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Dolinski, Muir, Cardenas &amp; Heitman (1997) PNAS; PubMed-verified; abstract-only in cache
+      (full_text_available: false). Directly names Cpr4 as the secretory-pathway cyclophilin,
+      establishes non-essentiality of all cyclophilins/FKBPs, and frames the &#34;unknown
+      physiological function / unique partners&#34; gap. Source of the ISS PPIase annotation.
+- id: PMID:15998457
+  title: The cyclophilins.
+  findings:
+  - statement: &gt;-
+      Cpr4 and Cpr8 each contain a single cyclophilin-like domain plus a long N-terminal signal
+      peptide and are localized to vacuoles.
+    supporting_text: &gt;-
+      Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are
+      located in vacuoles
+  - statement: &gt;-
+      None of the eight individual yeast cyclophilins is essential, and an octuple mutant lacking
+      all eight is viable with little or no evidence of functional redundancy.
+    supporting_text: &gt;-
+      an octuplet mutant lacking all eight cyclophilins was viable and that there was little or no
+      evidence for functional redundancy
+  - statement: &gt;-
+      Drosophila NinaA, the structural analog of Cpr4, is an ortholog of mammalian CypC and is
+      crucial for folding of rhodopsin isoforms.
+    supporting_text: &gt;-
+      NinaA (an ortholog of mammal CypC), is crucial for the folding of rhodopsin isoforms
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Wang &amp; Heitman (2005) Genome Biology review; PubMed-verified (PMID:15998457,
+      DOI:10.1186/gb-2005-6-7-226); full text in cache. Makes explicit CPR4-specific statements
+      (vacuolar localization, signal peptide, octuple-mutant viability, NinaA=CypC). Used for
+      localization and non-essentiality/redundancy claims.
+- id: PMID:15353296
+  title: Prolyl isomerases in yeast.
+  findings:
+  - statement: &gt;-
+      Comprehensive review of the S. cerevisiae prolyl isomerase repertoire (cyclophilins, FKBPs,
+      parvulins), providing family-level context for Cpr4 among Cpr1-Cpr8.
+    supporting_text: &gt;-
+      Prolyl isomerases in yeast.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Arevalo-Rodriguez, Wu, Hanes &amp; Heitman (2004) Frontiers in Bioscience; PubMed-verified
+      (PMID:15353296, DOI:10.2741/1405); abstract-only in cache. Background/context review for the
+      yeast prolyl-isomerase family; not used for a load-bearing CPR4-specific verbatim claim
+      beyond the title.
+- id: PMID:26928762
+  title: &#39;One library to make them all: streamlining the creation of yeast libraries
+    via a SWAp-Tag strategy.&#39;
+  findings:
+  - statement: &gt;-
+      Genome-wide N-terminal GFP tagging (SWAT) of endomembrane proteins assigned many proteins to
+      the ER, punctate structures and the vacuole; CPR4 received its high-throughput vacuole
+      localization from this class of systematic screen.
+    supporting_text: &gt;-
+      most new localization assignments were to the ER, punctate structures and vacuole
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Yofe et al. (2016) Nat Methods; PubMed-verified; full text in cache. A genome-wide
+      library/methods paper that does not discuss CPR4 individually; it is the dataset source for
+      the SGD HDA fungal-type vacuole annotation. Localization datapoint only.
+- id: file:yeast/CPR4/CPR4-deep-research-falcon.md
+  title: Falcon deep research report for CPR4 (Edison Scientific Literature)
+  findings:
+  - statement: &gt;-
+      The tryptophan equivalent to human cyclophilin A W121 (a key cyclosporin A contact) is
+      replaced by glutamate in CPR4/Scc3, predicting reduced cyclosporin A binding while leaving
+      catalytic PPIase features intact.
+    supporting_text: &gt;-
+      the conserved cyclophilin residue equivalent to W121, important for cyclosporin A binding in
+      other cyclophilins, is replaced by glutamate in Scc3/CPR4
+  - statement: &gt;-
+      No direct biochemical measurement of CPR4 PPIase catalytic activity, substrate specificity,
+      or kinetics has been reported, and its precise cellular function is unresolved.
+    supporting_text: &gt;-
+      direct biochemical measurement of Cpr4&#39;s PPIase catalytic activity, substrate specificity,
+      or kinetic parameters has not been reported
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Falcon (Edison) deep-research synthesis. Its W121-to-glutamate claim independently
+      corroborates this review&#39;s own sequence analysis (whole cyclophilin domain lacks a Trp;
+      the human CypA W121-homologous position is not a Trp in CPR4). Cited claims grep-verified as
+      verbatim substrings of the cached report.
+existing_annotations:
+- term:
+    id: GO:0003755
+    label: peptidyl-prolyl cis-trans isomerase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of cyclophilin PPIase activity, the defining molecular
+      function of the family and of CPR4.
+    action: ACCEPT
+    reason: &gt;-
+      CPR4 carries an intact cyclophilin-type PPIase domain (UniProt DOMAIN 55..225; Pfam
+      PF00160; CDD cd00317) and the conserved cyclophilin catalytic/substrate-binding motifs are
+      present and correctly positioned (inline sequence analysis, this review). PPIase is the
+      well-supported core molecular function. This is the correct core MF term.
+    supported_by:
+    - reference_id: PMID:1803821
+      supporting_text: &gt;-
+        an open reading frame of 954 nucleotides with coding potential for a protein with high
+        similarity to the ubiquitous cyclophilins which are both peptidyl-prolyl cis-trans
+        isomerases and cyclosporin A-binding proteins
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment to the endoplasmic reticulum, consistent with CPR4&#39;s
+      N-terminal signal peptide and entry into the secretory pathway.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      CPR4&#39;s signal peptide (UniProt SIGNAL 1..20) and C-terminal TM helix direct it into the ER
+      / secretory pathway, so ER is a defensible localization. However, the more specific
+      experimentally-supported steady-state localization for Cpr4 (and its paralog Cpr8) is the
+      vacuole; the ER assignment reflects the transit compartment / family topology. Retained as a
+      valid but non-core (localization, not molecular function) annotation; not contradicted.
+    supported_by:
+    - reference_id: PMID:15998457
+      supporting_text: &gt;-
+        Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are
+        located in vacuoles
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment to protein folding, the general biological process associated
+      with cyclophilin PPIase activity.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the family-level process for cyclophilins (PPIase accelerates the
+      rate-limiting proline-isomerization step of folding). This general BP is appropriate for
+      CPR4 on homology grounds. No CPR4-specific in-vivo substrate or more specific process is
+      known (see knowledge_gaps), so the general term is retained without further specialization.
+    supported_by:
+    - reference_id: PMID:15998457
+      supporting_text: &gt;-
+        both de novo protein folding and the refolding processes following cellular membrane traffic
+        necessitate isomerization to the cis form
+- term:
+    id: GO:0003755
+    label: peptidyl-prolyl cis-trans isomerase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Automated (InterPro/EC to GO) assignment of PPIase activity, redundant with the IBA and ISS
+      PPIase annotations.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro IPR002130 (cyclophilin-type PPIase domain) and EC 5.2.1.8 map to
+      GO:0003755; CPR4 carries this domain with intact catalytic residues. Consistent with the
+      core molecular function; a redundant but correct electronic confirmation.
+    supported_by:
+    - reference_id: PMID:1803821
+      supporting_text: &gt;-
+        high similarity to the ubiquitous cyclophilins which are both peptidyl-prolyl cis-trans
+        isomerases and cyclosporin A-binding proteins
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Automated (UniProt SubCell) assignment to membrane, based on the predicted C-terminal
+      transmembrane helix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      CPR4 has a single predicted C-terminal transmembrane helix (UniProt TRANSMEM 286..303),
+      so membrane localization is supported. This is a general CC term; retained as a valid but
+      non-core localization annotation. The specific membrane (ER/vacuolar endomembrane) is better
+      captured by the ER and vacuole terms.
+    supported_by:
+    - reference_id: PMID:1803821
+      supporting_text: &gt;-
+        the other one at the carboxyl end with a structure similar to a transmembrane helix
+- term:
+    id: GO:0000324
+    label: fungal-type vacuole
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput microscopy (HDA) assignment of CPR4 to the fungal-type vacuole.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental (HDA) localization from a systematic screen; concordant with the review-level
+      statement that Cpr4 and its paralog Cpr8 are vacuolar. This is the most specific
+      experimentally-supported steady-state localization for CPR4. Retained as a valid but
+      non-core (localization) annotation. Note the source paper (PMID:26928762) is a genome-wide
+      library/methods paper and does not discuss CPR4 individually; the vacuole is nonetheless
+      supported independently by Wang &amp; Heitman 2005.
+    supported_by:
+    - reference_id: PMID:15998457
+      supporting_text: &gt;-
+        Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are
+        located in vacuoles
+- term:
+    id: GO:0003755
+    label: peptidyl-prolyl cis-trans isomerase activity
+  evidence_type: ISS
+  original_reference_id: PMID:9371805
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity (ISS) assignment of PPIase activity to CPR4, based on cyclophilin
+      homology.
+    action: ACCEPT
+    reason: &gt;-
+      ISS PPIase from SGD, consistent with the family assignment and CPR4&#39;s intact cyclophilin
+      catalytic domain. Reinforces the core molecular function; correct.
+    supported_by:
+    - reference_id: PMID:9371805
+      supporting_text: &gt;-
+        Cpr8, a homolog of the secretory pathway cyclophilin Cpr4
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process annotation with ND (no biological data), recording that no specific
+      biological process has been experimentally determined for CPR4.
+    action: ACCEPT
+    reason: &gt;-
+      This ND root annotation is an honest and correct statement of the current state of
+      knowledge: despite the general protein-folding process inferred from homology, no
+      CPR4-specific in-vivo biological role has been experimentally established (see
+      knowledge_gaps). Root ND annotations are conventionally retained.
+    supported_by:
+    - reference_id: PMID:9371805
+      supporting_text: &gt;-
+        the physiological functions of these proteins are largely unknown
+core_functions:
+- description: &gt;-
+    CPR4 is a cyclophilin-type peptidyl-prolyl cis-trans isomerase (rotamase, EC 5.2.1.8) that
+    catalyzes cis-trans isomerization of peptidyl-prolyl bonds; its catalytic residues are
+    conserved, making PPIase activity its domain-defensible core molecular function.
+  supported_by:
+  - reference_id: PMID:1803821
+    supporting_text: &gt;-
+      high similarity to the ubiquitous cyclophilins which are both peptidyl-prolyl cis-trans
+      isomerases and cyclosporin A-binding proteins
+  molecular_function:
+    id: GO:0003755
+    label: peptidyl-prolyl cis-trans isomerase activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0000324
+    label: fungal-type vacuole
+  - id: GO:0005783
+    label: endoplasmic reticulum
+- description: &gt;-
+    CPR4 is a membrane-anchored cyclophilin of the secretory/endomembrane system: an N-terminal
+    signal peptide plus a single C-terminal transmembrane helix embed it in the ER/vacuolar
+    membrane, with the catalytic cyclophilin domain in the lumenal compartment. This dual topology
+    matches Drosophila NinaA, motivating a hypothesized (not yet demonstrated) role as a
+    substrate-specific foldase for secretory/membrane clients.
+  supported_by:
+  - reference_id: PMID:1803821
+    supporting_text: &gt;-
+      Its putative protein product (Scc3) contains two hydrophobic cores, one at the amino
+      terminal, 20 amino acids long, which could serve as a signal peptide, and the other one at
+      the carboxyl end with a structure similar to a transmembrane helix
+  - reference_id: PMID:15998457
+    supporting_text: &gt;-
+      Cpr4 and Cpr8 contain a single CLD domain plus a long amino-terminal signal peptide and are
+      located in vacuoles
+  molecular_function:
+    id: GO:0003755
+    label: peptidyl-prolyl cis-trans isomerase activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0000324
+    label: fungal-type vacuole
+  - id: GO:0005783
+    label: endoplasmic reticulum
+  - id: GO:0016020
+    label: membrane
+knowledge_gaps:
+- gap_statement: &gt;-
+    No physiological in vivo substrate or client protein of CPR4 has been identified. It is
+    unknown which secretory/membrane/vacuolar proteins (if any) require CPR4-catalyzed
+    peptidyl-prolyl isomerization for their folding, assembly, or transport.
+  boundary: &gt;-
+    Firmly established: CPR4 is a cyclophilin-family PPIase (EC 5.2.1.8) with an intact catalytic
+    domain, a signal peptide, and a C-terminal transmembrane anchor, localizing to the
+    ER/secretory pathway and vacuole. What is NOT established is any specific client protein or the
+    reaction it performs on that client in vivo.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Cyclophilins act on restricted, unique partner sets rather than as general foldases;
+    identifying CPR4&#39;s client(s) would convert a homology-level &#34;protein folding&#34; annotation into a
+    specific, mechanistically meaningful biological role and test the NinaA-analogous foldase
+    hypothesis in yeast.
+  provenance:
+  - reference_id: PMID:9371805
+    supporting_text: &gt;-
+      regulates a restricted number of unique partner proteins that remain to be identified
+  - reference_id: PMID:9371805
+    supporting_text: &gt;-
+      the physiological functions of these proteins are largely unknown
+- gap_statement: &gt;-
+    It is unknown whether CPR4 has measurable PPIase activity and whether that catalytic activity
+    is required in vivo for any process. No direct biochemical measurement of CPR4 PPIase kinetics,
+    substrate specificity, or catalysis-dependent phenotype has been reported.
+  boundary: &gt;-
+    Firmly established: the cyclophilin catalytic residues are conserved in the CPR4 sequence, so
+    catalytic competence is predicted. What is NOT established is any experimental enzyme
+    measurement for the CPR4 protein or a catalysis-requiring phenotype.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Cyclophilins can act as chaperones independently of catalysis; distinguishing a catalytic from
+    a catalysis-independent role for CPR4 is prerequisite to a mechanistic annotation.
+  provenance:
+  - reference_id: file:yeast/CPR4/CPR4-deep-research-falcon.md
+    supporting_text: &gt;-
+      direct biochemical measurement of Cpr4&#39;s PPIase catalytic activity, substrate specificity,
+      or kinetic parameters has not been reported
+- gap_statement: &gt;-
+    The extent of functional redundancy between CPR4 and its closest paralog CPR8 (and other
+    ER/secretory folding factors) is unknown. Viability data show non-essentiality but do not test
+    substrate-level or conditional redundancy.
+  boundary: &gt;-
+    Firmly established: CPR4 and CPR8 are paralogous vacuolar/secretory cyclophilins (same PANTHER
+    subfamily SF568, CypC-type), and none of the eight yeast cyclophilins — nor an octuple mutant —
+    is essential, with little evidence of functional redundancy at the level of viability. What is
+    NOT established is whether CPR4 and CPR8 (or other folding factors) share clients or buffer one
+    another under specific stresses.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Redundancy would explain the lack of a deletion phenotype and would guide combinatorial-mutant
+    experiments needed to reveal the pathway CPR4 serves.
+  provenance:
+  - reference_id: PMID:15998457
+    supporting_text: &gt;-
+      an octuplet mutant lacking all eight cyclophilins was viable and that there was little or no
+      evidence for functional redundancy
+- gap_statement: &gt;-
+    Whether CPR4 binds cyclosporin A is untested and predicted to be atypical: the tryptophan
+    equivalent to human cyclophilin A W121, which lines the cyclosporin A binding pocket, is not
+    conserved in CPR4.
+  boundary: &gt;-
+    Firmly established (this review): the entire CPR4 cyclophilin domain contains no tryptophan,
+    and the position homologous to human CypA W121 (in the motif TAKTE-W-LDGK) is not a Trp in
+    CPR4; the deep-research synthesis independently reports a W121-to-glutamate substitution. What
+    is NOT established is the actual cyclosporin A affinity/sensitivity of the CPR4 protein.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Cyclosporin A binding and PPIase catalysis are structurally separable in cyclophilins; a
+    non-canonical CsA pocket would distinguish CPR4 pharmacologically from CypA-type cyclophilins
+    and refine the family-propagated &#34;cyclosporin A binding&#34; inference for this protein.
+  provenance:
+  - reference_id: file:yeast/CPR4/CPR4-deep-research-falcon.md
+    supporting_text: &gt;-
+      the conserved cyclophilin residue equivalent to W121, important for cyclosporin A binding in
+      other cyclophilins, is replaced by glutamate in Scc3/CPR4
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which secretory, membrane, or vacuolar proteins are the physiological substrates/clients of
+    CPR4, and does their folding or transport depend on CPR4 (analogous to NinaA and rhodopsin)?
+  experts: []
+- question: &gt;-
+    Does CPR4 have measurable PPIase activity in vitro, and is that catalytic activity (versus a
+    catalysis-independent chaperone role) required for any in vivo function?
+  experts: []
+- question: &gt;-
+    Do CPR4 and CPR8 share clients or buffer each other, revealing a conditional phenotype in the
+    cpr4 cpr8 double mutant that is absent from either single mutant?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    CPR4 is a membrane-anchored, substrate-specific foldase of the secretory pathway (NinaA
+    analog) that assists folding/transport of a restricted set of secretory or vacuolar proteins.
+  description: &gt;-
+    Identify CPR4-proximal proteins and candidate substrates by proximity labeling (BioID/TurboID
+    or APEX2) on tagged CPR4 in the ER/vacuolar membrane, and by co-immunoprecipitation, then test
+    whether candidate clients misfold, mislocalize, or are destabilized in a cpr4 deletion
+    (optionally cpr4 cpr8 double deletion) under standard and ER-stress conditions.
+- hypothesis: &gt;-
+    CPR4 has cyclophilin PPIase catalytic activity but atypical (reduced) cyclosporin A binding
+    owing to the non-conserved W121-equivalent residue.
+  description: &gt;-
+    Purify recombinant CPR4 (catalytic domain) and measure PPIase activity with a standard
+    protease-coupled peptidyl-prolyl isomerization assay; determine cyclosporin A inhibition and
+    compare to CPR1 (CypA-type). Test a catalytic-dead point mutant for loss of any cpr4-dependent
+    phenotype to separate catalytic from chaperone roles.
+- hypothesis: &gt;-
+    CPR4 function is buffered by CPR8 and/or induced under ER/folding stress.
+  description: &gt;-
+    Compare growth, secretory-pathway integrity, and unfolded-protein-response activation across
+    wild-type, cpr4, cpr8, and cpr4 cpr8 strains under tunicamycin, heat, and other proteostatic
+    stresses; quantify CPR4 expression/induction under these conditions.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/DCV1/DCV1-ai-review.html
+++ b/genes/yeast/DCV1/DCV1-ai-review.html
@@ -1,0 +1,2802 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DCV1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>DCV1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P43595" target="_blank" class="term-link">
+                        P43595
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "DCV1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P43595" data-a="DESCRIPTION: DCV1 (systematic name YFR012W) is a small (202-res..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DCV1 (systematic name YFR012W) is a small (202-residue) polytopic integral membrane protein of the budding yeast Saccharomyces cerevisiae. It has an N-terminal signal sequence and three predicted transmembrane helices, and belongs to the fungal Sur7/PalI/Rim9 family of tetraspan membrane proteins (Pfam SUR7 / InterPro SUR7-Rim9-like; PANTHER PTHR28013), which also contains its budding-yeast paralog RIM9 and, by whole-genome duplication, TOS7. Family members are plasma-membrane / eisosome-associated proteins, and several act in the fungal Rim101/PacC ambient-pH signalling pathway; DCV1 has itself been localized to the nuclear envelope. Its own molecular function and biological role are not experimentally established. It is dispensable for viability under standard conditions, and its principal recorded genetic characteristic is a requirement for Cdc28 (Cdk1) activity for viability — the source of its name, &#34;Demands Cdc28 kinase activity for Viability&#34;.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-propagated (IBA) plasma-membrane localization across the Sur7/PalI/Rim9 family (PANTHER PTHR28013). Family-consistent for a tetraspan fungal membrane protein but not experimentally demonstrated for DCV1 itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Sur7/PalI-family members are characteristically plasma-membrane / eisosome (MCC) components, so a plasma-membrane localization is biologically plausible for DCV1 and is the most defensible of the propagated CC terms. It is flagged as an over-annotation because there is no DCV1-specific evidence placing it at the plasma membrane; the assignment is a whole-family default rather than a demonstrated DCV1 localization. This is a cellular-component term, not a molecular function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000004667</span>
+
+                                    &middot; RIM9
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Plasma-membrane/eisosome localization is well supported for Sur7/PalI-family members (the IBA donor set includes the S. cerevisiae PalI/Rim9 protein RIM9 (SGD:S000004667), the paralog TOS7 (SGD:S000005379), and S. pombe members), but transfer to DCV1 is a family default with no DCV1-specific plasma-membrane evidence.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032153" target="_blank" class="term-link">
+                                    GO:0032153
+                                </a>
+                            </span>
+                            <span class="term-label">cell division site</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0032153" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA &#34;cell division site&#34; localization propagated within PTHR28013 from a single Schizosaccharomyces pombe family member. Not supported for DCV1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The WITH/FROM evidence for this IBA is thin, tracing to one fission-yeast member (PomBase:SPCC1739.10). &#34;Cell division site&#34; (GO:0032153) is not lineage-specific — in S. cerevisiae the bud neck is a bona fide cell division site — so the problem is not a taxon mismatch but the absence of any DCV1-specific evidence for bud-neck / division-site localization; the term is a weak single-source phylogenetic propagation that should not transfer to DCV1.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">SOURCE EVIDENCE WEAK</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PomBase:SPCC1739.10</span>
+
+                                    &middot; S. pombe PTHR28013 member
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Single fission-yeast donor for this term; division-site localization is not demonstrated for DCV1, so the transfer is unsupported.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035838" target="_blank" class="term-link">
+                                    GO:0035838
+                                </a>
+                            </span>
+                            <span class="term-label">growing cell tip</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0035838" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA &#34;growing cell tip&#34; localization propagated from fission-yeast family members. The term describes polarized tip growth of elongated cells and is not applicable to the budding yeast S. cerevisiae.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Growing cell tip&#34; (GO:0035838) is defined as the polarized-growth region at the ends of cylindrical/elongated cells — a hallmark of fission yeast, which grows by tip extension. The donor evidence is from S. pombe members (PomBase:SPAC13G7.04c, PomBase:SPCC1739.10). S. cerevisiae grows by budding, not tip extension, so this localization is not biologically applicable to DCV1 and represents a fission-yeast-specific over-propagation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">LINEAGE OR TAXON MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PomBase:SPAC13G7.04c</span>
+
+                                    &middot; S. pombe PTHR28013 member (mac1-like)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Tip-growth localization is a fission-yeast trait; budding yeast has no growing cell tip, so the term cannot transfer to DCV1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0005886" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation (IPR009571 SUR7/Rim9-like → plasma membrane). Redundant with the family IBA plasma-membrane annotation and, like it, not directly demonstrated for DCV1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IEA duplicates the IBA plasma-membrane localization from the same protein family and adds no independent evidence for DCV1. It is a reasonable family-level default but is an over-annotation given the absence of any DCV1-specific plasma-membrane data.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic &#34;membrane&#34; localization from the UniProt Subcellular Location mapping (SL-0162). Correct but uninformative given that DCV1 is already known to be a multi-pass membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DCV1 is a bona fide integral membrane protein (signal peptide + three TM helices), so the annotation is not wrong, but &#34;membrane&#34; is the uninformative parent of the more specific compartment terms already present. It is retained only as a high-level default and is marked over-annotated relative to the specific localizations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005635" target="_blank" class="term-link">
+                                    GO:0005635
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear envelope</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33002606" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33002606
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Sur7/PalI family transmembrane protein Tos7 (Yol019w) pl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0005635" data-r="PMID:33002606" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) nuclear-envelope localization curated by SGD. This is the only DCV1-specific experimental annotation and is treated as the primary localization evidence, though the primary source could not be independently verified here.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) localization assigned by an SGD curator who read the full text; per curation policy an experimental annotation is not removed on the basis of an abstract-only cache. The cited paper&#39;s abstract concerns the paralog Tos7 at the plasma membrane and I could not access the full text to confirm the DCV1 assay, so the localization is retained but flagged (see reference_review) and marked non-core: it is a cellular-component observation, not a molecular function or established biological role. The nuclear envelope is contiguous with the ER, a plausible endomembrane location for a signal-peptide-bearing polytopic protein.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular-function term with ND (No biological Data available). Accurately reflects that no molecular function has been experimentally or computationally established for DCV1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DCV1 has no assigned enzymatic activity and no demonstrated specific binding partner; the Sur7/PalI family has no known catalytic activity. The ND root annotation is the honest representation of the current state of knowledge and should be retained.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P43595" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological-process term with ND. Accurately reflects that no biological process has been experimentally established for DCV1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No coherent biological process is demonstrated for DCV1. The recorded characteristics (a synthetic requirement for CDC28 activity, and dispersed high-throughput deletion phenotypes) are genetic/phenotypic observations rather than a defined pathway role. The family-level Rim101 pH-response role of the paralog RIM9 is not established for DCV1. The ND root annotation should be retained.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DCV1 is a Sur7/PalI/Rim9-family tetraspan integral membrane protein whose specific molecular activity is unknown. The family has no known catalytic activity; members act as plasma-membrane/eisosome scaffolding or pH-sensing components. No molecular function, catalytic activity, or specific binding partner has been demonstrated for DCV1, and no molecular-function term more specific than the ND root can be justified from current evidence. Its localization is likewise unresolved (a single nuclear-envelope IDA versus family-propagated plasma-membrane predictions), so no core localization is asserted here.</h3>
+                <span class="vote-buttons" data-g="P43595" data-a="FUNCTION: DCV1 is a Sur7/PalI/Rim9-family tetraspan integral..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33002606" target="_blank" class="term-link">
+                                PMID:33002606
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Tos7 (Yol019w) is a Sur7/PalI family transmembrane protein in the budding yeast</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33002606" target="_blank" class="term-link">
+                            PMID:33002606
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Sur7/PalI family transmembrane protein Tos7 (Yol019w) plays a role in secretion in budding yeast.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22042866" target="_blank" class="term-link">
+                            PMID:22042866
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A chemical-genetic screen to unravel the genetic network of CDC28/CDK1 links ubiquitin and Rad6-Bre1 to cell cycle progression.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does DCV1 function in the Rim101/PacC ambient-pH signalling pathway, as its PalI/Rim9 subfamily membership suggests, or has it diverged from that role?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43595" data-a="Q: Does DCV1 function in the Rim101/PacC ambient-pH s..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Why is DCV1 required for viability specifically when Cdc28 (Cdk1) activity is limiting, and what does this reveal about a link between a Sur7/PalI membrane protein and the cell cycle?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43595" data-a="Q: Why is DCV1 required for viability specifically wh..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is DCV1 functionally redundant with its whole-genome-duplication paralog TOS7?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P43595" data-a="Q: Is DCV1 functionally redundant with its whole-geno..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenously tag DCV1 (e.g. C-terminal GFP) and image it against nuclear-envelope/ER and plasma-membrane/eisosome (MCC) markers under standard and alkaline-pH conditions to resolve the conflicting nuclear-envelope (IDA) vs plasma-membrane (IBA/IEA) localizations.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DCV1 localizes to a defined endomembrane or plasma-membrane microdomain rather than to both.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P43595" data-a="EXPERIMENT: Endogenously tag DCV1 (e.g. C-terminal GFP) and im..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Assay dcv1 mutants for Rim101 proteolytic processing and for growth at alkaline pH, and test genetic interactions with RIM9 and other RIM-pathway genes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DCV1 contributes to the Rim101 pH-response pathway characteristic of its PalI/Rim9 subfamily.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P43595" data-a="EXPERIMENT: Assay dcv1 mutants for Rim101 proteolytic processi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct dcv1 tos7 single and double deletions and characterize growth, cell-wall stress sensitivity, secretion, and CDC28-dependence to test paralog redundancy.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DCV1 and its WGD paralog TOS7 share overlapping functions masked by redundancy in single mutants.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P43595" data-a="EXPERIMENT: Construct dcv1 tos7 single and double deletions an..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of DCV1 is unknown. No catalytic activity, transport activity, or specific binding partner has been assigned to DCV1, and the Sur7/PalI/Rim9 family to which it belongs has no defined molecular activity — its members are non-catalytic tetraspan membrane proteins whose scaffolding/sensing role is not captured by any GO molecular-function term. GOA carries only the ND root MF term for DCV1.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DCV1 is firmly established as a 202-residue polytopic integral membrane protein (N-terminal signal peptide plus three transmembrane helices) belonging to the fungal Sur7/PalI/Rim9 family (Pfam SUR7; InterPro IPR009571; PANTHER PTHR28013, subfamily SF3 with the PalI/Rim9 orthologs, including the S. cerevisiae paralog RIM9). Its WGD paralog is TOS7. What is NOT known is any activity the protein performs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> DCV1 is a conserved-family membrane protein that has never been functionally characterized in its own right. Assigning its activity would clarify whether the budding-yeast Sur7/PalI subfamily has functions beyond the eisosome/pH-response roles known for other members, and a suitable ontology term for non-catalytic tetraspan scaffold/sensor activity would let such functions be expressed at all.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> DCV1-specific biochemistry and interaction mapping (affinity/proximity proteomics, reconstitution) to identify partners or any activity; and, for the ontology gap, a GO molecular-function term for the scaffolding/pH-sensing activity of Sur7/PalI-family tetraspan membrane proteins.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the cellular roles of Tos7 have not been established"</em> — PMID:33002606</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process DCV1 participates in is unknown. Whether DCV1 functions in the Rim101/PacC ambient-pH response pathway (the process characterized for its subfamily relative RIM9), in eisosome/plasma-membrane organization, or in some unrelated process, has not been tested; its only distinctive genetic characteristic is a requirement for Cdc28 (Cdk1) activity for viability, which is a genetic interaction rather than a defined pathway role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> dcv1 deletion is viable under standard conditions but is lethal/synthetically sick when Cdc28 activity is compromised (the origin of the gene name), and dcv1 was a hit in a genome-wide chemical-genetic screen of the CDC28 network. High-throughput deletion phenotypes are dispersed (altered metal-ion accumulation, MMS sensitivity, reduced chronological lifespan) and do not converge on one process. Membership in the PalI/Rim9 subfamily is suggestive of a pH-response role but is homology-based only.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A defined process would explain why loss of DCV1 becomes lethal specifically when CDK1 activity is limiting, potentially linking a Sur7/PalI-family membrane protein to cell-cycle robustness — an unexpected connection for this family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test dcv1 for defects in Rim101 processing / alkaline-pH growth and in eisosome/MCC organization; dissect the dcv1-cdc28 genetic interaction (epistasis, suppressors); and test functional redundancy with the paralog TOS7 via a dcv1 tos7 double mutant.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We identified 107 genes that strongly"</em> — PMID:22042866</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of DCV1 is not resolved. A single SGD IDA places DCV1 at the nuclear envelope, whereas family/phylogenetic (IBA/IEA) evidence predicts the plasma membrane/eisosome; these have not been reconciled by an independent DCV1-specific study.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DCV1 is certainly membrane-embedded (three TM helices). The nuclear-envelope assignment rests on one IDA (curated by SGD from PMID:33002606, which I could not verify in full text), while plasma-membrane assignments are homology-based propagations across the Sur7/PalI family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Correct localization is a prerequisite for inferring function: a nuclear-envelope/ER protein and a plasma-membrane eisosome protein imply very different roles for DCV1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Independent, DCV1-specific localization (endogenously tagged Dcv1 imaged against nuclear envelope/ER and plasma-membrane/eisosome markers) under standard and stress (e.g. alkaline pH) conditions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Tos7 localized to punctate"</em> — PMID:33002606</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DCV1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P43595" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">19 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:13:58.732194</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="DCV1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-on-dcv1-yfr012w-in-saccharomyces-cerevisiae">Comprehensive Research Report on DCV1 (YFR012W) in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="1-gene-identity-and-preliminary-note-on-literature-availability">1. Gene Identity and Preliminary Note on Literature Availability</h3>
+<p>DCV1 (systematic name YFR012W; UniProt P43595) encodes a poorly characterized integral membrane protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The full protein name, "Demands CDC28 kinase activity for viability protein 1," suggests that the gene was originally named based on a genetic interaction screen—likely a synthetic dosage lethal (SDL) or synthetic lethal screen with the essential cyclin-dependent kinase CDC28/CDK1—though the original publication defining this naming could not be identified in the available literature. <strong>Direct experimental characterization of DCV1 itself is extremely limited</strong>, and almost all functional annotation must be inferred from its conserved domain architecture and the well-characterized biology of its protein family members.</p>
+<p>The summary table below consolidates the key features of DCV1 inferred from domain architecture and family biology:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene / locus</td>
+<td><strong>DCV1</strong>; ordered locus <strong>YFR012W</strong> in <em>Saccharomyces cerevisiae</em> S288c; UniProt accession <strong>P43595</strong>. The gene is poorly characterized in the primary literature, so most functional interpretation is inferred from conserved domain architecture and better-studied family members.</td>
+</tr>
+<tr>
+<td>UniProt protein name</td>
+<td><strong>Protein DCV1</strong>; alternative name <strong>Demands CDC28 kinase activity for viability protein 1</strong>. No direct primary paper was identified here explaining the origin of this name; it likely reflects a historical genetic interaction/screen rather than a biochemically defined activity.</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>SUR7/PalI/Rim9-like fungal membrane protein family</strong>. Rim9/PalI is explicitly described as part of the <strong>Sur7 family</strong>, and DCV1 carries the same family/domain signatures, supporting assignment to this family by homology (athanasopoulos2019fungalplasmamembrane pages 31-31).</td>
+</tr>
+<tr>
+<td>Conserved domains</td>
+<td>UniProt/domain annotations for DCV1 include <strong>pH-response_reg_palI/RIM9</strong> and <strong>SUR7/Rim9-like_fungi / SUR7 (PF06687)</strong>, consistent with the family of fungal tetraspanner membrane proteins implicated in plasma-membrane organization and pH-response signaling.</td>
+</tr>
+<tr>
+<td>Predicted membrane topology</td>
+<td>Best inferred as a <strong>tetraspanner integral membrane protein</strong> with <strong>4 transmembrane domains</strong>, because SUR7 family proteins are described as tetraspanners/four-pass membrane proteins in fungi (douglas2012sur7promotesplasma pages 1-2, grossmann2008plasmamembranemicrodomains pages 2-4).</td>
+</tr>
+<tr>
+<td>Most likely subcellular localization</td>
+<td><strong>Plasma membrane</strong>, likely in specialized cortical membrane domains. This is an inference from the behavior of SUR7/Rim9 family proteins, which localize to plasma-membrane patches/MCC-associated regions rather than being soluble or organellar proteins (obara2012membraneproteinrim21 pages 5-6, douglas2012sur7promotesplasma pages 1-1, athanasopoulos2019fungalplasmamembrane pages 10-11).</td>
+</tr>
+<tr>
+<td>Relationship to MCC/eisosomes</td>
+<td>SUR7-family proteins commonly localize to the <strong>MCC (membrane compartment containing Can1)/eisosome</strong> domain system. Rim9 specifically shows <strong>partial MCC localization</strong>, labeling only a subset of MCCs; thus DCV1 may also associate with specialized plasma-membrane subdomains, but this has not been demonstrated directly for DCV1 (athanasopoulos2019fungalplasmamembrane pages 31-31, athanasopoulos2019fungalplasmamembrane pages 13-13).</td>
+</tr>
+<tr>
+<td>Pathway involvement</td>
+<td><strong>Not directly demonstrated for DCV1.</strong> However, because DCV1 carries a <strong>PalI/Rim9-like pH-response domain</strong>, the strongest hypothesis is that it is related to the broader fungal membrane-protein toolkit used for plasma-membrane organization and/or environmental signaling. No direct evidence was found that DCV1 itself is a canonical core Rim101-pathway component.</td>
+</tr>
+<tr>
+<td>Closest functional analogue</td>
+<td><strong>Rim9/PalI</strong> is the best-studied analogue. Rim9 is an auxiliary component of the <strong>Rim101 ambient-pH sensing pathway</strong>, helping maintain the sensor complex at the plasma membrane and supporting Rim21 localization/stability (athanasopoulos2019fungalplasmamembrane pages 31-31, penalva2008ambientphgene pages 5-6, obara2012membraneproteinrim21 pages 5-6, obara2012membraneproteinrim21 pages 4-5).</td>
+</tr>
+<tr>
+<td>Mechanistic inference from Rim9</td>
+<td>In <em>S. cerevisiae</em>, <strong>Rim21, Dfg16, and Rim9</strong> form a mutually dependent plasma-membrane complex. Deleting <strong>RIM9</strong> reduces <strong>Rim21</strong> levels and mislocalizes Rim21 away from the plasma membrane, indicating an auxiliary stabilizing/chaperoning role rather than primary sensing itself (obara2012membraneproteinrim21 pages 5-6, obara2012membraneproteinrim21 pages 4-5). DCV1 may perform an analogous accessory membrane role, but this remains unproven.</td>
+</tr>
+<tr>
+<td>Biological processes most plausibly associated with DCV1</td>
+<td>Based on family membership, the most plausible processes are <strong>plasma-membrane domain organization</strong>, <strong>stress-responsive membrane homeostasis</strong>, <strong>cell wall/plasma-membrane coordination</strong>, and potentially <strong>pH-responsive signaling support</strong>. These functions are established for SUR7-family and Rim9-related proteins generally, not directly for DCV1 (athanasopoulos2019fungalplasmamembrane pages 10-11, athanasopoulos2019fungalplasmamembrane pages 8-9, douglas2012sur7promotesplasma pages 1-2).</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td><strong>Unknown / no enzymatic activity established.</strong> There is no evidence that DCV1 is an enzyme or transporter with a defined substrate. Family evidence instead supports a role as an <strong>integral membrane organizer/adaptor/accessory factor</strong>.</td>
+</tr>
+<tr>
+<td>Real-world implementation / research use</td>
+<td>Proteins of this family are used as markers or mechanistic entry points for studying <strong>fungal plasma-membrane compartmentation</strong>, <strong>MCC/eisosome biology</strong>, and <strong>ambient-pH signaling</strong>. In pathogens, related family members such as Sur7 influence stress resistance and virulence, underscoring the broader biological importance of the family (douglas2012sur7promotesplasma pages 1-1, athanasopoulos2019fungalplasmamembrane pages 10-11).</td>
+</tr>
+<tr>
+<td>Related family members in <em>S. cerevisiae</em></td>
+<td>Documented <strong>Sur7-like proteins</strong> in <em>S. cerevisiae</em> include <strong>Sur7, Fmp45, Ynl194c, and Pun1/Ylr414c</strong> (athanasopoulos2019fungalplasmamembrane pages 10-11, douglas2012sur7promotesplasma pages 1-2). <strong>Rim9</strong> is a Sur7-family member specialized for pH sensing (athanasopoulos2019fungalplasmamembrane pages 31-31). DCV1/YFR012W is best interpreted as an additional <strong>SUR7/PalI/Rim9-like paralog</strong> based on domain architecture.</td>
+</tr>
+<tr>
+<td>Evidence strength</td>
+<td><strong>Low for DCV1-specific function; moderate-to-strong for family-level inference.</strong> No direct experimental characterization of DCV1/YFR012W was identified in the retrieved literature, so conclusions should be treated as <strong>homology-based functional annotation</strong> rather than definitive gene-specific proof.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key annotated and inferred features of the poorly characterized yeast gene DCV1/YFR012W. It is useful because it separates direct evidence from family-based inference, especially regarding SUR7/PalI/Rim9 family membership, membrane localization, and possible pathway roles.</em></p>
+<h3 id="2-protein-family-and-domain-architecture">2. Protein Family and Domain Architecture</h3>
+<p>DCV1 belongs to the <strong>SUR7/PalI/Rim9-like protein family</strong>, a group of fungal integral membrane proteins defined by the SUR7 domain (Pfam PF06687) and the pH-response regulator PalI/Rim9 domain (IPR051380; IPR009571). Members of this family are characterized as <strong>tetraspanner proteins</strong>—integral membrane proteins predicted to contain <strong>four membrane-spanning domains</strong> (douglas2012sur7promotesplasma pages 1-2, grossmann2008plasmamembranemicrodomains pages 2-4). In <em>S. cerevisiae</em>, documented Sur7-like proteins include <strong>Sur7, Fmp45, Ynl194c, and Pun1/Ylr414c</strong>, all of which localize to the plasma membrane and are implicated in various aspects of membrane organization, cell wall integrity, sphingolipid signaling, and stress responses (athanasopoulos2019fungalplasmamembrane pages 10-11, douglas2012sur7promotesplasma pages 1-2). <strong>Rim9</strong> is another Sur7-family member that is specialized for ambient pH sensing within the Rim101/PacC signaling pathway (athanasopoulos2019fungalplasmamembrane pages 31-31). DCV1/YFR012W, by virtue of carrying both the SUR7 and PalI/Rim9 domains, is best classified as an additional paralog within this family.</p>
+<h3 id="3-inferred-function-plasma-membrane-organization-and-ph-response-signaling">3. Inferred Function: Plasma Membrane Organization and pH-Response Signaling</h3>
+<h4 id="31-the-sur7-family-and-mcceisosome-biology">3.1 The SUR7 Family and MCC/Eisosome Biology</h4>
+<p>Sur7-family proteins are components of the <strong>MCC (membrane compartment containing Can1)</strong>, a specialized plasma membrane subdomain that forms stable ~300 nm punctate patches and associates with cytoplasmic protein complexes called <strong>eisosomes</strong> (douglas2012sur7promotesplasma pages 1-1). Eisosomes are hemitubular structures composed primarily of the BAR-domain proteins Pil1 and Lsp1, which promote membrane curvature and compartmentalization (douglas2012sur7promotesplasma pages 1-2, grossmann2008plasmamembranemicrodomains pages 2-4). Sur7 serves as an endogenous marker of MCC patches (grossmann2008plasmamembranemicrodomains pages 2-4). These MCC/eisosome domains serve as <strong>protective membrane compartments</strong> that regulate turnover of nutrient transporters, control cell wall homeostasis, and participate in sphingolipid sensing through the Nce102-Pkh1/2-TORC2 signaling axis (athanasopoulos2019fungalplasmamembrane pages 8-9, athanasopoulos2019fungalplasmamembrane pages 13-13).</p>
+<p>A triple mutant lacking three Sur7-like proteins (sur7Δ fmp45Δ ynl194cΔ) exhibits <strong>altered sphingolipid biosynthesis and sporulation defects</strong>, indicating partial redundancy among family members but also their collective importance for lipid homeostasis (athanasopoulos2019fungalplasmamembrane pages 10-11). Individual Sur7-like proteins have distinct sub-functions: Sur7 is important for cell wall integrity, Pun1 for pseudohyphal growth, and Fmp45 for recovery from stationary phase (athanasopoulos2019fungalplasmamembrane pages 10-11). Given its domain homology, DCV1 likely performs a related but potentially distinct role in plasma membrane organization or signaling, though this has not been experimentally demonstrated.</p>
+<h4 id="32-the-rim9pali-paradigm-and-ph-sensing">3.2 The Rim9/PalI Paradigm and pH Sensing</h4>
+<p>The closest functional analogue to DCV1, based on domain composition, is <strong>Rim9</strong> (the <em>S. cerevisiae</em> homologue of PalI in <em>Aspergillus nidulans</em>). Rim9 is a core component of the <strong>Rim101 ambient pH signaling pathway</strong>, which senses extracellular alkalinization and activates the transcription factor Rim101/PacC (penalva2008ambientphgene pages 5-6, goodman2013furthercharacterisationof pages 17-20).</p>
+<p>In <em>S. cerevisiae</em>, the plasma membrane pH-sensing complex consists of three integral membrane proteins: <strong>Rim21</strong> (the primary pH sensor, a 7-transmembrane domain protein), <strong>Dfg16</strong>, and <strong>Rim9</strong> (obara2012membraneproteinrim21 pages 5-6, obara2012membraneproteinrim21 pages 4-5, obara2012membraneproteinrim21 pages 1-2). These three proteins form a complex at the plasma membrane and their localization and protein levels are <strong>mutually dependent</strong> (obara2012membraneproteinrim21 pages 4-5). Specifically:</p>
+<ul>
+<li>Rim21 levels are <strong>significantly decreased</strong> in rim9Δ cells, and Rim21 is largely mislocalized from the plasma membrane to intracellular organelles when Rim9 is absent (obara2012membraneproteinrim21 pages 5-6, obara2012membraneproteinrim21 pages 4-5).</li>
+<li>Transient degradation of Rim21 completely suppresses the Rim101 pathway, whereas degradation of Dfg16 or Rim9 alone does not, demonstrating that <strong>Rim21 is the actual sensor</strong> while <strong>Rim9 plays an auxiliary, stabilizing role</strong> (obara2012membraneproteinrim21 pages 5-6).</li>
+<li>Rim9 is proposed to function as a <strong>chaperone</strong> that maintains the sensor complex at the plasma membrane, assisting in the proper localization and stability of Rim21 (athanasopoulos2019fungalplasmamembrane pages 31-31, penalva2008ambientphgene pages 5-6, ost2015thecryptococcusneoformans pages 2-4).</li>
+</ul>
+<p>Upon external alkalinization, the Rim21-Dfg16-Rim9 complex is internalized and degraded, leading to ubiquitination of the arrestin-like protein Rim8/PalF, recruitment of ESCRT machinery, and ultimately proteolytic activation of Rim101 at endosomal membranes (penalva2008ambientphgene pages 5-6, goodman2013furthercharacterisationof pages 17-20).</p>
+<p>Rim9 contains four predicted transmembrane domains but is notably smaller (239 residues) than its <em>A. nidulans</em> homologue PalI (549 residues), lacking the large hydrophilic cytosolic tail present in PalI (penalva2002regulationofgene pages 12-13). The loss-of-function phenotype of rim9 mutants is milder than that of other Rim pathway components—palI/rim9 mutants retain some growth capability at alkaline pH, consistent with an auxiliary rather than essential sensing role (penalva2002regulationofgene pages 12-13, penalva2002regulationofgene pages 10-11).</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>Based on family membership, DCV1 is predicted to localize to the <strong>plasma membrane</strong>. Rim9 specifically displays a <strong>patchy distribution</strong> at the plasma membrane, with partial localization to MCC/eisosome domains—labeling only a subset of MCCs in both <em>S. cerevisiae</em> and <em>A. nidulans</em> (athanasopoulos2019fungalplasmamembrane pages 31-31). The physiological significance of this selective MCC localization remains unclear (athanasopoulos2019fungalplasmamembrane pages 31-31). Importantly, the RIM/Pal foci where Rim9 and related proteins function appear to be <strong>distinct from</strong> both MCC and other known plasma membrane compartments (MCP, MCL), as they form at PM regions devoid of cortical ER and with reduced Pma1 intensity (athanasopoulos2019fungalplasmamembrane pages 30-31). Given that DCV1 carries both the SUR7 and PalI/Rim9 domains, its subcellular localization is most likely the plasma membrane, potentially at specialized cortical foci.</p>
+<h3 id="5-signaling-pathway-context">5. Signaling Pathway Context</h3>
+<p>The Rim101 pathway is a conserved fungal signaling cascade responsible for sensing extracellular pH alkalization and regulating gene expression accordingly. The pathway proceeds as follows (goodman2013furthercharacterisationof pages 17-20, penalva2008ambientphgene pages 5-6):</p>
+<ol>
+<li><strong>Sensing</strong>: Rim21/Dfg16/Rim9 complex at the plasma membrane detects alkaline pH and/or loss of plasma membrane lipid asymmetry.</li>
+<li><strong>Signal transduction</strong>: The arrestin-like protein Rim8 is ubiquitinated, recruiting ESCRT-I via Vps23.</li>
+<li><strong>ESCRT assembly</strong>: ESCRT-I, -II, and -III (particularly Snf7/Vps20) are recruited to the endosomal membrane.</li>
+<li><strong>Proteolytic activation</strong>: Rim20 and the calpain-like protease Rim13 are recruited to cleave Rim101, generating its transcriptionally active form.</li>
+<li><strong>Transcriptional regulation</strong>: Active Rim101 translocates to the nucleus and represses acid-responsive genes while permitting alkaline-responsive gene expression.</li>
+</ol>
+<p>Whether DCV1 participates directly in this pathway or in a parallel membrane-organizing function has not been established experimentally.</p>
+<h3 id="6-genetic-interaction-with-cdc28">6. Genetic Interaction with CDC28</h3>
+<p>The alternative name "Demands CDC28 kinase activity for viability protein 1" implies a genetic interaction—most likely identified in a synthetic lethal or synthetic dosage lethal screen—between DCV1 and the essential cyclin-dependent kinase CDC28/CDK1, the master regulator of cell cycle progression in <em>S. cerevisiae</em>. CDC28 is known to participate in numerous genetic interaction networks, and synthetic dosage lethality screens have identified many genes whose overexpression is toxic specifically when CDC28 activity is compromised. The mechanistic basis for a DCV1–CDC28 interaction is unclear but could relate to a requirement for CDK activity in processes regulated by plasma membrane organization or the Rim101 pathway, such as cell wall remodeling during the cell cycle.</p>
+<h3 id="7-evolutionary-context">7. Evolutionary Context</h3>
+<p>The SUR7/PalI protein family is <strong>conserved across the fungal kingdom</strong>. The PalI/Rim9 module is present in ascomycete fungi including <em>A. nidulans</em>, <em>S. cerevisiae</em>, <em>Candida albicans</em>, and <em>Yarrowia lipolytica</em>, but is notably absent from basidiomycetes such as <em>Cryptococcus neoformans</em>, which have evolved alternative mechanisms (e.g., the Rra1 sensor) for Rim pathway activation (ost2015thecryptococcusneoformans pages 2-4). The SUR7 domain has been identified as a defining feature of the Rim9 protein family across fungal species (athanasopoulos2019fungalplasmamembrane pages 31-31). The presence of multiple SUR7/PalI paralogs in <em>S. cerevisiae</em> (Sur7, Fmp45, Ynl194c, Pun1, Rim9, and DCV1/YFR012W) suggests functional diversification within this family, with individual members acquiring specialized roles in membrane organization, stress response, and signaling.</p>
+<h3 id="8-conclusions-and-limitations">8. Conclusions and Limitations</h3>
+<p>DCV1/YFR012W is a <strong>poorly characterized member of the SUR7/PalI/Rim9 integral membrane protein family</strong> in <em>S. cerevisiae</em>. Its domain architecture strongly predicts it to be a <strong>tetraspanner plasma membrane protein</strong> potentially involved in <strong>plasma membrane domain organization and/or ambient pH signaling support</strong>, by analogy to its better-characterized relatives Sur7 and Rim9. DCV1 is not an enzyme, transporter, or receptor with a defined substrate or ligand; rather, it most likely functions as an <strong>integral membrane organizer or accessory/adaptor protein</strong> at the plasma membrane.</p>
+<p><strong>Key limitations</strong>: No direct biochemical or cell biological characterization of DCV1 was found in the available literature. All functional inferences are based on conserved domain architecture and the biology of related family members. Direct experimental studies—including localization by GFP tagging, deletion phenotype analysis, and genetic interaction mapping—would be needed to definitively establish DCV1's function, localization, and pathway membership.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 31-31): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(douglas2012sur7promotesplasma pages 1-2): Lois M. Douglas, Hong X. Wang, Sabine Keppler-Ross, Neta Dean, and James B. Konopka. Sur7 promotes plasma membrane organization and is needed for resistance to stressful conditions and to the invasive growth and virulence of candida albicans. mBio, Mar 2012. URL: https://doi.org/10.1128/mbio.00254-11, doi:10.1128/mbio.00254-11. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(grossmann2008plasmamembranemicrodomains pages 2-4): Guido Grossmann, Jan Malinsky, Wiebke Stahlschmidt, Martin Loibl, Ina Weig-Meckl, Wolf B. Frommer, Miroslava Opekarová, and Widmar Tanner. Plasma membrane microdomains regulate turnover of transport proteins in yeast. The Journal of Cell Biology, 183:1075-1088, Dec 2008. URL: https://doi.org/10.1083/jcb.200806035, doi:10.1083/jcb.200806035. This article has 284 citations.</p>
+</li>
+<li>
+<p>(obara2012membraneproteinrim21 pages 5-6): Keisuke Obara, Hayashi Yamamoto, and Akio Kihara. Membrane protein rim21 plays a central role in sensing ambient ph in saccharomyces cerevisiae. Journal of Biological Chemistry, 287:38473-38481, Nov 2012. URL: https://doi.org/10.1074/jbc.m112.394205, doi:10.1074/jbc.m112.394205. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(douglas2012sur7promotesplasma pages 1-1): Lois M. Douglas, Hong X. Wang, Sabine Keppler-Ross, Neta Dean, and James B. Konopka. Sur7 promotes plasma membrane organization and is needed for resistance to stressful conditions and to the invasive growth and virulence of candida albicans. mBio, Mar 2012. URL: https://doi.org/10.1128/mbio.00254-11, doi:10.1128/mbio.00254-11. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 10-11): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 13-13): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(penalva2008ambientphgene pages 5-6): Miguel A. Peñalva, Joan Tilburn, Elaine Bignell, and Herbert N. Arst. Ambient ph gene regulation in fungi: making connections. Trends in microbiology, 16 6:291-300, Jun 2008. URL: https://doi.org/10.1016/j.tim.2008.03.006, doi:10.1016/j.tim.2008.03.006. This article has 464 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(obara2012membraneproteinrim21 pages 4-5): Keisuke Obara, Hayashi Yamamoto, and Akio Kihara. Membrane protein rim21 plays a central role in sensing ambient ph in saccharomyces cerevisiae. Journal of Biological Chemistry, 287:38473-38481, Nov 2012. URL: https://doi.org/10.1074/jbc.m112.394205, doi:10.1074/jbc.m112.394205. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 8-9): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(goodman2013furthercharacterisationof pages 17-20): Daniel Goodman. Further characterisation of the rim101 pathway in saccharomyces cerevisiae. Text, 2013. URL: https://doi.org/10.25560/14476, doi:10.25560/14476. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(obara2012membraneproteinrim21 pages 1-2): Keisuke Obara, Hayashi Yamamoto, and Akio Kihara. Membrane protein rim21 plays a central role in sensing ambient ph in saccharomyces cerevisiae. Journal of Biological Chemistry, 287:38473-38481, Nov 2012. URL: https://doi.org/10.1074/jbc.m112.394205, doi:10.1074/jbc.m112.394205. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ost2015thecryptococcusneoformans pages 2-4): Kyla S. Ost, Teresa R. O’Meara, Naureen Huda, Shannon K. Esher, and J. Andrew Alspaugh. The cryptococcus neoformans alkaline response pathway: identification of a novel rim pathway activator. PLOS Genetics, 11:e1005159, Apr 2015. URL: https://doi.org/10.1371/journal.pgen.1005159, doi:10.1371/journal.pgen.1005159. This article has 102 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(penalva2002regulationofgene pages 12-13): Miguel A. Peñalva and Herbert N. Arst. Regulation of gene expression by ambient ph in filamentous fungi and yeasts. Microbiology and Molecular Biology Reviews, 66:426-446, Sep 2002. URL: https://doi.org/10.1128/mmbr.66.3.426-446.2002, doi:10.1128/mmbr.66.3.426-446.2002. This article has 437 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(penalva2002regulationofgene pages 10-11): Miguel A. Peñalva and Herbert N. Arst. Regulation of gene expression by ambient ph in filamentous fungi and yeasts. Microbiology and Molecular Biology Reviews, 66:426-446, Sep 2002. URL: https://doi.org/10.1128/mmbr.66.3.426-446.2002, doi:10.1128/mmbr.66.3.426-446.2002. This article has 437 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 30-31): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="DCV1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>athanasopoulos2019fungalplasmamembrane pages 31-31</li>
+<li>grossmann2008plasmamembranemicrodomains pages 2-4</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 10-11</li>
+<li>penalva2002regulationofgene pages 12-13</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 30-31</li>
+<li>ost2015thecryptococcusneoformans pages 2-4</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 13-13</li>
+<li>penalva2008ambientphgene pages 5-6</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 8-9</li>
+<li>goodman2013furthercharacterisationof pages 17-20</li>
+<li>penalva2002regulationofgene pages 10-11</li>
+<li>https://doi.org/10.1093/femsre/fuz022,</li>
+<li>https://doi.org/10.1128/mbio.00254-11,</li>
+<li>https://doi.org/10.1083/jcb.200806035,</li>
+<li>https://doi.org/10.1074/jbc.m112.394205,</li>
+<li>https://doi.org/10.1016/j.tim.2008.03.006,</li>
+<li>https://doi.org/10.25560/14476,</li>
+<li>https://doi.org/10.1371/journal.pgen.1005159,</li>
+<li>https://doi.org/10.1128/mmbr.66.3.426-446.2002,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DCV1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P43595" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dcv1-yfr012w-curation-notes">DCV1 (YFR012W) — Curation notes</h1>
+<p>UniProt: P43595 · SGD: S000001908 · systematic name YFR012W · 202 aa · organism <em>Saccharomyces cerevisiae</em> S288C (NCBITaxon:559292)</p>
+<p>This is an <strong>understudied ("dark") gene</strong>. The primary deliverable is an honest<br />
+<code>knowledge_gaps</code> section plus carefully-reasoned <code>description</code>/<code>core_functions</code><br />
+grounded in domain/orthology/literature — never invented function.</p>
+<h2 id="1-identity-and-naming">1. Identity and naming</h2>
+<ul>
+<li>Standard name <strong>DCV1</strong> = "<strong>D</strong>emands <strong>C</strong>dc28 kinase activity for <strong>V</strong>iability protein <strong>1</strong>".<br />
+  [UniProt P43595 record: <code>AltName: Full=Demands CDC28 kinase activity for viability protein 1</code>]</li>
+<li>SGD gene description: "predicted integral membrane protein whose biological role is unknown"; name reflects a genetic interaction with the <em>cdc28-as1</em> (analog-sensitive) allele. [SGD locus page S000001908, fetched 2026-07-05]</li>
+</ul>
+<h2 id="2-what-is-known-with-provenance">2. What is KNOWN (with provenance)</h2>
+<h3 id="protein-architecture-from-the-uniprot-record-verifiable">Protein architecture (from the UniProt record, verifiable)</h3>
+<ul>
+<li>202 aa precursor with an N-terminal <strong>signal peptide (1–18)</strong> (ECO:0000255) and a mature chain 19–202.</li>
+<li><strong>Three predicted transmembrane helices</strong> (91–107, 137–155, 168–189) → <strong>multi-pass (polytopic) integral membrane protein</strong> [UniProt FT lines; <code>SUBCELLULAR LOCATION: Membrane {ECO:0000305}; Multi-pass membrane protein {ECO:0000305}</code>].</li>
+<li>Domain assignments: <strong>Pfam PF06687 (SUR7)</strong>; <strong>InterPro IPR009571 (SUR7/Rim9-like_fungi)</strong> and <strong>IPR051380 (pH-response_reg palI/RIM9)</strong>; <strong>PANTHER PTHR28013</strong> ("Fungal pH-response regulator palI/RIM9"), subfamily <strong>PTHR28013:SF3 "PROTEIN DCV1-RELATED"</strong>.</li>
+<li>UniProt evidence level <strong>PE=3 (Inferred from homology)</strong> — i.e., no direct protein-level experimental characterization of function.</li>
+</ul>
+<h3 id="family-orthology-from-panther-pthr28013-member-list-interpropantherpthr28013pthr28013-entriescsv">Family / orthology (from PANTHER PTHR28013 member list, <code>interpro/panther/PTHR28013/PTHR28013-entries.csv</code>)</h3>
+<ul>
+<li>DCV1 sits in the <strong>Sur7/PalI/Rim9 family</strong> of fungal tetraspan plasma-membrane proteins.</li>
+<li>Its <strong>PANTHER SF3 subfamily</strong> groups it with the canonical <strong>pH-response regulator PalI/Rim9</strong> orthologs across fungi: <em>A. nidulans</em> palI (O93956), <em>S. cerevisiae</em> <strong>RIM9 (Q04734)</strong>, <em>C. albicans</em> RIM9, <em>N. crassa</em> prr-5, <em>S. pombe</em> mac1 (Q10268), etc. So <strong>DCV1 is a S. cerevisiae paralog of RIM9</strong> within the same subfamily.</li>
+<li>PANTHER family description (LLM-generated, EBI): the palI/RIM9 family is "involved in the regulation of pH response in various fungi … essential for the proteolytic cleavage of transcription factors, such as RIM101 … Some members may also function as pH sensors." <strong>NOTE: this is an LLM family blurb, <code>is_reviewed_llm: false</code> — treat as a hypothesis, not established fact for DCV1.</strong></li>
+<li>Paralog by whole-genome duplication (WGD): <strong>TOS7 / YOL019W</strong> (Q08157; PANTHER SF8). [SGD: "DCV1 has a paralog, TOS7, that arose from the whole genome duplication"]</li>
+</ul>
+<h3 id="cellular-localization">Cellular localization</h3>
+<ul>
+<li><strong>Nuclear envelope (GO:0005635)</strong> — <strong>IDA</strong>, assigned by SGD from <strong>PMID:33002606</strong> (date 20201016). [<code>DCV1-goa.tsv</code> row]</li>
+<li>CAVEAT: The cached PMID:33002606 record is <strong>abstract-only</strong> (<code>full_text_available: false</code>) and its title/abstract concern the <strong>paralog Tos7 (Yol019w)</strong> localizing to plasma-membrane MCC/eisosome microdomains, not DCV1. I could <strong>not</strong> access the full text (ScienceDirect 403; PubMed MCP OAuth unavailable) to confirm that DCV1/YFR012W was assayed for nuclear-envelope localization. Per curation policy I do <strong>not</strong> REMOVE an experimental (IDA) annotation on paralog grounds — the curator read the full text I cannot see. I ACCEPT it as a localization but flag the verification gap. SGD's own gene summary independently states DCV1 is "specifically localized to the nuclear envelope."</li>
+<li><strong>IBA (GO_Central) localizations</strong> propagated within PTHR28013:</li>
+<li>plasma membrane (GO:0005886), cell division site (GO:0032153), growing cell tip (GO:0035838). WITH/FROM includes S. pombe members (PomBase:SPAC13G7.04c, PomBase:SPCC1739.10) and A. nidulans palI (UniProtKB:O93956).</li>
+<li><strong>"growing cell tip" (GO:0035838)</strong> = polarized-growth region at the ends of elongated/cylindrical cells (OLS def). This is a <strong>fission-yeast</strong> concept; <em>S. cerevisiae</em> is a budding yeast and does not grow by tip extension. This IBA is a <strong>fission-yeast-specific localization over-propagated to budding yeast</strong> and is not appropriate for DCV1.</li>
+<li><strong>"cell division site" (GO:0032153)</strong> likewise reflects the S. pombe septation/tip pattern; questionable for budding-yeast DCV1 with no direct evidence.</li>
+<li><strong>plasma membrane (GO:0005886)</strong> is family-consistent (Sur7/PalI proteins are PM eisosome/MCC components) and is a defensible IBA localization for a tetraspan PM-family protein, even if DCV1's own IDA points to the nuclear envelope.</li>
+<li>IEA: plasma membrane (InterPro IPR009571 → GO:0005886, GO_REF:0000002) and membrane (UniProt SubCell SL-0162 → GO:0016020, GO_REF:0000044). The generic "membrane" (GO:0016020) is uninformative given 3 TM helices are known; plasma-membrane IEA duplicates the IBA.</li>
+</ul>
+<h3 id="genetics-phenotype">Genetics / phenotype</h3>
+<ul>
+<li><strong>Disruption/deletion phenotype (UniProt DISRUPTION PHENOTYPE, ECO:0000269|PMID:22042866): "Leads to lethality in absence of CDC28."</strong> i.e. <em>dcv1Δ</em> is synthetically lethal / sick with loss of Cdc28 (CDK1) activity — the source of the gene name. PMID:22042866 (Zimmermann et al. 2011 PNAS) is a genome-wide chemical-genetic array screen mapping the <em>CDC28</em> genetic network (107 strong interactors); DCV1/YFR012W was one of the hits. Cached record is abstract-only and the abstract does not name DCV1, but UniProt curators cite it specifically for this phenotype.</li>
+<li><em>dcv1Δ</em> is <strong>non-essential</strong> in S288C. Reported deletion phenotypes are pleiotropic and subtle (per SGD high-throughput phenotype data): altered metal-ion accumulation (Na+, Cd, Ni resistance), MMS sensitivity, decreased chronological lifespan/competitive fitness, reduced peroxisomal transport. These are dispersed HTP screen readouts, not a coherent molecular function.</li>
+</ul>
+<h2 id="3-what-is-not-known-knowledge-gaps">3. What is NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>Molecular function: unknown.</strong> No enzymatic activity; no direct binding partner established for DCV1 itself. The Sur7/PalI family has <strong>no catalytic activity</strong> — members are scaffolding/sensor tetraspan membrane proteins. GOA carries only the root MF (GO:0003674) with ND.</li>
+<li><strong>Biological process: unknown.</strong> GOA carries only the root BP (GO:0008150) with ND. Whether DCV1 participates in the <strong>Rim101 (PalI/Rim9) alkaline-pH response</strong> — the process characterised for its RIM9 paralog — is <strong>untested for DCV1</strong>; the subfamily assignment is suggestive but not evidence. The <em>cdc28</em>-dependence phenotype is a genetic interaction, not a defined pathway role.</li>
+<li><strong>Localization</strong> is only partly resolved: an SGD IDA says nuclear envelope, while family/IBA evidence points to plasma membrane/eisosome. These are not obviously reconcilable and the primary IDA source could not be verified here.</li>
+<li><strong>Redundancy with paralog TOS7</strong> is untested (no reported <em>dcv1Δ tos7Δ</em> double-mutant phenotype).</li>
+</ul>
+<h2 id="4-reasoning-for-annotation-actions">4. Reasoning for annotation actions</h2>
+<ul>
+<li>MF root (GO:0003674) ND, BP root (GO:0008150) ND → <strong>ACCEPT</strong> (correctly reflect "function unknown"; these are the honest state of knowledge).</li>
+<li>GO:0005635 nuclear envelope IDA (PMID:33002606) → <strong>KEEP_AS_NON_CORE</strong> (experimental, SGD-curated; keep, defer to curator, note verification gap; it is a localization, not a core function).</li>
+<li>GO:0005886 plasma membrane IBA and duplicate IEA (GO_REF:0000002) → both <strong>MARK_AS_OVER_ANNOTATED</strong> (family-consistent PM localization but no DCV1-specific evidence; DCV1's own IDA is nuclear envelope; kept consistent across evidence types for the same term).</li>
+<li>GO:0032153 cell division site IBA → <strong>REMOVE</strong>. NB (per PR review): GO:0032153 is NOT lineage-specific — the S. cerevisiae bud neck is a bona fide cell division site — so the justification is weak single-source phylogenetic propagation (one S. pombe donor, PomBase:SPCC1739.10) with no DCV1-specific division-site evidence, NOT a taxon mismatch. Failure mode set to SOURCE_EVIDENCE_WEAK + COMPARTMENT_OR_COMPLEX_MISMATCH (LINEAGE_OR_TAXON_MISMATCH reserved for GO:0035838 growing cell tip, which genuinely is a tip-growth concept absent in budding yeast).</li>
+<li>GO:0035838 growing cell tip IBA → <strong>REMOVE</strong> (fission-yeast polarized-tip-growth concept; not applicable to budding yeast S. cerevisiae).</li>
+<li>GO:0016020 membrane IEA (SubCell) → <strong>MARK_AS_OVER_ANNOTATED</strong> (uninformative generic parent; the protein's PM/multi-pass membrane status is already captured more specifically).</li>
+</ul>
+<p>No <code>protein binding</code> annotations present (good).</p>
+<h2 id="5-sources-consulted">5. Sources consulted</h2>
+<ul>
+<li>UniProt P43595 (<code>DCV1-uniprot.txt</code>) — architecture, family, disruption phenotype.</li>
+<li>GOA (<code>DCV1-goa.tsv</code>) — 8 annotations.</li>
+<li>PANTHER PTHR28013 member CSV + metadata (<code>interpro/panther/PTHR28013/</code>).</li>
+<li>SGD locus page S000001908 (WebFetch 2026-07-05) — description, paralog, phenotypes.</li>
+<li>PMID:33002606 (Tos7 paper, abstract-only cache) — paralog localization.</li>
+<li>PMID:22042866 (Zimmermann 2011 PNAS, abstract-only cache) — CDC28 genetic-network screen (source of DCV1 name/phenotype).</li>
+<li>OLS (GO term defs for GO:0035838, GO:0032153, GO:0005635).</li>
+<li>Falcon deep research: completed (<code>DCV1-deep-research-falcon.md</code>, ~29 min, 16 refs). <strong>Concordant</strong> with this review: it finds no DCV1-specific experimental characterization; all function is family-level inference (Sur7/PalI/Rim9 tetraspanner, plasma-membrane/MCC-eisosome, Rim101 pH-response by analogy to RIM9's auxiliary role in the Rim21–Dfg16–Rim9 sensor complex). Its citations are reviews / other-gene primary papers (Athanasopoulos 2019 FEMS Microbiol Rev; Obara 2012 JBC on Rim21; Douglas 2012 mBio on Sur7) — none are DCV1-specific, so they are used as background only and not added as <code>supporting_text</code> (falcon file: quote-tokens are not validator-verified per project guidance).<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P43595
+gene_symbol: DCV1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  DCV1 (systematic name YFR012W) is a small (202-residue) polytopic integral membrane protein
+  of the budding yeast Saccharomyces cerevisiae. It has an N-terminal signal sequence and three
+  predicted transmembrane helices, and belongs to the fungal Sur7/PalI/Rim9 family of tetraspan
+  membrane proteins (Pfam SUR7 / InterPro SUR7-Rim9-like; PANTHER PTHR28013), which also contains
+  its budding-yeast paralog RIM9 and, by whole-genome duplication, TOS7. Family members are
+  plasma-membrane / eisosome-associated proteins, and several act in the fungal Rim101/PacC
+  ambient-pH signalling pathway; DCV1 has itself been localized to the nuclear envelope. Its own
+  molecular function and biological role are not experimentally established. It is dispensable for
+  viability under standard conditions, and its principal recorded genetic characteristic is a
+  requirement for Cdc28 (Cdk1) activity for viability — the source of its name, &#34;Demands Cdc28
+  kinase activity for Viability&#34;.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms.
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt.
+- id: PMID:33002606
+  title: The Sur7/PalI family transmembrane protein Tos7 (Yol019w) plays a role in secretion
+    in budding yeast.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Cited by SGD for the DCV1 nuclear-envelope IDA (GO:0005635). The cached record is
+      abstract-only and its title/abstract concern the paralog Tos7 (Yol019w) localizing to
+      plasma-membrane MCC/eisosome microdomains; I could not access the full text to confirm
+      that DCV1/YFR012W was assayed for nuclear-envelope localization. Retained per policy
+      (do not overrule an experimental annotation from incomplete evidence); marked UNVERIFIED.
+- id: PMID:22042866
+  title: A chemical-genetic screen to unravel the genetic network of CDC28/CDK1 links ubiquitin
+    and Rad6-Bre1 to cell cycle progression.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genome-wide chemical-genetic array screen mapping the CDC28/CDK1 genetic network; DCV1
+      (YFR012W) was a screen hit and is the origin of the gene name (&#34;Demands Cdc28 kinase
+      activity for Viability&#34;) and of the UniProt disruption phenotype (lethal in absence of
+      CDC28). Cached record is abstract-only; the abstract does not name DCV1 individually,
+      but UniProt curators cite it specifically for the dcv1 phenotype.
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically-propagated (IBA) plasma-membrane localization across the Sur7/PalI/Rim9
+      family (PANTHER PTHR28013). Family-consistent for a tetraspan fungal membrane protein but
+      not experimentally demonstrated for DCV1 itself.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Sur7/PalI-family members are characteristically plasma-membrane / eisosome (MCC)
+      components, so a plasma-membrane localization is biologically plausible for DCV1 and is
+      the most defensible of the propagated CC terms. It is flagged as an over-annotation
+      because there is no DCV1-specific evidence placing it at the plasma membrane; the
+      assignment is a whole-family default rather than a demonstrated DCV1 localization. This is
+      a cellular-component term, not a molecular function.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: SGD:S000004667
+        source_label: RIM9
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Plasma-membrane/eisosome localization is well supported for Sur7/PalI-family members
+          (the IBA donor set includes the S. cerevisiae PalI/Rim9 protein RIM9 (SGD:S000004667),
+          the paralog TOS7 (SGD:S000005379), and S. pombe members), but transfer to DCV1 is a
+          family default with no DCV1-specific plasma-membrane evidence.
+- term:
+    id: GO:0032153
+    label: cell division site
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IBA &#34;cell division site&#34; localization propagated within PTHR28013 from a single
+      Schizosaccharomyces pombe family member. Not supported for DCV1.
+    action: REMOVE
+    reason: &gt;-
+      The WITH/FROM evidence for this IBA is thin, tracing to one fission-yeast member
+      (PomBase:SPCC1739.10). &#34;Cell division site&#34; (GO:0032153) is not lineage-specific — in
+      S. cerevisiae the bud neck is a bona fide cell division site — so the problem is not a
+      taxon mismatch but the absence of any DCV1-specific evidence for bud-neck / division-site
+      localization; the term is a weak single-source phylogenetic propagation that should not
+      transfer to DCV1.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - SOURCE_EVIDENCE_WEAK
+      source_entities:
+      - source_id: PomBase:SPCC1739.10
+        source_label: S. pombe PTHR28013 member
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Single fission-yeast donor for this term; division-site localization is not
+          demonstrated for DCV1, so the transfer is unsupported.
+- term:
+    id: GO:0035838
+    label: growing cell tip
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IBA &#34;growing cell tip&#34; localization propagated from fission-yeast family members. The
+      term describes polarized tip growth of elongated cells and is not applicable to the
+      budding yeast S. cerevisiae.
+    action: REMOVE
+    reason: &gt;-
+      &#34;Growing cell tip&#34; (GO:0035838) is defined as the polarized-growth region at the ends of
+      cylindrical/elongated cells — a hallmark of fission yeast, which grows by tip extension.
+      The donor evidence is from S. pombe members (PomBase:SPAC13G7.04c, PomBase:SPCC1739.10).
+      S. cerevisiae grows by budding, not tip extension, so this localization is not
+      biologically applicable to DCV1 and represents a fission-yeast-specific over-propagation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - LINEAGE_OR_TAXON_MISMATCH
+      source_entities:
+      - source_id: PomBase:SPAC13G7.04c
+        source_label: S. pombe PTHR28013 member (mac1-like)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Tip-growth localization is a fission-yeast trait; budding yeast has no growing cell
+          tip, so the term cannot transfer to DCV1.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation (IPR009571 SUR7/Rim9-like → plasma membrane). Redundant
+      with the family IBA plasma-membrane annotation and, like it, not directly demonstrated for
+      DCV1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This IEA duplicates the IBA plasma-membrane localization from the same protein family and
+      adds no independent evidence for DCV1. It is a reasonable family-level default but is an
+      over-annotation given the absence of any DCV1-specific plasma-membrane data.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic &#34;membrane&#34; localization from the UniProt Subcellular Location mapping (SL-0162).
+      Correct but uninformative given that DCV1 is already known to be a multi-pass membrane
+      protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      DCV1 is a bona fide integral membrane protein (signal peptide + three TM helices), so the
+      annotation is not wrong, but &#34;membrane&#34; is the uninformative parent of the more specific
+      compartment terms already present. It is retained only as a high-level default and is
+      marked over-annotated relative to the specific localizations.
+- term:
+    id: GO:0005635
+    label: nuclear envelope
+  evidence_type: IDA
+  original_reference_id: PMID:33002606
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct-assay (IDA) nuclear-envelope localization curated by SGD. This is the only
+      DCV1-specific experimental annotation and is treated as the primary localization evidence,
+      though the primary source could not be independently verified here.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimental (IDA) localization assigned by an SGD curator who read the full text; per
+      curation policy an experimental annotation is not removed on the basis of an
+      abstract-only cache. The cited paper&#39;s abstract concerns the paralog Tos7 at the plasma
+      membrane and I could not access the full text to confirm the DCV1 assay, so the
+      localization is retained but flagged (see reference_review) and marked non-core: it is a
+      cellular-component observation, not a molecular function or established biological role.
+      The nuclear envelope is contiguous with the ER, a plausible endomembrane location for a
+      signal-peptide-bearing polytopic protein.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular-function term with ND (No biological Data available). Accurately reflects
+      that no molecular function has been experimentally or computationally established for DCV1.
+    action: ACCEPT
+    reason: &gt;-
+      DCV1 has no assigned enzymatic activity and no demonstrated specific binding partner; the
+      Sur7/PalI family has no known catalytic activity. The ND root annotation is the honest
+      representation of the current state of knowledge and should be retained.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological-process term with ND. Accurately reflects that no biological process has
+      been experimentally established for DCV1.
+    action: ACCEPT
+    reason: &gt;-
+      No coherent biological process is demonstrated for DCV1. The recorded characteristics
+      (a synthetic requirement for CDC28 activity, and dispersed high-throughput deletion
+      phenotypes) are genetic/phenotypic observations rather than a defined pathway role. The
+      family-level Rim101 pH-response role of the paralog RIM9 is not established for DCV1.
+      The ND root annotation should be retained.
+core_functions:
+- description: &gt;-
+    DCV1 is a Sur7/PalI/Rim9-family tetraspan integral membrane protein whose specific molecular
+    activity is unknown. The family has no known catalytic activity; members act as
+    plasma-membrane/eisosome scaffolding or pH-sensing components. No molecular function,
+    catalytic activity, or specific binding partner has been demonstrated for DCV1, and no
+    molecular-function term more specific than the ND root can be justified from current
+    evidence. Its localization is likewise unresolved (a single nuclear-envelope IDA versus
+    family-propagated plasma-membrane predictions), so no core localization is asserted here.
+  supported_by:
+  - reference_id: PMID:33002606
+    supporting_text: &gt;-
+      Tos7 (Yol019w) is a Sur7/PalI family transmembrane protein in the budding yeast
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of DCV1 is unknown. No catalytic activity, transport activity, or
+    specific binding partner has been assigned to DCV1, and the Sur7/PalI/Rim9 family to which
+    it belongs has no defined molecular activity — its members are non-catalytic tetraspan
+    membrane proteins whose scaffolding/sensing role is not captured by any GO molecular-function
+    term. GOA carries only the ND root MF term for DCV1.
+  boundary: &gt;-
+    DCV1 is firmly established as a 202-residue polytopic integral membrane protein (N-terminal
+    signal peptide plus three transmembrane helices) belonging to the fungal Sur7/PalI/Rim9
+    family (Pfam SUR7; InterPro IPR009571; PANTHER PTHR28013, subfamily SF3 with the PalI/Rim9
+    orthologs, including the S. cerevisiae paralog RIM9). Its WGD paralog is TOS7. What is NOT
+    known is any activity the protein performs.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+  significance: &gt;-
+    DCV1 is a conserved-family membrane protein that has never been functionally characterized in
+    its own right. Assigning its activity would clarify whether the budding-yeast Sur7/PalI
+    subfamily has functions beyond the eisosome/pH-response roles known for other members, and a
+    suitable ontology term for non-catalytic tetraspan scaffold/sensor activity would let such
+    functions be expressed at all.
+  resolution: &gt;-
+    DCV1-specific biochemistry and interaction mapping (affinity/proximity proteomics,
+    reconstitution) to identify partners or any activity; and, for the ontology gap, a GO
+    molecular-function term for the scaffolding/pH-sensing activity of Sur7/PalI-family tetraspan
+    membrane proteins.
+  provenance:
+  - reference_id: PMID:33002606
+    supporting_text: &gt;-
+      the cellular roles of Tos7 have not been established
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The biological process DCV1 participates in is unknown. Whether DCV1 functions in the
+    Rim101/PacC ambient-pH response pathway (the process characterized for its subfamily relative
+    RIM9), in eisosome/plasma-membrane organization, or in some unrelated process, has not been
+    tested; its only distinctive genetic characteristic is a requirement for Cdc28 (Cdk1)
+    activity for viability, which is a genetic interaction rather than a defined pathway role.
+  boundary: &gt;-
+    dcv1 deletion is viable under standard conditions but is lethal/synthetically sick when Cdc28
+    activity is compromised (the origin of the gene name), and dcv1 was a hit in a genome-wide
+    chemical-genetic screen of the CDC28 network. High-throughput deletion phenotypes are
+    dispersed (altered metal-ion accumulation, MMS sensitivity, reduced chronological lifespan)
+    and do not converge on one process. Membership in the PalI/Rim9 subfamily is suggestive of a
+    pH-response role but is homology-based only.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A defined process would explain why loss of DCV1 becomes lethal specifically when CDK1
+    activity is limiting, potentially linking a Sur7/PalI-family membrane protein to cell-cycle
+    robustness — an unexpected connection for this family.
+  resolution: &gt;-
+    Test dcv1 for defects in Rim101 processing / alkaline-pH growth and in eisosome/MCC
+    organization; dissect the dcv1-cdc28 genetic interaction (epistasis, suppressors); and test
+    functional redundancy with the paralog TOS7 via a dcv1 tos7 double mutant.
+  provenance:
+  - reference_id: PMID:22042866
+    supporting_text: &gt;-
+      We identified 107 genes that strongly
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The subcellular localization of DCV1 is not resolved. A single SGD IDA places DCV1 at the
+    nuclear envelope, whereas family/phylogenetic (IBA/IEA) evidence predicts the plasma
+    membrane/eisosome; these have not been reconciled by an independent DCV1-specific study.
+  boundary: &gt;-
+    DCV1 is certainly membrane-embedded (three TM helices). The nuclear-envelope assignment rests
+    on one IDA (curated by SGD from PMID:33002606, which I could not verify in full text), while
+    plasma-membrane assignments are homology-based propagations across the Sur7/PalI family.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Correct localization is a prerequisite for inferring function: a nuclear-envelope/ER protein
+    and a plasma-membrane eisosome protein imply very different roles for DCV1.
+  resolution: &gt;-
+    Independent, DCV1-specific localization (endogenously tagged Dcv1 imaged against nuclear
+    envelope/ER and plasma-membrane/eisosome markers) under standard and stress (e.g. alkaline
+    pH) conditions.
+  provenance:
+  - reference_id: PMID:33002606
+    supporting_text: &gt;-
+      Tos7 localized to punctate
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Does DCV1 function in the Rim101/PacC ambient-pH signalling pathway, as its PalI/Rim9
+    subfamily membership suggests, or has it diverged from that role?
+- question: &gt;-
+    Why is DCV1 required for viability specifically when Cdc28 (Cdk1) activity is limiting, and
+    what does this reveal about a link between a Sur7/PalI membrane protein and the cell cycle?
+- question: &gt;-
+    Is DCV1 functionally redundant with its whole-genome-duplication paralog TOS7?
+suggested_experiments:
+- description: &gt;-
+    Endogenously tag DCV1 (e.g. C-terminal GFP) and image it against nuclear-envelope/ER and
+    plasma-membrane/eisosome (MCC) markers under standard and alkaline-pH conditions to resolve
+    the conflicting nuclear-envelope (IDA) vs plasma-membrane (IBA/IEA) localizations.
+  hypothesis: &gt;-
+    DCV1 localizes to a defined endomembrane or plasma-membrane microdomain rather than to both.
+- description: &gt;-
+    Assay dcv1 mutants for Rim101 proteolytic processing and for growth at alkaline pH, and test
+    genetic interactions with RIM9 and other RIM-pathway genes.
+  hypothesis: &gt;-
+    DCV1 contributes to the Rim101 pH-response pathway characteristic of its PalI/Rim9 subfamily.
+- description: &gt;-
+    Construct dcv1 tos7 single and double deletions and characterize growth, cell-wall stress
+    sensitivity, secretion, and CDC28-dependence to test paralog redundancy.
+  hypothesis: &gt;-
+    DCV1 and its WGD paralog TOS7 share overlapping functions masked by redundancy in single
+    mutants.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/DSF2/DSF2-ai-review.html
+++ b/genes/yeast/DSF2/DSF2-ai-review.html
@@ -1,0 +1,2792 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DSF2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>DSF2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P38213" target="_blank" class="term-link">
+                        P38213
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "DSF2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P38213" data-a="DESCRIPTION: DSF2 (YBR007C) is a 736-residue protein of the bud..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DSF2 (YBR007C) is a 736-residue protein of the budding yeast Saccharomyces cerevisiae composed of a large intrinsically disordered / low-complexity N-terminal half (~residues 1-461) and a C-terminal Sel1-like tetratricopeptide (TPR) repeat solenoid (~residues 560-736). Sel1/TPR repeats are alpha-helical scaffolds that typically mediate protein-protein interactions, and DSF2 has no predicted catalytic domain. The protein localizes to the bud tip and bud neck of growing cells and moves to the cytoplasm during DNA-replication stress. It is a low-abundance phosphoprotein. Its molecular function and the biological process it participates in are not experimentally established. DSF2 belongs to a Sel1-repeat protein family (PANTHER PTHR43628) whose best-characterized member is the fission-yeast mitotic inhibitor Nif1, which negatively regulates entry into mitosis; whether DSF2 has an analogous cell-cycle role in S. cerevisiae has not been demonstrated. DSF2 was originally identified as a deletion suppressor of the puf5/mpt5 RNA-binding-protein deletion, a genetic relationship that does not by itself define its own function. Despite the shared &#34;Dsf&#34; name, DSF2 is not a homolog of DSF1 (YEL070W, a mannitol dehydrogenase); both were merely recovered in the same suppressor screen.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010972" target="_blank" class="term-link">
+                                    GO:0010972
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of G2/M transition of mitotic cell cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38213" data-a="GO:0010972" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference propagated from the fission-yeast ortholog Nif1 (PomBase:SPBC23G7.04c), which negatively regulates mitotic entry. DSF2 and Nif1 share only Sel1-like/TPR repeats, and no S. cerevisiae experiment shows DSF2 acting on Swe1/Cdc28 or a Nim1-family kinase. The inference is plausible but uncorroborated for budding yeast, so it is kept as a non-core annotation rather than removed (per guidance not to REMOVE on distant-ortholog grounds alone).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Legitimate IBA transfer from Nif1 but not experimentally supported in S. cerevisiae; DSF2&#39;s own biological process is unknown, so this cannot be treated as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16328373" target="_blank" class="term-link">
+                                        PMID:16328373
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dsf1 (YEL070W), dsf2 (YBR007C)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032153" target="_blank" class="term-link">
+                                    GO:0032153
+                                </a>
+                            </span>
+                            <span class="term-label">cell division site</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38213" data-a="GO:0032153" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA inference from the same Nif1 ortholog. It is loosely consistent with the experimentally observed bud-tip / bud-neck localization of DSF2, but &#34;is_active_in the cell division site&#34; asserts a functional activity there that has not been demonstrated for DSF2. Retained as non-core given the supporting localization but flagged as unverified for activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Distant-ortholog IBA; the localization component is consistent with HDA bud-tip data, but no DSF2 activity at the division site is established.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005934" target="_blank" class="term-link">
+                                    GO:0005934
+                                </a>
+                            </span>
+                            <span class="term-label">cellular bud tip</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22842922
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissecting DNA damage response pathways by analysing protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38213" data-a="GO:0005934" data-r="PMID:22842922" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct high-throughput GFP-localization evidence (HDA) that Dsf2 localizes to the bud tip (and bud neck), from a genome-wide imaging screen. This is the best-supported annotation for DSF2 and is accepted; it is the anchor for the protein&#39;s cellular location, although localization alone does not define molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (HDA) localization for DSF2 itself; consistent with SGD&#39;s bud-tip/bud-neck localization and the replication-stress relocalization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
+                                        PMID:22842922
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">one that reflects movement away from the budneck or bud tip</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38213" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function annotation with ND (no biological data) evidence, correctly recording that DSF2&#39;s molecular function is unknown. This is an honest placeholder and is retained: no specific MF term is defensible from current evidence (the Sel1/TPR architecture suggests a protein-interaction module but no partner or activity has been shown).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurately reflects the genuine absence of molecular-function knowledge for this dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38213" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process annotation with ND evidence, correctly recording that DSF2&#39;s biological process is unknown at the level of direct evidence. The only BP signal is the distant-ortholog IBA (negative regulation of G2/M), which is not corroborated in S. cerevisiae, so retaining the ND root is the honest position.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurately reflects the genuine absence of direct biological-process knowledge for this dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DSF2 is a Sel1-like / TPR-repeat protein with a large disordered N-terminal region, an architecture consistent with a protein-interaction scaffold or adaptor, that localizes to the bud tip and bud neck. No specific molecular activity or partner has been experimentally established, so the molecular function is recorded at the root; the confident, evidence-based statement is the cellular location. The bud-tip localization is the only directly demonstrated feature of DSF2&#39;s cellular behavior.</h3>
+                <span class="vote-buttons" data-g="P38213" data-a="FUNCTION: DSF2 is a Sel1-like / TPR-repeat protein with a la..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                            molecular_function
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005934" target="_blank" class="term-link">
+                                cellular bud tip
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
+                                PMID:22842922
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">one that reflects movement away from the budneck or bud tip</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16328373" target="_blank" class="term-link">
+                                PMID:16328373
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">dsf1 (YEL070W), dsf2 (YBR007C)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/DSF2/DSF2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">non-enzymatic adaptor or scaffold protein</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
+                            PMID:22842922
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP screen scoring subcellular localization changes during DNA replication stress; one localization-change class captures proteins moving away from the bud neck / bud tip, and HU/MMS caused a decrease in bud-neck/bud-tip localization. DSF2 is one of the proteins scored (in the supplementary datasets), which is the basis for its high-throughput (HDA) bud-tip localization annotation.</div>
+
+                        <div class="finding-text">"one that reflects movement away from the budneck or bud tip"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/DSF2/DSF2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep-research report on S. cerevisiae DSF2 (YBR007C)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Domain-based synthesis: characterized Sel1-like-repeat proteins act as non-enzymatic adaptor/scaffold proteins; on this basis DSF2 is best interpreted as a scaffold/adaptor at the bud neck. The report also raises (as unverified inferences) a possible link to the Cbk1/RAM network and specific phosphosites; these are not adopted as supported claims here.</div>
+
+                        <div class="finding-text">"non-enzymatic adaptor or scaffold protein"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16328373" target="_blank" class="term-link">
+                            PMID:16328373
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Suppressor analysis of the mpt5/htr1/uth4/puf5 deletion in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Screen for deletion suppressors that rescue the temperature-sensitivity of an mpt5 (puf5) deletion identified dsf1 (YEL070W) and dsf2 (YBR007C), among others. This is the origin of the DSF2 gene name and its only dedicated functional study; it establishes a genetic suppressor relationship, not a molecular function.</div>
+
+                        <div class="finding-text">"dsf1 (YEL070W), dsf2 (YBR007C)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The mpt5 deletion strain is hydroxyurea (HU) sensitive; DSF2 loss partially suppresses this HU sensitivity (per UniProt disruption phenotype).</div>
+
+                        <div class="finding-text">"The Deltampt5 disruptant was also hydroxyurea (HU) sensitive"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the physiological binding partners of Dsf2, and do they define it as a scaffold/adaptor at the bud tip or bud neck?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38213" data-a="Q: What are the physiological binding partners of Dsf..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does DSF2 have any role in the budding-yeast G2/M transition (e.g. through Swe1 or Cdc28), as its phylogenetic annotation from Nif1 would predict?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38213" data-a="Q: Does DSF2 have any role in the budding-yeast G2/M ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> By what mechanism does dsf2 deletion suppress the temperature and hydroxyurea sensitivity of a puf5/mpt5 deletion?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38213" data-a="Q: By what mechanism does dsf2 deletion suppress the ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity purification-mass spectrometry (or proximity labeling such as BioID/TurboID) of endogenously tagged Dsf2 in log-phase and replication-stress conditions to identify stable and stress-dependent interactors.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Dsf2 uses its Sel1/TPR solenoid to scaffold a specific partner at the bud tip/neck; identifying that partner would define its molecular function.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38213" data-a="EXPERIMENT: Affinity purification-mass spectrometry (or proxim..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative cell-morphology and cell-cycle profiling of dsf2 deletion and overexpression strains, plus genetic-interaction tests with SWE1 and CDC28, to test the phylogenetically inferred negative regulation of G2/M.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: If the Nif1-based inference holds, perturbing DSF2 will change cell length or G2/M timing and interact genetically with the Swe1-Cdc28 axis.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic interaction / cell-cycle phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38213" data-a="EXPERIMENT: Quantitative cell-morphology and cell-cycle profil..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Epistasis analysis of the dsf2-mediated suppression of puf5/mpt5 phenotypes, testing dependence on known mpt5-suppression modifiers (e.g. PUF4, IME4) and whether Dsf2 abundance/localization changes in a puf5 background.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: dsf2 suppression of mpt5 operates through a definable branch of the Puf-family regulatory network rather than a nonspecific fitness effect.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38213" data-a="EXPERIMENT: Epistasis analysis of the dsf2-mediated suppressio..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of DSF2 is undetermined: no catalytic activity, no specific binding partner, and no scaffold/adaptor role has been experimentally demonstrated. The only structural clue is a C-terminal Sel1-like/TPR repeat solenoid, a generic protein-interaction module that does not specify an activity or a partner.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: DSF2 is a 736-aa protein with a disordered N-terminal half and a C-terminal Sel1-like/TPR-repeat region (UniProt P38213: SMART SEL1, InterPro IPR006597/IPR011990, SUPFAM HCP-like), it is a detected phosphoprotein, and it localizes to the bud tip/neck. SGD lists molecular function as Unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> DSF2 is a conserved (fungal-to-bacterial Sel1-repeat) yet functionally dark protein; identifying its binding partner(s) would convert a structural guess into an actual molecular function and likely explain its cell-cycle-adjacent annotations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity purification / proximity labeling of Dsf2 to identify stable interactors, followed by testing whether it acts as a scaffold for the identified partner(s); a defensible specific MF term (e.g. a protein-binding adaptor term) could then replace the MF root.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"dsf1 (YEL070W), dsf2 (YBR007C)"</em> — PMID:16328373</li>
+
+                <li><em>"SEL1"</em> — file:yeast/DSF2/DSF2-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process DSF2 participates in is unknown. The sole process annotation (negative regulation of the G2/M transition) is a phylogenetic (IBA) inference from the distant fission-yeast ortholog Nif1 and has never been tested in S. cerevisiae; whether DSF2 regulates the budding-yeast cell cycle (e.g. via Swe1/Cdc28) is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: the IBA is transferred from Nif1 (PomBase:SPBC23G7.04c), a Sel1-repeat mitotic inhibitor. DSF2 shares only Sel1/TPR repeats with Nif1, and there is no budding-yeast experimental link between DSF2 and the Swe1-Cdc28 or Nim1-kinase machinery.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Confirming or refuting a cell-cycle role would either validate the cross-species inference or reveal that DSF2&#39;s bud-tip localization serves an unrelated process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis and cell-length/cell-cycle phenotyping of dsf2 mutants combined with genetic interaction tests against SWE1/CDC28; direct assay of whether Dsf2 binds or modulates Swe1 or Cdc28.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"dsf1 (YEL070W), dsf2 (YBR007C)"</em> — PMID:16328373</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism by which loss of DSF2 suppresses the temperature- and hydroxyurea-sensitivity of a puf5/mpt5 deletion is unknown. It is not established whether this reflects a direct functional relationship between Dsf2 and the Puf5 RNA-binding pathway or an indirect, downstream effect.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: dsf2 was recovered as a deletion suppressor of mpt5/puf5 temperature-sensitivity, and DSF2 loss partially suppresses mpt5 HU sensitivity (PMID:16328373; UniProt P38213 disruption phenotype). No molecular mechanism for this suppression has been reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Puf5/Mpt5 is a well-studied Puf-family translational repressor; explaining how a bud-tip Sel1-repeat protein feeds into its pathway could place DSF2 in a defined regulatory network.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Dissect the suppression genetically (is it PUF4/IME4-dependent, as for other mpt5 suppressors?) and test whether Dsf2 abundance or localization changes in a puf5 background.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The Deltampt5 disruptant was also hydroxyurea (HU) sensitive"</em> — PMID:16328373</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The functional significance of DSF2 relocalizing from the bud tip/neck to the cytoplasm during DNA-replication stress (HU/MMS) is unknown; it is not known whether this movement is part of a stress response or an incidental consequence of bud-neck disassembly.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: a genome-wide GFP screen scored DSF2 among proteins that lose bud-neck/bud-tip localization under replication stress (PMID:22842922; SGD). No follow-up has tested the consequence of this relocalization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Stress-induced relocalization is often functionally informative; resolving it could link DSF2&#39;s location to a specific process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test whether blocking DSF2 relocalization (or deleting DSF2) alters replication-stress survival, and identify the signal driving the move.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"one that reflects movement away from the budneck or bud tip"</em> — PMID:22842922</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DSF2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38213" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: DSF2 (YBR007C) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">16 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:12:22.176383</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="DSF2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="DSF2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-dsf2-ybr007c-in-saccharomyces-cerevisiae">Comprehensive Research Report: DSF2 (YBR007C) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>DSF2 (systematic name YBR007C; UniProt P38213) encodes a protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c) whose full name is "Deletion Suppressor of MPT5 mutation protein 2." The gene was originally identified through genetic screens in which its deletion suppressed phenotypes associated with loss of MPT5 (also known as PUF5/HTR1/UTH4), an RNA-binding protein of the Pumilio family involved in mRNA regulation (coorey2012anovelhighthroughput pages 83-88, zhang2025theyeastgsk3 pages 14-15). DSF2 is a relatively undercharacterized gene, and no dedicated primary study of its molecular function has been published; instead, evidence about its function derives from high-throughput studies, phosphoproteomics, computational analyses, and comparative genomics.</p>
+<p>The following table summarizes verified properties of DSF2:</p>
+<table>
+<thead>
+<tr>
+<th>Gene Name</th>
+<th>Systematic Name</th>
+<th>UniProt ID</th>
+<th>Organism</th>
+<th>Protein Size</th>
+<th>Key Domains</th>
+<th>Subcellular Localization</th>
+<th>Genetic Interactions</th>
+<th>Phosphorylation Sites</th>
+<th>Potential Kinase Regulators</th>
+<th>Orthologs</th>
+<th>Proposed Function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>DSF2</strong></td>
+<td><strong>YBR007C</strong> (ORF alias reported by UniProt: <strong>YBR0113</strong>)</td>
+<td><strong>P38213</strong></td>
+<td><em>Saccharomyces cerevisiae</em> strain ATCC 204508 / S288c</td>
+<td>Not established from the literature retrieved here; UniProt accession verified as the target protein</td>
+<td><strong>Sel1-like repeats</strong>, <strong>TPR-like helical domain superfamily</strong>, <strong>Mitotic_Regulator</strong> domain; these domains are most consistent with a protein-protein interaction scaffold/adaptor role rather than catalytic activity (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2, mittl2007sel1likerepeatproteins pages 6-8)</td>
+<td>Localizes to the <strong>bud neck</strong> under standard conditions; reported to relocalize from the <strong>bud neck to the cytoplasm upon DNA replication stress</strong>, supporting a role in cell-cycle-linked cortical structures (mamun2023largescaleidentificationof pages 12-13, zhang2025theyeastgsk3 pages 14-15)</td>
+<td>Originally identified as <strong>deletion suppressor of MPT5 mutation</strong>; thus genetically linked to <strong>MPT5/PUF5</strong>, an RNA regulatory factor (coorey2012anovelhighthroughput pages 83-88, gogl2015thestructureof pages 12-15)</td>
+<td><strong>S391</strong>, <strong>S395</strong> detected in phosphoproteomic data (zhang2025theyeastgsk3 pages 13-14, zhang2025theyeastgsk3 pages 14-15)</td>
+<td><strong>Cbk1</strong> is the strongest inferred regulator from sequence/pathway analysis: Dsf2 contains conserved <strong>Cbk1 phosphorylation consensus motifs</strong> but lacks the canonical <strong>Cbk1 docking motif</strong>; therefore it is a <strong>putative non-docking Cbk1 substrate</strong> rather than a confirmed direct substrate (gogl2015thestructureof pages 12-15, gogl2015thestructureof pages 15-17)</td>
+<td><strong>Nif1</strong> in <em>Schizosaccharomyces pombe</em> and <strong>SppD</strong> in <em>Aspergillus</em> spp.; comparative analyses link this family to mitotic/cytokinetic functions, though septal-pore functions appear lineage-specialized in filamentous fungi (mamun2023largescaleidentificationof pages 12-13)</td>
+<td>Best-supported current model: <strong>non-enzymatic adaptor/scaffold protein</strong> acting at the <strong>bud neck</strong> in processes related to <strong>cell division/cytokinesis</strong> and possibly integrated with the <strong>RAM/Cbk1 signaling network</strong>; precise molecular mechanism remains incompletely characterized (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2, mamun2023largescaleidentificationof pages 12-13, gogl2015thestructureof pages 12-15, zhang2025theyeastgsk3 pages 14-15)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, domains, localization, genetic interactions, phosphorylation evidence, orthology, and best-supported functional interpretation for the yeast DSF2/YBR007C protein. It is useful as a compact reference for distinguishing experimentally supported facts from mechanistic inferences.</em></p>
+<h2 id="2-domain-architecture-and-structural-features">2. Domain Architecture and Structural Features</h2>
+<p>DSF2 harbors three notable domain annotations: Sel1-like repeats (SLR; InterPro IPR006597), a TPR-like helical domain superfamily (IPR011990), and a Mitotic Regulator domain (IPR052945). These domains provide strong functional clues.</p>
+<h3 id="21-sel1-like-repeats-slr">2.1 Sel1-like Repeats (SLR)</h3>
+<p>Sel1-like repeats are α-helical structural motifs related to tetratricopeptide repeats (TPRs). A comprehensive review of SLR proteins established that, despite their diverse cellular roles, all characterized SLR proteins function as <strong>adaptor or scaffold proteins</strong> that mediate protein-protein interactions and facilitate assembly of macromolecular complexes (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2). SLR domains achieve selectivity through a combination of short-range protein-peptide interactions and long-range electrostatic interactions, enabling discrimination between different target sequences (mittl2007sel1likerepeatproteins pages 6-8).</p>
+<p>In yeast specifically, well-characterized SLR proteins include:<br />
+- <strong>Hrd3</strong>, which contains 12 Sel1-like repeats and functions as the ER-lumenal substrate recognition adaptor for the Hrd1 ubiquitin ligase complex in ER-associated degradation (ERAD) (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 6-8);<br />
+- <strong>Chs4</strong>, which contains 7 Sel1-like repeats and functions as a chitin synthase III activator, recruiting the activated Chs3/Chs4 complex to the septum via interaction with the Bni4/Cdc10 complex (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2);<br />
+- <strong>Nif1</strong>, which regulates mitosis in fission yeast (mittl2007sel1likerepeatproteins pages 1-2).</p>
+<p>The SLR domain architecture of DSF2 thus strongly suggests it operates as a <strong>non-enzymatic adaptor or scaffold protein</strong> involved in protein-protein interactions at sites relevant to cell division.</p>
+<h3 id="22-mitotic-regulator-domain">2.2 Mitotic Regulator Domain</h3>
+<p>The Mitotic Regulator domain (IPR052945) connects DSF2 to Nif1, its ortholog in <em>Schizosaccharomyces pombe</em>. Nif1 acts as a <strong>mitotic inhibitor</strong> through direct interaction with the Nim1 protein kinase, thereby regulating mitotic entry (mamun2023largescaleidentificationof pages 12-13). This domain assignment is consistent with a role for DSF2 in cell cycle regulation.</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>Dsf2 localizes to the <strong>bud neck</strong> under normal growth conditions (mamun2023largescaleidentificationof pages 12-13, zhang2025theyeastgsk3 pages 14-15). The bud neck is the constriction site between mother and daughter cells in budding yeast, where the septin ring, actomyosin ring, and cell wall remodeling machinery converge to execute cytokinesis. Phosphoproteomic data from Zhang et al. (2025) demonstrate that upon <strong>DNA replication stress</strong>, Dsf2 <strong>relocalizes from the bud neck to the cytoplasm</strong>, indicating that its localization is dynamically regulated in a cell cycle- and stress-dependent manner (zhang2025theyeastgsk3 pages 14-15). Phosphorylation at residues <strong>S391 and S395</strong> was detected in phosphoproteomic analyses, suggesting regulation of Dsf2 by one or more kinases (zhang2025theyeastgsk3 pages 13-14, zhang2025theyeastgsk3 pages 14-15).</p>
+<p>The bud neck localization places Dsf2 at the same subcellular site as other key regulators of cytokinesis and cell separation, including Chs4 (septum formation), Dbf2-Mob1 (mitotic exit network), and components of the actomyosin ring.</p>
+<h2 id="4-genetic-interactions-and-the-mpt5-connection">4. Genetic Interactions and the MPT5 Connection</h2>
+<p>DSF2 was named for its property as a <strong>deletion suppressor of mpt5 mutations</strong>: deletion of DSF2 suppresses phenotypes caused by loss of MPT5/PUF5 (coorey2012anovelhighthroughput pages 83-88, zhang2025theyeastgsk3 pages 14-15). MPT5 is a member of the PUF (Pumilio and FBF) family of RNA-binding proteins that promotes mRNA decapping and deadenylation of target transcripts (gogl2015thestructureof pages 18-20). MPT5 targets include mRNAs encoding cell wall proteins and regulators of cell morphogenesis. The fact that loss of DSF2 can compensate for loss of MPT5 implies that DSF2 and MPT5 have opposing or balancing roles in a shared pathway, possibly related to post-transcriptional regulation of cell wall or cytokinesis-related transcripts.</p>
+<h2 id="5-connection-to-the-cbk1ram-signaling-network">5. Connection to the Cbk1/RAM Signaling Network</h2>
+<p>A key study by Gögl et al. (2015) systematically analyzed substrates of the NDR/LATS family kinase <strong>Cbk1</strong>, a central component of the RAM (Regulation of Ace2 and cellular Morphogenesis) signaling network. This analysis revealed that Dsf2 <strong>contains conserved Cbk1 phosphorylation consensus sequences</strong> (Hx[RK]xx[ST]) but notably <strong>lacks the canonical Cbk1 core docking motif</strong> ([YF]xFP) (gogl2015thestructureof pages 12-15). DSF2 was grouped alongside <strong>Mpt5 and Sec3</strong> as proteins with conserved Cbk1 consensus sites but no docking motif, suggesting these may represent a class of <strong>non-docking Cbk1 substrates</strong> (gogl2015thestructureof pages 12-15). While in vivo phosphorylation at Cbk1 consensus sites has been confirmed for Mpt5 and Sec3, such evidence for Dsf2 specifically remains indirect (gogl2015thestructureof pages 12-15).</p>
+<p>The RAM network, through Cbk1 phosphorylation of the mRNA-binding protein Ssd1 and the transcription factor Ace2, coordinates cell wall biogenesis, cell separation, and polarized growth (gogl2015thestructureof pages 17-18, gogl2015thestructureof pages 18-20, gogl2015thestructureof pages 11-12). Cbk1 phosphorylation of Ssd1 permits translation of mRNAs encoding cell wall proteins required for bud growth, while phosphorylation of Ace2 activates transcription of cell separation genes (gogl2015thestructureof pages 12-15). The connection of DSF2 to this network—through conserved phosphorylation motifs, bud neck localization, and genetic interaction with MPT5—suggests Dsf2 participates in this signaling axis, potentially as a scaffold or adaptor that facilitates pathway component interactions at the site of cytokinesis.</p>
+<h2 id="6-evolutionary-conservation-and-ortholog-analysis">6. Evolutionary Conservation and Ortholog Analysis</h2>
+<p>Comparative genomic and phylogenetic analyses have identified orthologs of DSF2 in other fungi, providing additional functional insight:</p>
+<table>
+<thead>
+<tr>
+<th>Protein Name</th>
+<th>Organism</th>
+<th>Domain Architecture</th>
+<th>Subcellular Localization</th>
+<th>Known Function</th>
+<th>Relationship to DSF2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Dsf2</strong></td>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>Sel1-like repeats; TPR-like helical domain; Mitotic_Regulator domain</td>
+<td>Bud neck; relocalizes to cytoplasm upon DNA replication stress</td>
+<td>Best-supported as a non-enzymatic adaptor/scaffold protein associated with bud-neck/cell-division functions; genetically linked to <strong>MPT5</strong> and inferred to connect to the <strong>Cbk1/RAM</strong> network (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2, gogl2015thestructureof pages 12-15, zhang2025theyeastgsk3 pages 14-15)</td>
+<td>Self</td>
+</tr>
+<tr>
+<td><strong>Nif1</strong></td>
+<td><em>Schizosaccharomyces pombe</em></td>
+<td>Sel1-like repeats</td>
+<td>Not clearly established in the retrieved evidence</td>
+<td>Mitotic inhibitor acting via interaction with <strong>Nim1</strong> protein kinase (mamun2023largescaleidentificationof pages 12-13)</td>
+<td>Ortholog</td>
+</tr>
+<tr>
+<td><strong>SppD</strong></td>
+<td><em>Aspergillus oryzae</em></td>
+<td>3 SEL1 domain repeats</td>
+<td>Septum / septal pore; accumulates at septal structures involved in wound response</td>
+<td>Required for septal pore plugging upon wounding; proposed to have evolved in Pezizomycotina by gene duplication from a yeast-like orthologous lineage (mamun2023largescaleidentificationof pages 7-8, mamun2023largescaleidentificationof pages 12-13)</td>
+<td>Ortholog; likely lineage-specialized derivative</td>
+</tr>
+<tr>
+<td><strong>Hrd3</strong></td>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>12 Sel1-like repeats</td>
+<td>ER membrane / ER lumenal HRD complex</td>
+<td>ERAD substrate-recognition adaptor/scaffold in the <strong>Hrd1</strong> complex; Sel1-like repeats mediate substrate and partner recognition (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 6-8)</td>
+<td>Same Sel1-like repeat protein family</td>
+</tr>
+<tr>
+<td><strong>Chs4</strong></td>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>7 Sel1-like repeats</td>
+<td>Septum / bud neck</td>
+<td>Activator and recruitment factor for chitin synthase III during septum formation; adaptor/scaffold role in cytokinetic cell-wall assembly (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2)</td>
+<td>Same Sel1-like repeat protein family</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares DSF2 with orthologous or domain-related fungal Sel1-like repeat proteins to clarify what is directly known about DSF2 versus what can be inferred from better-characterized family members. It is useful for interpreting DSF2 as a likely scaffold/adaptor protein involved in cell division-related processes.</em></p>
+<p>In <em>Schizosaccharomyces pombe</em>, the ortholog <strong>Nif1</strong> functions as a <strong>mitotic inhibitor</strong> through interaction with the Nim1 protein kinase, establishing a direct connection between this protein family and cell cycle control (mamun2023largescaleidentificationof pages 12-13). In <em>Aspergillus oryzae</em>, the ortholog <strong>SppD</strong> contains three SEL1 domain repeats and was identified in a large-scale screening of genes involved in <strong>septal pore plugging</strong> upon hyphal wounding (mamun2023largescaleidentificationof pages 7-8). Mamun et al. (2023) specifically noted that "Nif1 and Dsf2 are orthologs of SppD in fission and budding yeasts, respectively," and that "Nif1 acts as a mitotic inhibitor via interaction with Nim1 protein kinase, whereas Dsf2 localizes to the bud neck, the site of cytokinesis," suggesting a possible role of SppD in cell-cycle regulation or cytokinesis (mamun2023largescaleidentificationof pages 12-13). However, the SppD subclade in Pezizomycotina is distinct from the subclade containing yeast orthologs, and the authors hypothesize that SppD evolved through gene duplication to perform septal pore-related functions specific to filamentous fungi (mamun2023largescaleidentificationof pages 12-13).</p>
+<h2 id="7-proposed-functional-model">7. Proposed Functional Model</h2>
+<p>Based on the convergent lines of evidence, Dsf2 is best understood as a <strong>non-enzymatic adaptor/scaffold protein</strong> that functions at the <strong>bud neck</strong> in processes related to <strong>cell division and cytokinesis</strong>. Its Sel1-like repeat architecture is consistent with a role as a protein-protein interaction platform, analogous to other yeast SLR proteins such as Hrd3 (ERAD substrate recognition) and Chs4 (chitin synthase III activation at the septum) (mittl2007sel1likerepeatproteins pages 5-6, mittl2007sel1likerepeatproteins pages 1-2, mittl2007sel1likerepeatproteins pages 6-8). Its dynamic localization—from the bud neck to the cytoplasm upon DNA replication stress—implies cell-cycle-dependent regulation (zhang2025theyeastgsk3 pages 14-15).</p>
+<p>The genetic interaction with MPT5 (a PUF-family mRNA regulator) and the presence of conserved Cbk1 phosphorylation consensus sites place Dsf2 within the broader <strong>Cbk1/RAM signaling network</strong> that coordinates post-transcriptional control of cell wall biogenesis and cell separation with cell cycle progression (gogl2015thestructureof pages 12-15, gogl2015thestructureof pages 18-20). The Mitotic Regulator domain annotation and orthology with the fission yeast mitotic inhibitor Nif1 further support a cell-cycle regulatory function (mamun2023largescaleidentificationof pages 12-13).</p>
+<h2 id="8-knowledge-gaps-and-limitations">8. Knowledge Gaps and Limitations</h2>
+<p>It is important to note that DSF2 remains incompletely characterized. Key unresolved questions include:</p>
+<ol>
+<li><strong>Precise molecular function</strong>: No specific binding partners have been identified for Dsf2, and its exact role at the bud neck remains undefined.</li>
+<li><strong>Cbk1 phosphorylation</strong>: While Dsf2 contains conserved Cbk1 consensus phosphorylation sites, direct phosphorylation by Cbk1 has not been experimentally demonstrated.</li>
+<li><strong>Mechanism of MPT5 suppression</strong>: The molecular mechanism by which DSF2 deletion suppresses mpt5 mutation phenotypes is unknown.</li>
+<li><strong>Enzymatic activity</strong>: Dsf2 is predicted to lack enzymatic activity based on its domain architecture, but this has not been formally tested.</li>
+<li><strong>Physical interaction partners</strong>: No large-scale interaction studies have identified specific Dsf2-interacting proteins at the bud neck.</li>
+</ol>
+<p>In summary, DSF2 encodes a Sel1-like repeat-containing adaptor protein that localizes to the bud neck during cell division, is integrated into the Cbk1/RAM signaling network through conserved phosphorylation motifs, and functions in a pathway that intersects with MPT5-mediated post-transcriptional regulation. Its precise molecular role likely involves scaffolding protein-protein interactions at the site of cytokinesis, consistent with the established functions of the SLR protein family across eukaryotes.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(coorey2012anovelhighthroughput pages 83-88): Namal V C Coorey. A novel high-throughput screening tool in saccharomyces cerevisiae. ArXiv, 2012. URL: https://doi.org/10.26686/wgtn.17004727.v1, doi:10.26686/wgtn.17004727.v1. This article has 0 citations.</p>
+</li>
+<li>
+<p>(zhang2025theyeastgsk3 pages 14-15): Fan Zhang, Yingzhi Tang, Houjiang Zhou, Kaiqiang Li, James A. West, Julian L. Griffin, Kathryn S. Lilley, and Nianshu Zhang. The yeast gsk-3 kinase mck1 is necessary for cell wall remodeling in glucose-starved and cell wall-stressed cells. International Journal of Molecular Sciences, 26:3534, Apr 2025. URL: https://doi.org/10.3390/ijms26083534, doi:10.3390/ijms26083534. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mittl2007sel1likerepeatproteins pages 5-6): Peer R.E. Mittl and Wulf Schneider-Brachert. Sel1-like repeat proteins in signal transduction. Cellular signalling, 19 1:20-31, Jan 2007. URL: https://doi.org/10.1016/j.cellsig.2006.05.034, doi:10.1016/j.cellsig.2006.05.034. This article has 215 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mittl2007sel1likerepeatproteins pages 1-2): Peer R.E. Mittl and Wulf Schneider-Brachert. Sel1-like repeat proteins in signal transduction. Cellular signalling, 19 1:20-31, Jan 2007. URL: https://doi.org/10.1016/j.cellsig.2006.05.034, doi:10.1016/j.cellsig.2006.05.034. This article has 215 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mittl2007sel1likerepeatproteins pages 6-8): Peer R.E. Mittl and Wulf Schneider-Brachert. Sel1-like repeat proteins in signal transduction. Cellular signalling, 19 1:20-31, Jan 2007. URL: https://doi.org/10.1016/j.cellsig.2006.05.034, doi:10.1016/j.cellsig.2006.05.034. This article has 215 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mamun2023largescaleidentificationof pages 12-13): Md. Abdulla Al Mamun, Wei Cao, Shugo Nakamura, and Jun-ichi Maruyama. Large-scale identification of genes involved in septal pore plugging in multicellular fungi. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36925-y, doi:10.1038/s41467-023-36925-y. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gogl2015thestructureof pages 12-15): Gergő Gógl, Kyle D. Schneider, Brian J. Yeh, Nashida Alam, Alex N. Nguyen Ba, Alan M. Moses, Csaba Hetényi, Attila Reményi, and Eric L. Weiss. The structure of an ndr/lats kinase–mob complex reveals a novel kinase–coactivator system and substrate docking mechanism. PLOS Biology, 13:e1002146, May 2015. URL: https://doi.org/10.1371/journal.pbio.1002146, doi:10.1371/journal.pbio.1002146. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2025theyeastgsk3 pages 13-14): Fan Zhang, Yingzhi Tang, Houjiang Zhou, Kaiqiang Li, James A. West, Julian L. Griffin, Kathryn S. Lilley, and Nianshu Zhang. The yeast gsk-3 kinase mck1 is necessary for cell wall remodeling in glucose-starved and cell wall-stressed cells. International Journal of Molecular Sciences, 26:3534, Apr 2025. URL: https://doi.org/10.3390/ijms26083534, doi:10.3390/ijms26083534. This article has 0 citations.</p>
+</li>
+<li>
+<p>(gogl2015thestructureof pages 15-17): Gergő Gógl, Kyle D. Schneider, Brian J. Yeh, Nashida Alam, Alex N. Nguyen Ba, Alan M. Moses, Csaba Hetényi, Attila Reményi, and Eric L. Weiss. The structure of an ndr/lats kinase–mob complex reveals a novel kinase–coactivator system and substrate docking mechanism. PLOS Biology, 13:e1002146, May 2015. URL: https://doi.org/10.1371/journal.pbio.1002146, doi:10.1371/journal.pbio.1002146. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gogl2015thestructureof pages 18-20): Gergő Gógl, Kyle D. Schneider, Brian J. Yeh, Nashida Alam, Alex N. Nguyen Ba, Alan M. Moses, Csaba Hetényi, Attila Reményi, and Eric L. Weiss. The structure of an ndr/lats kinase–mob complex reveals a novel kinase–coactivator system and substrate docking mechanism. PLOS Biology, 13:e1002146, May 2015. URL: https://doi.org/10.1371/journal.pbio.1002146, doi:10.1371/journal.pbio.1002146. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gogl2015thestructureof pages 17-18): Gergő Gógl, Kyle D. Schneider, Brian J. Yeh, Nashida Alam, Alex N. Nguyen Ba, Alan M. Moses, Csaba Hetényi, Attila Reményi, and Eric L. Weiss. The structure of an ndr/lats kinase–mob complex reveals a novel kinase–coactivator system and substrate docking mechanism. PLOS Biology, 13:e1002146, May 2015. URL: https://doi.org/10.1371/journal.pbio.1002146, doi:10.1371/journal.pbio.1002146. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gogl2015thestructureof pages 11-12): Gergő Gógl, Kyle D. Schneider, Brian J. Yeh, Nashida Alam, Alex N. Nguyen Ba, Alan M. Moses, Csaba Hetényi, Attila Reményi, and Eric L. Weiss. The structure of an ndr/lats kinase–mob complex reveals a novel kinase–coactivator system and substrate docking mechanism. PLOS Biology, 13:e1002146, May 2015. URL: https://doi.org/10.1371/journal.pbio.1002146, doi:10.1371/journal.pbio.1002146. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mamun2023largescaleidentificationof pages 7-8): Md. Abdulla Al Mamun, Wei Cao, Shugo Nakamura, and Jun-ichi Maruyama. Large-scale identification of genes involved in septal pore plugging in multicellular fungi. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36925-y, doi:10.1038/s41467-023-36925-y. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="DSF2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="DSF2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>mamun2023largescaleidentificationof pages 12-13</li>
+<li>gogl2015thestructureof pages 18-20</li>
+<li>gogl2015thestructureof pages 12-15</li>
+<li>mamun2023largescaleidentificationof pages 7-8</li>
+<li>coorey2012anovelhighthroughput pages 83-88</li>
+<li>gogl2015thestructureof pages 15-17</li>
+<li>gogl2015thestructureof pages 17-18</li>
+<li>gogl2015thestructureof pages 11-12</li>
+<li>RK</li>
+<li>ST</li>
+<li>YF</li>
+<li>https://doi.org/10.26686/wgtn.17004727.v1,</li>
+<li>https://doi.org/10.3390/ijms26083534,</li>
+<li>https://doi.org/10.1016/j.cellsig.2006.05.034,</li>
+<li>https://doi.org/10.1038/s41467-023-36925-y,</li>
+<li>https://doi.org/10.1371/journal.pbio.1002146,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DSF2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38213" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dsf2-ybr007c-p38213-curation-notes">DSF2 (YBR007C / P38213) — curation notes</h1>
+<p>Journal-style notes for the AI GO review of <em>Saccharomyces cerevisiae</em> DSF2. Provenance is<br />
+recorded inline as <code>[PMID:xxxx "verbatim supporting text"]</code> or <code>[SGD]</code>/<code>[UniProt P38213]</code>.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li><strong>Standard name:</strong> DSF2 = "<strong>D</strong>eletion <strong>S</strong>uppressor of mpt<strong>F</strong>ive" (MPT5 = PUF5). The<br />
+  UniProt alt name is "Deletion suppressor of MPT5 mutation protein 2" [UniProt P38213].</li>
+<li><strong>Systematic name:</strong> YBR007C (chromosome II). UniProt AC <strong>P38213</strong>; SGD <strong>S000000211</strong>.</li>
+<li>736 aa, ~82.3 kDa, PE 1 (protein-level evidence: detected by mass spectrometry).</li>
+<li><strong>Verified ORF</strong> in SGD, but SGD lists <strong>molecular function = Unknown</strong> and <strong>biological<br />
+  process = Unknown</strong> [SGD]. This is a genuinely understudied ("dark") gene.</li>
+</ul>
+<h2 id="critical-attribution-dsf2-vs-dsf1-are-not-homologs">CRITICAL attribution: DSF2 vs DSF1 are NOT homologs</h2>
+<p>The names DSF1 and DSF2 come from the <strong>same phenotypic screen</strong>, not from sequence homology.<br />
+Both <code>dsf1</code> (YEL070W) and <code>dsf2</code> (YBR007C) were recovered as deletion suppressors that rescue<br />
+the temperature-sensitivity of an mpt5Δ (puf5Δ) strain<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16328373" title="we screened deletion suppressors to rescue the temperature sensitivity of Deltampt5, and identified dsf1 (YEL070W), dsf2 (YBR007C), sir2, sir3, sir4 and swe1">PMID:16328373</a>.</p>
+<ul>
+<li><strong>DSF1 (YEL070W)</strong> is a <strong>mannitol dehydrogenase</strong> (alias MAN1), an oxidoreductase enzyme<br />
+  with a paralog MAN2 [SGD].</li>
+<li><strong>DSF2 (YBR007C)</strong> is a <strong>Sel1-like / TPR-repeat protein</strong> with no known catalytic activity.</li>
+</ul>
+<p>So DSF1 and DSF2 are functionally and structurally <strong>unrelated</strong>; the shared "Dsf" prefix is a<br />
+phenotype label. DSF2-specific evidence must not be conflated with DSF1 enzymology. DSF2's<br />
+closest characterized family member is instead the fission-yeast <strong>Nif1</strong> (see Orthology).</p>
+<h2 id="domain-architecture-inline-analysis-of-dsf2-uniprottxt">Domain architecture (inline analysis of DSF2-uniprot.txt)</h2>
+<p>Reading <code>DSF2-uniprot.txt</code> (P38213):</p>
+<ul>
+<li><strong>N-terminal ~1–461: extensively disordered / low-complexity.</strong> UniProt/MobiDB-lite marks<br />
+  disordered REGIONs at 1–46, 178–208, 229–410, 440–461, with many polar / low-complexity /<br />
+  basic-and-acidic COMPBIAS stretches [UniProt P38213]. This half of the protein is a large<br />
+  intrinsically-disordered region with no recognizable folded domain.</li>
+<li><strong>C-terminal ~560–736: Sel1-like TPR/α-solenoid.</strong> UniProt records SMART <strong>SM00671 SEL1</strong><br />
+  (Sel1-like repeat), InterPro <strong>IPR006597 (Sel1-like)</strong>, <strong>IPR011990 (TPR-like helical domain<br />
+  superfamily)</strong>, Gene3D <strong>1.25.40.10 (TPR domain)</strong>, and SUPFAM <strong>SSF81901 (HCP-like)</strong><br />
+  [UniProt P38213]. Sel1/TPR repeats form α-helical solenoids that are generic<br />
+<strong>protein–protein interaction / scaffolding</strong> modules — they do NOT specify a catalytic<br />
+  activity or a particular partner.</li>
+<li><strong>Phosphoprotein.</strong> UniProt cites two large-scale phosphoproteomics/Cdk1-substrate studies<br />
+  (PMID:18407956, PMID:19779198) as evidence at protein level. DSF2 is not named in the cached<br />
+  text of either (the hits are in supplementary tables), so specific phosphosites are not<br />
+  extracted here; the safe statement is that DSF2 is a detected phosphoprotein.</li>
+</ul>
+<p>Interpretation: a disordered N-terminal region plus a C-terminal Sel1/TPR solenoid is the<br />
+architecture of a <strong>scaffold / adaptor</strong>, but the architecture alone does not tell us <em>which</em><br />
+complex or <em>which</em> partners, and there is no experimental interactor that pins down a molecular<br />
+function. Domain content is therefore consistent with, but not proof of, an adaptor role.</p>
+<h2 id="orthology-family-context-panther-pthr43628">Orthology / family context (PANTHER PTHR43628)</h2>
+<ul>
+<li>UniProt assigns DSF2 to <strong>PANTHER PTHR43628</strong> (family), subfamily <strong>PTHR43628:SF11 "PROTEIN<br />
+  DSF2"</strong> [UniProt P38213].</li>
+<li>The reviewed members of PTHR43628 (<code>interpro/panther/PTHR43628/PTHR43628-entries.csv</code>) are<br />
+  DSF2 (yeast), <strong>S. pombe Nif1 (P87159, "Mitosis inhibitor nif1", SPBC23G7.04c)</strong>, and several<br />
+  bacterial/viral Sel1-repeat proteins (E. coli YjcO/YbeT, mimivirus L18). The family is united<br />
+  by <strong>Sel1-like repeats</strong>, i.e. it is a <em>structural</em> family, not a family with a single shared<br />
+  biochemistry.</li>
+<li>The PANTHER family name "Mitotic Progression Regulator" and its description are<br />
+<strong>LLM-generated and unreviewed</strong> (<code>llm: true, checked: false</code> in the metadata YAML) — treat<br />
+  as a hypothesis, not evidence.</li>
+<li><strong>S. pombe Nif1</strong> negatively regulates mitotic entry by binding and inhibiting the Nim1/Cdr1<br />
+  kinase (Nim1 normally inhibits Wee1, so Nif1 keeps Wee1 active → Cdc2/Cdk1 stays inhibited)<br />
+  [Wu &amp; Russell 1997 EMBO J 16:1342, PMID:9135149 (Nif1 novel mitotic inhibitor); via WebSearch].<br />
+  This is the biological source of the DSF2 <strong>IBA</strong> annotations (GOA <code>with</code> field =<br />
+<code>PomBase:SPBC23G7.04c</code>).</li>
+</ul>
+<p><strong>Caveat on the IBA propagation:</strong> the inference DSF2 → "negative regulation of G2/M transition"<br />
++ "cell division site" is a <strong>phylogenetic (IBA) transfer from a distant fungal ortholog that<br />
+shares only Sel1/TPR repeats</strong>. There is <strong>no S. cerevisiae experimental evidence</strong> that DSF2<br />
+acts on Swe1 (the budding-yeast Wee1), Cdc28/Cdk1, or a Nim1-family kinase. The IBA is a<br />
+reasonable placeholder but is not independently corroborated for DSF2.</p>
+<h2 id="what-is-experimentally-known-about-dsf2-budding-yeast">What is experimentally KNOWN about DSF2 (budding yeast)</h2>
+<ol>
+<li><strong>Genetic:</strong> dsf2 deletion suppresses (rescues) the temperature-sensitivity of mpt5Δ/puf5Δ,<br />
+   and partially suppresses its hydroxyurea sensitivity<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16328373" title="identified dsf1 (YEL070W), dsf2 (YBR007C), sir2, sir3, sir4 and swe1">PMID:16328373</a>;<br />
+   [UniProt P38213 DISRUPTION PHENOTYPE "Rescues temperature-sensitivity of MPT5 deletion. Partially suppresses the hydroxyurea (HU) sensitivity of MPT5 deletion."].<br />
+   Note this is a <strong>suppressor genetic interaction</strong>, i.e. loss of DSF2 compensates for loss of<br />
+   the Puf5 RNA-binding protein; it does not define DSF2's own molecular function.</li>
+<li><strong>Localization:</strong> Dsf2-GFP localizes to the <strong>bud tip / bud neck</strong> in unperturbed cells and<br />
+<strong>relocalizes to the cytoplasm upon DNA-replication stress (HU/MMS)</strong> in a genome-wide GFP<br />
+   screen [SGD; PMID:22842922]. This is the basis of the HDA "cellular bud tip" (GO:0005934)<br />
+   annotation. DSF2 is not discussed individually in the PMID:22842922 text (it is one of the<br />
+   254 relocalizing proteins scored in the supplementary tables), so the localization is a<br />
+   high-throughput imaging call, not a dedicated study of DSF2.</li>
+<li><strong>Expression:</strong> low-abundance protein (~377 molecules/cell log phase per UniProt<br />
+   [UniProt P38213 MISCELLANEOUS]; ~1,600/cell per SGD).</li>
+<li><strong>Post-translational:</strong> detected as a phosphoprotein in Cdk1-substrate / phosphoproteome<br />
+   screens (PMID:19779198, PMID:18407956) — DSF2 in the supplementary hit lists.</li>
+<li><strong>Deletion phenotypes (SGD systematic data):</strong> increased replicative lifespan; decreased<br />
+   competitive fitness; sensitivity to the calcium chelator BAPTA [SGD]. These are pleiotropic<br />
+   fitness readouts, not a mechanistic function.</li>
+</ol>
+<h2 id="what-is-not-known-candidate-knowledge-gaps">What is NOT known (candidate knowledge gaps)</h2>
+<ul>
+<li><strong>Molecular function is unknown.</strong> No catalytic activity is expected (Sel1/TPR = binding<br />
+  module). No specific binding partner has been shown to define an adaptor/scaffold role.<br />
+  → MF_DARK.</li>
+<li><strong>Biological process is unknown.</strong> The only BP annotation is the distant-ortholog IBA<br />
+  (negative regulation of G2/M). There is no direct evidence DSF2 regulates the budding-yeast<br />
+  cell cycle, and the suppressor and lifespan phenotypes could reflect an unrelated process.</li>
+<li><strong>Mechanism of mpt5Δ suppression is unknown</strong> — how loss of a bud-tip Sel1/TPR protein<br />
+  rescues loss of the Puf5 RNA-binding protein is not established.</li>
+<li><strong>Relationship to DNA-replication-stress relocalization is unexplained</strong> — why a bud-tip<br />
+  protein moves to the cytoplasm under HU/MMS, and whether this matters functionally, is unknown.</li>
+<li><strong>Redundancy:</strong> DSF2 has NO close sequence paralog in S. cerevisiae (it is NOT a paralog of<br />
+  DSF1); the only same-family protein is the distant fission-yeast Nif1. So genetic redundancy<br />
+  is unlikely to explain the mild phenotypes; the weak phenotypes more likely reflect a<br />
+  conditional / accessory role.</li>
+</ul>
+<h2 id="go-annotation-review-plan">GO annotation review plan</h2>
+<p>Five GOA annotations:</p>
+<table>
+<thead>
+<tr>
+<th>term</th>
+<th>ev</th>
+<th>ref</th>
+<th>plan</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0010972 neg reg G2/M transition (P, involved_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE — distant-ortholog (Nif1) inference; plausible but not corroborated in S. cerevisiae; not a core function</td>
+</tr>
+<tr>
+<td>GO:0032153 cell division site (C, is_active_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE — same Nif1 IBA source; consistent with bud-tip/bud-neck localization but low-confidence for "is_active_in"</td>
+</tr>
+<tr>
+<td>GO:0005934 cellular bud tip (C, located_in)</td>
+<td>HDA</td>
+<td>PMID:22842922</td>
+<td>ACCEPT — high-throughput GFP localization, direct experimental (HDA) for DSF2</td>
+</tr>
+<tr>
+<td>GO:0003674 molecular_function (root)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT — correctly records MF unknown; honest root annotation</td>
+</tr>
+<tr>
+<td>GO:0008150 biological_process (root)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT — correctly records BP unknown</td>
+</tr>
+</tbody>
+</table>
+<p>Rationale for keeping the IBAs rather than removing: per CLAUDE.md we do not REMOVE on<br />
+paralog/ortholog grounds alone; the Nif1 IBA is a legitimate phylogenetic inference and the<br />
+bud-tip/bud-neck localization is loosely consistent with a cell-division-site association. But<br />
+neither is corroborated by DSF2 experiment, so they are marked non-core and the honest position<br />
+(MF/BP unknown) is retained in core_functions/knowledge_gaps.</p>
+<h2 id="falcon-deep-research-dsf2-deep-research-falconmd-corroboration-and-cautions">Falcon deep-research (DSF2-deep-research-falcon.md) — corroboration and cautions</h2>
+<p>The falcon report (2026-07-05, 16 citations) corroborates the core picture: Sel1-like/TPR<br />
+scaffold with no catalytic domain, bud-neck localization, relocalization to the cytoplasm under<br />
+DNA-replication stress, mpt5/puf5 deletion-suppressor origin, and Nif1 (S. pombe) as the<br />
+same-family mitotic inhibitor. It adds two <em>inferences</em> that I deliberately did NOT promote into<br />
+the review's supported claims because they are not verified from primary full text here:</p>
+<ul>
+<li>A proposed link to the <strong>Cbk1 / RAM</strong> signaling network (Dsf2 has Cbk1 phospho-consensus<br />
+  motifs but LACKS the canonical Cbk1 docking motif — a "non-docking putative substrate", per<br />
+  Gögl et al. 2015). This is an inference from motif presence, and even the report states the<br />
+  in-vivo phosphorylation evidence for Dsf2 specifically "remains indirect". Treated as a lead.</li>
+<li>Specific phosphosites (S391/S395) attributed to a 2025 GSK3 phosphoproteomics preprint.<br />
+  Unverified against cached full text; not cited in the review.</li>
+</ul>
+<p>The falcon report's citations use internal keys (e.g. <code>gogl2015thestructureof</code>), not PMIDs, so<br />
+per project policy they are NOT used as <code>supported_by</code> in the review; the review is grounded only<br />
+on verified PMIDs (16328373, 22842922), UniProt P38213, and the PANTHER family file. The falcon<br />
+file is retained in the gene folder as the deep-research artifact.</p>
+<h2 id="core_functions-position">core_functions position</h2>
+<p>Given MF and BP are genuinely unknown, <code>core_functions</code> will be <strong>minimal</strong>: a single entry<br />
+capturing the best-supported, domain-grounded statement — that DSF2 is a Sel1-like/TPR-repeat<br />
+protein consistent with a protein-interaction/scaffold module localizing to the bud tip/neck —<br />
+using the MF root (GO:0003674) since no specific MF term is defensible, and locations<br />
+(GO:0005934). The real deliverable is <code>knowledge_gaps</code>.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P38213
+gene_symbol: DSF2
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  DSF2 (YBR007C) is a 736-residue protein of the budding yeast Saccharomyces
+  cerevisiae composed of a large intrinsically disordered / low-complexity
+  N-terminal half (~residues 1-461) and a C-terminal Sel1-like tetratricopeptide
+  (TPR) repeat solenoid (~residues 560-736). Sel1/TPR repeats are alpha-helical
+  scaffolds that typically mediate protein-protein interactions, and DSF2 has no
+  predicted catalytic domain. The protein localizes to the bud tip and bud neck
+  of growing cells and moves to the cytoplasm during DNA-replication stress. It
+  is a low-abundance phosphoprotein. Its molecular function and the biological
+  process it participates in are not experimentally established. DSF2 belongs to
+  a Sel1-repeat protein family (PANTHER PTHR43628) whose best-characterized
+  member is the fission-yeast mitotic inhibitor Nif1, which negatively regulates
+  entry into mitosis; whether DSF2 has an analogous cell-cycle role in
+  S. cerevisiae has not been demonstrated. DSF2 was originally identified as a
+  deletion suppressor of the puf5/mpt5 RNA-binding-protein deletion, a genetic
+  relationship that does not by itself define its own function. Despite the
+  shared &#34;Dsf&#34; name, DSF2 is not a homolog of DSF1 (YEL070W, a mannitol
+  dehydrogenase); both were merely recovered in the same suppressor screen.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: PMID:22842922
+  title: Dissecting DNA damage response pathways by analysing protein localization
+    and abundance changes during DNA replication stress.
+  findings:
+  - statement: &gt;-
+      Genome-wide GFP screen scoring subcellular localization changes during DNA
+      replication stress; one localization-change class captures proteins moving
+      away from the bud neck / bud tip, and HU/MMS caused a decrease in
+      bud-neck/bud-tip localization. DSF2 is one of the proteins scored (in the
+      supplementary datasets), which is the basis for its high-throughput
+      (HDA) bud-tip localization annotation.
+    supporting_text: &gt;-
+      one that reflects movement away from the budneck or bud tip
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text confirmed. This is a large-scale GFP localization screen;
+      DSF2 is not discussed by name in the main text (it is one of hundreds of
+      scored strains in the supplementary tables). It legitimately supports the
+      HDA &#34;cellular bud tip&#34; localization annotation but does not provide a
+      dedicated functional characterization of DSF2.
+- id: file:yeast/DSF2/DSF2-deep-research-falcon.md
+  title: Falcon deep-research report on S. cerevisiae DSF2 (YBR007C)
+  findings:
+  - statement: &gt;-
+      Domain-based synthesis: characterized Sel1-like-repeat proteins act as
+      non-enzymatic adaptor/scaffold proteins; on this basis DSF2 is best
+      interpreted as a scaffold/adaptor at the bud neck. The report also raises
+      (as unverified inferences) a possible link to the Cbk1/RAM network and
+      specific phosphosites; these are not adopted as supported claims here.
+    supporting_text: &gt;-
+      non-enzymatic adaptor or scaffold protein
+- id: PMID:16328373
+  title: Suppressor analysis of the mpt5/htr1/uth4/puf5 deletion in Saccharomyces
+    cerevisiae.
+  findings:
+  - statement: &gt;-
+      Screen for deletion suppressors that rescue the temperature-sensitivity of
+      an mpt5 (puf5) deletion identified dsf1 (YEL070W) and dsf2 (YBR007C), among
+      others. This is the origin of the DSF2 gene name and its only dedicated
+      functional study; it establishes a genetic suppressor relationship, not a
+      molecular function.
+    supporting_text: &gt;-
+      dsf1 (YEL070W), dsf2 (YBR007C)
+  - statement: &gt;-
+      The mpt5 deletion strain is hydroxyurea (HU) sensitive; DSF2 loss partially
+      suppresses this HU sensitivity (per UniProt disruption phenotype).
+    supporting_text: &gt;-
+      The Deltampt5 disruptant was also hydroxyurea (HU) sensitive
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache (full_text_available: false). PubMed-verified. This is
+      the paper that named DSF2 and is the primary DSF2-specific functional
+      report, but it only demonstrates a genetic suppressor relationship with
+      mpt5/puf5; it does not assign DSF2 a molecular function or a direct
+      biological process. Note dsf1 and dsf2 are unrelated genes co-recovered in
+      the same screen.
+existing_annotations:
+- term:
+    id: GO:0010972
+    label: negative regulation of G2/M transition of mitotic cell cycle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference propagated from the fission-yeast ortholog
+      Nif1 (PomBase:SPBC23G7.04c), which negatively regulates mitotic entry.
+      DSF2 and Nif1 share only Sel1-like/TPR repeats, and no S. cerevisiae
+      experiment shows DSF2 acting on Swe1/Cdc28 or a Nim1-family kinase. The
+      inference is plausible but uncorroborated for budding yeast, so it is kept
+      as a non-core annotation rather than removed (per guidance not to REMOVE
+      on distant-ortholog grounds alone).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Legitimate IBA transfer from Nif1 but not experimentally supported in
+      S. cerevisiae; DSF2&#39;s own biological process is unknown, so this cannot be
+      treated as a core function.
+    supported_by:
+    - reference_id: PMID:16328373
+      supporting_text: &gt;-
+        dsf1 (YEL070W), dsf2 (YBR007C)
+- term:
+    id: GO:0032153
+    label: cell division site
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IBA inference from the same Nif1 ortholog. It is loosely consistent with
+      the experimentally observed bud-tip / bud-neck localization of DSF2, but
+      &#34;is_active_in the cell division site&#34; asserts a functional activity there
+      that has not been demonstrated for DSF2. Retained as non-core given the
+      supporting localization but flagged as unverified for activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Distant-ortholog IBA; the localization component is consistent with HDA
+      bud-tip data, but no DSF2 activity at the division site is established.
+- term:
+    id: GO:0005934
+    label: cellular bud tip
+  evidence_type: HDA
+  original_reference_id: PMID:22842922
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct high-throughput GFP-localization evidence (HDA) that Dsf2 localizes
+      to the bud tip (and bud neck), from a genome-wide imaging screen. This is
+      the best-supported annotation for DSF2 and is accepted; it is the anchor
+      for the protein&#39;s cellular location, although localization alone does not
+      define molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental (HDA) localization for DSF2 itself; consistent with SGD&#39;s
+      bud-tip/bud-neck localization and the replication-stress relocalization.
+    supported_by:
+    - reference_id: PMID:22842922
+      supporting_text: &gt;-
+        one that reflects movement away from the budneck or bud tip
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function annotation with ND (no biological data) evidence,
+      correctly recording that DSF2&#39;s molecular function is unknown. This is an
+      honest placeholder and is retained: no specific MF term is defensible from
+      current evidence (the Sel1/TPR architecture suggests a protein-interaction
+      module but no partner or activity has been shown).
+    action: ACCEPT
+    reason: &gt;-
+      Accurately reflects the genuine absence of molecular-function knowledge for
+      this dark gene.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process annotation with ND evidence, correctly recording
+      that DSF2&#39;s biological process is unknown at the level of direct evidence.
+      The only BP signal is the distant-ortholog IBA (negative regulation of
+      G2/M), which is not corroborated in S. cerevisiae, so retaining the ND root
+      is the honest position.
+    action: ACCEPT
+    reason: &gt;-
+      Accurately reflects the genuine absence of direct biological-process
+      knowledge for this dark gene.
+core_functions:
+- description: &gt;-
+    DSF2 is a Sel1-like / TPR-repeat protein with a large disordered N-terminal
+    region, an architecture consistent with a protein-interaction scaffold or
+    adaptor, that localizes to the bud tip and bud neck. No specific molecular
+    activity or partner has been experimentally established, so the molecular
+    function is recorded at the root; the confident, evidence-based statement is
+    the cellular location. The bud-tip localization is the only directly
+    demonstrated feature of DSF2&#39;s cellular behavior.
+  molecular_function:
+    id: GO:0003674
+    label: molecular_function
+  locations:
+  - id: GO:0005934
+    label: cellular bud tip
+  supported_by:
+  - reference_id: PMID:22842922
+    supporting_text: &gt;-
+      one that reflects movement away from the budneck or bud tip
+  - reference_id: PMID:16328373
+    supporting_text: &gt;-
+      dsf1 (YEL070W), dsf2 (YBR007C)
+  - reference_id: file:yeast/DSF2/DSF2-deep-research-falcon.md
+    supporting_text: &gt;-
+      non-enzymatic adaptor or scaffold protein
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of DSF2 is undetermined: no catalytic activity, no
+    specific binding partner, and no scaffold/adaptor role has been experimentally
+    demonstrated. The only structural clue is a C-terminal Sel1-like/TPR repeat
+    solenoid, a generic protein-interaction module that does not specify an
+    activity or a partner.
+  boundary: &gt;-
+    Established: DSF2 is a 736-aa protein with a disordered N-terminal half and a
+    C-terminal Sel1-like/TPR-repeat region (UniProt P38213: SMART SEL1, InterPro
+    IPR006597/IPR011990, SUPFAM HCP-like), it is a detected phosphoprotein, and
+    it localizes to the bud tip/neck. SGD lists molecular function as Unknown.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    DSF2 is a conserved (fungal-to-bacterial Sel1-repeat) yet functionally dark
+    protein; identifying its binding partner(s) would convert a structural guess
+    into an actual molecular function and likely explain its cell-cycle-adjacent
+    annotations.
+  resolution: &gt;-
+    Affinity purification / proximity labeling of Dsf2 to identify stable
+    interactors, followed by testing whether it acts as a scaffold for the
+    identified partner(s); a defensible specific MF term (e.g. a protein-binding
+    adaptor term) could then replace the MF root.
+  provenance:
+  - reference_id: PMID:16328373
+    supporting_text: &gt;-
+      dsf1 (YEL070W), dsf2 (YBR007C)
+  - reference_id: file:yeast/DSF2/DSF2-uniprot.txt
+    supporting_text: SEL1
+- gap_statement: &gt;-
+    The biological process DSF2 participates in is unknown. The sole process
+    annotation (negative regulation of the G2/M transition) is a phylogenetic
+    (IBA) inference from the distant fission-yeast ortholog Nif1 and has never
+    been tested in S. cerevisiae; whether DSF2 regulates the budding-yeast cell
+    cycle (e.g. via Swe1/Cdc28) is undetermined.
+  boundary: &gt;-
+    Established: the IBA is transferred from Nif1 (PomBase:SPBC23G7.04c), a
+    Sel1-repeat mitotic inhibitor. DSF2 shares only Sel1/TPR repeats with Nif1,
+    and there is no budding-yeast experimental link between DSF2 and the
+    Swe1-Cdc28 or Nim1-kinase machinery.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Confirming or refuting a cell-cycle role would either validate the
+    cross-species inference or reveal that DSF2&#39;s bud-tip localization serves an
+    unrelated process.
+  resolution: &gt;-
+    Epistasis and cell-length/cell-cycle phenotyping of dsf2 mutants combined
+    with genetic interaction tests against SWE1/CDC28; direct assay of whether
+    Dsf2 binds or modulates Swe1 or Cdc28.
+  provenance:
+  - reference_id: PMID:16328373
+    supporting_text: &gt;-
+      dsf1 (YEL070W), dsf2 (YBR007C)
+- gap_statement: &gt;-
+    The mechanism by which loss of DSF2 suppresses the temperature- and
+    hydroxyurea-sensitivity of a puf5/mpt5 deletion is unknown. It is not
+    established whether this reflects a direct functional relationship between
+    Dsf2 and the Puf5 RNA-binding pathway or an indirect, downstream effect.
+  boundary: &gt;-
+    Established: dsf2 was recovered as a deletion suppressor of mpt5/puf5
+    temperature-sensitivity, and DSF2 loss partially suppresses mpt5 HU
+    sensitivity (PMID:16328373; UniProt P38213 disruption phenotype). No
+    molecular mechanism for this suppression has been reported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Puf5/Mpt5 is a well-studied Puf-family translational repressor; explaining
+    how a bud-tip Sel1-repeat protein feeds into its pathway could place DSF2 in
+    a defined regulatory network.
+  resolution: &gt;-
+    Dissect the suppression genetically (is it PUF4/IME4-dependent, as for other
+    mpt5 suppressors?) and test whether Dsf2 abundance or localization changes in
+    a puf5 background.
+  provenance:
+  - reference_id: PMID:16328373
+    supporting_text: &gt;-
+      The Deltampt5 disruptant was also hydroxyurea (HU) sensitive
+- gap_statement: &gt;-
+    The functional significance of DSF2 relocalizing from the bud tip/neck to
+    the cytoplasm during DNA-replication stress (HU/MMS) is unknown; it is not
+    known whether this movement is part of a stress response or an incidental
+    consequence of bud-neck disassembly.
+  boundary: &gt;-
+    Established: a genome-wide GFP screen scored DSF2 among proteins that lose
+    bud-neck/bud-tip localization under replication stress (PMID:22842922; SGD).
+    No follow-up has tested the consequence of this relocalization.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Stress-induced relocalization is often functionally informative; resolving it
+    could link DSF2&#39;s location to a specific process.
+  resolution: &gt;-
+    Test whether blocking DSF2 relocalization (or deleting DSF2) alters
+    replication-stress survival, and identify the signal driving the move.
+  provenance:
+  - reference_id: PMID:22842922
+    supporting_text: &gt;-
+      one that reflects movement away from the budneck or bud tip
+suggested_questions:
+- question: &gt;-
+    What are the physiological binding partners of Dsf2, and do they define it as
+    a scaffold/adaptor at the bud tip or bud neck?
+- question: &gt;-
+    Does DSF2 have any role in the budding-yeast G2/M transition (e.g. through
+    Swe1 or Cdc28), as its phylogenetic annotation from Nif1 would predict?
+- question: &gt;-
+    By what mechanism does dsf2 deletion suppress the temperature and hydroxyurea
+    sensitivity of a puf5/mpt5 deletion?
+suggested_experiments:
+- description: &gt;-
+    Affinity purification-mass spectrometry (or proximity labeling such as
+    BioID/TurboID) of endogenously tagged Dsf2 in log-phase and replication-stress
+    conditions to identify stable and stress-dependent interactors.
+  hypothesis: &gt;-
+    Dsf2 uses its Sel1/TPR solenoid to scaffold a specific partner at the bud
+    tip/neck; identifying that partner would define its molecular function.
+  experiment_type: affinity purification-mass spectrometry
+- description: &gt;-
+    Quantitative cell-morphology and cell-cycle profiling of dsf2 deletion and
+    overexpression strains, plus genetic-interaction tests with SWE1 and CDC28,
+    to test the phylogenetically inferred negative regulation of G2/M.
+  hypothesis: &gt;-
+    If the Nif1-based inference holds, perturbing DSF2 will change cell length or
+    G2/M timing and interact genetically with the Swe1-Cdc28 axis.
+  experiment_type: genetic interaction / cell-cycle phenotyping
+- description: &gt;-
+    Epistasis analysis of the dsf2-mediated suppression of puf5/mpt5 phenotypes,
+    testing dependence on known mpt5-suppression modifiers (e.g. PUF4, IME4) and
+    whether Dsf2 abundance/localization changes in a puf5 background.
+  hypothesis: &gt;-
+    dsf2 suppression of mpt5 operates through a definable branch of the Puf-family
+    regulatory network rather than a nonspecific fitness effect.
+  experiment_type: genetic epistasis
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/EFM6/EFM6-ai-review.html
+++ b/genes/yeast/EFM6/EFM6-ai-review.html
@@ -1,0 +1,2966 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EFM6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>EFM6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P53970" target="_blank" class="term-link">
+                        P53970
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "EFM6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P53970" data-a="DESCRIPTION: EFM6 (YNL024C) is a cytoplasmic S-adenosyl-L-methi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>EFM6 (YNL024C) is a cytoplasmic S-adenosyl-L-methionine-dependent protein-lysine N-methyltransferase of the seven-beta-strand (Class I) methyltransferase superfamily, specifically a member of methyltransferase family 16 (MTF16) within the METTL21 clade. It methylates the eukaryotic translation elongation factor 1A (eEF1A, encoded in S. cerevisiae by the paralogous genes TEF1 and TEF2) on lysine 390. EFM6 is one of a set of dedicated elongation-factor methyltransferases in budding yeast; the four known lysine methylations of eEF1A are each installed by a distinct enzyme, with EFM6 responsible for the Lys390 site. The enzyme is highly substrate-specific: despite being the closest yeast sequence homolog of the human Hsp70-specific methyltransferase METTL21A, it does not methylate yeast Hsp70 proteins. eEF1A-Lys390 methylation is a low-occupancy modification and is not conserved to mammalian eEF1A; the physiological consequence of the modification is not established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008276" target="_blank" class="term-link">
+                                    GO:0008276
+                                </a>
+                            </span>
+                            <span class="term-label">protein methyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0008276" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred protein methyltransferase activity. Correct but general: EFM6 is experimentally a protein-LYSINE N-methyltransferase acting on eEF1A-Lys390 (PMID:26115316), a specific child of this term. Retained as a valid parent; the specific molecular function is captured by GO:0016279.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence (protein methyltransferase) is correct, but a more informative and experimentally supported term exists (GO:0016279 protein-lysine N-methyltransferase activity, already annotated by IEA and consistent with PMID:26115316).
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000378681</span>
+
+                                    &middot; METTL21/protein methyltransferase family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The family-level protein methyltransferase activity is correct for EFM6, but the IBA term is a general parent; EFM6&#39;s experimentally established activity is the more specific protein-lysine N-methyltransferase activity (GO:0016279), so this is a granularity issue, not a bad transfer.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016279" target="_blank" class="term-link">
+                                    protein-lysine N-methyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26115316" target="_blank" class="term-link">
+                                        PMID:26115316
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we here show that the YNL024C gene is required for methylation of eEF1A at Lys390, the only of these methylations for which the responsible MTase has not yet been identified.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic cytoplasmic-localization annotation (UniProt SubCell/UniRule). Consistent with the experimental HDA localization (PMID:14562095) and with a translation-associated cytoplasmic methyltransferase.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008757" target="_blank" class="term-link">
+                                    GO:0008757
+                                </a>
+                            </span>
+                            <span class="term-label">S-adenosylmethionine-dependent methyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0008757" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) SAM-dependent methyltransferase activity. Correct general parent term; the SAM-binding scaffold (motif I region, residues around 51/87-89/115) is intact in EFM6 and its SAM-dependent activity is experimentally established (PMID:26115316). More specific term GO:0016279 also annotated.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016279" target="_blank" class="term-link">
+                                    GO:0016279
+                                </a>
+                            </span>
+                            <span class="term-label">protein-lysine N-methyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000104
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0016279" data-r="GO_REF:0000104" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein-lysine N-methyltransferase activity, the correct specific molecular function. This exactly matches the experimental demonstration that EFM6 methylates eEF1A on the epsilon-amino group of Lys390 (PMID:26115316). Core molecular function of EFM6.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26115316" target="_blank" class="term-link">
+                                        PMID:26115316
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">over-expression of Ynl024c caused a dramatic increase in Lys390 methylation, with trimethylation becoming the predominant state.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008757" target="_blank" class="term-link">
+                                    GO:0008757
+                                </a>
+                            </span>
+                            <span class="term-label">S-adenosylmethionine-dependent methyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12872006" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12872006
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Automated identification of putative methyltransferases from...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0008757" data-r="PMID:12872006" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity prediction of SAM-dependent methyltransferase activity from the genome-wide Katz/Clarke MTase catalog. A correct general parent term, later confirmed experimentally (PMID:26115316). Redundant with the ARBA IEA annotation to the same term.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0005737" data-r="PMID:14562095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (high-throughput GFP) cytoplasmic localization from the global yeast localization study. Consistent with EFM6 acting on the abundant cytoplasmic translation factor eEF1A. Core cellular location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P53970" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with No Data. This honestly reflects the state of knowledge: although EFM6&#39;s molecular function (eEF1A-Lys390 methylation) is established, the downstream biological process served by this low-occupancy modification is unknown and described as an enigma (PMID:26115316). No specific BP should be invented.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The biological role of EFM6-mediated eEF1A methylation is genuinely undetermined in the literature; ND is the appropriate state rather than an over-annotated process term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>S-adenosyl-L-methionine-dependent protein-lysine N-methyltransferase that monomethylates (and, when overexpressed, di-/tri-methylates) eukaryotic translation elongation factor 1A (eEF1A; TEF1/TEF2) on Lys390 in the cytoplasm. EFM6 is highly specific for this eEF1A site and is the dedicated enzyme for the Lys390 modification, distinct from the other elongation-factor methyltransferases.</h3>
+                <span class="vote-buttons" data-g="P53970" data-a="FUNCTION: S-adenosyl-L-methionine-dependent protein-lysine N..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016279" target="_blank" class="term-link">
+                            protein-lysine N-methyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26115316" target="_blank" class="term-link">
+                                PMID:26115316
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we here show that the YNL024C gene is required for methylation of eEF1A at Lys390, the only of these methylations for which the responsible MTase has not yet been identified.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26115316" target="_blank" class="term-link">
+                                PMID:26115316
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">demonstrating that the enzyme is highly specific for eEF1A</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with manually curated functional descriptions</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
+                            GO_REF:0000104
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined automated annotation with UniProt keyword to GO mapping and UniRule</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12872006" target="_blank" class="term-link">
+                            PMID:12872006
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automated identification of putative methyltransferases from genomic open reading frames.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide computational method assigning S-adenosylmethionine-dependent methyltransferase functionality to yeast open reading frames on the basis of seven-strand twisted beta-sheet signature motifs; source of the ISS methyltransferase-activity prediction for EFM6.</div>
+
+                        <div class="finding-text">"automatic assignment of S-adenosylmethionine (AdoMet)-dependent methyltransferase functionality to genomic open reading frames based on predicted protein sequences."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP-fusion localization study; the basis for the experimental (HDA) cytoplasmic localization annotation for EFM6.</div>
+
+                        <div class="finding-text">"a collection of yeast strains expressing full-length, chromosomally tagged green fluorescent protein fusion proteins"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26115316" target="_blank" class="term-link">
+                            PMID:26115316
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Saccharomyces cerevisiae Eukaryotic Elongation Factor 1A (eEF1A) Is Methylated at Lys-390 by a METTL21-Like Methyltransferase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YNL024C/EFM6 is required for methylation of eEF1A at Lys390; the residue is monomethylated in wild-type cells but exclusively unmethylated in a ynl024c deletion strain, establishing EFM6 as the responsible methyltransferase.</div>
+
+                        <div class="finding-text">"we here show that the YNL024C gene is required for methylation of eEF1A at Lys390, the only of these methylations for which the responsible MTase has not yet been identified."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Overexpression of EFM6 dramatically increases eEF1A-Lys390 methylation, with trimethylation becoming predominant, demonstrating that EFM6 activity drives the modification.</div>
+
+                        <div class="finding-text">"over-expression of Ynl024c caused a dramatic increase in Lys390 methylation, with trimethylation becoming the predominant state."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">EFM6 directly methylates eEF1A in vitro (GTP-dependent labelling of the ~50 kDa eEF1A band by an E. coli extract expressing EFM6), indicating a direct methyltransferase activity on eEF1A rather than an indirect effect.</div>
+
+                        <div class="finding-text">"when GTP was present, a markedly stronger, Ynl024c-specific labelling was observed in the 50 kDa region of the ynl024cΔ yeast extract"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">EFM6 is highly specific for eEF1A and, unlike its closest human homolog METTL21A, does not methylate yeast Hsp70 proteins.</div>
+
+                        <div class="finding-text">"demonstrating that the enzyme is highly specific for eEF1A"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">EFM6 harbours the conserved seven-beta-strand methyltransferase motifs (Motif I, Motif post I, Motif II) and the MTF16 hallmark DXXY motif, confirming it as a Class I SAM-dependent methyltransferase.</div>
+
+                        <div class="finding-text">"Ynl024c harbours hallmark conserved motifs found in 7BS MTases, i. e. Motif I, Motif post I and Motif II"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The biological significance of EFM6-mediated eEF1A-Lys390 methylation is unknown and remains to be determined.</div>
+
+                        <div class="finding-text">"the precise function of Efm6-mediated eEF1A methylation does remain an enigma and further studies are required to reveal its role."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiological function of eEF1A-Lys390 methylation, and under what conditions (stress, sporulation, aging) is it regulated?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Yeast translation and elongation-factor biologists, Protein methylation / post-translational modification biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53970" data-a="Q: What is the physiological function of eEF1A-Lys390..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does EFM6 act as a standalone methyltransferase on eEF1A, and does the GTP/GDP conformational state of eEF1A gate the modification?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Methyltransferase enzymologists, eEF1A structural biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53970" data-a="Q: Does EFM6 act as a standalone methyltransferase on..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare efm6Δ and eEF1A-K390R strains to wild type across growth, translational fidelity, stress and sporulation conditions, and non-canonical eEF1A assays (actin bundling, nuclear export), including quantitative phenotyping and proteomics.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: eEF1A-Lys390 methylation modulates a specific (possibly non-canonical) eEF1A function or a stress/aging response rather than bulk translation.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative phenotyping / functional assays</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53970" data-a="EXPERIMENT: Compare efm6Δ and eEF1A-K390R strains to wild type..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute methylation with purified active EFM6 and eEF1A in defined GTP- vs GDP-bound states and measure steady-state kinetics; if soluble EFM6 cannot be purified, use co-expression or on-substrate/extract-based quantitative assays.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: EFM6 is a self-sufficient methyltransferase whose activity depends on the eEF1A nucleotide state.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro enzymology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53970" data-a="EXPERIMENT: Reconstitute methylation with purified active EFM6..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process served by EFM6-mediated methylation of eEF1A at Lys390 is undetermined. It is not known why this specific low-occupancy lysine methylation is installed, what phenotype (if any) it modulates, or which of eEF1A&#39;s canonical (translation) or non-canonical (e.g. actin bundling, nuclear export) activities it influences.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The molecular function is firmly established: EFM6 is a SAM-dependent protein-lysine N-methyltransferase that specifically and directly methylates eEF1A on Lys390 (deletion abolishes the modification, overexpression drives di/tri-methylation, and an EFM6-containing extract methylates eEF1A in vitro). What is unknown is the downstream consequence, not the activity or the substrate site.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> eEF1A is one of the most abundant proteins in the cell and carries four distinct, enzyme-dedicated lysine methylations; understanding what the Lys390 mark does would clarify why the cell maintains a dedicated methyltransferase for a modification present on only a small fraction of eEF1A molecules, and whether it tunes a specific eEF1A subfunction or acts as a regulated switch.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Determine a phenotype for efm6Δ (and for eEF1A K390R) under stress/aging/sporulation and non-canonical eEF1A assays; test whether Lys390 methylation is regulated in response to physiological cues; identify any interacting demethylase; measure effects on translational fidelity and on eEF1A actin/nuclear functions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the precise function of Efm6-mediated eEF1A methylation does remain an enigma and further studies are required to reveal its role."</em> — PMID:26115316</li>
+
+                <li><em>"simultaneous mutations of the four lysine methylation sites to arginine does not affect the proliferation rate of the resulting mutant yeast strain nor the enzymatic properties of the eEF1A protein in vitro"</em> — PMID:26115316</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether EFM6 is enzymatically active as an isolated, purified protein, and its steady-state kinetic parameters and possible cofactor/partner requirements on eEF1A, are not established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Direct methylation was demonstrated only from crude E. coli extracts overexpressing EFM6 (and required GTP), because soluble recombinant EFM6 with activity could not be purified; genetic and in vivo evidence for EFM6-dependent Lys390 methylation is nonetheless unambiguous.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A reconstituted single-enzyme assay would confirm EFM6 acts alone (versus needing a partner or a particular eEF1A/GTP conformational state) and enable mechanistic and structural study of an otherwise well-defined activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Obtain soluble active recombinant EFM6 (e.g. alternative tags/hosts, co-expression with eEF1A, or on-substrate assays) and measure kinetics against eEF1A in defined GTP/GDP-bound states.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We were unable to purify recombinant soluble Efm6 protein showing activity on eEF1A."</em> — PMID:26115316</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether EFM6 has any substrate other than eEF1A-Lys390 is untested beyond the exclusion of yeast Hsp70 proteins.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> EFM6 does not methylate yeast Hsp70 (Ssa1/Ssb1/Ssb2) despite being the closest yeast homolog of the Hsp70-specific human METTL21A, and it is highly specific for eEF1A; no unbiased, proteome-wide substrate screen for EFM6 has been reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Excluding or discovering additional substrates would define the full functional scope of the enzyme and rule out (or in) a broader role beyond eEF1A.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Perform an activity-based, proteome-wide substrate screen (e.g. using EFM6 as enzyme source with a methyltransferase-deficient extract, or SILAC/heavy-methyl profiling of efm6Δ vs WT).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"demonstrating that the enzyme is highly specific for eEF1A"</em> — PMID:26115316</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(EFM6-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53970" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: EFM6 (YNL024C) — A Protein-Lysine N-Methyltransferase in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">11 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:07:08.944777</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="EFM6-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="EFM6-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-efm6-ynl024c-a-protein-lysine-n-methyltransferase-in-saccharomyces-cerevisiae">Comprehensive Research Report: EFM6 (YNL024C) — A Protein-Lysine N-Methyltransferase in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>EFM6 (Elongation Factor Methyltransferase 6) is encoded by the <em>YNL024C</em> open reading frame in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein was originally uncharacterized and was renamed from Ynl024c to Efm6 following the discovery of its enzymatic function, in accordance with the nomenclature established for similar elongation factor methyltransferases in yeast (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2). The gene product is classified as a class I-like SAM-binding methyltransferase belonging to the seven-β-strand (7BS) methyltransferase superfamily, specifically within Methyltransferase Family 16 (MTF16), which also includes the human METTL21 proteins (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7).</p>
+<p>The key properties of EFM6 are summarized below:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>EFM6</strong> (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2)</td>
+</tr>
+<tr>
+<td>Systematic name</td>
+<td><strong>YNL024C</strong> (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>P53970</strong></td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Saccharomyces cerevisiae</em> strain S288c / ATCC 204508 (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein length / molecular weight</td>
+<td>Not established in the gathered literature evidence; refer to UniProt entry P53970 for sequence-level metadata</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Class I-like SAM-binding methyltransferase; seven-β-strand (7BS) methyltransferase; Methyltransferase Family 16 (MTF16); METTL21-like protein (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td>EFM6; Methyltransf_16 / IPR019410; SAM-dependent methyltransferases superfamily / IPR029063; PF10294 (from UniProt annotation)</td>
+</tr>
+<tr>
+<td>Enzymatic activity</td>
+<td>Protein-lysine N-methyltransferase; catalyzes methylation of eEF1A lysine residue using AdoMet/SAM; EC 2.1.1.- (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14)</td>
+</tr>
+<tr>
+<td>Substrate</td>
+<td>Eukaryotic elongation factor 1A (eEF1A), specifically <strong>Lys390</strong> in the 2015 primary paper; some reviews number the equivalent site as Lys395 (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2018regulationofeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Methyl donor</td>
+<td>S-adenosylmethionine / AdoMet / SAM (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Key catalytic / cofactor-binding residues</td>
+<td><strong>Asp170</strong> and <strong>Tyr173</strong> in the DXXY motif, <strong>Trp143</strong> stacking with the adenine of AdoMet, and <strong>Asp115</strong> contacting the ribose moiety of AdoMet (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Conserved motifs / fold</td>
+<td>Canonical 7BS methyltransferase Motif I, Post I, Motif II, and downstream <strong>DXXY</strong> motif; modeled canonical 7BS topology with two additional N-terminal β-strands (z1, z2) (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>In vivo methylation level</td>
+<td>In wild-type yeast, Lys390 methylation is low-occupancy, about <strong>~20% monomethylation</strong> / ~0.2 methyl groups per eEF1A molecule; overexpression of Efm6 markedly increases methylation and can drive higher methylation states including trimethylation (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2018regulationofeukaryotic pages 7-9)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Not directly established in the gathered EFM6 literature; <strong>cytoplasmic localization is inferred</strong> from its substrate eEF1A and role in translation elongation (jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4, jakobsson2018regulationofeukaryotic pages 7-9)</td>
+</tr>
+<tr>
+<td>Biological pathway / process</td>
+<td>Post-translational modification of the translation elongation factor eEF1A within the broader eEF1A methylation network that modulates translation-related functions; EFM6 expression is reported to increase under hypoxia (jakobsson2018regulationofeukaryotic pages 5-7, jakobsson2018regulationofeukaryotic pages 7-9)</td>
+</tr>
+<tr>
+<td>Closest human homologs</td>
+<td>Closely related to <strong>METTL21 family</strong> proteins, especially <strong>METTL21A</strong>, and discussed in relation to human <strong>eEF1A-KMT3/METTL21B</strong> as a close functional family member; however, mammalian eEF1A Lys392 (equivalent position) is unmethylated, indicating divergence in substrate/site usage (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 4-5, jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core molecular, enzymatic, structural, and functional properties of the yeast EFM6/YNL024C protein based on the gathered evidence and the supplied UniProt record. It is useful as a compact reference for functional annotation and for distinguishing EFM6 from related METTL21-family methyltransferases.</em></p>
+<h2 id="2-enzymatic-activity-and-substrate-specificity">2. Enzymatic Activity and Substrate Specificity</h2>
+<h3 id="21-primary-reaction">2.1 Primary Reaction</h3>
+<p>EFM6 functions as a protein-lysine N-methyltransferase (EC 2.1.1.-). Its sole identified substrate is eukaryotic translation elongation factor 1A (eEF1A), and it specifically catalyzes the methylation of lysine 390 (Lys390) on this protein using S-adenosylmethionine (AdoMet/SAM) as the methyl donor (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14). EEF1A is a highly abundant, essential protein that functions as the eukaryotic homolog of bacterial EF-Tu, delivering aminoacylated tRNAs to the ribosomal A-site during the elongation phase of mRNA translation (jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4).</p>
+<h3 id="22-methylation-stoichiometry-and-dynamics">2.2 Methylation Stoichiometry and Dynamics</h3>
+<p>In wild-type yeast cells, Lys390 methylation occurs at very low occupancy, with only approximately 20% of eEF1A molecules bearing monomethylation at this residue (~0.2 methyl groups per eEF1A molecule) (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2018regulationofeukaryotic pages 7-9). In a <em>ynl024c</em>Δ knockout strain, Lys390 is exclusively unmethylated, confirming that Efm6 is the sole enzyme responsible for this modification (jakobsson2015saccharomycescerevisiaeeukaryotic pages 7-9). Notably, overexpression of Efm6 causes a dramatic increase in Lys390 methylation, elevating it to approximately 2 methyl groups per eEF1A molecule, with trimethylation becoming the predominant modification state (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2018regulationofeukaryotic pages 7-9). This observation indicates that the entire cellular pool of eEF1A is accessible as substrate for Efm6, and that the low in vivo methylation level reflects limited Efm6 enzyme availability under normal growth conditions rather than substrate inaccessibility (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14).</p>
+<h3 id="23-substrate-specificity-what-efm6-does-not-methylate">2.3 Substrate Specificity — What EFM6 Does Not Methylate</h3>
+<p>Despite high sequence similarity to human METTL21A — an Hsp70-specific lysine methyltransferase — Efm6 does not methylate yeast Hsp70 proteins (SSA1, SSA3, SSB1, SSB2) at their corresponding lysine residues (jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4, jakobsson2015saccharomycescerevisiaeeukaryotic pages 7-9, jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2). This finding indicates that while Efm6 and METTL21A share structural features, they have diverged in substrate specificity. EFM6 was the last of the four previously known eEF1A methylation sites to have its responsible methyltransferase identified (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14).</p>
+<h2 id="3-structural-basis-of-catalytic-activity">3. Structural Basis of Catalytic Activity</h2>
+<p>Efm6 adopts the canonical seven-β-strand (7BS) methyltransferase fold, with two additional N-terminal β-strands (z1 and z2) as revealed by structural modeling using human METTL21A as a template (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7). The protein contains several conserved motifs characteristic of class I methyltransferases:</p>
+<ul>
+<li><strong>Motif I, Post I, and Motif II</strong>: canonical SAM-binding motifs of the 7BS family.</li>
+<li><strong>DXXY motif</strong>: a hallmark of MTF16 family enzymes, located downstream of Motif II. In Efm6, the key catalytic residues <strong>Asp170</strong> and <strong>Tyr173</strong> within this motif are positioned near the methyl group of AdoMet.</li>
+<li><strong>Trp143</strong>: stacks with the adenine base of AdoMet, contributing to cofactor binding.</li>
+<li><strong>Asp115</strong> (in Motif Post I): forms hydrogen bonds with hydroxyl groups on the ribose moiety of AdoMet (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7).</li>
+</ul>
+<p>Sequence comparison reveals that Efm6 shows higher similarity to human METTL21A than to any other <em>S. cerevisiae</em> protein, including the related yeast methyltransferase Efm2 (jakobsson2015saccharomycescerevisiaeeukaryotic pages 4-5, jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7). The structural and sequence similarity between Efm6 and the METTL21 family is even higher than between some human METTL21 paralogs themselves (jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7).</p>
+<h2 id="4-context-within-the-eef1a-methylation-landscape">4. Context Within the eEF1A Methylation Landscape</h2>
+<p>EEF1A in <em>S. cerevisiae</em> is one of the most extensively post-translationally modified translation factors, bearing methylation at multiple lysine residues. Five dedicated eEF1A-specific lysine methyltransferases have been identified in yeast, each targeting a distinct residue:</p>
+<table>
+<thead>
+<tr>
+<th>Enzyme</th>
+<th>Systematic name / gene</th>
+<th>Target residue on <em>S. cerevisiae</em> eEF1A</th>
+<th>Methylation state</th>
+<th>MTase family</th>
+<th>Human orthologue / counterpart (if known)</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Efm1</td>
+<td><strong>EFM1</strong></td>
+<td>Lys30</td>
+<td>Monomethylation</td>
+<td>SET-domain KMT</td>
+<td>No clear human orthologue established in the gathered evidence</td>
+<td>One of the first yeast eEF1A-specific KMTs identified (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2018regulationofeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Efm4</td>
+<td><strong>EFM4</strong></td>
+<td>Lys316</td>
+<td>Dimethylation</td>
+<td>7BS methyltransferase</td>
+<td>METTL10 / eEF1A-KMT2; human site Lys318 trimethylated</td>
+<td>Yeast Lys316 methylation is conserved functionally to human Lys318 methylation (jakobsson2018regulationofeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Efm5</td>
+<td><strong>EFM5</strong></td>
+<td>Lys79</td>
+<td>Trimethylation</td>
+<td>7BS methyltransferase</td>
+<td>N6AMT2 / eEF1A-KMT1</td>
+<td>Originally notable because a putative RNA MTase was found to methylate eEF1A Lys79 (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2018regulationofeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td><strong>Efm6</strong></td>
+<td><strong>YNL024C / EFM6</strong></td>
+<td><strong>Lys390</strong> (also referred to as Lys395 in some review numbering)</td>
+<td><strong>Primarily monomethylation in vivo; overexpression can drive higher methylation, including trimethylation</strong></td>
+<td><strong>7BS methyltransferase; MTF16 / METTL21-like</strong></td>
+<td><strong>No direct human orthologue for the same site; closest homologue discussed is METTL21B / eEF1A-KMT3, but mammalian Lys392 is unmethylated</strong></td>
+<td><strong>Focus of this report. Identified as the enzyme responsible for the previously orphan eEF1A Lys390 methylation site in yeast</strong> (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2018regulationofeukaryotic pages 7-9, jakobsson2018regulationofeukaryotic pages 5-7)</td>
+</tr>
+<tr>
+<td>Efm7</td>
+<td><strong>EFM7</strong></td>
+<td>Lys3</td>
+<td>Dimethylation</td>
+<td>7BS methyltransferase</td>
+<td>No human orthologue specified in the gathered evidence</td>
+<td>Dual activity: also methylates the N-terminus of eEF1A (jakobsson2018regulationofeukaryotic pages 5-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the known eEF1A-specific lysine methyltransferases in </em>S. cerevisiae<em>, their target residues, methylation states, enzyme families, and human counterparts where known. Efm6/YNL024C is highlighted because it is the focus gene and catalyzes the Lys390 methylation event discussed in the report.</em></p>
+<p>Each of these methyltransferases was identified primarily through knockout studies in <em>S. cerevisiae</em>, followed by mass spectrometric analysis of eEF1A methylation status (jakobsson2018regulationofeukaryotic pages 5-7, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14). The methylation at Lys79 and Lys316 is conserved to human eEF1A, with human orthologs N6AMT2 (eEF1A-KMT1) and METTL10 (eEF1A-KMT2) catalyzing the corresponding modifications (jakobsson2018regulationofeukaryotic pages 5-7). Except for Efm1, which is a SET-domain protein, all of the identified eEF1A-specific KMTs in yeast and human belong to the 7BS family of methyltransferases (jakobsson2018regulationofeukaryotic pages 5-7).</p>
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>The subcellular localization of Efm6 has not been explicitly established through dedicated localization studies in the literature reviewed. However, its function can be confidently inferred to occur in the <strong>cytoplasm</strong>, as its substrate eEF1A is a cytoplasmic translation elongation factor that functions at the ribosome during mRNA translation (jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4). The closest human homolog of Efm6 discussed in this context — eEF1A-KMT3/METTL21B — has been shown to be partially cytosolic and partially localized to centrosomes, suggesting potential non-canonical functions (jakobsson2018regulationofeukaryotic pages 7-9, jakobsson2018regulationofeukaryotic pages 5-7). It has been suggested that eEF1A methylation may occur prior to complex assembly, as proteins within larger complexes may become inaccessible for methylation once assembled (jakobsson2015saccharomycescerevisiaeeukaryotic pages 14-16).</p>
+<h2 id="6-biological-significance-and-pathway-context">6. Biological Significance and Pathway Context</h2>
+<h3 id="61-role-in-translation-regulation">6.1 Role in Translation Regulation</h3>
+<p>EEF1A is a GTPase that delivers aminoacylated tRNAs to the ribosomal A-site during translational elongation, and its proper function is critical for efficient and accurate protein synthesis (jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4). The ablation of eEF1A-modifying methyltransferases has been associated with translation-related phenotypes such as decreased accuracy of protein synthesis and increased sensitivity to protein synthesis inhibitors (jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4). However, the specific functional consequence of Lys390 methylation by Efm6 remains largely elusive. Structural analysis of eEF1A revealed that Lys390 does not show striking co-localization with residues involved in known eEF1A functional activities, including actin interaction, nuclear transport, GTP-binding, or tRNA binding (jakobsson2015saccharomycescerevisiaeeukaryotic pages 14-16, jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14).</p>
+<h3 id="62-hypoxia-responsive-regulation">6.2 Hypoxia-Responsive Regulation</h3>
+<p>A particularly notable finding is that <em>EFM6</em> expression is strongly upregulated by hypoxia, suggesting that Efm6-mediated Lys390 methylation may serve as a hypoxia-inducible modulator of protein synthesis (jakobsson2018regulationofeukaryotic pages 7-9). This dynamic, inducible nature of Efm6-mediated methylation is consistent with a regulatory rather than constitutive "editing" role for this modification (jakobsson2018regulationofeukaryotic pages 7-9). The concept of dynamic, stress-responsive eEF1A methylation has been extended to the mammalian system, where the close Efm6 family member eEF1A-KMT3 is induced by various stressors such as growth factor withdrawal and ER stress, with concomitant increases in methylation at its target site (jakobsson2018regulationofeukaryotic pages 5-7).</p>
+<h3 id="63-phenotypic-effects-of-loss-of-eef1a-methylation">6.3 Phenotypic Effects of Loss of eEF1A Methylation</h3>
+<p>A yeast quadruple mutant in which all four previously known methylated lysine residues of eEF1A (K30R, K79R, K316R, K395R) were simultaneously replaced with arginine was viable and showed no obvious growth phenotype under standard laboratory conditions (jakobsson2018regulationofeukaryotic pages 7-9). This suggests that the effects of eEF1A lysine methylation on the basic, essential function of eEF1A are modest during near-optimal growth conditions. However, it has been proposed that methylation may protect lysine residues against ubiquitin-mediated degradation, a function that would also be preserved by lysine-to-arginine substitution, potentially masking the true importance of methylation (jakobsson2018regulationofeukaryotic pages 7-9).</p>
+<h3 id="64-the-eef1a-code-hypothesis">6.4 The "eEF1A Code" Hypothesis</h3>
+<p>The abundance and specificity of lysine methylations on eEF1A, installed by multiple dedicated KMTs, has led to the proposal of an "eEF1A code" — analogous to the histone code — in which combinatorial lysine methylation patterns regulate eEF1A function, potentially influencing both canonical translation and non-canonical functions such as actin cytoskeleton regulation and viral replication (jakobsson2018regulationofeukaryotic pages 7-9, jakobsson2018regulationofeukaryotic pages 5-7). Efm6-mediated Lys390 methylation represents one layer of this regulatory code.</p>
+<h2 id="7-evolutionary-conservation-and-divergence">7. Evolutionary Conservation and Divergence</h2>
+<p>Efm6 is the closest <em>S. cerevisiae</em> sequence homolog of the human METTL21 protein family (METTL21A, METTL21B/eEF1A-KMT3, METTL21C, VCP-KMT/METTL21D), with METTL21A being the most closely related human protein in reciprocal BLAST searches (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2, jakobsson2015saccharomycescerevisiaeeukaryotic pages 4-5). Despite this high sequence similarity, the substrate specificity has diverged: human METTL21A methylates Hsp70 proteins, whereas yeast Efm6 methylates eEF1A at Lys390 (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2). Furthermore, the Lys390 residue in eEF1A, although structurally conserved in mammalian eEF1A (corresponding to Lys392), is exclusively unmethylated in rabbit reticulocytes and human HeLa cells, indicating that this particular methylation event is yeast-specific (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14). This represents a case of functional divergence following gene duplication and speciation, where homologous enzymes have acquired different substrate specificities.</p>
+<h2 id="8-summary">8. Summary</h2>
+<p>EFM6 (YNL024C, UniProt P53970) is a seven-β-strand methyltransferase in <em>S. cerevisiae</em> that catalyzes the SAM-dependent monomethylation of eEF1A at Lys390. It was identified in 2015 as the last of the yeast eEF1A-specific lysine methyltransferases (jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2). The enzyme operates in the cytoplasm, where its substrate eEF1A functions in translational elongation. Its methylation activity is notable for being low-occupancy under normal conditions but highly inducible through enzyme overexpression and under hypoxic stress, suggesting a regulatory rather than constitutive role (jakobsson2018regulationofeukaryotic pages 7-9). Although structurally homologous to human METTL21 proteins, Efm6 targets eEF1A rather than Hsp70 proteins, and the Lys390 methylation event it catalyzes is not conserved in mammals (jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14, jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2). The precise functional consequence of Lys390 methylation remains an active area of investigation, but current evidence places it within a broader regulatory framework — the proposed "eEF1A code" — that modulates translation through combinatorial post-translational modifications of this essential elongation factor.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2018regulationofeukaryotic pages 5-7): Magnus E. Jakobsson, Jędrzej Małecki, and Pål Ø. Falnes. Regulation of eukaryotic elongation factor 1 alpha (eef1a) by dynamic lysine methylation. RNA Biology, 15:314-319, Mar 2018. URL: https://doi.org/10.1080/15476286.2018.1440875, doi:10.1080/15476286.2018.1440875. This article has 64 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2018regulationofeukaryotic pages 7-9): Magnus E. Jakobsson, Jędrzej Małecki, and Pål Ø. Falnes. Regulation of eukaryotic elongation factor 1 alpha (eef1a) by dynamic lysine methylation. RNA Biology, 15:314-319, Mar 2018. URL: https://doi.org/10.1080/15476286.2018.1440875, doi:10.1080/15476286.2018.1440875. This article has 64 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 4-5): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 7-9): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jakobsson2015saccharomycescerevisiaeeukaryotic pages 14-16): Magnus E. Jakobsson, Erna Davydova, Jędrzej Małecki, Anders Moen, and Pål Ø. Falnes. Saccharomyces cerevisiae eukaryotic elongation factor 1a (eef1a) is methylated at lys-390 by a mettl21-like methyltransferase. PLoS ONE, 10:e0131426, Jun 2015. URL: https://doi.org/10.1371/journal.pone.0131426, doi:10.1371/journal.pone.0131426. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="EFM6-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="EFM6-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 1-2</li>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 5-7</li>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 2-4</li>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 7-9</li>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 12-14</li>
+<li>jakobsson2018regulationofeukaryotic pages 5-7</li>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 14-16</li>
+<li>jakobsson2018regulationofeukaryotic pages 7-9</li>
+<li>jakobsson2015saccharomycescerevisiaeeukaryotic pages 4-5</li>
+<li>https://doi.org/10.1371/journal.pone.0131426,</li>
+<li>https://doi.org/10.1080/15476286.2018.1440875,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(EFM6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53970" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="efm6-ynl024c-curation-notes">EFM6 (YNL024C) — curation notes</h1>
+<p>UniProt: P53970 (EFM6_YEAST). SGD: S000004969. Systematic name YNL024C. 246 aa, 27.7 kDa.<br />
+Standard name EFM6 = "Elongation Factor Methyltransferase 6".</p>
+<h2 id="summary-of-identity-domain-from-uniprot-p53970-record-read-inline">Summary of identity / domain (from UniProt P53970 record, read inline)</h2>
+<ul>
+<li>RecName: <strong>Protein-lysine N-methyltransferase EFM6</strong>; EC=2.1.1.- .</li>
+<li>SIMILARITY: "Belongs to the class I-like SAM-binding methyltransferase superfamily.<br />
+  METTL21 family. EFM6 subfamily." So EFM6 is a <strong>seven-beta-strand (7BS) / Class I<br />
+  SAM-dependent methyltransferase</strong>, specifically an MTase-Family-16 (MTF16 / Methyltransf_16)<br />
+  member. Pfam PF10294 (Methyltransf_16); InterPro IPR033684 (EFM6), IPR019410<br />
+  (Methyltransf_16), IPR029063 (SAM-dependent MTases superfamily). Gene3D 3.40.50.150.<br />
+  HAMAP MF_03198 (Methyltr_EFM6). PANTHER PTHR14614:SF152 "PROTEIN-LYSINE<br />
+  N-METHYLTRANSFERASE EFM6".</li>
+<li><strong>SAM-binding site present</strong> (motif I and downstream elements): UniProt BINDING features<br />
+  for S-adenosyl-L-methionine at residues 51, 87-89, 115, 143, 169 (by similarity to human<br />
+  Q9H867 = METTL21A and HAMAP MF_03198). So the SAM-binding scaffold (motif I region and<br />
+  post-I) is intact → the protein is expected to be a competent SAM-dependent methyltransferase.</li>
+<li>SUBCELLULAR LOCATION: Cytoplasm (HAMAP + PubMed:14562095).</li>
+<li>Abundance: ~1760 molecules/cell in log-phase SD medium (PubMed:14562106).</li>
+</ul>
+<h2 id="known-efm6-specific-experimental-evidence">KNOWN (EFM6-specific experimental evidence)</h2>
+<p>The molecular function of EFM6 is firmly established — this gene is NOT functionally dark;<br />
+only its physiological/biological role is unknown.</p>
+<ul>
+<li><strong>EFM6 methylates eukaryotic elongation factor 1A (eEF1A; TEF1/TEF2) at Lys390.</strong><br />
+  [PMID:26115316 Jakobsson et al. 2015, "we here show that the YNL024C gene is required for<br />
+  methylation of eEF1A at Lys390, the only of these methylations for which the responsible<br />
+  MTase has not yet been identified"].</li>
+<li>Genetic dependence: [PMID:26115316, "Lys390 was found in a partially monomethylated state<br />
+  in wild-type yeast cells but was exclusively unmethylated in a ynl024cΔ strain"].</li>
+<li>Overexpression drives higher methylation: [PMID:26115316, "over-expression of Ynl024c<br />
+  caused a dramatic increase in Lys390 methylation, with trimethylation becoming the<br />
+  predominant state"]. Also [PMID:26115316, "when Ynl024c was overexpressed ... the di- and<br />
+  tri-methylated forms of Lys390 in eEF1A were the dominant species (&gt;70% of total)"].</li>
+<li>Direct catalysis in vitro (crude extract, GTP-dependent): [PMID:26115316, "when GTP was<br />
+  present, a markedly stronger, Ynl024c-specific labelling was observed in the 50 kDa region<br />
+  of the ynl024cΔ yeast extract"] and [PMID:26115316, "Taken together, these results suggest<br />
+  that the Ynl024c protein is capable of directly methylating eEF1A ... but reflect KMT<br />
+  activity of Ynl024c on eEF1A"].</li>
+<li>High substrate specificity for eEF1A (does NOT methylate yeast Hsp70, unlike its closest<br />
+  human homolog METTL21A): [PMID:26115316, "the lysine in Ssa1/Ssb1/Ssb2 that correspond to<br />
+  the target site of human METTL21A in Hsp70 was exclusively found as unmethylated in cells<br />
+  overexpressing Ynl024c ... demonstrating that the enzyme is highly specific for eEF1A"] and<br />
+  [PMID:26115316, "yeast Hsp70 proteins are unmethylated ... consequently, that Ynl024c is<br />
+  likely not a functional orthologue of human METTL21A"].</li>
+<li>Domain/motif analysis (bioinformatics in the same paper): [PMID:26115316, "an alignment of<br />
+  Ynl024c with the human METTL21 proteins clearly demonstrates that Ynl024c harbours hallmark<br />
+  conserved motifs found in 7BS MTases, i. e. Motif I, Motif post I and Motif II ... Ynl024c<br />
+  possesses the characteristic DXXY ... motif"]. Predicted catalytic residues Asp170/Tyr173<br />
+  (DXXY), Trp143, Asp115 (post-I) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>.</li>
+<li>Cytoplasmic localization (global GFP study): [PMID:14562095 Huh et al. 2003] — HDA evidence<br />
+  in GOA; consistent with a translation-machinery-associated enzyme.</li>
+<li>Putative-MTase prediction (genome-wide bioinformatics, basis of ISS): [PMID:12872006 Katz,<br />
+  Dlakić, Clarke 2003, "automatic assignment of S-adenosylmethionine (AdoMet)-dependent<br />
+  methyltransferase functionality to genomic open reading frames"]; abstract-only.</li>
+</ul>
+<h2 id="separating-efm6-from-the-other-efm-methyltransferases">Separating EFM6 from the other EFM methyltransferases</h2>
+<p>eEF1A carries four methylated lysines, each installed by a distinct, dedicated enzyme<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>:<br />
+- <strong>Lys30</strong> by <strong>Efm1</strong> (Yhl039w; a SET-domain enzyme, not 7BS) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>.<br />
+- <strong>Lys79</strong> by <strong>Efm5</strong> (YGR001C) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>.<br />
+- <strong>Lys316</strong> by <strong>Efm4</strong> / See1 (human ortholog METTL10) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>. (The paper's<br />
+  abstract writes "Lys318" but the Results table and Discussion consistently write "Lys316";<br />
+  the Efm4/See1 site is the same eEF1A dimethylation regardless of the numbering slip.)<br />
+- <strong>Lys390</strong> by <strong>Efm6</strong> / Ynl024c (this gene) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>.</p>
+<p>Other "Efm" enzymes act on eEF2, not eEF1A: Efm2 (YBR271W, eEF2 Lys613) and Efm3 (YJR129C,<br />
+eEF2 Lys509; human ortholog FAM86A/eEF2-KMT) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a>. Efm2 is EFM6's closest yeast<br />
+paralog (BLAST e=7e-7) but has a different substrate (eEF2). <strong>Care must be taken NOT to<br />
+transfer eEF2 substrate or the other Lys sites to EFM6.</strong> The Lys390-specific evidence is<br />
+uniquely attributed to YNL024C/EFM6.</p>
+<p>Closest human homolog is METTL21A (HSPA-KMT; e=2e-17), but EFM6 is NOT its functional<br />
+ortholog (see Hsp70 result above). Lys390-equivalent (Lys392) in human/rabbit eEF1A is<br />
+unmethylated [PMID:26115316, "Lys392 was exclusively detected as unmethylated ... mammalian<br />
+METTL21 enzymes do not target this site"] — so the modification and, by extension, EFM6's<br />
+in-vivo role are not conserved to mammals.</p>
+<h2 id="not-known-genuine-knowledge-gaps">NOT known (genuine knowledge gaps)</h2>
+<ul>
+<li><strong>Physiological/biological role of eEF1A-Lys390 methylation is unknown.</strong> [PMID:26115316,<br />
+  "the precise function of Efm6-mediated eEF1A methylation does remain an enigma and further<br />
+  studies are required to reveal its role"]. No downstream biological process can be assigned<br />
+  → BP is legitimately ND.</li>
+<li>No growth/fitness phenotype tied to the methylation: [PMID:26115316, "simultaneous<br />
+  mutations of the four lysine methylation sites to arginine does not affect the proliferation<br />
+  rate of the resulting mutant yeast strain nor the enzymatic properties of the eEF1A protein<br />
+  in vitro"].</li>
+<li>The modification is low-occupancy (~20% mono in WT; a separate study ~5%) <a href="https://pubmed.ncbi.nlm.nih.gov/26115316">PMID:26115316</a> —<br />
+  functional significance of such low stoichiometry is unclear.</li>
+<li>Recombinant soluble Efm6 could not be purified; direct activity shown only from crude<br />
+  extracts, so kinetics / a fully reconstituted single-protein assay are lacking<br />
+  [PMID:26115316, "We were unable to purify recombinant soluble Efm6 protein showing activity<br />
+  on eEF1A"].</li>
+<li>Whether EFM6 has additional substrates beyond eEF1A is untested (only Hsp70 excluded;<br />
+  eEF1A found via candidate approach).</li>
+<li>Regulation (whether Lys390 methylation responds to stimuli / cell state, possible demethylase)<br />
+  is speculative [PMID:26115316 Discussion].</li>
+</ul>
+<h2 id="go-annotation-review-plan">GO annotation review plan</h2>
+<p>7 GOA annotations:<br />
+1. GO:0008276 protein methyltransferase activity — IBA (GO_REF:0000033). Correct but general;<br />
+   EFM6 is specifically a protein-LYSINE N-MTase → MODIFY toward GO:0016279 as core; keep IBA<br />
+   framing. Actually the more specific GO:0016279 is already separately annotated (IEA), so<br />
+   ACCEPT this general IBA as a valid (if less specific) parent; core function captured by<br />
+   GO:0016279.<br />
+2. GO:0005737 cytoplasm — IEA (GO_REF:0000120, UniRule/SubCell). ACCEPT (redundant with HDA).<br />
+3. GO:0008757 SAM-dependent methyltransferase activity — IEA (ARBA). ACCEPT; general parent MF.<br />
+4. GO:0016279 protein-lysine N-methyltransferase activity — IEA (UniRule). ACCEPT — this is<br />
+   the correct specific MF, matching the experimental eEF1A-Lys390 result. CORE.<br />
+5. GO:0008757 SAM-dependent methyltransferase activity — ISS (PMID:12872006). ACCEPT; general<br />
+   parent, computational prediction consistent with experiment.<br />
+6. GO:0005737 cytoplasm — HDA (PMID:14562095). ACCEPT — experimental localization. CORE location.<br />
+7. GO:0008150 biological_process — ND (GO_REF:0000015). ACCEPT/KEEP — BP genuinely unknown<br />
+   (root ND); do not invent a BP. This IS the honest state given the enigmatic role.</p>
+<p>Note: the strongest experimental MF evidence (PMID:26115316, IDA/IMP-grade eEF1A-Lys390) is<br />
+NOT itself in GOA as a separate row, but the IEA GO:0016279 term coincides with it. I will<br />
+cite PMID:26115316 in the review reasons and core_functions.</p>
+<h2 id="falcon-deep-research-efm6-deep-research-falconmd-corroboration-extra-context">Falcon deep-research (EFM6-deep-research-falcon.md) — corroboration + extra context</h2>
+<p>Falcon completed (1279 s, 11 citations) and is fully consistent with the primary paper. It<br />
+draws on PMID:26115316 plus a review I did not cache (Jakobsson, Małecki, Falnes 2018, RNA<br />
+Biology, "Regulation of eukaryotic elongation factor 1 alpha (eEF1A) by dynamic lysine<br />
+methylation", DOI:10.1080/15476286.2018.1440875). Extra context NOT added to the review YAML<br />
+(uncached review → no verifiable supporting_text; recorded here only, not as a GO claim):<br />
+- EFM6 expression reported to be upregulated by hypoxia → possible stress-responsive/regulatory<br />
+  role for Lys390 methylation (per the 2018 review). This strengthens the "regulated switch"<br />
+  hypothesis in the knowledge_gaps but is not itself GO-annotatable evidence for a BP.<br />
+- The "eEF1A code" framing: multiple dedicated KMTs install a combinatorial methylation pattern<br />
+  on eEF1A; methylation may also protect lysines from ubiquitin-mediated degradation (a role<br />
+  that would be preserved by K→R and thus masked in the quadruple-K→R mutant).<br />
+- Efm7 (EFM7) methylates eEF1A Lys3 (a fifth eEF1A KMT, post-dating the 2015 paper). So the<br />
+  full set of yeast eEF1A KMTs is Efm1 (Lys30, SET), Efm4/See1 (Lys316), Efm5 (Lys79),<br />
+  Efm6 (Lys390, this gene), Efm7 (Lys3). Care: keep EFM6 = Lys390 only.<br />
+- The alternate residue number "Lys395" seen in some reviews is a numbering variant of the same<br />
+  eEF1A site; the primary paper uses Lys390 (mature-protein numbering), which I follow.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P53970
+gene_symbol: EFM6
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  EFM6 (YNL024C) is a cytoplasmic S-adenosyl-L-methionine-dependent protein-lysine
+  N-methyltransferase of the seven-beta-strand (Class I) methyltransferase superfamily,
+  specifically a member of methyltransferase family 16 (MTF16) within the METTL21 clade.
+  It methylates the eukaryotic translation elongation factor 1A (eEF1A, encoded in
+  S. cerevisiae by the paralogous genes TEF1 and TEF2) on lysine 390. EFM6 is one of a
+  set of dedicated elongation-factor methyltransferases in budding yeast; the four
+  known lysine methylations of eEF1A are each installed by a distinct enzyme, with EFM6
+  responsible for the Lys390 site. The enzyme is highly substrate-specific: despite being
+  the closest yeast sequence homolog of the human Hsp70-specific methyltransferase METTL21A,
+  it does not methylate yeast Hsp70 proteins. eEF1A-Lys390 methylation is a low-occupancy
+  modification and is not conserved to mammalian eEF1A; the physiological consequence of
+  the modification is not established.
+references:
+- id: GO_REF:0000015
+  title: &#39;Gene Ontology annotation through association of InterPro records with manually
+    curated functional descriptions&#39;
+  findings: []
+- id: GO_REF:0000033
+  title: &#39;Annotation inferences using phylogenetic trees&#39;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      GO_Central IBA pipeline reference for the phylogenetically inferred
+      protein methyltransferase activity annotation; consistent with the
+      experimentally established protein-lysine methyltransferase function.
+- id: GO_REF:0000104
+  title: &#39;Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara&#39;
+  findings: []
+- id: GO_REF:0000117
+  title: &#39;Electronic Gene Ontology annotations created by ARBA machine learning models&#39;
+  findings: []
+- id: GO_REF:0000120
+  title: &#39;Combined automated annotation with UniProt keyword to GO mapping and UniRule&#39;
+  findings: []
+- id: PMID:12872006
+  title: Automated identification of putative methyltransferases from genomic open
+    reading frames.
+  findings:
+  - statement: &gt;-
+      Genome-wide computational method assigning S-adenosylmethionine-dependent
+      methyltransferase functionality to yeast open reading frames on the basis of
+      seven-strand twisted beta-sheet signature motifs; source of the ISS
+      methyltransferase-activity prediction for EFM6.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      automatic assignment of S-adenosylmethionine (AdoMet)-dependent methyltransferase
+      functionality to genomic open reading frames based on predicted protein sequences.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only, but this is the well-known Katz/Dlakic/Clarke yeast MTase catalog;
+      it correctly predicts EFM6 as a SAM-dependent methyltransferase, a prediction later
+      experimentally confirmed by PMID:26115316. Supports the general SAM-MTase activity
+      annotation, not a specific substrate.
+- id: PMID:14562095
+  title: Global analysis of protein localization in budding yeast.
+  findings:
+  - statement: &gt;-
+      Genome-wide GFP-fusion localization study; the basis for the experimental (HDA)
+      cytoplasmic localization annotation for EFM6.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      a collection of yeast strains expressing full-length, chromosomally tagged green
+      fluorescent protein fusion proteins
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache; the Huh et al. global GFP localization dataset is the standard
+      source for the cytoplasm HDA annotation. Cytoplasmic localization is consistent with
+      a translation-machinery-associated methyltransferase.
+- id: PMID:26115316
+  title: Saccharomyces cerevisiae Eukaryotic Elongation Factor 1A (eEF1A) Is Methylated
+    at Lys-390 by a METTL21-Like Methyltransferase.
+  findings:
+  - statement: &gt;-
+      YNL024C/EFM6 is required for methylation of eEF1A at Lys390; the residue is
+      monomethylated in wild-type cells but exclusively unmethylated in a ynl024c deletion
+      strain, establishing EFM6 as the responsible methyltransferase.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      we here show that the YNL024C gene is required for methylation of eEF1A at Lys390,
+      the only of these methylations for which the responsible MTase has not yet been
+      identified.
+  - statement: &gt;-
+      Overexpression of EFM6 dramatically increases eEF1A-Lys390 methylation, with
+      trimethylation becoming predominant, demonstrating that EFM6 activity drives the
+      modification.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      over-expression of Ynl024c caused a dramatic increase in Lys390 methylation, with
+      trimethylation becoming the predominant state.
+  - statement: &gt;-
+      EFM6 directly methylates eEF1A in vitro (GTP-dependent labelling of the ~50 kDa eEF1A
+      band by an E. coli extract expressing EFM6), indicating a direct methyltransferase
+      activity on eEF1A rather than an indirect effect.
+    reference_section_type: RESULTS
+    supporting_text: &gt;-
+      when GTP was present, a markedly stronger, Ynl024c-specific labelling was observed in
+      the 50 kDa region of the ynl024cΔ yeast extract
+  - statement: &gt;-
+      EFM6 is highly specific for eEF1A and, unlike its closest human homolog METTL21A,
+      does not methylate yeast Hsp70 proteins.
+    reference_section_type: RESULTS
+    supporting_text: &gt;-
+      demonstrating that the enzyme is highly specific for eEF1A
+  - statement: &gt;-
+      EFM6 harbours the conserved seven-beta-strand methyltransferase motifs (Motif I,
+      Motif post I, Motif II) and the MTF16 hallmark DXXY motif, confirming it as a Class I
+      SAM-dependent methyltransferase.
+    reference_section_type: RESULTS
+    supporting_text: &gt;-
+      Ynl024c harbours hallmark conserved motifs found in 7BS MTases, i. e. Motif I, Motif
+      post I and Motif II
+  - statement: &gt;-
+      The biological significance of EFM6-mediated eEF1A-Lys390 methylation is unknown and
+      remains to be determined.
+    reference_section_type: DISCUSSION
+    supporting_text: &gt;-
+      the precise function of Efm6-mediated eEF1A methylation does remain an enigma and
+      further studies are required to reveal its role.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified primary research article (Jakobsson et al. 2015, PLoS ONE). This
+      is the defining functional characterization of EFM6/YNL024C. Full text read; all
+      supporting_text quotes are verbatim substrings. The Lys390 substrate is uniquely and
+      experimentally attributed to YNL024C, distinct from the other Efm enzymes (Efm1/4/5 on
+      other eEF1A lysines; Efm2/3 on eEF2).
+existing_annotations:
+- term:
+    id: GO:0008276
+    label: protein methyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred protein methyltransferase activity. Correct but general:
+      EFM6 is experimentally a protein-LYSINE N-methyltransferase acting on eEF1A-Lys390
+      (PMID:26115316), a specific child of this term. Retained as a valid parent; the
+      specific molecular function is captured by GO:0016279.
+    action: MODIFY
+    reason: &gt;-
+      The essence (protein methyltransferase) is correct, but a more informative and
+      experimentally supported term exists (GO:0016279 protein-lysine N-methyltransferase
+      activity, already annotated by IEA and consistent with PMID:26115316).
+    proposed_replacement_terms:
+    - id: GO:0016279
+      label: protein-lysine N-methyltransferase activity
+    supported_by:
+    - reference_id: PMID:26115316
+      supporting_text: &gt;-
+        we here show that the YNL024C gene is required for methylation of eEF1A at Lys390,
+        the only of these methylations for which the responsible MTase has not yet been
+        identified.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000378681
+        source_label: METTL21/protein methyltransferase family node
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          The family-level protein methyltransferase activity is correct for EFM6, but the
+          IBA term is a general parent; EFM6&#39;s experimentally established activity is the more
+          specific protein-lysine N-methyltransferase activity (GO:0016279), so this is a
+          granularity issue, not a bad transfer.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic cytoplasmic-localization annotation (UniProt SubCell/UniRule). Consistent
+      with the experimental HDA localization (PMID:14562095) and with a translation-associated
+      cytoplasmic methyltransferase.
+    action: ACCEPT
+- term:
+    id: GO:0008757
+    label: S-adenosylmethionine-dependent methyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (ARBA) SAM-dependent methyltransferase activity. Correct general parent
+      term; the SAM-binding scaffold (motif I region, residues around 51/87-89/115) is
+      intact in EFM6 and its SAM-dependent activity is experimentally established
+      (PMID:26115316). More specific term GO:0016279 also annotated.
+    action: ACCEPT
+- term:
+    id: GO:0016279
+    label: protein-lysine N-methyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Protein-lysine N-methyltransferase activity, the correct specific molecular function.
+      This exactly matches the experimental demonstration that EFM6 methylates eEF1A on the
+      epsilon-amino group of Lys390 (PMID:26115316). Core molecular function of EFM6.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:26115316
+      supporting_text: &gt;-
+        over-expression of Ynl024c caused a dramatic increase in Lys390 methylation, with
+        trimethylation becoming the predominant state.
+- term:
+    id: GO:0008757
+    label: S-adenosylmethionine-dependent methyltransferase activity
+  evidence_type: ISS
+  original_reference_id: PMID:12872006
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity prediction of SAM-dependent methyltransferase activity from the
+      genome-wide Katz/Clarke MTase catalog. A correct general parent term, later confirmed
+      experimentally (PMID:26115316). Redundant with the ARBA IEA annotation to the same term.
+    action: ACCEPT
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: HDA
+  original_reference_id: PMID:14562095
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental (high-throughput GFP) cytoplasmic localization from the global yeast
+      localization study. Consistent with EFM6 acting on the abundant cytoplasmic
+      translation factor eEF1A. Core cellular location.
+    action: ACCEPT
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process with No Data. This honestly reflects the state of knowledge:
+      although EFM6&#39;s molecular function (eEF1A-Lys390 methylation) is established, the
+      downstream biological process served by this low-occupancy modification is unknown and
+      described as an enigma (PMID:26115316). No specific BP should be invented.
+    action: ACCEPT
+    reason: &gt;-
+      The biological role of EFM6-mediated eEF1A methylation is genuinely undetermined in the
+      literature; ND is the appropriate state rather than an over-annotated process term.
+core_functions:
+- description: &gt;-
+    S-adenosyl-L-methionine-dependent protein-lysine N-methyltransferase that
+    monomethylates (and, when overexpressed, di-/tri-methylates) eukaryotic translation
+    elongation factor 1A (eEF1A; TEF1/TEF2) on Lys390 in the cytoplasm. EFM6 is highly
+    specific for this eEF1A site and is the dedicated enzyme for the Lys390 modification,
+    distinct from the other elongation-factor methyltransferases.
+  molecular_function:
+    id: GO:0016279
+    label: protein-lysine N-methyltransferase activity
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:26115316
+    supporting_text: &gt;-
+      we here show that the YNL024C gene is required for methylation of eEF1A at Lys390,
+      the only of these methylations for which the responsible MTase has not yet been
+      identified.
+  - reference_id: PMID:26115316
+    supporting_text: &gt;-
+      demonstrating that the enzyme is highly specific for eEF1A
+knowledge_gaps:
+- gap_statement: &gt;-
+    The biological process served by EFM6-mediated methylation of eEF1A at Lys390 is
+    undetermined. It is not known why this specific low-occupancy lysine methylation is
+    installed, what phenotype (if any) it modulates, or which of eEF1A&#39;s canonical
+    (translation) or non-canonical (e.g. actin bundling, nuclear export) activities it
+    influences.
+  boundary: &gt;-
+    The molecular function is firmly established: EFM6 is a SAM-dependent protein-lysine
+    N-methyltransferase that specifically and directly methylates eEF1A on Lys390
+    (deletion abolishes the modification, overexpression drives di/tri-methylation, and an
+    EFM6-containing extract methylates eEF1A in vitro). What is unknown is the downstream
+    consequence, not the activity or the substrate site.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    eEF1A is one of the most abundant proteins in the cell and carries four distinct,
+    enzyme-dedicated lysine methylations; understanding what the Lys390 mark does would
+    clarify why the cell maintains a dedicated methyltransferase for a modification present
+    on only a small fraction of eEF1A molecules, and whether it tunes a specific eEF1A
+    subfunction or acts as a regulated switch.
+  resolution: &gt;-
+    Determine a phenotype for efm6Δ (and for eEF1A K390R) under stress/aging/sporulation and
+    non-canonical eEF1A assays; test whether Lys390 methylation is regulated in response to
+    physiological cues; identify any interacting demethylase; measure effects on translational
+    fidelity and on eEF1A actin/nuclear functions.
+  provenance:
+  - reference_id: PMID:26115316
+    supporting_text: &gt;-
+      the precise function of Efm6-mediated eEF1A methylation does remain an enigma and
+      further studies are required to reveal its role.
+  - reference_id: PMID:26115316
+    supporting_text: &gt;-
+      simultaneous mutations of the four lysine methylation sites to arginine does not affect
+      the proliferation rate of the resulting mutant yeast strain nor the enzymatic properties
+      of the eEF1A protein in vitro
+- gap_statement: &gt;-
+    Whether EFM6 is enzymatically active as an isolated, purified protein, and its steady-state
+    kinetic parameters and possible cofactor/partner requirements on eEF1A, are not established.
+  boundary: &gt;-
+    Direct methylation was demonstrated only from crude E. coli extracts overexpressing EFM6
+    (and required GTP), because soluble recombinant EFM6 with activity could not be purified;
+    genetic and in vivo evidence for EFM6-dependent Lys390 methylation is nonetheless
+    unambiguous.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    A reconstituted single-enzyme assay would confirm EFM6 acts alone (versus needing a
+    partner or a particular eEF1A/GTP conformational state) and enable mechanistic and
+    structural study of an otherwise well-defined activity.
+  resolution: &gt;-
+    Obtain soluble active recombinant EFM6 (e.g. alternative tags/hosts, co-expression with
+    eEF1A, or on-substrate assays) and measure kinetics against eEF1A in defined
+    GTP/GDP-bound states.
+  provenance:
+  - reference_id: PMID:26115316
+    supporting_text: &gt;-
+      We were unable to purify recombinant soluble Efm6 protein showing activity on eEF1A.
+- gap_statement: &gt;-
+    Whether EFM6 has any substrate other than eEF1A-Lys390 is untested beyond the exclusion of
+    yeast Hsp70 proteins.
+  boundary: &gt;-
+    EFM6 does not methylate yeast Hsp70 (Ssa1/Ssb1/Ssb2) despite being the closest yeast homolog
+    of the Hsp70-specific human METTL21A, and it is highly specific for eEF1A; no unbiased,
+    proteome-wide substrate screen for EFM6 has been reported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Excluding or discovering additional substrates would define the full functional scope of
+    the enzyme and rule out (or in) a broader role beyond eEF1A.
+  resolution: &gt;-
+    Perform an activity-based, proteome-wide substrate screen (e.g. using EFM6 as enzyme source
+    with a methyltransferase-deficient extract, or SILAC/heavy-methyl profiling of efm6Δ vs WT).
+  provenance:
+  - reference_id: PMID:26115316
+    supporting_text: &gt;-
+      demonstrating that the enzyme is highly specific for eEF1A
+suggested_questions:
+- question: &gt;-
+    What is the physiological function of eEF1A-Lys390 methylation, and under what conditions
+    (stress, sporulation, aging) is it regulated?
+  experts:
+  - Yeast translation and elongation-factor biologists
+  - Protein methylation / post-translational modification biologists
+- question: &gt;-
+    Does EFM6 act as a standalone methyltransferase on eEF1A, and does the GTP/GDP conformational
+    state of eEF1A gate the modification?
+  experts:
+  - Methyltransferase enzymologists
+  - eEF1A structural biologists
+suggested_experiments:
+- hypothesis: &gt;-
+    eEF1A-Lys390 methylation modulates a specific (possibly non-canonical) eEF1A function or a
+    stress/aging response rather than bulk translation.
+  description: &gt;-
+    Compare efm6Δ and eEF1A-K390R strains to wild type across growth, translational fidelity,
+    stress and sporulation conditions, and non-canonical eEF1A assays (actin bundling, nuclear
+    export), including quantitative phenotyping and proteomics.
+  experiment_type: comparative phenotyping / functional assays
+- hypothesis: &gt;-
+    EFM6 is a self-sufficient methyltransferase whose activity depends on the eEF1A nucleotide state.
+  description: &gt;-
+    Reconstitute methylation with purified active EFM6 and eEF1A in defined GTP- vs GDP-bound
+    states and measure steady-state kinetics; if soluble EFM6 cannot be purified, use co-expression
+    or on-substrate/extract-based quantitative assays.
+  experiment_type: in vitro enzymology
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/FSH3/FSH3-ai-review.html
+++ b/genes/yeast/FSH3/FSH3-ai-review.html
@@ -1,0 +1,2680 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FSH3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>FSH3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q99369" target="_blank" class="term-link">
+                        Q99369
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "FSH3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q99369" data-a="DESCRIPTION: FSH3 (YOR280C, &#34;Family of Serine Hydrolases 3&#34;) is..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>FSH3 (YOR280C, &#34;Family of Serine Hydrolases 3&#34;) is a 266-residue serine hydrolase of the alpha/beta-hydrolase fold (AB-hydrolase-3 / Pfam FSH1 family) in the budding yeast Saccharomyces cerevisiae. It carries a complete, canonical Ser-Asp-His catalytic triad, with the nucleophilic serine (Ser117) in a classic GXSXG &#34;nucleophile elbow&#34; motif, and was directly detected as a catalytically active serine hydrolase in yeast by activity-based protein profiling. Its physiological substrate and specific reaction are undetermined; UniProt assigns only the uncommitted esterase activity EC 3.1.-.- and describes it as a &#34;serine hydrolase of unknown specificity&#34;. FSH3 is one of three paralogous S. cerevisiae FSH proteins (with FSH1 and FSH2) and is the yeast counterpart of the human candidate tumor-suppressor esterase OVCA2. It localizes to the peroxisome and to cytoplasmic pools; its expression is induced by the DNA-damage-checkpoint effector Crt1/RFX1 and by oxidative (H2O2) stress. Overexpression of FSH3 perturbs cellular lipid content (notably reducing phosphatidylcholine) and triggers a NUC1-dependent apoptotic phenotype. Single deletion causes no growth defect under standard conditions, but a double mutant lacking both FSH3 and the peroxisomal lipase Lpx1 has reduced peroxisomal fatty-acid beta-oxidation activity, implicating FSH3 (redundantly with Lpx1) in peroxisomal lipid/fatty-acid metabolism; its precise molecular contribution and physiological substrate remain unresolved.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q99369" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) nuclear localization propagated across the OVCA2/FSH family. It is not supported by the yeast-specific experimental evidence, which places FSH3 in the peroxisome (IDA), nor by any FSH3 assay. This is a weak, over-propagated location for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA-only nuclear localization with no experimental support in yeast; the experimentally verified compartment is the peroxisome (GO:0005777, IDA). Family-wide phylogenetic propagation of a nuclear location is not substantiated for FSH3.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q8WZ82</span>
+
+                                    &middot; OVCA2 (human)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">PANTHER OVCA2 subfamily (PTHR48070:SF6) seed; a nuclear location for the family is not substantiated for yeast FSH3, whose experimental compartment is the peroxisome.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q99369" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) cytoplasmic localization. FSH3 has cytoplasmic/stress-granule associations (CD-CODE stress granule cross-ref) and a soluble alpha/beta-hydrolase is consistent with a cytoplasmic pool, so this general location is plausible, but it is non-core relative to the experimentally established peroxisomal localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> General, phylogenetically inferred location that is plausible for a soluble hydrolase but is not the informative, experimentally supported compartment; retained as non-core alongside the IDA peroxisome annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
+                                    GO:0016787
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q99369" data-a="GO:0016787" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but uninformatively general. FSH3 has a complete, canonical Ser-Asp-His catalytic triad (Ser117 in a GXSXG motif, Asp180, His209) on an alpha/beta-hydrolase scaffold, and was detected as a catalytically active serine hydrolase by activity-based proteomics. These support the more specific mechanism-defined term serine hydrolase activity (GO:0017171).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic hydrolase activity term should be replaced by the mechanism-specific GO:0017171 (serine hydrolase activity), which is directly supported by the intact Ser-Asp-His triad, the diagnostic GXSXG nucleophile-elbow motif, and the activity-based proteomic detection of FSH3 as an active serine hydrolase. The specific substrate/reaction remains unknown (EC 3.1.-.-), so a more specific catalytic term is not yet justified.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q8WZ82</span>
+
+                                    &middot; OVCA2 (human)
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The IBA hydrolase-activity transfer from the OVCA2 esterase subfamily is correct in branch but too general; the intact Ser-Asp-His triad and GXSXG motif in FSH3 support the more specific serine hydrolase activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017171" target="_blank" class="term-link">
+                                    serine hydrolase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14645503" target="_blank" class="term-link">
+                                        PMID:14645503
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Three of the previously uncharacterized proteins are members of a eukaryotic serine hydrolase family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                    GO:0005777
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36164978" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36164978
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Systematic multi-level analysis of an organelle proteome rev...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99369" data-a="GO:0005777" data-r="PMID:36164978" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally determined (IDA) peroxisomal localization from a systematic peroxisome-proteome analysis in which FSH3 is one of the newly identified peroxisomal proteins. This is the informative, experimentally supported compartment for FSH3 and is retained as a core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence (IDA) from a systematic peroxisome-proteome study; the curator had access to the full dataset. This is the strongest localization annotation for FSH3.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36164978" target="_blank" class="term-link">
+                                        PMID:36164978
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Lipidomic analysis on mutants of 10 newly identified peroxisomal proteins whose molecular function in the yeast cell is putative or unknown shows that cells overexpressing FSH3 had the most significant change in all conditions compared to the control strain, with a reduction of PC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q99369" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND, &#34;no biological data&#34;) reflecting the historical absence of a curated molecular function. It is superseded by the informative serine hydrolase activity now supported by the domain/triad analysis and the IBA hydrolase annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root placeholder is superseded by informative molecular-function evidence (serine hydrolase activity); root ND annotations should not be retained once a real function is available.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q99369" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder (ND) for biological process. FSH3&#39;s native biological process is genuinely unresolved (no deletion phenotype under standard conditions), so this remains a real knowledge gap rather than a curatable term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root placeholder; uninformative. The genuine uncertainty about FSH3&#39;s biological role is recorded in knowledge_gaps rather than as a root-term ND annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Serine hydrolase (alpha/beta-hydrolase fold, AB-hydrolase-3 / Fsh family) with a complete, canonical Ser-Asp-His catalytic triad: the nucleophilic Ser117 sits in a diagnostic GXSXG motif (G115-F-S-Q-G119), with Asp180 and His209 completing the charge-relay system. FSH3 was directly detected as a catalytically active serine hydrolase in yeast by activity-based protein profiling, confirming the triad is functional. The specific physiological substrate and reaction are undetermined (UniProt EC 3.1.-.-, &#34;serine hydrolase of unknown specificity&#34;), so only the mechanism-defined activity is asserted here.</h3>
+                <span class="vote-buttons" data-g="Q99369" data-a="FUNCTION: Serine hydrolase (alpha/beta-hydrolase fold, AB-hy..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017171" target="_blank" class="term-link">
+                            serine hydrolase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                peroxisome
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14645503" target="_blank" class="term-link">
+                                PMID:14645503
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Three of the previously uncharacterized proteins are members of a eukaryotic serine hydrolase family</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36164978" target="_blank" class="term-link">
+                                PMID:36164978
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">cells overexpressing FSH3 had the most significant change in all conditions compared to the control strain, with a reduction of PC</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14645503" target="_blank" class="term-link">
+                            PMID:14645503
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synergistic computational and experimental proteomics approaches for more accurate detection of active serine hydrolases in yeast.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15494396" target="_blank" class="term-link">
+                            PMID:15494396
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of new genes regulated by the Crt1 transcription factor, an effector of the DNA damage checkpoint pathway in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36164978" target="_blank" class="term-link">
+                            PMID:36164978
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Systematic multi-level analysis of an organelle proteome reveals new peroxisomal functions.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30776074" target="_blank" class="term-link">
+                            PMID:30776074
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">FSH3 mediated cell death is dependent on NUC1 in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24187129" target="_blank" class="term-link">
+                            PMID:24187129
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Screening for hydrolytic enzymes reveals Ayr1p as a novel triacylglycerol lipase in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the natural substrate of FSH3, and does the S117A catalytic-dead mutant lose the overexpression phenotypes (apoptosis, PC reduction)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99369" data-a="Q: What is the natural substrate of FSH3, and does th..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is FSH3 functionally redundant with FSH2 (its OVCA2-subfamily paralog) and/or FSH1, and does a triple fsh deletion reveal a phenotype absent in single mutants?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99369" data-a="Q: Is FSH3 functionally redundant with FSH2 (its OVCA..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does FSH3 act in peroxisomal glycerophospholipid metabolism, and is the OVCA2 human ortholog&#39;s function conserved?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99369" data-a="Q: Does FSH3 act in peroxisomal glycerophospholipid m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare wild-type FSH3, catalytic-dead FSH3(S117A), and empty-vector strains for the overexpression phenotypes (ROS accumulation, viability, PC levels). Loss of phenotype in S117A would establish that they depend on catalytic serine-hydrolase activity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: FSH3 is a catalytically active serine hydrolase whose in-cell phenotypes require the Ser117 nucleophile.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q99369" data-a="EXPERIMENT: Compare wild-type FSH3, catalytic-dead FSH3(S117A)..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant FSH3 and assay activity against fluorogenic ester panels and defined lipids (including phosphatidylcholine) in vitro; combine with untargeted lipidomics/metabolomics of fsh3-delta vs wild type to identify accumulating candidate substrates.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: FSH3 hydrolyzes a peroxisomal glycerophospholipid or ester substrate.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q99369" data-a="EXPERIMENT: Purify recombinant FSH3 and assay activity against..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct single, double and triple fsh deletions and phenotype across oxidative, DNA-damage and oleate (peroxisome-inducing) conditions, with epistasis to NUC1.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Single-deletion silence of FSH3 is due to redundancy with FSH1/FSH2.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q99369" data-a="EXPERIMENT: Construct single, double and triple fsh deletions ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate of FSH3 and the specific reaction it catalyzes are undetermined. Only an uncommitted esterase activity (EC 3.1.-.-) is assigned, and UniProt describes FSH3 as a &#34;serine hydrolase of unknown specificity&#34;.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> FSH3 has a complete, canonical Ser-Asp-His serine-hydrolase catalytic triad (Ser117 in a GXSXG motif, Asp180, His209) on an alpha/beta-hydrolase fold and was detected as a catalytically active serine hydrolase by activity-based proteomics in yeast; the class of chemistry (serine-nucleophile ester/amide hydrolysis) is therefore known, but no natural substrate has been identified.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> FSH3 is the yeast counterpart of the human candidate tumor-suppressor esterase OVCA2; identifying its substrate would define the molecular function of a conserved but functionally dark eukaryotic serine-hydrolase family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In-vitro substrate profiling (e.g. fluorogenic ester/lipid panels, competitive activity-based protein profiling with FP-probes) of recombinant FSH3 and a catalytic-serine (S117A) mutant, paired with untargeted metabolomics/lipidomics of fsh3-delta vs wild type to identify accumulating candidate substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Three of the previously uncharacterized proteins are members of a eukaryotic serine hydrolase family"</em> — PMID:14645503</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The precise biological role/pathway of FSH3 is not fully resolved. Its single deletion causes no growth defect under standard conditions, and its overexpression phenotypes (PC reduction, NUC1-dependent apoptosis) cannot be read as its native role. A loss-of-function clue does exist: a double mutant lacking both FSH3 and the peroxisomal lipase Lpx1 (but neither single mutant) has reduced peroxisomal fatty-acid beta-oxidation activity, implicating FSH3 in peroxisomal fatty-acid beta-oxidation (GO:0006635; peroxisomal in yeast) redundantly with Lpx1 -- but FSH3&#39;s specific molecular step in that pathway is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> FSH3 localizes to the peroxisome, is induced by the DNA-damage-checkpoint effector Crt1/RFX1 and by H2O2, its overexpression reduces phosphatidylcholine and triggers NUC1-dependent apoptosis, and a double deletion of FSH3 with LPX1 shows a significant reduction in beta-oxidation activity relative to control and both single mutants (an overlapping role for Fsh3 with Lpx1). Single-deletion growth is silent, so the specific pathway step and whether the beta-oxidation contribution is direct (an acyl-ester hydrolase step) or indirect remain open.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The Fsh3/Lpx1 double-mutant beta-oxidation defect provides a candidate pathway (peroxisomal fatty-acid beta-oxidation / lipid mobilization) and explains why single deletions look silent (redundancy with Lpx1); resolving FSH3&#39;s specific role there would move it from BP-dark to an annotatable biological process (candidate GO:0006635 fatty acid beta-oxidation), and let the overexpression apoptosis phenotype be interpreted.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Condition-specific phenotyping of fsh3-delta and fsh3/lpx1 combinations on fatty-acid (oleate) growth and direct beta-oxidation-flux assays, epistasis with FSH1/FSH2 and NUC1, to define FSH3&#39;s step in peroxisomal fatty-acid metabolism and justify a GO:0006635 (fatty acid beta-oxidation) annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The deletion of FSH3 improved the yeast growth rate under H2O2-induction as compared to WT control cells."</em> — PMID:30776074</li>
+
+                <li><em>"suggesting an overlapping role for Fsh3 with Lpx1"</em> — PMID:36164978</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The degree and direction of functional redundancy among the three paralogous S. cerevisiae serine hydrolases FSH1, FSH2 and FSH3 is unresolved; whether they share substrates or act in overlapping/opposing pathways is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> All three are members of the Fsh serine-hydrolase family sharing conservation with human OVCA2, and fsh double deletions (fsh1 fsh2, fsh1 fsh3, fsh2 fsh3) grow faster than wild type, indicating some shared or overlapping influence on growth; but no shared molecular substrate or pathway has been established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Redundancy among paralogs is the most likely reason single deletions are silent; resolving it is a prerequisite for detecting loss-of-function phenotypes and for assigning family-level function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Comparative biochemistry of purified FSH1/FSH2/FSH3 on shared substrate panels and phenotyping of single, double, and triple fsh deletions across stress conditions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The double deletions fsh1Δ fsh2Δ, fsh1Δ fsh3Δ and fsh2Δ fsh3Δ displayed increased growth compared to WT cells."</em> — PMID:30776074</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether peroxisomal FSH3 acts directly on a glycerophospholipid substrate (e.g. phosphatidylcholine) or whether the phosphatidylcholine reduction seen on FSH3 overexpression is an indirect consequence of a different activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> FSH3 overexpression produces the strongest lipidome change (PC reduction) among a panel of dark peroxisomal proteins, and FSH3 has the catalytic machinery of a serine ester hydrolase; but no in-vitro assay has shown FSH3 hydrolyzing PC or any defined lipid.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A direct link between FSH3 and glycerophospholipid turnover would give the family a concrete molecular function and connect it to peroxisomal lipid metabolism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct in-vitro lipase/phospholipase assays on recombinant FSH3 (and S117A) against PC and related glycerophospholipids, with lipidomics of fsh3-delta to test for the reciprocal (accumulation) effect.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"cells overexpressing FSH3 had the most significant change in all conditions compared to the control strain, with a reduction of PC"</em> — PMID:36164978</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FSH3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q99369" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fsh3-yor280c-research-notes">FSH3 (YOR280C) research notes</h1>
+<p>Gene: FSH3 / YOR280C, <em>Saccharomyces cerevisiae</em> (S288C), UniProt Q99369, SGD S000005806.<br />
+Name: "Family of Serine Hydrolases 3". 266 aa. UniProt EC=3.1.-.- (esterase, generic).<br />
+This is a functionally dark gene: a putative serine hydrolase of <strong>unknown physiological<br />
+substrate / reaction / in-vivo role</strong>.</p>
+<h2 id="summary-of-what-is-known-vs-not-known">Summary of what is KNOWN vs NOT KNOWN</h2>
+<p>KNOWN (defensible):<br />
+- Belongs to the α/β-hydrolase fold, AB-hydrolase-3 family; Pfam FSH1 (PF03959),<br />
+  InterPro AB_hydrolase_fold (IPR029058) + FSH-like domain (IPR005645); PANTHER family<br />
+  PTHR48070 subfamily SF6 "ESTERASE OVCA2"; SCOP/SUPFAM alpha/beta-Hydrolases (SSF53474).<br />
+- Has an intact, canonical serine-hydrolase catalytic triad (Ser-Asp-His) with the<br />
+  nucleophile in a classic GXSXG motif (see domain analysis below).<br />
+- Was directly detected as an <em>active</em> serine hydrolase by activity-based protein profiling<br />
+  (chemical + computational proteomics) in yeast — i.e. the catalytic serine is chemically<br />
+  reactive in vivo <a href="https://pubmed.ncbi.nlm.nih.gov/14645503">PMID:14645503</a>.<br />
+- Transcriptionally induced as a target of the Crt1/RFX1 repressor (DNA-damage-checkpoint<br />
+  effector) <a href="https://pubmed.ncbi.nlm.nih.gov/15494396">PMID:15494396</a>, and induced by H2O2/oxidative stress <a href="https://pubmed.ncbi.nlm.nih.gov/30776074">PMID:30776074</a>.<br />
+- Localizes to the peroxisome (IDA, SGD) <a href="https://pubmed.ncbi.nlm.nih.gov/36164978">PMID:36164978</a>; is one of a set of newly identified<br />
+  peroxisomal proteins of unknown molecular function.<br />
+- Overexpression phenotypes: overexpression causes an apoptotic/ROS phenotype dependent on<br />
+  NUC1 <a href="https://pubmed.ncbi.nlm.nih.gov/30776074">PMID:30776074</a>, and overexpression produces the strongest lipidome change (reduction<br />
+  of phosphatidylcholine, PC) among a panel of dark peroxisomal proteins <a href="https://pubmed.ncbi.nlm.nih.gov/36164978">PMID:36164978</a>.</p>
+<p>NOT KNOWN (the gaps — primary deliverable):<br />
+- The physiological substrate and the specific reaction it catalyzes. UniProt states<br />
+  "Serine hydrolase of unknown specificity" and assigns only EC 3.1.-.- (uncommitted esterase).<br />
+- The in-vivo biological role / pathway. Single deletion has no reported <em>growth</em> phenotype<br />
+  under standard conditions, but a double-deletion (Δlpx1Δfsh3) shows reduced peroxisomal<br />
+  β-oxidation activity <a href="https://pubmed.ncbi.nlm.nih.gov/36164978">PMID:36164978</a>, implicating FSH3 (redundantly with Lpx1) in<br />
+  peroxisomal fatty-acid β-oxidation. The specific molecular step/substrate remains unassigned.<br />
+- Functional redundancy with paralogs FSH1 and FSH2 (double-deletion data below suggest<br />
+  partial redundancy / opposing roles but do not assign a molecular function).<br />
+- Whether the PC reduction on overexpression reflects a direct enzymatic activity on a<br />
+  glycerophospholipid substrate, or an indirect consequence.</p>
+<h2 id="domain-catalytic-triad-analysis-inline-from-fsh3-uniprottxt-sequence">Domain / catalytic-triad analysis (inline, from FSH3-uniprot.txt sequence)</h2>
+<p>UniProt annotates three "Charge relay system" active-site residues (by similarity, ECO:0000250):<br />
+- ACT_SITE 117, 180, 209.</p>
+<p>Mapping onto the 266-aa sequence (verified computationally, see below):<br />
+- Position 117 = <strong>Ser</strong> (nucleophile), embedded in <strong>G115-F116-S117-Q118-G119 = GFSQG</strong>, a<br />
+  textbook <strong>GXSXG</strong> "nucleophile elbow" motif of α/β-hydrolases.<br />
+- Position 180 = <strong>Asp</strong> (acid of the triad).<br />
+- Position 209 = <strong>His</strong> (base of the triad).</p>
+<p>So FSH3 carries a <strong>complete, canonical Ser-Asp-His serine-hydrolase catalytic triad</strong> on an<br />
+α/β-hydrolase scaffold, with the nucleophilic serine in the diagnostic GXSXG motif. The triad<br />
+is intact (this is NOT a pseudoenzyme). Consistent with this, activity-based profiling detected<br />
+FSH3 as a <em>catalytically active</em> serine hydrolase in vivo <a href="https://pubmed.ncbi.nlm.nih.gov/14645503">PMID:14645503</a>. This makes a generic<br />
+serine-hydrolase molecular function (GO:0017171 serine hydrolase activity) domain-defensible;<br />
+a <em>specific</em> substrate/reaction remains a genuine gap.</p>
+<p>Verification (residue identity + motif), reproducible:</p>
+<div class="codehilite"><pre><span></span><code><span class="n">seq</span> <span class="o">=</span> <span class="p">(</span><span class="s2">&quot;MSEKKKVLMLHGFVQSDKIFSAKTGGLRKNLKKLGYDLYYPCAPHSIDKKALFQSESEKG&quot;</span>
+       <span class="s2">&quot;RDAAKEFNTSATSDEVYGWFFRNPESFNSFQIDQKVFNYLRNYVLENGPFDGVIGFSQGA&quot;</span>
+       <span class="s2">&quot;GLGGYLVTDFNRILNLTDEQQPALKFFISFSGFKLEDQSYQKEYHRIIQVPSLHVRGELD&quot;</span>
+       <span class="s2">&quot;EVVAESRIMALYESWPDNKRTLLVHPGAHFVPNSKPFVSQVCNWIQGITSKEGQEHNAQP&quot;</span>
+       <span class="s2">&quot;EVDRKQFDKPQLEDDLLDMIDSLGKL&quot;</span><span class="p">)</span>
+<span class="k">assert</span> <span class="n">seq</span><span class="p">[</span><span class="mi">116</span><span class="p">]</span> <span class="o">==</span> <span class="s2">&quot;S&quot;</span> <span class="ow">and</span> <span class="n">seq</span><span class="p">[</span><span class="mi">179</span><span class="p">]</span> <span class="o">==</span> <span class="s2">&quot;D&quot;</span> <span class="ow">and</span> <span class="n">seq</span><span class="p">[</span><span class="mi">208</span><span class="p">]</span> <span class="o">==</span> <span class="s2">&quot;H&quot;</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">re</span><span class="p">;</span> <span class="k">assert</span> <span class="n">re</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;G.S.G&quot;</span><span class="p">,</span> <span class="n">seq</span><span class="p">)</span><span class="o">.</span><span class="n">start</span><span class="p">()</span><span class="o">+</span><span class="mi">1</span> <span class="o">==</span> <span class="mi">115</span>  <span class="c1"># GFSQG, Ser at 117</span>
+</code></pre></div>
+
+<h2 id="fsh3-vs-paralogs-fsh1-fsh2-and-human-ovca2-keep-these-separate">FSH3 vs paralogs FSH1 / FSH2 and human OVCA2 (keep these separate)</h2>
+<p><em>S. cerevisiae</em> has three FSH paralogs, all named for this "Family of Serine Hydrolases":<br />
+- <strong>FSH1</strong> = P38777 / YHR049W (243 aa). PANTHER subfamily <strong>SF9</strong> (distinct from FSH3).<br />
+  The crystal structure 1YCD is FSH1/YHR049W, "a member of the serine hydrolase family"<br />
+  (PANTHER PTHR48070 representative structure).<br />
+- <strong>FSH2</strong> = Q05015 / YMR222C (223 aa). PANTHER subfamily <strong>SF6</strong> (same subfamily as FSH3).<br />
+- <strong>FSH3</strong> = Q99369 / YOR280C (266 aa). PANTHER subfamily <strong>SF6</strong> "ESTERASE OVCA2".</p>
+<p>So FSH3 is in the OVCA2 subfamily (SF6) together with FSH2 and human OVCA2, and is more<br />
+distantly related to FSH1 (SF9). The human ortholog is <strong>OVCA2 (Q8WZ82)</strong>, a candidate ovarian<br />
+tumor-suppressor esterase; OVCA2 is the source of the phylogenetic (IBA) inferences in GOA<br />
+(GOA IBA uses UniProtKB:Q8WZ82 and PANTHER:PTN000512658 as with/from). The <em>S. pombe</em> member of<br />
+this family is DYR-SCHPO / SPAC22A12.06c.</p>
+<p>Provenance for the family framing:<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/14645503" title="Three of the previously uncharacterized proteins are members of a eukaryotic   serine hydrolase family, designated as Fsh (family of serine hydrolase), identified here for   the first time. OVCA2, a potential human tumor suppressor, and DYR-SCHPO, a dihydrofolate   reductase from Schizosaccharomyces pombe, are members of this family.">PMID:14645503</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/30776074" title="Family of Serine Hydrolases (FSH) members FSH1, FSH2 and FSH3 in   Saccharomyces cerevisiae share conserved sequences with the human candidate tumor suppressor   OVCA2.">PMID:30776074</a></p>
+<p>CAUTION: The DYR-SCHPO/DHFR association in <a href="https://pubmed.ncbi.nlm.nih.gov/14645503">PMID:14645503</a> and the speculation in<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15494396">PMID:15494396</a> that "FSH3p ... may be involved in folate metabolism ... by carrying serine<br />
+hydrolase activity required for the novel metabolic pathway involving dihydrofolate reductase<br />
+(DHFR) or by directly interacting with the DHFR enzyme" is <strong>speculation from sequence<br />
+similarity</strong>, not experimental evidence for a FSH3 DHFR/folate function. Do not annotate folate<br />
+metabolism from this.</p>
+<h2 id="evidence-by-reference">Evidence by reference</h2>
+<h3 id="pmid14645503-baxter-et-al-2004-mol-cell-proteomics-function-abpp">PMID:14645503 (Baxter et al. 2004, Mol Cell Proteomics) — FUNCTION (ABPP)</h3>
+<p>Activity-based/computational proteomics identifying active serine hydrolases in yeast; defines<br />
+the Fsh family and detects FSH3 as an active serine hydrolase. This is the source cited by<br />
+UniProt for FUNCTION "Serine hydrolase of unknown specificity" (ECO:0000269|PubMed:14645503).<br />
+- Supports: serine hydrolase activity (catalytically active in vivo), family definition.<br />
+- Abstract-only in cache (full_text_available: false).</p>
+<h3 id="pmid15494396-zaim-et-al-2005-j-biol-chem-induction-crt1rfx1">PMID:15494396 (Zaim et al. 2005, J Biol Chem) — INDUCTION (Crt1/RFX1)</h3>
+<p>FSH3 is a confirmed transcriptional target of Crt1p (RFX1), the DNA-damage-checkpoint effector.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/15494396" title="Our results indicated that FSH3, YLR345W, and NTH2 are indeed under the   regulation of Crt1p.">PMID:15494396</a><br />
+- The DHFR/folate idea here is speculative (see CAUTION above).<br />
+- Source of UniProt INDUCTION "Regulated by RFX1/CRT1".</p>
+<h3 id="pmid36164978-yifrach-et-al-2022-embo-j-family-peroxisome-ida-lipidome">PMID:36164978 (Yifrach et al. 2022, EMBO J-family) — peroxisome IDA + lipidome</h3>
+<p>Systematic multi-level analysis of the peroxisome proteome. FSH3 is a newly identified<br />
+peroxisomal protein (basis of the SGD IDA C:peroxisome annotation).<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/36164978" title="Lipidomic analysis on mutants of 10 newly identified peroxisomal proteins   whose molecular function in the yeast cell is putative or unknown shows that cells   overexpressing FSH3 had the most significant change in all conditions compared to the control   strain, with a reduction of PC (raw data is in Dataset EV7).">PMID:36164978</a><br />
+- Supports: C:peroxisome (IDA); a lipid-metabolism-linked phenotype on overexpression<br />
+  (reduction of phosphatidylcholine). Note this is an overexpression lipidome effect, not<br />
+  proof of a direct PC-hydrolase activity.<br />
+- IMPORTANT (deletion-based phenotype, from full text): a peroxisomal β-oxidation activity<br />
+  assay of single and double deletions shows Δfsh3 contributes to β-oxidation:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36164978" title="A β‐oxidation activity assay of Δlpx1, Δfsh3, and Δlpx1Δfsh3 strains   supplemented with labeled 8 carbon‐ or 18 carbon‐free fatty acids in media supplemented   with 0.5% glucose shows a significant reduction in β‐oxidation activity compared to the   control strain and the two single mutants, suggesting an overlapping role for Fsh3 with   Lpx1.">PMID:36164978</a>. Lpx1 is the peroxisomal lipase; the double mutant Δlpx1Δfsh3 (but not either<br />
+  single mutant) has reduced β-oxidation. This is a concrete deletion (loss-of-function)<br />
+  clue that FSH3 has a redundant/overlapping role in peroxisomal fatty-acid β-oxidation —<br />
+  consistent with the peroxisomal localization and the PC-reduction lipidome result. It<br />
+  refines the "no deletion phenotype" statement: single-deletion <em>growth</em> is silent, but<br />
+  a biochemical double-mutant β-oxidation phenotype exists and points to a candidate<br />
+  pathway (GO:0006635 fatty acid beta-oxidation; in yeast this is exclusively peroxisomal).<br />
+  This is why single fsh/lpx1 deletions look silent (redundancy). The molecular role of<br />
+  FSH3 in that pathway (which acyl-ester substrate it hydrolyzes) is still unassigned.</p>
+<h3 id="pmid30776074-gowsalya-et-al-2019-fems-yeast-res-overexpression-apoptosis-nuc1">PMID:30776074 (Gowsalya et al. 2019, FEMS Yeast Res) — overexpression apoptosis, NUC1</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/30776074" title="hydrogen peroxide (H2O2) exposure increased the expression of both mRNA and   protein levels of FSH3">PMID:30776074</a> — H2O2/oxidative-stress induction.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/30776074" title="The overexpression of FSH3 in WT yeast cells caused an apoptotic phenotype,   including accumulation of reaction oxygen species, decreased cell viability and cell death.">PMID:30776074</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/30776074" title="Our results suggest that FSH3 induced apoptosis of yeast in a NUC1 dependent   manner.">PMID:30776074</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/30776074" title="The deletion of FSH3 improved the yeast growth rate under H2O2-induction as   compared to WT control cells.">PMID:30776074</a> — deletion is not required for viability; gives a growth<br />
+  benefit under H2O2.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/30776074" title="The double deletions fsh1Δ fsh2Δ, fsh1Δ fsh3Δ and fsh2Δ fsh3Δ displayed   increased growth compared to WT cells.">PMID:30776074</a> — partial redundancy / shared pathway among paralogs.</li>
+</ul>
+<h3 id="pmid24187129-ploier-et-al-2013-j-biol-chem-background-on-yeast-peroxisomalld-hydrolases">PMID:24187129 (Ploier et al. 2013, J Biol Chem) — background on yeast peroxisomal/LD hydrolases</h3>
+<p>Screen for hydrolytic enzymes in yeast peroxisomes and lipid droplets using GXSXG-motif serine<br />
+hydrolases; identifies Ayr1p as a TG lipase and confirms Lpx1p. Provides context for the class<br />
+of GXSXG serine hydrolases acting in peroxisomal/lipid metabolism (not a FSH3-specific paper).<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/24187129" title="All of these proteins contain the consensus sequence for a classical lipase   (G X S X G motif) with a classical catalytic triad containing a nucleophile serine.">PMID:24187129</a><br />
+- Relevance: contextual (LOW/MEDIUM) — supports plausibility of a peroxisomal lipid-related<br />
+  serine-hydrolase role, does not assign FSH3 a substrate.</p>
+<h2 id="annotation-decisions-rationale">Annotation decisions (rationale)</h2>
+<ul>
+<li>GO:0016787 hydrolase activity (IBA, MF): correct but too general. The intact Ser-His-Asp<br />
+  triad + GXSXG + ABPP reactivity support the more specific GO:0017171 serine hydrolase<br />
+  activity. MODIFY → GO:0017171.</li>
+<li>GO:0005777 peroxisome (IDA, PMID:36164978): ACCEPT (experimental, curator-verified).</li>
+<li>GO:0005634 nucleus (IBA), GO:0005737 cytoplasm (IBA): phylogenetically-inferred locations<br />
+  from the OVCA2 family. Cytoplasm is plausible/general; nucleus is not supported by the<br />
+  yeast-specific IDA evidence (which places it in peroxisome) and is a weak IBA. Keep as<br />
+  non-core (cytoplasm) / mark over-annotated (nucleus) rather than REMOVE — these are IBA, not<br />
+  experimental. FSH3 is also reported in stress granules (CD-CODE E03F929F) consistent with<br />
+  cytoplasmic pools.</li>
+<li>GO:0003674 molecular_function ND, GO:0008150 biological_process ND: root placeholders; REMOVE<br />
+  (superseded by informative annotations we now have / the IBA hydrolase annotation).</li>
+</ul>
+<h2 id="open-questions-gaps-primary-deliverable">Open questions / gaps (primary deliverable)</h2>
+<ol>
+<li>Physiological substrate + specific reaction (only EC 3.1.-.-; "unknown specificity"). The<br />
+   Δlpx1Δfsh3 β-oxidation phenotype nudges this toward a fatty-acyl/lipid ester substrate.</li>
+<li>In-vivo biological role/pathway. Refined: single-deletion growth is silent, but a<br />
+   double-mutant (Δlpx1Δfsh3) β-oxidation defect implicates FSH3 in peroxisomal fatty-acid<br />
+   β-oxidation (GO:0006635, peroxisomal in yeast), overlapping with the lipase Lpx1. The<br />
+   precise molecular contribution is still unknown.</li>
+<li>Redundancy vs paralogs and vs Lpx1: fsh double deletions grow faster <a href="https://pubmed.ncbi.nlm.nih.gov/30776074">PMID:30776074</a>,<br />
+   and Δlpx1Δfsh3 (but not single mutants) reduces β-oxidation <a href="https://pubmed.ncbi.nlm.nih.gov/36164978">PMID:36164978</a> — redundancy<br />
+   is the likely reason single deletions look silent; molecular function still unassigned.</li>
+<li>Whether peroxisomal FSH3 acts directly on a glycerophospholipid (PC) / fatty-acyl ester,<br />
+   or the PC/β-oxidation effects are indirect.<br />
+</content><br />
+</invoke></li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q99369
+gene_symbol: FSH3
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  FSH3 (YOR280C, &#34;Family of Serine Hydrolases 3&#34;) is a 266-residue serine
+  hydrolase of the alpha/beta-hydrolase fold (AB-hydrolase-3 / Pfam FSH1 family)
+  in the budding yeast Saccharomyces cerevisiae. It carries a complete, canonical
+  Ser-Asp-His catalytic triad, with the nucleophilic serine (Ser117) in a classic
+  GXSXG &#34;nucleophile elbow&#34; motif, and was directly detected as a catalytically
+  active serine hydrolase in yeast by activity-based protein profiling. Its
+  physiological substrate and specific reaction are undetermined; UniProt assigns
+  only the uncommitted esterase activity EC 3.1.-.- and describes it as a &#34;serine
+  hydrolase of unknown specificity&#34;. FSH3 is one of three paralogous S. cerevisiae
+  FSH proteins (with FSH1 and FSH2) and is the yeast counterpart of the human
+  candidate tumor-suppressor esterase OVCA2. It localizes to the peroxisome and to
+  cytoplasmic pools; its expression is induced by the DNA-damage-checkpoint
+  effector Crt1/RFX1 and by oxidative (H2O2) stress. Overexpression of FSH3
+  perturbs cellular lipid content (notably reducing phosphatidylcholine) and
+  triggers a NUC1-dependent apoptotic phenotype. Single deletion causes no growth
+  defect under standard conditions, but a double mutant lacking both FSH3 and the
+  peroxisomal lipase Lpx1 has reduced peroxisomal fatty-acid beta-oxidation
+  activity, implicating FSH3 (redundantly with Lpx1) in peroxisomal lipid/fatty-acid
+  metabolism; its precise molecular contribution and physiological substrate remain
+  unresolved.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: PMID:14645503
+  title: Synergistic computational and experimental proteomics approaches for more
+    accurate detection of active serine hydrolases in yeast.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines the eukaryotic Fsh (family of serine hydrolase) group and detects FSH3
+      as a catalytically active serine hydrolase by combined chemical/computational
+      activity-based proteomics. This is the paper UniProt cites for FUNCTION
+      (&#34;Serine hydrolase of unknown specificity&#34;). Abstract-only in cache; the FSH3
+      identification is in the full text/supplementary of this yeast serine-hydrolase
+      survey. Anchored to the yeast serine-hydrolase-family framing and the UniProt
+      FUNCTION evidence tag ECO:0000269|PubMed:14645503.
+- id: PMID:15494396
+  title: Identification of new genes regulated by the Crt1 transcription factor, an
+    effector of the DNA damage checkpoint pathway in Saccharomyces cerevisiae.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Experimentally confirms FSH3 is a transcriptional target of Crt1p (RFX1) by
+      RT-PCR in wild-type vs crt1-delta strains (source of UniProt INDUCTION).
+      NOTE: this paper&#39;s suggestion that FSH3 acts in folate metabolism / with DHFR
+      is explicit speculation from OVCA2/DYR-SCHPO sequence similarity, not
+      experimental data; it must not be used to annotate folate metabolism.
+- id: PMID:36164978
+  title: Systematic multi-level analysis of an organelle proteome reveals new peroxisomal
+    functions.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Systematic peroxisome-proteome study; basis of the SGD IDA C:peroxisome
+      annotation for FSH3 and reports that FSH3 overexpression gives the strongest
+      lipidome change (reduction of phosphatidylcholine) among dark peroxisomal
+      proteins. It also reports a deletion-based phenotype: a Fsh3/Lpx1 double
+      deletion (but neither single mutant) has reduced peroxisomal beta-oxidation
+      activity, suggesting FSH3 has an overlapping role with the peroxisomal lipase
+      Lpx1 in fatty-acid beta-oxidation. The PC lipid effect is an overexpression
+      phenotype, not proof of a direct PC-hydrolase activity.
+- id: PMID:30776074
+  title: FSH3 mediated cell death is dependent on NUC1 in Saccharomyces cerevisiae.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      FSH3-specific study: H2O2 induces FSH3; overexpression causes ROS
+      accumulation and NUC1-dependent apoptosis; single deletion is viable (grows
+      better under H2O2); fsh double deletions grow faster, indicating partial
+      redundancy among FSH paralogs. Establishes phenotype without assigning a
+      molecular substrate.
+- id: PMID:24187129
+  title: Screening for hydrolytic enzymes reveals Ayr1p as a novel triacylglycerol
+    lipase in Saccharomyces cerevisiae.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Background/contextual: characterizes GXSXG serine-hydrolase enzymes acting in
+      yeast peroxisomal and lipid-droplet lipid metabolism (Ayr1p, Lpx1p). Does not
+      assay FSH3 or assign it a substrate; supports the plausibility of a peroxisomal
+      serine-hydrolase acting in lipid metabolism.
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) nuclear localization propagated across the
+      OVCA2/FSH family. It is not supported by the yeast-specific experimental
+      evidence, which places FSH3 in the peroxisome (IDA), nor by any FSH3 assay.
+      This is a weak, over-propagated location for this gene.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      IBA-only nuclear localization with no experimental support in yeast; the
+      experimentally verified compartment is the peroxisome (GO:0005777, IDA).
+      Family-wide phylogenetic propagation of a nuclear location is not
+      substantiated for FSH3.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:Q8WZ82
+        source_label: OVCA2 (human)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          PANTHER OVCA2 subfamily (PTHR48070:SF6) seed; a nuclear location for the
+          family is not substantiated for yeast FSH3, whose experimental compartment
+          is the peroxisome.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) cytoplasmic localization. FSH3 has
+      cytoplasmic/stress-granule associations (CD-CODE stress granule cross-ref)
+      and a soluble alpha/beta-hydrolase is consistent with a cytoplasmic pool, so
+      this general location is plausible, but it is non-core relative to the
+      experimentally established peroxisomal localization.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      General, phylogenetically inferred location that is plausible for a soluble
+      hydrolase but is not the informative, experimentally supported compartment;
+      retained as non-core alongside the IDA peroxisome annotation.
+- term:
+    id: GO:0016787
+    label: hydrolase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct but uninformatively general. FSH3 has a complete, canonical
+      Ser-Asp-His catalytic triad (Ser117 in a GXSXG motif, Asp180, His209) on an
+      alpha/beta-hydrolase scaffold, and was detected as a catalytically active
+      serine hydrolase by activity-based proteomics. These support the more
+      specific mechanism-defined term serine hydrolase activity (GO:0017171).
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0017171
+      label: serine hydrolase activity
+    reason: &gt;-
+      The generic hydrolase activity term should be replaced by the mechanism-specific
+      GO:0017171 (serine hydrolase activity), which is directly supported by the intact
+      Ser-Asp-His triad, the diagnostic GXSXG nucleophile-elbow motif, and the
+      activity-based proteomic detection of FSH3 as an active serine hydrolase. The
+      specific substrate/reaction remains unknown (EC 3.1.-.-), so a more specific
+      catalytic term is not yet justified.
+    supported_by:
+    - reference_id: PMID:14645503
+      supporting_text: &gt;-
+        Three of the previously uncharacterized proteins are members of a eukaryotic
+        serine hydrolase family
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:Q8WZ82
+        source_label: OVCA2 (human)
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          The IBA hydrolase-activity transfer from the OVCA2 esterase subfamily is
+          correct in branch but too general; the intact Ser-Asp-His triad and GXSXG
+          motif in FSH3 support the more specific serine hydrolase activity.
+- term:
+    id: GO:0005777
+    label: peroxisome
+  evidence_type: IDA
+  original_reference_id: PMID:36164978
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally determined (IDA) peroxisomal localization from a systematic
+      peroxisome-proteome analysis in which FSH3 is one of the newly identified
+      peroxisomal proteins. This is the informative, experimentally supported
+      compartment for FSH3 and is retained as a core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence (IDA) from a systematic peroxisome-proteome study;
+      the curator had access to the full dataset. This is the strongest localization
+      annotation for FSH3.
+    supported_by:
+    - reference_id: PMID:36164978
+      supporting_text: &gt;-
+        Lipidomic analysis on mutants of 10 newly identified peroxisomal proteins
+        whose molecular function in the yeast cell is putative or unknown shows that
+        cells overexpressing FSH3 had the most significant change in all conditions
+        compared to the control strain, with a reduction of PC
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND, &#34;no biological data&#34;) reflecting the historical
+      absence of a curated molecular function. It is superseded by the informative
+      serine hydrolase activity now supported by the domain/triad analysis and the
+      IBA hydrolase annotation.
+    action: REMOVE
+    reason: &gt;-
+      ND root placeholder is superseded by informative molecular-function evidence
+      (serine hydrolase activity); root ND annotations should not be retained once a
+      real function is available.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root-level placeholder (ND) for biological process. FSH3&#39;s native biological
+      process is genuinely unresolved (no deletion phenotype under standard
+      conditions), so this remains a real knowledge gap rather than a curatable term.
+    action: REMOVE
+    reason: &gt;-
+      ND root placeholder; uninformative. The genuine uncertainty about FSH3&#39;s
+      biological role is recorded in knowledge_gaps rather than as a root-term ND
+      annotation.
+core_functions:
+- description: &gt;-
+    Serine hydrolase (alpha/beta-hydrolase fold, AB-hydrolase-3 / Fsh family) with a
+    complete, canonical Ser-Asp-His catalytic triad: the nucleophilic Ser117 sits in
+    a diagnostic GXSXG motif (G115-F-S-Q-G119), with Asp180 and His209 completing the
+    charge-relay system. FSH3 was directly detected as a catalytically active serine
+    hydrolase in yeast by activity-based protein profiling, confirming the triad is
+    functional. The specific physiological substrate and reaction are undetermined
+    (UniProt EC 3.1.-.-, &#34;serine hydrolase of unknown specificity&#34;), so only the
+    mechanism-defined activity is asserted here.
+  molecular_function:
+    id: GO:0017171
+    label: serine hydrolase activity
+  locations:
+  - id: GO:0005777
+    label: peroxisome
+  supported_by:
+  - reference_id: PMID:14645503
+    supporting_text: &gt;-
+      Three of the previously uncharacterized proteins are members of a eukaryotic
+      serine hydrolase family
+  - reference_id: PMID:36164978
+    supporting_text: &gt;-
+      cells overexpressing FSH3 had the most significant change in all conditions
+      compared to the control strain, with a reduction of PC
+knowledge_gaps:
+- gap_statement: &gt;-
+    The physiological substrate of FSH3 and the specific reaction it catalyzes are
+    undetermined. Only an uncommitted esterase activity (EC 3.1.-.-) is assigned, and
+    UniProt describes FSH3 as a &#34;serine hydrolase of unknown specificity&#34;.
+  boundary: &gt;-
+    FSH3 has a complete, canonical Ser-Asp-His serine-hydrolase catalytic triad
+    (Ser117 in a GXSXG motif, Asp180, His209) on an alpha/beta-hydrolase fold and was
+    detected as a catalytically active serine hydrolase by activity-based proteomics
+    in yeast; the class of chemistry (serine-nucleophile ester/amide hydrolysis) is
+    therefore known, but no natural substrate has been identified.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    FSH3 is the yeast counterpart of the human candidate tumor-suppressor esterase
+    OVCA2; identifying its substrate would define the molecular function of a
+    conserved but functionally dark eukaryotic serine-hydrolase family.
+  resolution: &gt;-
+    In-vitro substrate profiling (e.g. fluorogenic ester/lipid panels, competitive
+    activity-based protein profiling with FP-probes) of recombinant FSH3 and a
+    catalytic-serine (S117A) mutant, paired with untargeted metabolomics/lipidomics
+    of fsh3-delta vs wild type to identify accumulating candidate substrates.
+  provenance:
+  - reference_id: PMID:14645503
+    supporting_text: &gt;-
+      Three of the previously uncharacterized proteins are members of a eukaryotic
+      serine hydrolase family
+- gap_statement: &gt;-
+    The precise biological role/pathway of FSH3 is not fully resolved. Its single
+    deletion causes no growth defect under standard conditions, and its overexpression
+    phenotypes (PC reduction, NUC1-dependent apoptosis) cannot be read as its native
+    role. A loss-of-function clue does exist: a double mutant lacking both FSH3 and the
+    peroxisomal lipase Lpx1 (but neither single mutant) has reduced peroxisomal
+    fatty-acid beta-oxidation activity, implicating FSH3 in peroxisomal fatty-acid
+    beta-oxidation (GO:0006635; peroxisomal in yeast) redundantly with Lpx1 -- but
+    FSH3&#39;s specific molecular step in that pathway is undetermined.
+  boundary: &gt;-
+    FSH3 localizes to the peroxisome, is induced by the DNA-damage-checkpoint effector
+    Crt1/RFX1 and by H2O2, its overexpression reduces phosphatidylcholine and triggers
+    NUC1-dependent apoptosis, and a double deletion of FSH3 with LPX1 shows a
+    significant reduction in beta-oxidation activity relative to control and both single
+    mutants (an overlapping role for Fsh3 with Lpx1). Single-deletion growth is silent,
+    so the specific pathway step and whether the beta-oxidation contribution is direct
+    (an acyl-ester hydrolase step) or indirect remain open.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: NARROWING
+  significance: &gt;-
+    The Fsh3/Lpx1 double-mutant beta-oxidation defect provides a candidate pathway
+    (peroxisomal fatty-acid beta-oxidation / lipid mobilization) and explains why single
+    deletions look silent (redundancy with Lpx1); resolving FSH3&#39;s specific role there
+    would move it from BP-dark to an annotatable biological process (candidate
+    GO:0006635 fatty acid beta-oxidation), and let the overexpression apoptosis
+    phenotype be interpreted.
+  resolution: &gt;-
+    Condition-specific phenotyping of fsh3-delta and fsh3/lpx1 combinations on
+    fatty-acid (oleate) growth and direct beta-oxidation-flux assays, epistasis with
+    FSH1/FSH2 and NUC1, to define FSH3&#39;s step in peroxisomal fatty-acid metabolism and
+    justify a GO:0006635 (fatty acid beta-oxidation) annotation.
+  provenance:
+  - reference_id: PMID:30776074
+    supporting_text: &gt;-
+      The deletion of FSH3 improved the yeast growth rate under H2O2-induction as
+      compared to WT control cells.
+  - reference_id: PMID:36164978
+    supporting_text: &gt;-
+      suggesting an overlapping role for Fsh3 with Lpx1
+- gap_statement: &gt;-
+    The degree and direction of functional redundancy among the three paralogous
+    S. cerevisiae serine hydrolases FSH1, FSH2 and FSH3 is unresolved; whether they
+    share substrates or act in overlapping/opposing pathways is unknown.
+  boundary: &gt;-
+    All three are members of the Fsh serine-hydrolase family sharing conservation with
+    human OVCA2, and fsh double deletions (fsh1 fsh2, fsh1 fsh3, fsh2 fsh3) grow faster
+    than wild type, indicating some shared or overlapping influence on growth; but no
+    shared molecular substrate or pathway has been established.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Redundancy among paralogs is the most likely reason single deletions are silent;
+    resolving it is a prerequisite for detecting loss-of-function phenotypes and for
+    assigning family-level function.
+  resolution: &gt;-
+    Comparative biochemistry of purified FSH1/FSH2/FSH3 on shared substrate panels and
+    phenotyping of single, double, and triple fsh deletions across stress conditions.
+  provenance:
+  - reference_id: PMID:30776074
+    supporting_text: &gt;-
+      The double deletions fsh1Δ fsh2Δ, fsh1Δ fsh3Δ and fsh2Δ fsh3Δ displayed
+      increased growth compared to WT cells.
+- gap_statement: &gt;-
+    It is unknown whether peroxisomal FSH3 acts directly on a glycerophospholipid
+    substrate (e.g. phosphatidylcholine) or whether the phosphatidylcholine reduction
+    seen on FSH3 overexpression is an indirect consequence of a different activity.
+  boundary: &gt;-
+    FSH3 overexpression produces the strongest lipidome change (PC reduction) among a
+    panel of dark peroxisomal proteins, and FSH3 has the catalytic machinery of a
+    serine ester hydrolase; but no in-vitro assay has shown FSH3 hydrolyzing PC or any
+    defined lipid.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    A direct link between FSH3 and glycerophospholipid turnover would give the family
+    a concrete molecular function and connect it to peroxisomal lipid metabolism.
+  resolution: &gt;-
+    Direct in-vitro lipase/phospholipase assays on recombinant FSH3 (and S117A) against
+    PC and related glycerophospholipids, with lipidomics of fsh3-delta to test for the
+    reciprocal (accumulation) effect.
+  provenance:
+  - reference_id: PMID:36164978
+    supporting_text: &gt;-
+      cells overexpressing FSH3 had the most significant change in all conditions
+      compared to the control strain, with a reduction of PC
+suggested_questions:
+- question: &gt;-
+    What is the natural substrate of FSH3, and does the S117A catalytic-dead mutant
+    lose the overexpression phenotypes (apoptosis, PC reduction)?
+- question: &gt;-
+    Is FSH3 functionally redundant with FSH2 (its OVCA2-subfamily paralog) and/or
+    FSH1, and does a triple fsh deletion reveal a phenotype absent in single mutants?
+- question: &gt;-
+    Does FSH3 act in peroxisomal glycerophospholipid metabolism, and is the OVCA2
+    human ortholog&#39;s function conserved?
+suggested_experiments:
+- hypothesis: &gt;-
+    FSH3 is a catalytically active serine hydrolase whose in-cell phenotypes require
+    the Ser117 nucleophile.
+  description: &gt;-
+    Compare wild-type FSH3, catalytic-dead FSH3(S117A), and empty-vector strains for
+    the overexpression phenotypes (ROS accumulation, viability, PC levels). Loss of
+    phenotype in S117A would establish that they depend on catalytic serine-hydrolase
+    activity.
+- hypothesis: &gt;-
+    FSH3 hydrolyzes a peroxisomal glycerophospholipid or ester substrate.
+  description: &gt;-
+    Purify recombinant FSH3 and assay activity against fluorogenic ester panels and
+    defined lipids (including phosphatidylcholine) in vitro; combine with untargeted
+    lipidomics/metabolomics of fsh3-delta vs wild type to identify accumulating
+    candidate substrates.
+- hypothesis: &gt;-
+    Single-deletion silence of FSH3 is due to redundancy with FSH1/FSH2.
+  description: &gt;-
+    Construct single, double and triple fsh deletions and phenotype across oxidative,
+    DNA-damage and oleate (peroxisome-inducing) conditions, with epistasis to NUC1.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/GTT3/GTT3-ai-review.html
+++ b/genes/yeast/GTT3/GTT3-ai-review.html
@@ -1,0 +1,2692 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GTT3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>GTT3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P39996" target="_blank" class="term-link">
+                        P39996
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "GTT3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P39996" data-a="DESCRIPTION: GTT3 (systematic name YEL017W) encodes an understu..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GTT3 (systematic name YEL017W) encodes an understudied Saccharomyces cerevisiae multi-pass membrane protein of 337 residues. It has a large N-terminal cytoplasmic region containing two disordered, phosphorylation-bearing low-complexity segments, followed by two transmembrane helices that anchor it in the membrane. Global GFP localization and an N-terminal-tag localization library independently place the protein at the nuclear envelope / nuclear periphery. Although named &#34;glutathione transferase 3&#34; by analogy to the yeast Gtt/Gto glutathione transferases, GTT3 carries a distinct, GTT3-specific domain architecture (the InterPro &#34;putative GTT3&#34; signature IPR038872 with Pfam GTT3_N) rather than the canonical soluble glutathione S-transferase fold, and no glutathione-conjugation activity, substrate, or catalytic mechanism has been demonstrated for it. Its molecular function and biological role remain unknown.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39996" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that Gtt3 is a membrane protein. This is consistent with the UniProt topology model, which annotates two transmembrane helices and classifies Gtt3 as a multi-pass membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The membrane localization is well supported: UniProt models transmembrane segments at residues 240-260 and 314-336 and describes Gtt3 as a multi-pass membrane protein, and two independent high-throughput localization datasets place it at the nuclear envelope. The term is broad but not incorrect. A more specific cellular-component term (nuclear membrane) is also present in GOA and better captures the location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P39996
+
+                                </span>
+
+                                <div class="support-text">TRANSMEM        240..260</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P39996
+
+                                </span>
+
+                                <div class="support-text">TRANSMEM        314..336</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
+                                    GO:0031965
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39996" data-a="GO:0031965" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to nuclear membrane derived from the UniProt Subcellular Location vocabulary. UniProt records &#34;Nucleus membrane; Multi-pass membrane protein&#34;, based on the Huh et al. global GFP localization study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the most informative and best-supported cellular-component annotation for Gtt3. It is corroborated by an independent experimental screen (the SWAp-Tag N&#39;-GFP library) that assigns Gtt3 a nuclear-periphery localization (GO:0034399, HDA). The nuclear-envelope location, together with the multi-pass topology, is the core established fact about this protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P39996
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Nucleus membrane {ECO:0000269|PubMed:14562095};</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                        PMID:14562095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">into 22 distinct subcellular localization categories</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034399" target="_blank" class="term-link">
+                                    GO:0034399
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear periphery</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26928762
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    One library to make them all: streamlining the creation of y...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39996" data-a="GO:0034399" data-r="PMID:26928762" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput direct-assay (HDA) localization to the nuclear periphery from the SWAp-Tag (SWAT) N&#39;-terminal GFP library, in which each strain was imaged and manually assigned up to three subcellular localization categories, one of which is &#34;Nuclear periphery&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This experimental localization is consistent with, and complementary to, the UniProt nuclear-membrane annotation and the Huh et al. GFP screen. Nuclear periphery (the nuclear-lumen region proximal to the inner nuclear membrane) is an appropriate descriptor for a nuclear-envelope multi-pass membrane protein. There is no reason to overrule this curator-assigned experimental call.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Nuclear periphery; Nucleolus; Nucleus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39996" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The molecular function of Gtt3 is annotated ND (no data). No enzymatic activity, substrate, catalytic mechanism, transporter activity, or specific binding has been demonstrated for the YEL017W protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND annotation is the correct and honest representation of the current evidence. Although Gtt3 is named &#34;glutathione transferase 3&#34;, this is an annotation-by-name/family assignment (PANTHER PTHR41807; InterPro IPR038872 is literally named &#34;Put_GTT3&#34;, i.e. putative). Gtt3 carries a GTT3-specific domain architecture distinct from the canonical soluble glutathione S-transferases Gtt1/Gtt2 and the omega-class Gto1-3, it has a multi-pass membrane topology unlike those soluble enzymes, and no glutathione-conjugation assay has ever been reported for it. Inferring glutathione transferase activity (GO:0004364) would over-annotate the gene, so ND is retained.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GTT3/GTT3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">no direct enzymatic assay, substrate specificity, or catalytic mechanism for the specific YEL017W protein was retrieved</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GTT3/GTT3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">possesses unique domains (Put_GTT3, GTT3_N) that distinguish it from these paralogs</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P39996" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The biological process is annotated ND (no data). No specific process has been experimentally assigned to Gtt3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retaining ND is appropriate. Unlike its namesake paralogs Gtt1 and Gtt2, which are transcriptionally induced by H2O2 and cumene hydroperoxide and are implicated in oxidative-stress detoxification, GTT3 is not induced under oxidative stress (its transcription is unchanged in a frataxin-deficient oxidative-stress model), which argues against simply transferring an oxidative-stress / glutathione-metabolism process from the paralogs. The only reported deletion phenotype (altered prodeoxyviolacein output in a SCRaMbLE synthetic-chromosome experiment) is mechanistically unresolved and confounded by co-deletions, and cannot support a specific process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GTT3/GTT3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">GTT3 transcription was not detectably altered</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GTT3/GTT3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">the exact mechanism by which YEL017W deletion increases PDV productivity was not elucidated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Gtt3 is a nuclear-envelope multi-pass membrane protein. Its subcellular location is the only well-established aspect of its function; its molecular activity and the biological process it participates in are unknown. The &#34;glutathione transferase&#34; name is an unverified family/name assignment and is not supported by any demonstrated glutathione-conjugation activity.</h3>
+                <span class="vote-buttons" data-g="P39996" data-a="FUNCTION: Gtt3 is a nuclear-envelope multi-pass membrane pro..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
+                                nuclear membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034399" target="_blank" class="term-link">
+                                nuclear periphery
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P39996
+
+                        </span>
+
+                        <div class="finding-text">SUBCELLULAR LOCATION: Nucleus membrane {ECO:0000269|PubMed:14562095};</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                PMID:26928762
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Nuclear periphery; Nucleolus; Nucleus</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:P39996
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry for GTT3_YEAST (P39996)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Gtt3 is a multi-pass membrane protein with two transmembrane helices and is localized to the nuclear membrane; it is named glutathione transferase 3 but no molecular function is experimentally established.</div>
+
+                        <div class="finding-text">"SUBCELLULAR LOCATION: Nucleus membrane {ECO:0000269|PubMed:14562095};"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Global GFP-fusion localization study that is the basis for the UniProt nuclear-membrane annotation of Gtt3.</div>
+
+                        <div class="finding-text">"into 22 distinct subcellular localization categories"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                            PMID:26928762
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SWAp-Tag N&#39;-terminal GFP library methods paper; source of the SGD HDA nuclear-periphery localization for Gtt3. Localization categories assigned by manual imaging include &#34;Nuclear periphery&#34;.</div>
+
+                        <div class="finding-text">"Nuclear periphery; Nucleolus; Nucleus"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/GTT3/GTT3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for GTT3 (YEL017W)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Comprehensive literature synthesis finding no direct biochemical, enzymatic, or localization characterization specific to Gtt3, and noting its distinct domain architecture and lack of oxidative-stress co-regulation with Gtt1/Gtt2.</div>
+
+                        <div class="finding-text">"no direct enzymatic assay, substrate specificity, or catalytic mechanism for the specific YEL017W protein was retrieved"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is Gtt3 a bona fide glutathione transferase, or is the &#34;glutathione transferase 3&#34; name an unverified family assignment? Does purified Gtt3 catalyze glutathione conjugation of any electrophilic substrate?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="Q: Is Gtt3 a bona fide glutathione transferase, or is..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional significance of Gtt3&#39;s nuclear-envelope multi-pass membrane topology, and which nuclear-membrane proteins or complexes does it interact with?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="Q: What is the functional significance of Gtt3&#39;s nucl..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the N-terminal Cdk1/phosphorylation sites regulate Gtt3, and does Gtt3 have a cell-cycle- or nuclear-envelope-related role distinct from the oxidative-stress roles of its paralogs Gtt1/Gtt2?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="Q: Do the N-terminal Cdk1/phosphorylation sites regul..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant Gtt3 and assay glutathione S-transferase activity against canonical (CDNB) and alternative electrophilic substrates, alongside Gtt1/Gtt2 as positive controls, to test the GST hypothesis directly.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemistry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="EXPERIMENT: Purify recombinant Gtt3 and assay glutathione S-tr..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the Gtt3 protein fold (experimental structure or AlphaFold analysis of the GTT3_N domain) and compare it with the canonical cytosolic GST fold to assess whether a catalytic GSH-binding site is present.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural_biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="EXPERIMENT: Determine the Gtt3 protein fold (experimental stru..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Identify Gtt3 physical interactors by affinity-purification mass spectrometry of endogenously tagged, functional Gtt3, focusing on nuclear-envelope and membrane-protein partners.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="EXPERIMENT: Identify Gtt3 physical interactors by affinity-pur..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Phenotype a gtt3-null strain (and gtt3 combined with gtt1/gtt2/gto deletions) across stress conditions and cell-cycle assays to assign a biological process and test for redundancy with the other glutathione transferases.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39996" data-a="EXPERIMENT: Phenotype a gtt3-null strain (and gtt3 combined wi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of Gtt3 (YEL017W) is unknown. Despite the name &#34;glutathione transferase 3&#34;, no glutathione-conjugation (or any other) enzymatic activity, substrate, catalytic mechanism, transporter activity, or specific binding partner has ever been demonstrated for the protein; it is not even established that Gtt3 is a bona fide glutathione transferase.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established is the protein&#39;s location and topology: Gtt3 is a multi-pass membrane protein (two transmembrane helices) with a large cytoplasmic N-terminal region, localized to the nuclear envelope / nuclear periphery by two independent high-throughput screens (Huh et al. global GFP; the SWAp-Tag N&#39;-GFP library), and it is expressed at the protein level and phosphorylated on several N-terminal serines. Its GTT3-specific domain architecture (InterPro &#34;putative GTT3&#34; IPR038872 / Pfam GTT3_N) differs from the soluble Gtt1/Gtt2 and omega-class Gto1-3 glutathione transferases, and unlike them it is not induced by oxidative stress.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Gtt3 belongs to a conserved family (PANTHER PTHR41807 spans more than 1200 proteins across more than 2500 taxa) that has no experimentally established molecular function at any level, so resolving Gtt3 would illuminate a widespread but wholly dark protein family. The mismatch between its &#34;glutathione transferase&#34; name and its atypical membrane topology and non-canonical domains makes it a candidate mis-annotation whose correct function is unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical activity screens on purified Gtt3 (including glutathione-conjugation assays with CDNB and other electrophiles to test the GST hypothesis directly); structure determination / AlphaFold-based fold assignment to test whether the GTT3_N domain adopts a GST fold; affinity-purification mass spectrometry to identify nuclear-envelope partners; and phenotyping of a gtt3-null (and its combination with gtt1/gtt2/gto deletions) to assign a biological process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"no direct enzymatic assay, substrate specificity, or catalytic mechanism for the specific YEL017W protein was retrieved"</em> — file:yeast/GTT3/GTT3-deep-research-falcon.md</li>
+
+                <li><em>"no direct localization study for YEL017W/Gtt3 was found in the retrieved literature"</em> — file:yeast/GTT3/GTT3-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GTT3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P39996" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">17 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:12:08.900175</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="GTT3-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-gtt3-yel017w-glutathione-transferase-3-in-saccharomyces-cerevisiae">Research Report: GTT3 (YEL017W) — Glutathione Transferase 3 in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="important-note-on-literature-availability">Important Note on Literature Availability</h3>
+<p>GTT3 (systematic name YEL017W; UniProt accession P39996) is a <strong>poorly characterized</strong> protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). Despite extensive searching across primary literature, reviews, and high-throughput datasets, very little direct biochemical or functional characterization of Gtt3p was identified. The vast majority of research on yeast glutathione transferases focuses on the better-characterized family members GTT1 and GTT2. The following report synthesizes all available evidence, clearly distinguishing between direct evidence for GTT3 and inferences drawn from family context.</p>
+<hr />
+<h3 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h3>
+<p>GTT3 (YEL017W) encodes a protein annotated as "Glutathione transferase 3" in <em>S. cerevisiae</em>. The protein is 285 amino acids in length and contains two distinctive domains: Put_GTT3 (IPR038872) and GTT3_N (PF27945). These domains are specific to GTT3 and its close homologs, and are not shared with the better-characterized yeast glutathione transferases Gtt1 and Gtt2, nor with the omega-class glutathione transferases (Gto1, Gto2, Gto3). This domain architecture suggests that Gtt3p may represent a structurally and functionally distinct class of glutathione transferase within the yeast proteome.</p>
+<h3 id="2-family-context-yeast-glutathione-transferases">2. Family Context: Yeast Glutathione Transferases</h3>
+<p><em>S. cerevisiae</em> possesses multiple glutathione-related transferases. The best characterized are:</p>
+<ul>
+<li>
+<p><strong>Gtt1 and Gtt2</strong>: These are the two canonical glutathione S-transferases (GSTs) that act on standard GST substrates such as 1-chloro-2,4-dinitrobenzene (CDNB). They catalyze the enzymatic conjugation of glutathione (GSH) with a multitude of exogenously and endogenously derived toxic compounds (mariani2008involvementofglutathione pages 2-4). Gtt1 has been described as a membrane-bound, ER-localized glutathione S-transferase, while Gtt2 has been characterized as a mitochondrial GST. Both are involved in oxidative stress defense, particularly during H₂O₂ exposure (mariani2008involvementofglutathione pages 4-6, mariani2008involvementofglutathione pages 1-2).</p>
+</li>
+<li>
+<p><strong>Gto1, Gto2, Gto3</strong>: These are omega-class glutathione transferases that display homology with human omega-class GSTs. Their enzyme activities differ from those of the Gtt isoforms, and they act as 1-Cys thiol transferases related to glutaredoxins Grx1 and Grx2 (mariani2008involvementofglutathione pages 8-9, mariani2008involvementofglutathione pages 1-2).</p>
+</li>
+<li>
+<p><strong>GTT3 (YEL017W)</strong>: Grouped by name with the Gtt family but possesses unique domains (Put_GTT3, GTT3_N) that distinguish it from both Gtt1/Gtt2 and the Gto proteins. No direct biochemical characterization of Gtt3p enzymatic activity was identified in the available literature.</p>
+</li>
+</ul>
+<p>The following table summarizes the comparative features of the three GTT-family members:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Systematic name</th>
+<th>Protein / annotation</th>
+<th>Known or reported localization</th>
+<th>Characterized function</th>
+<th>Evidence summary</th>
+<th>Level of characterization</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GTT1</strong></td>
+<td>not established from gathered evidence</td>
+<td>Glutathione transferase 1</td>
+<td>Endoplasmic reticulum / membrane-bound, based on review citation to earlier primary work; also treated broadly as a yeast GST acting on standard GST substrates (mariani2008involvementofglutathione pages 1-2)</td>
+<td>Canonical GST activity: conjugates glutathione (GSH) to electrophilic substrates; implicated in oxidative-stress defense, especially during <strong>H2O2</strong> exposure; contributes to control of protein oxidation and cell survival/apoptosis-related stress outcomes (mariani2008involvementofglutathione pages 4-6, mariani2008involvementofglutathione pages 2-4, hayes2005glutathionetransferases. pages 6-7)</td>
+<td>Primary evidence in the gathered set focuses on oxidative-stress phenotypes and standard GST function, but not on a fully resolved substrate spectrum for yeast Gtt1 specifically (mariani2008involvementofglutathione pages 4-6, mariani2008involvementofglutathione pages 2-4, hayes2005glutathionetransferases. pages 6-7)</td>
+<td><strong>Moderately characterized</strong></td>
+</tr>
+<tr>
+<td><strong>GTT2</strong></td>
+<td>not established from gathered evidence</td>
+<td>Glutathione transferase 2</td>
+<td>Often described as mitochondrial in the literature context gathered; direct localization evidence was not independently retrieved here, so this should be treated cautiously (auchere2008glutathionedependentredoxstatus pages 3-4)</td>
+<td>Canonical GST activity with major role in oxidative-stress defense; especially important for detoxifying lipid peroxides / oxidized products and limiting lipid peroxidation and protein carbonylation during <strong>H2O2</strong> stress (mariani2008involvementofglutathione pages 6-8, mariani2008involvementofglutathione pages 1-2, mariani2008involvementofglutathione pages 2-4)</td>
+<td>Best-supported functional member in the gathered evidence set; repeatedly linked to peroxide stress and detoxification of oxidized cellular components (mariani2008involvementofglutathione pages 6-8, mariani2008involvementofglutathione pages 1-2, sha2013thegenomewideearly pages 9-11)</td>
+<td><strong>Moderately to well characterized</strong></td>
+</tr>
+<tr>
+<td><strong>GTT3</strong></td>
+<td><strong>YEL017W</strong></td>
+<td>Glutathione transferase 3; UniProt target P39996</td>
+<td><strong>Unknown from the gathered primary evidence</strong>; no direct localization study for YEL017W/Gtt3 was found in the retrieved literature</td>
+<td><strong>Specific biochemical activity remains unclear</strong>. By annotation and family context, Gtt3 is expected to be a GST-like protein, but no direct enzymatic assay, substrate specificity, or catalytic mechanism for the specific YEL017W protein was retrieved. Expression was measured in frataxin-deficient yeast and showed no major change (relative expression ~1.14 in YNB; ~0.86 in iron-supplemented YNB) (auchere2008glutathionedependentredoxstatus pages 5-6, auchere2008glutathionedependentredoxstatus pages 4-5)</td>
+<td>The strongest direct evidence retrieved is that <strong>GTT3 transcription was not detectably altered</strong> in the frataxin-deficient oxidative-stress model, unlike some other glutathione-related genes (auchere2008glutathionedependentredoxstatus pages 5-6, auchere2008glutathionedependentredoxstatus pages 4-5). A deletion including <strong>YEL017W</strong> was associated with increased prodeoxyviolacein production in SCRaMbLE experiments, but mechanism was not resolved (wang2018ringsyntheticchromosome pages 5-6)</td>
+<td><strong>Poorly characterized / largely uncharacterized</strong></td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the three Saccharomyces cerevisiae glutathione transferase genes discussed in the evidence, highlighting that GTT1 and GTT2 are functionally better supported, whereas GTT3/YEL017W remains poorly characterized with little direct biochemical or localization evidence.</em></p>
+<h3 id="3-presumed-enzymatic-function">3. Presumed Enzymatic Function</h3>
+<p>Based on its annotation as a glutathione transferase, Gtt3p is predicted to catalyze the conjugation of the tripeptide glutathione (γ-L-glutamyl-L-cysteinyl-glycine) with electrophilic substrates. The general mechanism of GSTs involves nucleophilic attack by the thiol group of reduced glutathione (GSH) on nonpolar compounds containing electrophilic carbon, nitrogen, or sulfur atoms (hayes2005glutathionetransferases. pages 1-3). This reaction produces less reactive, more water-soluble conjugates that can be further processed and excreted. Substrates for GSTs broadly include α,β-unsaturated carbonyls (such as 4-hydroxynonenal from lipid peroxidation), epoxides, quinones, and various xenobiotics (hayes2005glutathionetransferases. pages 6-7, hayes2005glutathionetransferases. pages 4-6). In yeast specifically, Gtt1 and Gtt2 have been shown to protect cells from lipid peroxidation and protein carbonylation during oxidative stress (mariani2008involvementofglutathione pages 6-8, mariani2008involvementofglutathione pages 4-6).</p>
+<p><strong>However, no direct enzymatic assay data for Gtt3p was identified.</strong> Its substrate specificity, catalytic efficiency, and whether it acts on the canonical GST substrate CDNB or on alternative substrates remain unknown. The unique domain architecture (Put_GTT3, GTT3_N) suggests that Gtt3p may have a distinct substrate preference or catalytic activity compared to Gtt1 and Gtt2.</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>No direct experimental localization of Gtt3p was found in the retrieved literature. The global yeast GFP localization study by Huh et al. (2003, <em>Nature</em> 425:686–691) is the standard reference for yeast protein localization, but the Huh et al. paper was unobtainable in this search, and no specific localization data for YEL017W/Gtt3p was retrieved from secondary sources. By contrast, Gtt1p has been described as an endoplasmic reticulum (ER)-localized, membrane-bound glutathione S-transferase, and Gtt2p has been associated with mitochondria (mariani2008involvementofglutathione pages 1-2). The localization of Gtt3p remains an open question.</p>
+<h3 id="5-gene-expression-and-regulation">5. Gene Expression and Regulation</h3>
+<p>Quantitative PCR analysis in a yeast model of Friedreich's ataxia (frataxin-deficient <em>S. cerevisiae</em>) measured GTT3 expression alongside other glutathione-related genes. The relative expression ratio of GTT3 in frataxin-deficient versus wild-type cells was 1.14 ± 0.45 on standard YNB medium and 0.86 ± 0.17 on iron-supplemented YNB medium, indicating that GTT3 transcription was not significantly altered under these oxidative stress conditions (auchere2008glutathionedependentredoxstatus pages 5-6, auchere2008glutathionedependentredoxstatus pages 4-5). The authors concluded that there was "no evidence of a change in transcription of... the glutathione transferase GTT1-3" in frataxin-deficient cells, even though these cells exhibited severe oxidative stress with elevated glutathione peroxidase activity, depleted NADPH, and increased G6PDH activity (auchere2008glutathionedependentredoxstatus pages 4-5).</p>
+<p>This is in contrast to GTT1 and GTT2, which are both transcriptionally upregulated in response to cumene hydroperoxide (CHP) and H₂O₂ stress (sha2013thegenomewideearly pages 9-11). The lack of GTT3 induction under oxidative stress conditions suggests either that GTT3 is constitutively expressed, that it responds to different stress signals, or that it has a distinct physiological role from GTT1/GTT2.</p>
+<h3 id="6-phenotypic-effects-of-deletion">6. Phenotypic Effects of Deletion</h3>
+<p>In SCRaMbLE (Synthetic Chromosome Recombination and Modification by LoxP-mediated Evolution) experiments using a ring synthetic chromosome V, deletion of YEL017W was identified among a set of gene deletions (along with YEL017C-A, YER151C, and YER182W) that contributed to increased production of prodeoxyviolacein (PDV), a chromogenic compound used as a phenotypic marker (wang2018ringsyntheticchromosome pages 5-6). The SCRaMbLEd strain showed approximately 3.48-fold increased PDV production compared to the control strain (zhou2021directedgenomeevolution pages 9-10). However, the exact mechanism by which YEL017W deletion increases PDV productivity was not elucidated, and the deletion was identified in combination with other genetic changes, making it difficult to attribute the phenotype solely to loss of GTT3 (wang2018ringsyntheticchromosome pages 5-6).</p>
+<h3 id="7-biological-pathways">7. Biological Pathways</h3>
+<p>Given its annotation as a glutathione transferase, Gtt3p is expected to participate in glutathione metabolism and potentially in cellular detoxification pathways. The yeast glutathione system is a major component of the antioxidant defense network, involved in:</p>
+<ul>
+<li><strong>Detoxification of reactive oxygen species (ROS)</strong> and their by-products, including lipid peroxides and oxidized proteins (mariani2008involvementofglutathione pages 6-8, mariani2008involvementofglutathione pages 4-6)</li>
+<li><strong>Conjugation of xenobiotics</strong> with glutathione to form less toxic, water-soluble products for vacuolar sequestration or export (mariani2008involvementofglutathione pages 2-4)</li>
+<li><strong>Maintenance of cellular redox homeostasis</strong> through glutathione cycling (mariani2008involvementofglutathione pages 8-9)</li>
+</ul>
+<p>However, the specific pathway in which Gtt3p operates cannot be definitively assigned from current evidence. The fact that GTT3 expression is not induced by oxidative stress in the frataxin-deficiency model, unlike GTT2, may suggest a role distinct from canonical oxidative stress defense.</p>
+<h3 id="8-structural-features-and-evolutionary-context">8. Structural Features and Evolutionary Context</h3>
+<p>Gtt3p contains two domains unique to this protein family: Put_GTT3 (IPR038872) and GTT3_N (PF27945). These domains are not found in the canonical cytosolic GST superfamily classes (alpha, mu, pi, sigma, theta, omega, zeta) that have been extensively characterized in mammals (hayes2005glutathionetransferases. pages 9-12). The distinctive domain architecture suggests that Gtt3p may represent a fungal-specific or <em>Saccharomyces</em>-specific variation of the glutathione transferase fold. Recent work using AI-based structure prediction (AlphaFold) has revealed "hidden" glutathione transferases in the human genome that share the cytosolic GST fold but have divergent sequences, suggesting that GST-fold proteins are more diverse than previously appreciated. Similar analysis could potentially illuminate the structural relationship of Gtt3p to other GST-fold proteins, but such analysis specific to Gtt3p was not identified in the literature.</p>
+<h3 id="9-summary-and-conclusions">9. Summary and Conclusions</h3>
+<p>GTT3 (YEL017W) encodes a putative glutathione transferase in <em>S. cerevisiae</em> that remains largely uncharacterized at the biochemical level. While it is named alongside the better-characterized Gtt1 and Gtt2 as part of the yeast glutathione transferase family, Gtt3p possesses unique domains (Put_GTT3, GTT3_N) that distinguish it from these paralogs and from other GST classes. No direct enzymatic activity, substrate specificity, or subcellular localization data for Gtt3p were identified in the available literature. Its transcription is not induced under oxidative stress conditions that activate other glutathione-related genes, and its deletion has been associated with altered secondary metabolite production in synthetic biology experiments but without a resolved mechanism. The function of Gtt3p can currently only be inferred by analogy to the broader glutathione transferase superfamily: it is predicted to catalyze the conjugation of glutathione with electrophilic substrates, but its specific biological role, substrates, and cellular compartment of action remain open questions requiring future experimental investigation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(mariani2008involvementofglutathione pages 2-4): Diana Mariani, Cristiane J. Mathias, Carmelita G. da Silva, Ricardo da Silva Herdeiro, Ricardo Pereira, Anita D. Panek, Elis C.A. Eleutherio, and Marcos Dias Pereira. Involvement of glutathione transferases, gtt1and gtt2, with oxidative stress response generated by h2o2 during growth of saccharomyces cerevisiae. Redox Report, 13:246-254, Dec 2008. URL: https://doi.org/10.1179/135100008x309028, doi:10.1179/135100008x309028. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mariani2008involvementofglutathione pages 4-6): Diana Mariani, Cristiane J. Mathias, Carmelita G. da Silva, Ricardo da Silva Herdeiro, Ricardo Pereira, Anita D. Panek, Elis C.A. Eleutherio, and Marcos Dias Pereira. Involvement of glutathione transferases, gtt1and gtt2, with oxidative stress response generated by h2o2 during growth of saccharomyces cerevisiae. Redox Report, 13:246-254, Dec 2008. URL: https://doi.org/10.1179/135100008x309028, doi:10.1179/135100008x309028. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mariani2008involvementofglutathione pages 1-2): Diana Mariani, Cristiane J. Mathias, Carmelita G. da Silva, Ricardo da Silva Herdeiro, Ricardo Pereira, Anita D. Panek, Elis C.A. Eleutherio, and Marcos Dias Pereira. Involvement of glutathione transferases, gtt1and gtt2, with oxidative stress response generated by h2o2 during growth of saccharomyces cerevisiae. Redox Report, 13:246-254, Dec 2008. URL: https://doi.org/10.1179/135100008x309028, doi:10.1179/135100008x309028. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mariani2008involvementofglutathione pages 8-9): Diana Mariani, Cristiane J. Mathias, Carmelita G. da Silva, Ricardo da Silva Herdeiro, Ricardo Pereira, Anita D. Panek, Elis C.A. Eleutherio, and Marcos Dias Pereira. Involvement of glutathione transferases, gtt1and gtt2, with oxidative stress response generated by h2o2 during growth of saccharomyces cerevisiae. Redox Report, 13:246-254, Dec 2008. URL: https://doi.org/10.1179/135100008x309028, doi:10.1179/135100008x309028. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hayes2005glutathionetransferases. pages 6-7): John D. Hayes, Jack U. Flanagan, and Ian R. Jowsey. Glutathione transferases. Annual review of pharmacology and toxicology, 45:51-88, Sep 2005. URL: https://doi.org/10.1146/annurev.pharmtox.45.120403.095857, doi:10.1146/annurev.pharmtox.45.120403.095857. This article has 5256 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(auchere2008glutathionedependentredoxstatus pages 3-4): F. Auchère, Renata Santos, S. Planamente, E. Lesuisse, and J. Camadro. Glutathione-dependent redox status of frataxin-deficient cells in a yeast model of friedreich's ataxia. Human molecular genetics, 17 18:2790-802, Sep 2008. URL: https://doi.org/10.1093/hmg/ddn178, doi:10.1093/hmg/ddn178. This article has 101 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mariani2008involvementofglutathione pages 6-8): Diana Mariani, Cristiane J. Mathias, Carmelita G. da Silva, Ricardo da Silva Herdeiro, Ricardo Pereira, Anita D. Panek, Elis C.A. Eleutherio, and Marcos Dias Pereira. Involvement of glutathione transferases, gtt1and gtt2, with oxidative stress response generated by h2o2 during growth of saccharomyces cerevisiae. Redox Report, 13:246-254, Dec 2008. URL: https://doi.org/10.1179/135100008x309028, doi:10.1179/135100008x309028. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sha2013thegenomewideearly pages 9-11): Wei Sha, Ana M. Martins, Reinhard Laubenbacher, Pedro Mendes, and Vladimir Shulaev. The genome-wide early temporal response of saccharomyces cerevisiae to oxidative stress induced by cumene hydroperoxide. PLoS ONE, 8:e74939, Sep 2013. URL: https://doi.org/10.1371/journal.pone.0074939, doi:10.1371/journal.pone.0074939. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(auchere2008glutathionedependentredoxstatus pages 5-6): F. Auchère, Renata Santos, S. Planamente, E. Lesuisse, and J. Camadro. Glutathione-dependent redox status of frataxin-deficient cells in a yeast model of friedreich's ataxia. Human molecular genetics, 17 18:2790-802, Sep 2008. URL: https://doi.org/10.1093/hmg/ddn178, doi:10.1093/hmg/ddn178. This article has 101 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(auchere2008glutathionedependentredoxstatus pages 4-5): F. Auchère, Renata Santos, S. Planamente, E. Lesuisse, and J. Camadro. Glutathione-dependent redox status of frataxin-deficient cells in a yeast model of friedreich's ataxia. Human molecular genetics, 17 18:2790-802, Sep 2008. URL: https://doi.org/10.1093/hmg/ddn178, doi:10.1093/hmg/ddn178. This article has 101 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2018ringsyntheticchromosome pages 5-6): Juan Wang, Ze-Xiong Xie, Yuan Ma, Xiang-Rong Chen, Yao-Qing Huang, Bo He, Bin Jia, Bing-Zhi Li, and Ying-Jin Yuan. Ring synthetic chromosome v scramble. Nature Communications, Sep 2018. URL: https://doi.org/10.1038/s41467-018-06216-y, doi:10.1038/s41467-018-06216-y. This article has 90 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hayes2005glutathionetransferases. pages 1-3): John D. Hayes, Jack U. Flanagan, and Ian R. Jowsey. Glutathione transferases. Annual review of pharmacology and toxicology, 45:51-88, Sep 2005. URL: https://doi.org/10.1146/annurev.pharmtox.45.120403.095857, doi:10.1146/annurev.pharmtox.45.120403.095857. This article has 5256 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hayes2005glutathionetransferases. pages 4-6): John D. Hayes, Jack U. Flanagan, and Ian R. Jowsey. Glutathione transferases. Annual review of pharmacology and toxicology, 45:51-88, Sep 2005. URL: https://doi.org/10.1146/annurev.pharmtox.45.120403.095857, doi:10.1146/annurev.pharmtox.45.120403.095857. This article has 5256 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2021directedgenomeevolution pages 9-10): Sijie Zhou, Yi Wu, Ze-Xiong Xie, Bin Jia, and Ying-Jin Yuan. Directed genome evolution driven by structural rearrangement techniques. Chemical Society reviews, 50:12788-12807, Oct 2021. URL: https://doi.org/10.1039/d1cs00722j, doi:10.1039/d1cs00722j. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hayes2005glutathionetransferases. pages 9-12): John D. Hayes, Jack U. Flanagan, and Ian R. Jowsey. Glutathione transferases. Annual review of pharmacology and toxicology, 45:51-88, Sep 2005. URL: https://doi.org/10.1146/annurev.pharmtox.45.120403.095857, doi:10.1146/annurev.pharmtox.45.120403.095857. This article has 5256 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="GTT3-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>mariani2008involvementofglutathione pages 2-4</li>
+<li>mariani2008involvementofglutathione pages 1-2</li>
+<li>auchere2008glutathionedependentredoxstatus pages 3-4</li>
+<li>wang2018ringsyntheticchromosome pages 5-6</li>
+<li>auchere2008glutathionedependentredoxstatus pages 4-5</li>
+<li>sha2013thegenomewideearly pages 9-11</li>
+<li>zhou2021directedgenomeevolution pages 9-10</li>
+<li>mariani2008involvementofglutathione pages 8-9</li>
+<li>mariani2008involvementofglutathione pages 4-6</li>
+<li>mariani2008involvementofglutathione pages 6-8</li>
+<li>auchere2008glutathionedependentredoxstatus pages 5-6</li>
+<li>https://doi.org/10.1179/135100008x309028,</li>
+<li>https://doi.org/10.1146/annurev.pharmtox.45.120403.095857,</li>
+<li>https://doi.org/10.1093/hmg/ddn178,</li>
+<li>https://doi.org/10.1371/journal.pone.0074939,</li>
+<li>https://doi.org/10.1038/s41467-018-06216-y,</li>
+<li>https://doi.org/10.1039/d1cs00722j,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GTT3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P39996" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gtt3-yel017w-p39996-curation-notes">GTT3 (YEL017W / P39996) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> GTT3, an<br />
+understudied ("dark") gene. Provenance is recorded inline as<br />
+<code>[PMID:xxxx "verbatim quote"]</code> or <code>[file:... "quote"]</code>.</p>
+<h2 id="identity-from-uniprot-p39996-gtt3-uniprottxt">Identity (from UniProt P39996, <code>GTT3-uniprot.txt</code>)</h2>
+<ul>
+<li><strong>Standard name</strong> GTT3; <strong>systematic</strong> YEL017W; UniProtKB <strong>P39996</strong> (<code>GTT3_YEAST</code>),<br />
+  337 aa, 38.2 kDa. RecName "Glutathione transferase 3".</li>
+<li><strong>PE 1 (evidence at protein level)</strong> — detected in proteomics (phospho-MS,<br />
+  PaxDb/PeptideAtlas), so the protein is genuinely expressed<br />
+  [<code>GTT3-uniprot.txt</code> "PE   1: Evidence at protein level"; "Present with 1300 molecules/cell in log phase SD medium."].</li>
+</ul>
+<h2 id="domain-topology-reasoning-inline-from-gtt3-uniprottxt">Domain / topology reasoning (inline, from <code>GTT3-uniprot.txt</code>)</h2>
+<ul>
+<li>Family/domain signatures are <strong>GTT3-specific and named "putative"</strong>: Pfam<br />
+<strong>PF27945 (GTT3_N)</strong>, PANTHER <strong>PTHR41807</strong> ("GLUTATHIONE TRANSFERASE 3"),<br />
+  InterPro <strong>IPR038872</strong> — whose InterPro name is <strong>"Put_GTT3"</strong> = <em>putative</em> GTT3<br />
+  [<code>GTT3-uniprot.txt</code> "InterPro; IPR038872; Put_GTT3." / "Pfam; PF27945; GTT3_N; 1."].<br />
+  These are <strong>not</strong> the canonical soluble-GST signatures (no thioredoxin/GST N-<br />
+  and C-terminal domain PROSITE/Pfam hits, no PF00043/PF02798). So the "glutathione<br />
+  transferase" name is an <strong>annotation-by-name</strong>, not a domain-supported catalytic call.</li>
+<li><strong>Membrane topology is the strongest structural fact.</strong> UniProt models a large<br />
+  N-terminal cytoplasmic region (1-239) then <strong>two transmembrane helices</strong><br />
+  (TRANSMEM 240-260 and 314-336) flanking a short perinuclear-space loop (261-313)<br />
+  [<code>GTT3-uniprot.txt</code> "TRANSMEM        240..260"; "TRANSMEM        314..336";<br />
+  "TOPO_DOM        261..313 /note=Perinuclear space"]. Multi-pass membrane protein.<br />
+  Canonical cytosolic GSTs (Gtt1/Gtt2, Gto1-3) are <strong>soluble</strong>, so a tail-anchored /<br />
+  multi-pass topology is unusual for a GST and argues against classic soluble-GST<br />
+  catalysis.</li>
+<li>The cytoplasmic N-terminus contains two disordered/low-complexity regions<br />
+  (66-95, 107-132; polar-residue biased) carrying multiple <strong>Cdk1/phospho sites</strong><br />
+  (Ser-66/72/99/116) [<code>GTT3-uniprot.txt</code> "MobiDB-lite" REGIONs; MOD_RES phosphoserines<br />
+  from PMID:17330950, PMID:19779198]. Phospho-regulation is consistent with a<br />
+  regulated membrane protein but does not by itself assign a molecular function.</li>
+</ul>
+<h2 id="localization-known-high-throughput-experimental">Localization (KNOWN, high-throughput / experimental)</h2>
+<ul>
+<li><strong>Nuclear membrane / multi-pass membrane protein</strong> — UniProt SUBCELLULAR LOCATION,<br />
+  from the Huh et al. global GFP screen<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/14562095" title="provide localization information for 70% of previously unlocalized proteins">PMID:14562095</a>.</li>
+<li><strong>Nuclear periphery (HDA)</strong> — SGD annotation GO:0034399 from the SWAp-Tag N'-GFP<br />
+  library screen [PMID:26928762; localization category "Nuclear periphery" is one of the<br />
+  assigned classes: <code>GTT3-goa.tsv</code> row GO:0034399 HDA PMID:26928762].</li>
+<li><strong>Membrane (IBA)</strong> — GO:0016020, phylogenetic (GO_Central) inference.</li>
+<li>Two orthogonal high-throughput localizations agree on nuclear-envelope / perinuclear<br />
+  membrane. <code>nuclear periphery</code> (a nuclear-lumen-proximal region) and <code>nuclear membrane</code><br />
+  are consistent with a nuclear-envelope multi-pass protein.</li>
+</ul>
+<h2 id="molecular-function-not-known">Molecular function (NOT known)</h2>
+<ul>
+<li>GOA carries <strong>GO:0003674 molecular_function, ND (no data)</strong> — SGD explicitly records<br />
+  no molecular-function data [<code>GTT3-goa.tsv</code> GO:0003674 ND GO_REF:0000015].</li>
+<li>Deep research: <em>no direct enzymatic assay, substrate specificity, catalytic mechanism,<br />
+  or localization study</em> for Gtt3p was found<br />
+  [file:yeast/GTT3/GTT3-deep-research-falcon.md "no direct enzymatic assay, substrate<br />
+  specificity, or catalytic mechanism for the specific YEL017W protein was retrieved"].</li>
+<li>The GST-family literature (Gtt1/Gtt2/Gto1-3) is about the <strong>paralogs</strong>, not GTT3;<br />
+  Gtt1/Gtt2 are soluble ER/mitochondrial CDNB-active GSTs induced by oxidative stress<br />
+  [file:...falcon.md "Gtt1 and Gtt2 ... catalyze the enzymatic conjugation of glutathione<br />
+  (GSH) with a multitude of ... toxic compounds"]. GTT3 has the distinct Put_GTT3/GTT3_N<br />
+  domains and does <strong>not</strong> share these signatures.</li>
+</ul>
+<h2 id="biological-process-not-known">Biological process (NOT known)</h2>
+<ul>
+<li>GOA carries <strong>GO:0008150 biological_process, ND</strong> [<code>GTT3-goa.tsv</code>].</li>
+<li>GTT3 is <strong>not</strong> co-regulated with the oxidative-stress GSTs: in a frataxin-deficient<br />
+  Friedreich's-ataxia yeast model its transcription is essentially unchanged<br />
+  [file:...falcon.md "GTT3 transcription was not detectably altered in the<br />
+  frataxin-deficient oxidative-stress model, unlike some other glutathione-related genes"],<br />
+  whereas Gtt1/Gtt2 are induced by H2O2 / cumene hydroperoxide. This weakens the<br />
+  assumption that GTT3 belongs to the same oxidative-stress detox pathway.</li>
+<li>The only deletion phenotype found is indirect: a SCRaMbLE synthetic-chromosome-V study<br />
+  where a YEL017W-containing deletion set increased prodeoxyviolacein output, mechanism<br />
+  unresolved and confounded by co-deletions [file:...falcon.md "the exact mechanism by<br />
+  which YEL017W deletion increases PDV productivity was not elucidated ... difficult to<br />
+  attribute the phenotype solely to loss of GTT3"]. Not curatable as a specific GTT3 role.</li>
+</ul>
+<h2 id="caveats-about-the-falcon-report">Caveats about the falcon report</h2>
+<ul>
+<li>The falcon report states "285 amino acids" — this is <strong>wrong</strong> (UniProt P39996 is<br />
+<strong>337 aa</strong>). I do not propagate the length claim.</li>
+<li>Falcon could not retrieve the Huh et al. full text; I rely on the cached UniProt<br />
+  SUBCELLULAR LOCATION + GOA HDA rows for localization, which are independent of falcon.</li>
+</ul>
+<h2 id="curation-decisions-summary">Curation decisions (summary)</h2>
+<ul>
+<li><strong>GO:0016020 membrane (IBA)</strong> — ACCEPT (broad but correct; multi-pass TM helices).</li>
+<li><strong>GO:0031965 nuclear membrane (IEA, SubCell)</strong> — ACCEPT (Huh GFP + SubCell mapping;<br />
+  agrees with nuclear-periphery HDA). Core location.</li>
+<li><strong>GO:0034399 nuclear periphery (HDA, PMID:26928762)</strong> — ACCEPT (experimental HT<br />
+  localization; do not overrule a curator's HDA call).</li>
+<li><strong>GO:0003674 molecular_function ND</strong> — ACCEPT. No demonstrated activity; explicitly<br />
+  do NOT infer "glutathione transferase activity" (GO:0004364) — the name is<br />
+  annotation-by-analogy, domains are Put_GTT3-specific, no substrate demonstrated.</li>
+<li><strong>GO:0008150 biological_process ND</strong> — ACCEPT. No specific process demonstrated;<br />
+  do NOT infer oxidative-stress/glutathione-metabolism from the paralogs.</li>
+</ul>
+<h2 id="knowledge-gap-primary-deliverable">Knowledge gap (primary deliverable)</h2>
+<p>Gtt3 is <strong>MF-dark and BP-dark with a solid CC</strong>: its subcellular home (nuclear-envelope /<br />
+perinuclear multi-pass membrane) is established by two orthogonal screens, but its<br />
+<strong>molecular activity, substrate, and biological role are entirely unknown</strong>. The<br />
+"glutathione transferase" name rests on a family/name assignment (PTHR41807 / Put_GTT3),<br />
+not on any demonstrated GSH-conjugation activity; the GTT3-specific domains and the<br />
+multi-pass membrane topology distinguish it from the soluble Gtt1/Gtt2/Gto GSTs, and it<br />
+is not co-regulated with them under oxidative stress. Whether Gtt3 is even a bona fide<br />
+glutathione transferase is unresolved.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P39996
+gene_symbol: GTT3
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  GTT3 (systematic name YEL017W) encodes an understudied Saccharomyces cerevisiae
+  multi-pass membrane protein of 337 residues. It has a large N-terminal cytoplasmic
+  region containing two disordered, phosphorylation-bearing low-complexity segments,
+  followed by two transmembrane helices that anchor it in the membrane. Global GFP
+  localization and an N-terminal-tag localization library independently place the
+  protein at the nuclear envelope / nuclear periphery. Although named &#34;glutathione
+  transferase 3&#34; by analogy to the yeast Gtt/Gto glutathione transferases, GTT3
+  carries a distinct, GTT3-specific domain architecture (the InterPro &#34;putative GTT3&#34;
+  signature IPR038872 with Pfam GTT3_N) rather than the canonical soluble glutathione
+  S-transferase fold, and no glutathione-conjugation activity, substrate, or catalytic
+  mechanism has been demonstrated for it. Its molecular function and biological role
+  remain unknown.
+existing_annotations:
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that Gtt3 is a membrane protein. This is
+      consistent with the UniProt topology model, which annotates two
+      transmembrane helices and classifies Gtt3 as a multi-pass membrane protein.
+    action: ACCEPT
+    reason: &gt;-
+      The membrane localization is well supported: UniProt models transmembrane
+      segments at residues 240-260 and 314-336 and describes Gtt3 as a multi-pass
+      membrane protein, and two independent high-throughput localization datasets
+      place it at the nuclear envelope. The term is broad but not incorrect. A more
+      specific cellular-component term (nuclear membrane) is also present in GOA and
+      better captures the location.
+    supported_by:
+    - reference_id: UniProt:P39996
+      supporting_text: &gt;-
+        TRANSMEM        240..260
+    - reference_id: UniProt:P39996
+      supporting_text: &gt;-
+        TRANSMEM        314..336
+- term:
+    id: GO:0031965
+    label: nuclear membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to nuclear membrane derived from the UniProt
+      Subcellular Location vocabulary. UniProt records &#34;Nucleus membrane;
+      Multi-pass membrane protein&#34;, based on the Huh et al. global GFP
+      localization study.
+    action: ACCEPT
+    reason: &gt;-
+      This is the most informative and best-supported cellular-component
+      annotation for Gtt3. It is corroborated by an independent experimental
+      screen (the SWAp-Tag N&#39;-GFP library) that assigns Gtt3 a nuclear-periphery
+      localization (GO:0034399, HDA). The nuclear-envelope location, together with
+      the multi-pass topology, is the core established fact about this protein.
+    supported_by:
+    - reference_id: UniProt:P39996
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Nucleus membrane {ECO:0000269|PubMed:14562095};
+    - reference_id: PMID:14562095
+      supporting_text: &gt;-
+        into 22 distinct subcellular localization categories
+- term:
+    id: GO:0034399
+    label: nuclear periphery
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput direct-assay (HDA) localization to the nuclear periphery
+      from the SWAp-Tag (SWAT) N&#39;-terminal GFP library, in which each strain was
+      imaged and manually assigned up to three subcellular localization
+      categories, one of which is &#34;Nuclear periphery&#34;.
+    action: ACCEPT
+    reason: &gt;-
+      This experimental localization is consistent with, and complementary to, the
+      UniProt nuclear-membrane annotation and the Huh et al. GFP screen. Nuclear
+      periphery (the nuclear-lumen region proximal to the inner nuclear membrane)
+      is an appropriate descriptor for a nuclear-envelope multi-pass membrane
+      protein. There is no reason to overrule this curator-assigned experimental
+      call.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: &gt;-
+        Nuclear periphery; Nucleolus; Nucleus
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      The molecular function of Gtt3 is annotated ND (no data). No enzymatic
+      activity, substrate, catalytic mechanism, transporter activity, or specific
+      binding has been demonstrated for the YEL017W protein.
+    action: ACCEPT
+    reason: &gt;-
+      The ND annotation is the correct and honest representation of the current
+      evidence. Although Gtt3 is named &#34;glutathione transferase 3&#34;, this is an
+      annotation-by-name/family assignment (PANTHER PTHR41807; InterPro IPR038872
+      is literally named &#34;Put_GTT3&#34;, i.e. putative). Gtt3 carries a GTT3-specific
+      domain architecture distinct from the canonical soluble glutathione
+      S-transferases Gtt1/Gtt2 and the omega-class Gto1-3, it has a multi-pass
+      membrane topology unlike those soluble enzymes, and no glutathione-conjugation
+      assay has ever been reported for it. Inferring glutathione transferase
+      activity (GO:0004364) would over-annotate the gene, so ND is retained.
+    supported_by:
+    - reference_id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+      supporting_text: &gt;-
+        no direct enzymatic assay, substrate specificity, or catalytic mechanism
+        for the specific YEL017W protein was retrieved
+    - reference_id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+      supporting_text: &gt;-
+        possesses unique domains (Put_GTT3, GTT3_N) that distinguish it from these
+        paralogs
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The biological process is annotated ND (no data). No specific process has
+      been experimentally assigned to Gtt3.
+    action: ACCEPT
+    reason: &gt;-
+      Retaining ND is appropriate. Unlike its namesake paralogs Gtt1 and Gtt2,
+      which are transcriptionally induced by H2O2 and cumene hydroperoxide and are
+      implicated in oxidative-stress detoxification, GTT3 is not induced under
+      oxidative stress (its transcription is unchanged in a frataxin-deficient
+      oxidative-stress model), which argues against simply transferring an
+      oxidative-stress / glutathione-metabolism process from the paralogs. The only
+      reported deletion phenotype (altered prodeoxyviolacein output in a SCRaMbLE
+      synthetic-chromosome experiment) is mechanistically unresolved and confounded
+      by co-deletions, and cannot support a specific process annotation.
+    supported_by:
+    - reference_id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+      supporting_text: &gt;-
+        GTT3 transcription was not detectably altered
+    - reference_id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+      supporting_text: &gt;-
+        the exact mechanism by which YEL017W deletion increases PDV productivity
+        was not elucidated
+core_functions:
+- description: &gt;-
+    Gtt3 is a nuclear-envelope multi-pass membrane protein. Its subcellular location
+    is the only well-established aspect of its function; its molecular activity and
+    the biological process it participates in are unknown. The &#34;glutathione
+    transferase&#34; name is an unverified family/name assignment and is not supported by
+    any demonstrated glutathione-conjugation activity.
+  locations:
+  - id: GO:0031965
+    label: nuclear membrane
+  - id: GO:0034399
+    label: nuclear periphery
+  supported_by:
+  - reference_id: UniProt:P39996
+    supporting_text: &gt;-
+      SUBCELLULAR LOCATION: Nucleus membrane {ECO:0000269|PubMed:14562095};
+  - reference_id: PMID:26928762
+    supporting_text: &gt;-
+      Nuclear periphery; Nucleolus; Nucleus
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of Gtt3 (YEL017W) is unknown. Despite the name
+    &#34;glutathione transferase 3&#34;, no glutathione-conjugation (or any other) enzymatic
+    activity, substrate, catalytic mechanism, transporter activity, or specific
+    binding partner has ever been demonstrated for the protein; it is not even
+    established that Gtt3 is a bona fide glutathione transferase.
+  boundary: &gt;-
+    What is established is the protein&#39;s location and topology: Gtt3 is a multi-pass
+    membrane protein (two transmembrane helices) with a large cytoplasmic N-terminal
+    region, localized to the nuclear envelope / nuclear periphery by two independent
+    high-throughput screens (Huh et al. global GFP; the SWAp-Tag N&#39;-GFP library), and
+    it is expressed at the protein level and phosphorylated on several N-terminal
+    serines. Its GTT3-specific domain architecture (InterPro &#34;putative GTT3&#34;
+    IPR038872 / Pfam GTT3_N) differs from the soluble Gtt1/Gtt2 and omega-class
+    Gto1-3 glutathione transferases, and unlike them it is not induced by oxidative
+    stress.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Gtt3 belongs to a conserved family (PANTHER PTHR41807 spans more than 1200
+    proteins across more than 2500 taxa) that has no experimentally established
+    molecular function at any level, so resolving Gtt3 would illuminate a widespread
+    but wholly dark protein family. The mismatch between its &#34;glutathione transferase&#34;
+    name and its atypical membrane topology and non-canonical domains makes it a
+    candidate mis-annotation whose correct function is unknown.
+  resolution: &gt;-
+    Biochemical activity screens on purified Gtt3 (including glutathione-conjugation
+    assays with CDNB and other electrophiles to test the GST hypothesis directly);
+    structure determination / AlphaFold-based fold assignment to test whether the
+    GTT3_N domain adopts a GST fold; affinity-purification mass spectrometry to
+    identify nuclear-envelope partners; and phenotyping of a gtt3-null (and its
+    combination with gtt1/gtt2/gto deletions) to assign a biological process.
+  provenance:
+    - reference_id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+      supporting_text: &gt;-
+        no direct enzymatic assay, substrate specificity, or catalytic mechanism
+        for the specific YEL017W protein was retrieved
+    - reference_id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+      supporting_text: &gt;-
+        no direct localization study for YEL017W/Gtt3 was found in the retrieved
+        literature
+  proposed_terms: []
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Is Gtt3 a bona fide glutathione transferase, or is the &#34;glutathione transferase 3&#34;
+    name an unverified family assignment? Does purified Gtt3 catalyze glutathione
+    conjugation of any electrophilic substrate?
+- question: &gt;-
+    What is the functional significance of Gtt3&#39;s nuclear-envelope multi-pass membrane
+    topology, and which nuclear-membrane proteins or complexes does it interact with?
+- question: &gt;-
+    Do the N-terminal Cdk1/phosphorylation sites regulate Gtt3, and does Gtt3 have a
+    cell-cycle- or nuclear-envelope-related role distinct from the oxidative-stress
+    roles of its paralogs Gtt1/Gtt2?
+suggested_experiments:
+- description: &gt;-
+    Purify recombinant Gtt3 and assay glutathione S-transferase activity against
+    canonical (CDNB) and alternative electrophilic substrates, alongside Gtt1/Gtt2 as
+    positive controls, to test the GST hypothesis directly.
+  experiment_type: biochemistry
+- description: &gt;-
+    Determine the Gtt3 protein fold (experimental structure or AlphaFold analysis of
+    the GTT3_N domain) and compare it with the canonical cytosolic GST fold to assess
+    whether a catalytic GSH-binding site is present.
+  experiment_type: structural_biology
+- description: &gt;-
+    Identify Gtt3 physical interactors by affinity-purification mass spectrometry of
+    endogenously tagged, functional Gtt3, focusing on nuclear-envelope and
+    membrane-protein partners.
+  experiment_type: proteomics
+- description: &gt;-
+    Phenotype a gtt3-null strain (and gtt3 combined with gtt1/gtt2/gto deletions)
+    across stress conditions and cell-cycle assays to assign a biological process and
+    test for redundancy with the other glutathione transferases.
+  experiment_type: genetics
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: UniProt:P39996
+  title: UniProtKB entry for GTT3_YEAST (P39996)
+  findings:
+  - statement: &gt;-
+      Gtt3 is a multi-pass membrane protein with two transmembrane helices and is
+      localized to the nuclear membrane; it is named glutathione transferase 3 but
+      no molecular function is experimentally established.
+    supporting_text: &gt;-
+      SUBCELLULAR LOCATION: Nucleus membrane {ECO:0000269|PubMed:14562095};
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt record for the target protein; supports the membrane topology and
+      nuclear-membrane localization used in this review. The RecName &#34;Glutathione
+      transferase 3&#34; is a name/family assignment, not experimentally demonstrated
+      activity.
+- id: PMID:14562095
+  title: Global analysis of protein localization in budding yeast.
+  findings:
+  - statement: &gt;-
+      Global GFP-fusion localization study that is the basis for the UniProt
+      nuclear-membrane annotation of Gtt3.
+    supporting_text: &gt;-
+      into 22 distinct subcellular localization categories
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified genome-wide GFP localization study (Huh et al., Nature 2003);
+      it is the ECO:0000269 source cited by UniProt for Gtt3&#39;s nuclear-membrane
+      location. The cached entry is abstract-only, but the per-protein localization
+      is captured in the UniProt SUBCELLULAR LOCATION annotation.
+- id: PMID:26928762
+  title: &gt;-
+    One library to make them all: streamlining the creation of yeast libraries via a
+    SWAp-Tag strategy.
+  findings:
+  - statement: &gt;-
+      SWAp-Tag N&#39;-terminal GFP library methods paper; source of the SGD HDA
+      nuclear-periphery localization for Gtt3. Localization categories assigned by
+      manual imaging include &#34;Nuclear periphery&#34;.
+    supporting_text: &gt;-
+      Nuclear periphery; Nucleolus; Nucleus
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. This is the high-throughput N&#39;-GFP localization resource from
+      which SGD derived Gtt3&#39;s nuclear-periphery (GO:0034399, HDA) annotation; the
+      paper describes the localization category set but does not name GTT3 in the
+      cached text (per-gene calls are in the library data).
+- id: file:yeast/GTT3/GTT3-deep-research-falcon.md
+  title: Falcon deep research report for GTT3 (YEL017W)
+  findings:
+  - statement: &gt;-
+      Comprehensive literature synthesis finding no direct biochemical, enzymatic, or
+      localization characterization specific to Gtt3, and noting its distinct
+      domain architecture and lack of oxidative-stress co-regulation with Gtt1/Gtt2.
+    supporting_text: &gt;-
+      no direct enzymatic assay, substrate specificity, or catalytic mechanism for
+      the specific YEL017W protein was retrieved
+  reference_review:
+    relevance: HIGH
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      Genuine Edison/falcon deep-research report (17 citations). Used for its
+      well-supported &#34;no direct evidence&#34; statements about GTT3 and the paralog
+      contrast. Note one factual error: it states GTT3 is &#34;285 amino acids&#34;, whereas
+      UniProt P39996 is 337 aa; that length claim was not propagated into this review.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/ICY1/ICY1-ai-review.html
+++ b/genes/yeast/ICY1/ICY1-ai-review.html
@@ -1,0 +1,2577 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ICY1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ICY1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q04329" target="_blank" class="term-link">
+                        Q04329
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ICY1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q04329" data-a="DESCRIPTION: ICY1 (YMR195W) is a small (127-residue, ~14 kDa) p..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ICY1 (YMR195W) is a small (127-residue, ~14 kDa) protein of the budding yeast Saccharomyces cerevisiae whose molecular function is undetermined. It is a moderately abundant protein (~4050 molecules per cell in log-phase minimal medium) that has been reported both in the cytosol and, in a genome-wide GFP localization screen, at the vacuole (fungal-type vacuole) membrane as a peripheral membrane protein. Genetically, ICY1 is required for viability of cells that lack mitochondrial DNA: its overexpression rescues the petite-negative phenotype of mutants defective in mitochondrial protein import, and deletion of ICY1 renders cells unable to grow without mitochondrial DNA. Cells lacking ICY1 also show an invasive-growth defect with elongated cell morphology, and ICY1 transcription is induced by amino-acid starvation; its promoter is also reported as a target of carbon-source / respiratory-state transcriptional regulators (Ert1 and related factors), linking its expression to the fermentation-to-respiration transition. The protein has no recognizable catalytic motif or characterized domain, and its whole-genome-duplication paralog ATG41/ICY2 acts in autophagosome formation, a role that ICY1 (which has low sequence similarity to the paralog) does not appear to share. The direct molecular activity, binding partners, and mechanism underlying its phenotypes remain unknown.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005774" target="_blank" class="term-link">
+                                    GO:0005774
+                                </a>
+                            </span>
+                            <span class="term-label">vacuolar membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q04329" data-a="GO:0005774" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation propagated from the UniProtKB Subcellular Location keyword (Vacuole membrane; Peripheral membrane protein). This is the IEA/SubCell shadow of the experimental GFP localization; the general &#34;vacuolar membrane&#34; term is a valid location but redundant with, and less specific than, the experimental fungal-type vacuole membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization, not molecular function; supported indirectly through the same GFP evidence that underlies the more specific HDA term. Kept as non-core because ICY1&#39;s location is real but does not define its function, and the cytosolic pool reported by Dunn &amp; Jensen 2003 leaves the functionally relevant compartment unresolved.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                        PMID:14562095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Global analysis of protein localization in budding yeast.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000329" target="_blank" class="term-link">
+                                    GO:0000329
+                                </a>
+                            </span>
+                            <span class="term-label">fungal-type vacuole membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q04329" data-a="GO:0000329" data-r="PMID:14562095" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput direct assay (genome-wide GFP-fusion screen) localizing Icy1p to the fungal-type vacuole membrane. This is the single positive experimental localization for ICY1 and the most specific, defensible cellular-component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported experimental localization, but a compartment call rather than a molecular function; retained as non-core. Note the literature also reports a cytosolic pool (Dunn &amp; Jensen 2003), so the functionally active compartment is not fully settled.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                                        PMID:14562095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Global analysis of protein localization in budding yeast.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04329" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with ND (No biological Data available) evidence, correctly recording that ICY1 has no experimentally or computationally determined molecular activity. No catalytic motif or characterized domain is present in the sequence, and the only functional data (a genetic high-copy-suppressor relationship and mutant phenotypes) do not pin a biochemical activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND on the MF root is the appropriate representation for a gene whose molecular function is genuinely undetermined; there is no defensible specific MF term to substitute. This is a real molecular-function knowledge gap (see knowledge_gaps), not a curation omission.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04329" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with ND evidence. Although ICY1 has associated phenotypes (petite-negativity, invasive-growth defect, amino-acid-starvation induction), these are genetic/indirect and do not identify the pathway in which ICY1 acts directly; SGD therefore records the process as undetermined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND on the BP root is appropriate. The available phenotypes are consequences that could arise indirectly and do not, on current evidence, justify a specific process annotation. Represented as a knowledge gap rather than an invented process term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP-fusion localization screen; ICY1 (Icy1p) is assigned to the vacuole (fungal-type vacuole) membrane in this dataset.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14504216" target="_blank" class="term-link">
+                            PMID:14504216
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Suppression of a defect in mitochondrial protein import identifies cytosolic proteins required for viability of yeast cells lacking mitochondrial DNA.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Overexpression of ICY1 (with CCT6, SSB1, TIP41, PBP1) is a high-copy suppressor that rescues the mtDNA-dependence (petite-negative phenotype) of mitochondrial protein-import mutants; disruption of ICY1 produces cells unable to grow without mitochondrial DNA. ICY1 is described as a cytosolic protein.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12673624" target="_blank" class="term-link">
+                            PMID:12673624
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Screening and characterization of transposon-insertion mutants in a pseudohyphal strain of Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Transposon-insertion screen in a Sigma1278b pseudohyphal background; ICY1 disruption is associated with an invasive-growth defect and elongated cell morphology (UniProt DISRUPTION PHENOTYPE).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15843968" target="_blank" class="term-link">
+                            PMID:15843968
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transcriptional profiling of Saccharomyces cerevisiae cells under adhesion-inducing conditions.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide expression profiling under amino-acid starvation (adhesion-inducing, Gcn4-linked conditions); ICY1 is among the genes induced by amino-acid starvation (UniProt INDUCTION).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26565778" target="_blank" class="term-link">
+                            PMID:26565778
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Atg41/Icy2 regulates autophagosome formation.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes ICY1&#39;s whole-genome-duplication paralog ICY2, renamed ATG41, as an autophagosome-formation factor that interacts with Atg9. The full text reports that ICY1 has low sequence similarity to Atg41/Icy2 and that icy1 deletion, unlike icy2/atg41 deletion, does not impair autophagy.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25123508" target="_blank" class="term-link">
+                            PMID:25123508
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The switch from fermentation to respiration in Saccharomyces cerevisiae is regulated by the Ert1 transcriptional activator/repressor.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Ert1 is a zinc-cluster transcriptional regulator of the fermentation-to-respiration switch; the paper&#39;s target-gene analysis (in supplementary tables not present in the cached text) lists ICY1 among Ert1 targets, linking ICY1 transcription to carbon-source/respiratory regulation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Icy1p have any detectable biochemical activity or a stable protein/RNA partner that would define a molecular function, and does it physically associate with the cytoskeleton as its name implies?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Dunn CD, Jensen RE</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04329" data-a="Q: Does Icy1p have any detectable biochemical activit..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is ICY1&#39;s requirement for viability of rho0 cells due to a direct effect on mitochondrial inner-membrane potential/protein import, or an indirect cytosolic role shared with the co-identified suppressors?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Dunn CD, Jensen RE</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04329" data-a="Q: Is ICY1&#39;s requirement for viability of rho0 cells ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Delete and overexpress ICY1 in import-machinery mutant backgrounds (e.g. tim18delta) and measure mitochondrial inner-membrane potential and in vivo/in vitro protein-import efficiency, testing epistasis with the co-identified suppressors CCT6, SSB1, TIP41 and PBP1.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Icy1p acts as a non-catalytic factor that supports mitochondrial protein import or inner-membrane potential when import is compromised.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic and biochemical epistasis / mitochondrial import assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04329" data-a="EXPERIMENT: Delete and overexpress ICY1 in import-machinery mu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged Icy1p from cells grown in rich medium and under amino-acid starvation, identify co-purifying proteins by mass spectrometry, and specifically probe for cytoskeletal components; validate top hits by reciprocal co-immunoprecipitation and imaging.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Icy1p has one or more stable interaction partners that reveal its molecular function and test the implied cytoskeletal connection.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry / interaction validation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04329" data-a="EXPERIMENT: Affinity-purify tagged Icy1p from cells grown in r..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantify endogenous Icy1p localization by live-cell microscopy and subcellular fractionation across rich medium, amino-acid starvation, and rho0 backgrounds to determine which compartment correlates with its phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The functionally active pool of Icy1p is condition-dependent (cytosolic vs. vacuole membrane).</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: quantitative localization / fractionation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04329" data-a="EXPERIMENT: Quantify endogenous Icy1p localization by live-cel..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of ICY1 is entirely undetermined: no catalytic activity, ligand, RNA/DNA/protein-binding activity, or structural/scaffolding role has been demonstrated or can be inferred from sequence.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that ICY1 is a small (127 aa) fungal protein, moderately abundant (~4050 molecules/cell), that localizes to the vacuole membrane in a GFP screen and is reported cytosolic elsewhere. What is unknown is the biochemical activity that ICY1 performs.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning a specific molecular function would let ICY1&#39;s MF annotation move off the ND root and would clarify whether its phenotypes reflect a direct biochemical role or an indirect/regulatory one.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization (activity assays, affinity purification with mass-spectrometry identification of stable partners, and structural determination) is required, since no domain/motif or informative ortholog provides a functional handle.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We identified several genes encoding cytosolic proteins, including CCT6, SSB1, ICY1, TIP41, and PBP1, which, when overproduced, rescue the mtDNA dependence of tim18Delta cells."</em> — PMID:14504216</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process in which ICY1 acts directly is unknown; whether its requirement for viability of mtDNA-less (rho0) cells reflects a direct role in mitochondrial function/protein import or an indirect cytosolic contribution is unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Genetically, ICY1 overexpression suppresses the petite-negative phenotype of mitochondrial-import mutants and icy1 deletion makes cells unable to grow without mtDNA. The gap is the mechanistic pathway linking ICY1 to these outcomes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving this would determine whether ICY1 warrants a specific biological-process annotation (e.g. related to mitochondrial homeostasis, protein import, or the response to loss of mtDNA) rather than the ND root.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis analysis with the co-identified suppressors (CCT6, SSB1, TIP41, PBP1) and with import-machinery components, plus assays of inner-membrane potential and import efficiency in icy1 mutants, would test the proposed import/membrane-potential model.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Strikingly, disruption of the genes identified by the different suppressors produces cells that are unable to grow without mtDNA."</em> — PMID:14504216</li>
+
+                <li><em>"We speculate that loss of mtDNA leads to a lowered inner membrane potential, and subtle changes in import efficiency can no longer be tolerated."</em> — PMID:14504216</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The gene name &#34;Interacting with cytoskeleton&#34; is not supported by any verified molecular-interaction evidence in the reviewed literature; whether ICY1 physically or functionally associates with the cytoskeleton is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ICY1 mutants show altered cell morphology (elongated cells, invasive-growth defect), which is consistent with, but does not demonstrate, a cytoskeletal connection. No verified direct cytoskeletal partner is documented here.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Confirming or refuting a cytoskeletal association would either justify a cytoskeleton-related function/process annotation or formally retire an unsupported implication carried by the gene symbol.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Targeted interaction assays (co-immunoprecipitation, proximity labeling, two-hybrid against cytoskeletal components) and cytoskeleton-morphology imaging in icy1 mutants would test the association directly.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Viable haploid strains with mTn3 insertions were examined for invasive growth, which is a differentiation process in haploid strains including agar penetration on rich medium, and cell morphology during invasive growth."</em> — PMID:12673624</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The functionally relevant subcellular compartment for ICY1 is unresolved: it is reported at the vacuole membrane (GFP screen) yet described as cytosolic in the functional genetics study.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Both localizations are experimentally reported; there is no transmembrane segment or signal peptide in the sequence, so any membrane association is peripheral. Which pool mediates ICY1&#39;s function is unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifying the active compartment would guide interpretation of the vacuole membrane annotation and connect localization to the mtDNA-viability and morphology phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous-level, quantitative localization (e.g. under amino-acid starvation vs. rich medium, and in rho0 cells) and fractionation would establish which pool is functional and under which conditions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We identified several genes encoding cytosolic proteins, including CCT6, SSB1, ICY1, TIP41, and PBP1, which, when overproduced, rescue the mtDNA dependence of tim18Delta cells."</em> — PMID:14504216</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ICY1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q04329" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: ICY1 (YMR195W) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">6 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:07:52.056293</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ICY1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="ICY1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-icy1-ymr195w-in-saccharomyces-cerevisiae">Comprehensive Research Report: ICY1 (YMR195W) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>ICY1 (systematic name YMR195W; UniProt accession Q04329) encodes a small protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c) annotated as "Interacting with cytoskeleton protein 1." Despite this name, the precise nature of the cytoskeletal interaction remains poorly characterized, and the primary molecular function of ICY1 has not been definitively established through focused experimental studies. ICY1 is a paralog of ICY2 (YNL015W), which was renamed Atg41 after its role in autophagosome formation was discovered (yao2015atg41icy2regulatesautophagosome pages 7-9, yao2015atg41icy2regulatesautophagosome pages 2-4).</p>
+<p>The following blockquote summarizes the key findings about ICY1 from the available literature:</p>
+<blockquote>
+<p>ICY1 (YMR195W; UniProt Q04329) in <em>Saccharomyces cerevisiae</em> is a poorly characterized protein historically named “interacting with cytoskeleton protein 1,” but the retrieved primary literature does not establish a direct cytoskeletal binding mechanism or a precise molecular role for the protein. Current evidence instead supports treating ICY1 as a largely uncharacterized cytoplasmic factor rather than a defined cytoskeletal effector (proft2005genomewideidentificationof pages 4-5, gasmi2014theswitchfrom pages 14-17).</p>
+<p>The clearest experimentally grounded statement about ICY1 comes from comparison with its paralog ICY2, renamed Atg41. Yao et al. showed that ICY1 is a paralog of ICY2/Atg41 with low sequence similarity, and unlike ICY2/Atg41, deletion of <em>ICY1</em> does not significantly impair autophagy; thus ICY1 is not required for normal autophagy flux and should not be conflated with the bona fide autophagy factor Atg41 (yao2015atg41icy2regulatesautophagosome pages 7-9, yao2015atg41icy2regulatesautophagosome pages 2-4).</p>
+<p>Genome-scale regulatory analysis further describes ICY1 as a “protein of unknown function, required for viability in rich media of cells lacking mitochondrial DNA,” which points to a possible role in adaptation to the metabolic consequences of mtDNA loss rather than in autophagosome biogenesis. In the same dataset, the ICY1 promoter was bound by Ert1 and also associated with Adr1, Cat8, and Rds2, linking ICY1 transcription to carbon-source and respiratory-state regulatory networks that govern the switch from fermentation to respiration (gasmi2014theswitchfrom pages 14-17).</p>
+<p>Evidence for direct stress-pathway regulation by Sko1 is weak: although ICY1 appeared in a genome-wide Sko1 ChIP analysis, the authors noted that the enrichment at ICY1 was likely nonspecific/background rather than convincing promoter binding. This argues against overinterpreting ICY1 as a validated osmotic-stress target (proft2005genomewideidentificationof pages 2-3).</p>
+<p>For localization, no focused low-throughput cell-biological study of ICY1 was identified in the retrieved literature, but high-throughput GFP localization resources cited in the literature base and curated annotations place ICY1 in the cytoplasm. This contrasts with the paralog ICY2/Atg41, which shows a peri-mitochondrial distribution and Atg9 association during starvation-induced autophagy (yao2015atg41icy2regulatesautophagosome pages 4-5, proft2005genomewideidentificationof pages 4-5).</p>
+<p>Overall, the best current interpretation is that ICY1 is a cytoplasmic, fungal, paralogous small protein with unresolved biochemical function. No enzymatic activity, substrate specificity, transport function, or definitive molecular mechanism has been established in the retrieved literature; the strongest clues instead place ICY1 in transcriptional programs associated with carbon-source remodeling and survival of cells lacking mitochondrial DNA (yao2015atg41icy2regulatesautophagosome pages 2-4, gasmi2014theswitchfrom pages 14-17).</p>
+</blockquote>
+<p><em>Blockquote: This blockquote summarizes the strongest evidence-based conclusions about yeast ICY1, separating it from the better-characterized paralog ICY2/Atg41. It is useful for emphasizing what is known, what is inferred, and what remains unresolved about ICY1 function.</em></p>
+<h2 id="2-relationship-to-the-paralog-icy2atg41-and-autophagy">2. Relationship to the Paralog ICY2/Atg41 and Autophagy</h2>
+<p>The most informative experimental data concerning ICY1 comes from studies of its paralog, ICY2/Atg41. Yao et al. (2015) identified ICY2/Atg41 as a novel autophagy-related protein required for efficient autophagosome formation in yeast. The study explicitly tested whether ICY1 shares this role and found that deletion of ICY1 (<em>icy1Δ</em>) did not result in a significant difference in autophagy activity compared to wild-type cells, whereas <em>icy2Δ</em> caused a severe reduction in autophagy flux (yao2015atg41icy2regulatesautophagosome pages 2-4). This functional divergence was attributed to the low sequence similarity between ICY1 and ICY2, which likely explains why ICY1 cannot substitute for ICY2 in the autophagy pathway (yao2015atg41icy2regulatesautophagosome pages 7-9).</p>
+<p>ICY2/Atg41 is a 136-residue protein that localizes to peri-mitochondrial sites, where it colocalizes substantially with MitoTracker Red and partially with the transmembrane autophagy protein Atg9 (yao2015atg41icy2regulatesautophagosome pages 4-5). Through bimolecular fluorescence complementation (BiFC) assays and yeast two-hybrid experiments, Atg41 was shown to physically associate with Atg9. The extreme C-terminal region of Atg41 (residues 127–136), which corresponds to an intrinsically disordered region (IDR) predicted by PONDR-FIT, is required for this interaction; deletion of these residues abrogated the Atg41-Atg9 association and severely impaired autophagy function (yao2015atg41icy2regulatesautophagosome pages 5-7). Under autophagy-inducing conditions, the Atg41 protein level increases more than 10-fold—among the most dramatic increases observed for any Atg protein, exceeded only by Atg8—and this upregulation is both required for efficient autophagy and driven by the transcription factor Gcn4, which directly binds the ATG41 promoter (yao2015atg41icy2regulatesautophagosome pages 7-9).</p>
+<p>The following table provides a detailed side-by-side comparison of ICY1 and ICY2/Atg41:</p>
+<table>
+<thead>
+<tr>
+<th>Gene / protein</th>
+<th>Systematic name</th>
+<th style="text-align: right;">Protein size</th>
+<th>Subcellular localization</th>
+<th>Key function / current interpretation</th>
+<th>Role in autophagy</th>
+<th>Transcriptional regulation / pathway context</th>
+<th>Evolutionary / structural notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>ICY1</strong></td>
+<td><strong>YMR195W</strong></td>
+<td style="text-align: right;">Small protein; exact size not established in the retrieved primary literature</td>
+<td>Cytoplasmic in high-throughput GFP localization datasets; no focused low-throughput localization study was identified in the retrieved literature (proft2005genomewideidentificationof pages 4-5)</td>
+<td>Primary function remains <strong>unclear</strong>. Current evidence supports that ICY1 is <strong>not</strong> the autophagy factor corresponding to its paralog ICY2/Atg41. In transcriptional/network studies, ICY1 is described as a <strong>protein of unknown function required for viability in rich media of cells lacking mitochondrial DNA</strong> (yao2015atg41icy2regulatesautophagosome pages 2-4, gasmi2014theswitchfrom pages 14-17)</td>
+<td><strong>No detectable requirement for autophagy</strong>: deletion of <strong>ICY1</strong> did not significantly alter autophagy activity, in contrast to <strong>ICY2/ATG41</strong> deletion (yao2015atg41icy2regulatesautophagosome pages 2-4)</td>
+<td>Identified as an <strong>Ert1 target</strong> with promoter enrichment in both glucose and ethanol conditions; its promoter is also reported as bound by <strong>Adr1, Cat8, and Rds2</strong> in the Ert1 target list, linking ICY1 to the fermentation-to-respiration / carbon-source regulatory network (gasmi2014theswitchfrom pages 14-17). A reported Sko1 association appears likely <strong>non-specific/background</strong> rather than convincing regulation (proft2005genomewideidentificationof pages 2-3)</td>
+<td><strong>Paralog of ICY2/Atg41</strong> but with <strong>low sequence similarity</strong>, likely explaining functional divergence; no clear higher-eukaryote homolog/function was established in the retrieved literature (yao2015atg41icy2regulatesautophagosome pages 7-9, yao2015atg41icy2regulatesautophagosome pages 2-4)</td>
+</tr>
+<tr>
+<td><strong>ICY2 / Atg41</strong></td>
+<td><strong>YNL015W</strong></td>
+<td style="text-align: right;"><strong>136 aa</strong> (yao2015atg41icy2regulatesautophagosome pages 7-9)</td>
+<td><strong>Peri-mitochondrial</strong> distribution, substantially colocalizing with mitochondria and partially colocalizing with Atg9-containing peripheral structures (yao2015atg41icy2regulatesautophagosome pages 4-5, yao2015atg41icy2regulatesautophagosome pages 5-7)</td>
+<td><strong>Autophagy factor required for autophagosome formation</strong>. Atg41 associates with <strong>Atg9</strong>, influences the <strong>rate of autophagosome formation</strong>, and is proposed to function as part of the <strong>Atg9 complex</strong> involved in delivery of donor membrane to the expanding phagophore (yao2015atg41icy2regulatesautophagosome pages 1-2, yao2015atg41icy2regulatesautophagosome pages 5-7, yao2015atg41icy2regulatesautophagosome pages 7-9, yao2015atg41icy2regulatesautophagosome pages 9-10)</td>
+<td><strong>Required for robust nonselective autophagy</strong>: atg41/icy2Δ causes a severe autophagy defect; reduced Atg41 lowers autophagosome number and total autophagic flux by about <strong>50%</strong> in the reported assays (yao2015atg41icy2regulatesautophagosome pages 1-2, yao2015atg41icy2regulatesautophagosome pages 4-5)</td>
+<td>Strongly induced during nitrogen starvation; among Atg proteins, <strong>Atg8 and Atg41</strong> were the only ones reported to increase by <strong>&gt;10-fold</strong> at the protein level. <strong>Gcn4</strong> directly binds the <strong>ATG41</strong> promoter and positively regulates its transcription during starvation (yao2015atg41icy2regulatesautophagosome pages 7-9, yao2015atg41icy2regulatesautophagosome pages 9-10)</td>
+<td>Small fungal autophagy protein with <strong>multiple predicted intrinsically disordered regions (IDRs)</strong> by PONDR-FIT; the <strong>extreme C terminus (aa 127-136)</strong> is required for Atg9 association and function (yao2015atg41icy2regulatesautophagosome pages 5-7, yao2015atg41icy2regulatesautophagosome pages 7-9). Homologs were noted in fungi, but no clear higher-eukaryotic homolog was identified by sequence analysis (yao2015atg41icy2regulatesautophagosome pages 9-10)</td>
+</tr>
+<tr>
+<td><strong>Comparison / takeaway</strong></td>
+<td>—</td>
+<td style="text-align: right;">Both are small proteins</td>
+<td>ICY1 appears <strong>cytoplasmic</strong>; ICY2/Atg41 is <strong>peri-mitochondrial / Atg9-associated</strong> (yao2015atg41icy2regulatesautophagosome pages 4-5, yao2015atg41icy2regulatesautophagosome pages 5-7, proft2005genomewideidentificationof pages 4-5)</td>
+<td>Despite paralogy, the proteins are <strong>functionally divergent</strong>: ICY2/Atg41 is a defined autophagy protein, whereas ICY1 remains poorly characterized and may instead be connected to <strong>mtDNA-loss fitness / metabolic state adaptation</strong> (yao2015atg41icy2regulatesautophagosome pages 2-4, yao2015atg41icy2regulatesautophagosome pages 9-10, gasmi2014theswitchfrom pages 14-17)</td>
+<td>Only <strong>ICY2/Atg41</strong> has a demonstrated mechanistic role in autophagy (yao2015atg41icy2regulatesautophagosome pages 2-4, yao2015atg41icy2regulatesautophagosome pages 1-2)</td>
+<td>ICY1 is linked to <strong>carbon-source / respiratory-state transcriptional control</strong>; ICY2 is linked to <strong>starvation-induced autophagy control by Gcn4</strong> (yao2015atg41icy2regulatesautophagosome pages 9-10, gasmi2014theswitchfrom pages 14-17)</td>
+<td>The <strong>low sequence similarity</strong> between the paralogs likely underlies their divergent biology (yao2015atg41icy2regulatesautophagosome pages 7-9, yao2015atg41icy2regulatesautophagosome pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the two yeast paralogs ICY1 and ICY2/Atg41 across localization, function, autophagy involvement, regulation, and evolutionary features. It is useful for separating the poorly characterized ICY1 protein from the mechanistically defined autophagy factor ICY2/Atg41.</em></p>
+<h2 id="3-functional-annotation-and-biological-processes">3. Functional Annotation and Biological Processes</h2>
+<h3 id="31-requirement-for-viability-in-cells-lacking-mitochondrial-dna">3.1 Requirement for Viability in Cells Lacking Mitochondrial DNA</h3>
+<p>The strongest functional annotation for ICY1 from genome-wide studies describes it as a "protein of unknown function, required for viability in rich media of cells lacking mitochondrial DNA" (gasmi2014theswitchfrom pages 14-17). This annotation was derived from the Saccharomyces Genome Database (SGD) and cited in a ChIP-chip study of Ert1 targets by Gasmi et al. (2014). The phenotype suggests that ICY1 plays a role when cells must cope with the metabolic consequences of mitochondrial genome loss (i.e., rho0 or petite cells), which is consistent with a function in metabolic adaptation or cellular homeostasis under respiratory-deficient conditions.</p>
+<h3 id="32-transcriptional-regulation-and-carbon-source-responsive-networks">3.2 Transcriptional Regulation and Carbon-Source Responsive Networks</h3>
+<p>ICY1 was identified as a direct target of the transcription factor Ert1, a zinc cluster protein that regulates the switch from fermentation to respiration in <em>S. cerevisiae</em>. Gasmi et al. (2014) showed that the ICY1 promoter was enriched in Ert1 ChIP-chip experiments both under glucose conditions (enrichment 2.7) and ethanol conditions (enrichment 14), indicating robust binding under respiratory growth conditions (gasmi2014theswitchfrom pages 14-17). Strikingly, ICY1 was also listed as a target of three additional transcription factors—Adr1, Cat8, and Rds2—all of which are key regulators of genes required for non-fermentable carbon source utilization and gluconeogenesis (gasmi2014theswitchfrom pages 14-17). This convergent regulatory profile places ICY1 within transcriptional programs governing the adaptation from fermentative to respiratory metabolism.</p>
+<h3 id="33-osmotic-stress-and-sko1-regulation">3.3 Osmotic Stress and Sko1 Regulation</h3>
+<p>ICY1 appeared in a genome-wide Sko1 target identification study by Proft et al. (2005) as a "group II region" (P values between 10^-4 and 0.004). However, the authors noted that the enrichment at ICY1 was observed independently of Sko1-HA tagging, suggesting that the signal was likely due to non-specific cross-reactivity of the HA antibody with other chromatin-associated proteins or to the general stickiness of these genomic regions during immunoprecipitation (proft2005genomewideidentificationof pages 2-3). Therefore, ICY1 should not be considered a validated Sko1 target gene in the osmotic stress response pathway.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>No focused, low-throughput localization study of ICY1 was identified in the retrieved primary literature. However, based on high-throughput GFP-tagging studies (Huh et al. 2003, which was referenced in multiple studies but the paper itself was not accessible) and curated database annotations, ICY1 is assigned a cytoplasmic localization. This contrasts with its paralog ICY2/Atg41, which shows a distinctive peri-mitochondrial distribution pattern that colocalizes with mitochondria and Atg9-containing peripheral structures (yao2015atg41icy2regulatesautophagosome pages 4-5, yao2015atg41icy2regulatesautophagosome pages 5-7). The differing localization patterns further support the functional divergence between the two paralogs.</p>
+<h2 id="5-structural-features-and-evolutionary-conservation">5. Structural Features and Evolutionary Conservation</h2>
+<p>ICY1 is a small protein. Its paralog ICY2/Atg41 is 136 amino acids in length and contains at least four predicted intrinsically disordered regions (IDRs) based on PONDR-FIT analysis (yao2015atg41icy2regulatesautophagosome pages 5-7). Given the paralogy, ICY1 may share some structural features such as small size and potential IDR content, though the low sequence similarity between the two proteins means that specific structural predictions for ICY2 cannot be directly transferred to ICY1.</p>
+<p>Regarding evolutionary conservation, Yao et al. (2015) noted that homologs of Atg41/ICY2 are found in different fungal species, but no homolog has been reported in higher eukaryotes based on sequence analysis (yao2015atg41icy2regulatesautophagosome pages 7-9). The authors speculated that a functional counterpart might exist in mammals—one that either functions similarly to Atg41 or combines the functions of Atg41 and other yeast proteins—similar to how RB1CC1 in mammals combines functions of yeast Atg17, Atg29, and Atg31 (yao2015atg41icy2regulatesautophagosome pages 7-9). Given that ICY1 has even lower sequence conservation and no established autophagy function, it is likely restricted to fungal lineages.</p>
+<h2 id="6-summary-and-knowledge-gaps">6. Summary and Knowledge Gaps</h2>
+<p>ICY1 remains a poorly characterized <em>S. cerevisiae</em> protein. Its primary function has not been established through dedicated biochemical or molecular studies. The strongest evidence-based inferences are:</p>
+<ol>
+<li>
+<p><strong>It is not an autophagy factor</strong>: Despite being a paralog of Atg41/ICY2, ICY1 does not contribute to autophagy flux, as demonstrated by direct experimental comparison (yao2015atg41icy2regulatesautophagosome pages 2-4).</p>
+</li>
+<li>
+<p><strong>It may function in metabolic adaptation</strong>: The requirement for viability in cells lacking mitochondrial DNA, together with transcriptional regulation by carbon source-responsive factors (Ert1, Adr1, Cat8, Rds2), suggests a role in cellular fitness during metabolic state transitions, particularly under conditions of respiratory deficiency (gasmi2014theswitchfrom pages 14-17).</p>
+</li>
+<li>
+<p><strong>Its localization is cytoplasmic</strong>: High-throughput studies place ICY1 in the cytoplasm, consistent with a soluble intracellular function rather than a membrane-associated or organelle-specific role.</p>
+</li>
+<li>
+<p><strong>No enzymatic activity, substrate, or defined molecular mechanism</strong> has been established for ICY1. Its original designation as "interacting with cytoskeleton" lacks clear experimental substantiation in the accessible literature.</p>
+</li>
+</ol>
+<p>Major knowledge gaps include: (a) the molecular basis of the cytoskeletal interaction implied by the gene name; (b) the precise mechanism by which ICY1 contributes to viability of rho0 cells; (c) whether ICY1 functions as a structural adapter, signaling factor, or has some other biochemical activity; and (d) the identity and significance of any physical interaction partners specific to ICY1.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(yao2015atg41icy2regulatesautophagosome pages 7-9): Zhiyuan Yao, Elizabeth Delorme-Axford, Steven K Backues, and Daniel J Klionsky. Atg41/icy2 regulates autophagosome formation. Autophagy, 11:2288-2299, Dec 2015. URL: https://doi.org/10.1080/15548627.2015.1107692, doi:10.1080/15548627.2015.1107692. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2015atg41icy2regulatesautophagosome pages 2-4): Zhiyuan Yao, Elizabeth Delorme-Axford, Steven K Backues, and Daniel J Klionsky. Atg41/icy2 regulates autophagosome formation. Autophagy, 11:2288-2299, Dec 2015. URL: https://doi.org/10.1080/15548627.2015.1107692, doi:10.1080/15548627.2015.1107692. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(proft2005genomewideidentificationof pages 4-5): Markus Proft, Francis D. Gibbons, Matthew Copeland, Frederick P. Roth, and Kevin Struhl. Genomewide identification of sko1 target promoters reveals a regulatory network that operates in response to osmotic stress in saccharomyces cerevisiae. Eukaryotic Cell, 4:1343-1352, Aug 2005. URL: https://doi.org/10.1128/ec.4.8.1343-1352.2005, doi:10.1128/ec.4.8.1343-1352.2005. This article has 91 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gasmi2014theswitchfrom pages 14-17): Najla Gasmi, Pierre-Etienne Jacques, Natalia Klimova, Xiao Guo, Alessandra Ricciardi, François Robert, and Bernard Turcotte. The switch from fermentation to respiration in saccharomyces cerevisiae is regulated by the ert1 transcriptional activator/repressor. Genetics, 198:547-560, Aug 2014. URL: https://doi.org/10.1534/genetics.114.168609, doi:10.1534/genetics.114.168609. This article has 65 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(proft2005genomewideidentificationof pages 2-3): Markus Proft, Francis D. Gibbons, Matthew Copeland, Frederick P. Roth, and Kevin Struhl. Genomewide identification of sko1 target promoters reveals a regulatory network that operates in response to osmotic stress in saccharomyces cerevisiae. Eukaryotic Cell, 4:1343-1352, Aug 2005. URL: https://doi.org/10.1128/ec.4.8.1343-1352.2005, doi:10.1128/ec.4.8.1343-1352.2005. This article has 91 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2015atg41icy2regulatesautophagosome pages 4-5): Zhiyuan Yao, Elizabeth Delorme-Axford, Steven K Backues, and Daniel J Klionsky. Atg41/icy2 regulates autophagosome formation. Autophagy, 11:2288-2299, Dec 2015. URL: https://doi.org/10.1080/15548627.2015.1107692, doi:10.1080/15548627.2015.1107692. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2015atg41icy2regulatesautophagosome pages 5-7): Zhiyuan Yao, Elizabeth Delorme-Axford, Steven K Backues, and Daniel J Klionsky. Atg41/icy2 regulates autophagosome formation. Autophagy, 11:2288-2299, Dec 2015. URL: https://doi.org/10.1080/15548627.2015.1107692, doi:10.1080/15548627.2015.1107692. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2015atg41icy2regulatesautophagosome pages 1-2): Zhiyuan Yao, Elizabeth Delorme-Axford, Steven K Backues, and Daniel J Klionsky. Atg41/icy2 regulates autophagosome formation. Autophagy, 11:2288-2299, Dec 2015. URL: https://doi.org/10.1080/15548627.2015.1107692, doi:10.1080/15548627.2015.1107692. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yao2015atg41icy2regulatesautophagosome pages 9-10): Zhiyuan Yao, Elizabeth Delorme-Axford, Steven K Backues, and Daniel J Klionsky. Atg41/icy2 regulates autophagosome formation. Autophagy, 11:2288-2299, Dec 2015. URL: https://doi.org/10.1080/15548627.2015.1107692, doi:10.1080/15548627.2015.1107692. This article has 112 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ICY1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="ICY1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>gasmi2014theswitchfrom pages 14-17</li>
+<li>proft2005genomewideidentificationof pages 2-3</li>
+<li>proft2005genomewideidentificationof pages 4-5</li>
+<li>https://doi.org/10.1080/15548627.2015.1107692,</li>
+<li>https://doi.org/10.1128/ec.4.8.1343-1352.2005,</li>
+<li>https://doi.org/10.1534/genetics.114.168609,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ICY1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q04329" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="icy1-ymr195w-curator-notes">ICY1 (YMR195W) — curator notes</h1>
+<p>UniProt: Q04329 (ICY1_YEAST). Systematic name YMR195W. SGD: S000004808.<br />
+Standard name ICY1 = "Interacting with CYtoskeleton" (SGD nomenclature; the name<br />
+predates and is not backed by a demonstrated molecular function). 127 aa, 14.3 kDa.<br />
+This is an UNDERSTUDIED ("dark") gene: molecular function and biological process<br />
+are officially undetermined (GO ND).</p>
+<h2 id="provenance-of-primary-facts">Provenance of primary facts</h2>
+<ul>
+<li><strong>Function (indirect / genetic):</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/14504216" title="we screened for high-copy   suppressors of the inability of tim18Delta mutants to live without mitochondrial   DNA (mtDNA). We identified several genes encoding cytosolic proteins, including   CCT6, SSB1, ICY1, TIP41, and PBP1, which, when overproduced, rescue the mtDNA   dependence of tim18Delta cells.">PMID:14504216</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/14504216" title="disruption of the genes   identified by the different suppressors produces cells that are unable to grow   without mtDNA.">PMID:14504216</a>. Interpretation: ICY1 overexpression is a high-copy suppressor<br />
+  of the petite-negative phenotype of mitochondrial-import mutants, and icy1Δ cells<br />
+  cannot survive loss of mtDNA (become petite-negative). This paper describes ICY1<br />
+  as a <strong>cytosolic</strong> protein. It does NOT assign a molecular function.</li>
+<li><strong>Subcellular location (GFP screen, HDA):</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/14562095">PMID:14562095</a> Huh et al. global GFP<br />
+  localization — ICY1 is called to the <strong>vacuole membrane</strong> (SGD GO:0000329<br />
+  fungal-type vacuole membrane; UniProt "Vacuole membrane; Peripheral membrane<br />
+  protein"). Note the abstract is method-level; the ICY1 call is from the dataset.<br />
+  There is thus a localization discrepancy in the literature: cytosolic (14504216)<br />
+  vs. vacuole membrane (14562095). Both are recorded; neither pins a mechanism.</li>
+<li><strong>Disruption phenotype:</strong> UniProt records "Invasive growth defect with elongated<br />
+  cell morphology" citing <a href="https://pubmed.ncbi.nlm.nih.gov/12673624">PMID:12673624</a> (Suzuki et al., transposon screen in a<br />
+  Sigma1278b pseudohyphal strain). The abstract is a general screen description and<br />
+  does not name ICY1; the ICY1-specific phenotype is in the full-text tables (curator<br />
+  read full text — do not overrule).</li>
+<li><strong>Induction:</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/15843968">PMID:15843968</a> ICY1 is induced by amino acid starvation<br />
+  (adhesion-inducing conditions). Abstract: ["adhesion can be induced by starvation<br />
+  for amino acids, and depends on the transcriptional activator of the general amino<br />
+  acid control system, Gcn4p"] and ["Twenty-two novel genes were identified as<br />
+  inducible by amino acid starvation"]. ICY1 is among the induced set (full-text<br />
+  table). UniProt: "Induced by amino acids starvation."</li>
+<li><strong>Abundance:</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/14562106">PMID:14562106</a> ~4050 molecules/cell in log-phase SD medium<br />
+  (UniProt MISCELLANEOUS). Consistent with a real, moderately expressed protein.</li>
+<li><strong>SGD description (verbatim):</strong> "Protein of unknown function; required for<br />
+  viability in rich media of cells lacking mitochondrial DNA; mutants have an<br />
+  invasive growth defect with elongated morphology; induced by amino acid<br />
+  starvation." (yeastgenome.org locus S000004808).</li>
+</ul>
+<h2 id="orthology-paralogy">Orthology / paralogy</h2>
+<ul>
+<li>SGD lists ICY1's <strong>paralog</strong> (from the whole-genome duplication) as <strong>ATG41 /<br />
+  ICY2 (YPL250C)</strong>, which functions in autophagosome formation. However, Icy1 has<br />
+  only <strong>low sequence similarity</strong> to Atg41/Icy2, and — unlike icy2Δ — icy1Δ does<br />
+  NOT show an autophagy defect. So the autophagy role of the paralog cannot be<br />
+  transferred to ICY1. (yeastgenome.org; Atg41 autophagy paper PMID via search.)</li>
+<li>No InterPro / Pfam / PANTHER / SUPFAM / PROSITE / SMART family is assigned in the<br />
+  UniProt record (checked: none). No transmembrane segment, no signal peptide, no<br />
+  coiled-coil, no recognizable catalytic motif. OrthoDB cluster 4033322at2759,<br />
+  HOGENOM CLU_149528_0_0_1 — small, fungal-restricted grouping.</li>
+</ul>
+<h2 id="inline-domain-sequence-reasoning-done-inline-no-sub-agent">Inline domain / sequence reasoning (done inline, no sub-agent)</h2>
+<p>Sequence (127 aa):<br />
+MSSNYATPLDDEVFPLSFANYQFTEHVSLGEHYSLNTSEDAKYNNLNGPFVVPRDTGKFDLNTSSASDETVFSLDNPQENNYKHQAMNNVQDCRMAVAAKTTQSCDKLTDLYANAAQQNYRLWLSSF</p>
+<ul>
+<li>Composition: Asn-rich (N 11.0%), Ser 10.2%, Thr 7.1%; net acidic (D+E 16 vs K+R 8);<br />
+  only 2 Cys, 1 Trp. This bias (Asn/Ser/Thr-rich, acidic, low aromatic/Cys) is<br />
+  typical of an intrinsically disordered / low-complexity small protein rather than<br />
+  a globular enzyme.</li>
+<li>No PROSITE-style catalytic signature is apparent by eye; the "MAVAAK" / "CDKLTD"<br />
+  stretches are not diagnostic motifs. UniProt annotates the whole chain as a single<br />
+  feature (PRO_0000203325) with no domains.</li>
+<li>The "Membrane / Vacuole; Peripheral membrane protein" keywords derive purely from<br />
+  the GFP localization; there is no hydrophobic membrane anchor in the sequence, so<br />
+  any membrane association is peripheral (consistent with the SubCell IEA).</li>
+</ul>
+<h2 id="known-vs-not-known-summary">KNOWN vs NOT-known summary</h2>
+<p>KNOWN (evidence-supported):<br />
+- Small (127 aa) fungal protein, moderately abundant (~4050 molecules/cell).<br />
+- Genetic role linked to survival of mtDNA-less (rho0) cells: high-copy suppressor<br />
+  of petite-negativity in import mutants; icy1Δ is petite-negative <a href="https://pubmed.ncbi.nlm.nih.gov/14504216">PMID:14504216</a>.<br />
+- Localizes to vacuole membrane in a genome-wide GFP screen <a href="https://pubmed.ncbi.nlm.nih.gov/14562095">PMID:14562095</a>;<br />
+  described as cytosolic in <a href="https://pubmed.ncbi.nlm.nih.gov/14504216">PMID:14504216</a> — location not fully settled.<br />
+- icy1Δ: invasive-growth defect with elongated morphology <a href="https://pubmed.ncbi.nlm.nih.gov/12673624">PMID:12673624</a>; SGD also<br />
+  lists abnormal vacuolar morphology, petite-negative, decreased growth.<br />
+- Transcriptionally induced by amino-acid starvation (Gcn4-linked context)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15843968">PMID:15843968</a>.</p>
+<p>NOT known (knowledge gaps — the real deliverable):<br />
+- Molecular function: NO biochemical activity, ligand, or catalytic role known<br />
+  (GO MF = ND). No enzymatic motif; likely non-enzymatic. The "cytoskeleton<br />
+  interaction" implied by the ICY1 name is not substantiated by any cited<br />
+  molecular-interaction evidence I could verify.<br />
+- Biological process: the mtDNA-survival and invasive-growth phenotypes are<br />
+  genetic/indirect; the direct pathway ICY1 acts in is undefined (GO BP = ND).<br />
+- Whether the vacuole-membrane localization is functionally meaningful or the<br />
+  cytosolic pool is the active one is unresolved.<br />
+- Direct binding partners / whether it truly "interacts with the cytoskeleton" —<br />
+  unverified in the sources available here.</p>
+<h2 id="curation-plan">Curation plan</h2>
+<ul>
+<li>4 GOA annotations. Localization terms (GO:0005774 IEA SubCell; GO:0000329 HDA)<br />
+  are supported by the GFP screen → keep. The vacuole-membrane call is the only<br />
+  positive experimental localization; keep as non-core (localization, not function).</li>
+<li>ND root terms (GO:0003674, GO:0008150) are placeholders indicating "no data";<br />
+  keep as-is (standard ND handling), do not invent MF/BP.</li>
+<li>core_functions: minimal/empty — no defensible molecular function to assert.</li>
+<li>knowledge_gaps: REQUIRED, primary deliverable (unknown MF, BP, mechanism of the<br />
+  petite-negative/invasive-growth phenotypes, reality of cytoskeleton interaction).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q04329
+gene_symbol: ICY1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ICY1 (YMR195W) is a small (127-residue, ~14 kDa) protein of the budding yeast
+  Saccharomyces cerevisiae whose molecular function is undetermined. It is a
+  moderately abundant protein (~4050 molecules per cell in log-phase minimal
+  medium) that has been reported both in the cytosol and, in a genome-wide GFP
+  localization screen, at the vacuole (fungal-type vacuole) membrane as a
+  peripheral membrane protein. Genetically, ICY1 is required for viability of
+  cells that lack mitochondrial DNA: its overexpression rescues the
+  petite-negative phenotype of mutants defective in mitochondrial protein
+  import, and deletion of ICY1 renders cells unable to grow without
+  mitochondrial DNA. Cells lacking ICY1 also show an invasive-growth defect with
+  elongated cell morphology, and ICY1 transcription is induced by amino-acid
+  starvation; its promoter is also reported as a target of carbon-source /
+  respiratory-state transcriptional regulators (Ert1 and related factors),
+  linking its expression to the fermentation-to-respiration transition. The
+  protein has no recognizable catalytic motif or characterized domain, and its
+  whole-genome-duplication paralog ATG41/ICY2 acts in autophagosome formation, a
+  role that ICY1 (which has low sequence similarity to the paralog) does not
+  appear to share. The direct molecular activity, binding partners, and mechanism
+  underlying its phenotypes remain unknown.
+references:
+- id: GO_REF:0000015
+  title: Gene Ontology annotation through association of InterPro records with GO terms.
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping.
+  findings: []
+- id: PMID:14562095
+  title: Global analysis of protein localization in budding yeast.
+  findings:
+  - statement: &gt;-
+      Genome-wide GFP-fusion localization screen; ICY1 (Icy1p) is assigned to the
+      vacuole (fungal-type vacuole) membrane in this dataset.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified Huh et al. 2003 Nature GFP localization study; source of the
+      HDA fungal-type vacuole membrane annotation. Abstract is method-level; the
+      ICY1-specific call is in the accompanying dataset, which the SGD curator used.
+- id: PMID:14504216
+  title: &gt;-
+    Suppression of a defect in mitochondrial protein import identifies cytosolic
+    proteins required for viability of yeast cells lacking mitochondrial DNA.
+  findings:
+  - statement: &gt;-
+      Overexpression of ICY1 (with CCT6, SSB1, TIP41, PBP1) is a high-copy
+      suppressor that rescues the mtDNA-dependence (petite-negative phenotype) of
+      mitochondrial protein-import mutants; disruption of ICY1 produces cells
+      unable to grow without mitochondrial DNA. ICY1 is described as a cytosolic
+      protein.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified Dunn &amp; Jensen 2003 Genetics; primary source for the UniProt
+      FUNCTION statement &#34;Required for viability of cells lacking mtDNA&#34;. Provides
+      only a genetic/indirect link, not a molecular function; also describes ICY1
+      as cytosolic (a localization discrepancy with the vacuole-membrane GFP call).
+- id: PMID:12673624
+  title: &gt;-
+    Screening and characterization of transposon-insertion mutants in a
+    pseudohyphal strain of Saccharomyces cerevisiae.
+  findings:
+  - statement: &gt;-
+      Transposon-insertion screen in a Sigma1278b pseudohyphal background; ICY1
+      disruption is associated with an invasive-growth defect and elongated cell
+      morphology (UniProt DISRUPTION PHENOTYPE).
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified Suzuki et al. 2003 Yeast. The cached abstract describes the
+      screen generally and does not name ICY1; the ICY1-specific phenotype is in
+      the full-text tables read by the UniProt curator. Supports a phenotype, not a
+      molecular function.
+- id: PMID:15843968
+  title: &gt;-
+    Transcriptional profiling of Saccharomyces cerevisiae cells under
+    adhesion-inducing conditions.
+  findings:
+  - statement: &gt;-
+      Genome-wide expression profiling under amino-acid starvation
+      (adhesion-inducing, Gcn4-linked conditions); ICY1 is among the genes induced
+      by amino-acid starvation (UniProt INDUCTION).
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified Kleinschmidt et al. 2005. Abstract confirms the
+      amino-acid-starvation/Gcn4 induction paradigm; the ICY1-specific induction is
+      in the full-text gene tables. Regulatory context only, not a function.
+- id: PMID:26565778
+  title: Atg41/Icy2 regulates autophagosome formation.
+  findings:
+  - statement: &gt;-
+      Characterizes ICY1&#39;s whole-genome-duplication paralog ICY2, renamed ATG41,
+      as an autophagosome-formation factor that interacts with Atg9. The full text
+      reports that ICY1 has low sequence similarity to Atg41/Icy2 and that icy1
+      deletion, unlike icy2/atg41 deletion, does not impair autophagy.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Yao et al. 2015, Autophagy). The cached record is
+      abstract-only and is about the paralog Atg41/Icy2, not ICY1; the
+      ICY1-specific comparison (low similarity, no autophagy defect) is in the
+      full text. Cited to support the paralog framing, not to assign ICY1 a
+      function.
+  full_text_unavailable: true
+- id: PMID:25123508
+  title: &gt;-
+    The switch from fermentation to respiration in Saccharomyces cerevisiae is
+    regulated by the Ert1 transcriptional activator/repressor.
+  findings:
+  - statement: &gt;-
+      Ert1 is a zinc-cluster transcriptional regulator of the
+      fermentation-to-respiration switch; the paper&#39;s target-gene analysis (in
+      supplementary tables not present in the cached text) lists ICY1 among Ert1
+      targets, linking ICY1 transcription to carbon-source/respiratory regulation.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Gasmi et al. 2014, Genetics). The cached full text does not
+      contain the string &#34;ICY1&#34;/&#34;YMR195W&#34;; the ICY1-as-Ert1-target detail is in the
+      supplementary target lists. Cited for regulatory context only; no ICY1-specific
+      verbatim quote is anchored to this reference.
+existing_annotations:
+- term:
+    id: GO:0005774
+    label: vacuolar membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation propagated from the UniProtKB Subcellular Location
+      keyword (Vacuole membrane; Peripheral membrane protein). This is the
+      IEA/SubCell shadow of the experimental GFP localization; the general
+      &#34;vacuolar membrane&#34; term is a valid location but redundant with, and less
+      specific than, the experimental fungal-type vacuole membrane annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Localization, not molecular function; supported indirectly through the same
+      GFP evidence that underlies the more specific HDA term. Kept as non-core
+      because ICY1&#39;s location is real but does not define its function, and the
+      cytosolic pool reported by Dunn &amp; Jensen 2003 leaves the functionally
+      relevant compartment unresolved.
+    supported_by:
+    - reference_id: PMID:14562095
+      supporting_text: Global analysis of protein localization in budding yeast.
+- term:
+    id: GO:0000329
+    label: fungal-type vacuole membrane
+  evidence_type: HDA
+  original_reference_id: PMID:14562095
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput direct assay (genome-wide GFP-fusion screen) localizing
+      Icy1p to the fungal-type vacuole membrane. This is the single positive
+      experimental localization for ICY1 and the most specific, defensible
+      cellular-component annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Well-supported experimental localization, but a compartment call rather than
+      a molecular function; retained as non-core. Note the literature also reports
+      a cytosolic pool (Dunn &amp; Jensen 2003), so the functionally active
+      compartment is not fully settled.
+    supported_by:
+    - reference_id: PMID:14562095
+      supporting_text: Global analysis of protein localization in budding yeast.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function term with ND (No biological Data available)
+      evidence, correctly recording that ICY1 has no experimentally or
+      computationally determined molecular activity. No catalytic motif or
+      characterized domain is present in the sequence, and the only functional data
+      (a genetic high-copy-suppressor relationship and mutant phenotypes) do not
+      pin a biochemical activity.
+    action: ACCEPT
+    reason: &gt;-
+      ND on the MF root is the appropriate representation for a gene whose
+      molecular function is genuinely undetermined; there is no defensible specific
+      MF term to substitute. This is a real molecular-function knowledge gap (see
+      knowledge_gaps), not a curation omission.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with ND evidence. Although ICY1 has associated
+      phenotypes (petite-negativity, invasive-growth defect, amino-acid-starvation
+      induction), these are genetic/indirect and do not identify the pathway in
+      which ICY1 acts directly; SGD therefore records the process as undetermined.
+    action: ACCEPT
+    reason: &gt;-
+      ND on the BP root is appropriate. The available phenotypes are consequences
+      that could arise indirectly and do not, on current evidence, justify a
+      specific process annotation. Represented as a knowledge gap rather than an
+      invented process term.
+core_functions: []
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of ICY1 is entirely undetermined: no catalytic
+    activity, ligand, RNA/DNA/protein-binding activity, or structural/scaffolding
+    role has been demonstrated or can be inferred from sequence.
+  boundary: &gt;-
+    It is firmly established that ICY1 is a small (127 aa) fungal protein,
+    moderately abundant (~4050 molecules/cell), that localizes to the vacuole
+    membrane in a GFP screen and is reported cytosolic elsewhere. What is unknown
+    is the biochemical activity that ICY1 performs.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning a specific molecular function would let ICY1&#39;s MF annotation move off
+    the ND root and would clarify whether its phenotypes reflect a direct
+    biochemical role or an indirect/regulatory one.
+  resolution: &gt;-
+    Biochemical characterization (activity assays, affinity purification with
+    mass-spectrometry identification of stable partners, and structural
+    determination) is required, since no domain/motif or informative ortholog
+    provides a functional handle.
+  provenance:
+  - reference_id: PMID:14504216
+    supporting_text: &gt;-
+      We identified several genes encoding cytosolic proteins, including CCT6,
+      SSB1, ICY1, TIP41, and PBP1, which, when overproduced, rescue the mtDNA
+      dependence of tim18Delta cells.
+- gap_statement: &gt;-
+    The biological process in which ICY1 acts directly is unknown; whether its
+    requirement for viability of mtDNA-less (rho0) cells reflects a direct role in
+    mitochondrial function/protein import or an indirect cytosolic contribution is
+    unresolved.
+  boundary: &gt;-
+    Genetically, ICY1 overexpression suppresses the petite-negative phenotype of
+    mitochondrial-import mutants and icy1 deletion makes cells unable to grow
+    without mtDNA. The gap is the mechanistic pathway linking ICY1 to these
+    outcomes.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving this would determine whether ICY1 warrants a specific
+    biological-process annotation (e.g. related to mitochondrial homeostasis,
+    protein import, or the response to loss of mtDNA) rather than the ND root.
+  resolution: &gt;-
+    Epistasis analysis with the co-identified suppressors (CCT6, SSB1, TIP41,
+    PBP1) and with import-machinery components, plus assays of inner-membrane
+    potential and import efficiency in icy1 mutants, would test the proposed
+    import/membrane-potential model.
+  provenance:
+  - reference_id: PMID:14504216
+    supporting_text: &gt;-
+      Strikingly, disruption of the genes identified by the different suppressors
+      produces cells that are unable to grow without mtDNA.
+  - reference_id: PMID:14504216
+    supporting_text: &gt;-
+      We speculate that loss of mtDNA leads to a lowered inner membrane potential,
+      and subtle changes in import efficiency can no longer be tolerated.
+- gap_statement: &gt;-
+    The gene name &#34;Interacting with cytoskeleton&#34; is not supported by any verified
+    molecular-interaction evidence in the reviewed literature; whether ICY1
+    physically or functionally associates with the cytoskeleton is unknown.
+  boundary: &gt;-
+    ICY1 mutants show altered cell morphology (elongated cells, invasive-growth
+    defect), which is consistent with, but does not demonstrate, a cytoskeletal
+    connection. No verified direct cytoskeletal partner is documented here.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Confirming or refuting a cytoskeletal association would either justify a
+    cytoskeleton-related function/process annotation or formally retire an
+    unsupported implication carried by the gene symbol.
+  resolution: &gt;-
+    Targeted interaction assays (co-immunoprecipitation, proximity labeling,
+    two-hybrid against cytoskeletal components) and cytoskeleton-morphology imaging
+    in icy1 mutants would test the association directly.
+  provenance:
+  - reference_id: PMID:12673624
+    supporting_text: &gt;-
+      Viable haploid strains with mTn3 insertions were examined for invasive
+      growth, which is a differentiation process in haploid strains including agar
+      penetration on rich medium, and cell morphology during invasive growth.
+- gap_statement: &gt;-
+    The functionally relevant subcellular compartment for ICY1 is unresolved: it
+    is reported at the vacuole membrane (GFP screen) yet described as cytosolic in
+    the functional genetics study.
+  boundary: &gt;-
+    Both localizations are experimentally reported; there is no transmembrane
+    segment or signal peptide in the sequence, so any membrane association is
+    peripheral. Which pool mediates ICY1&#39;s function is unknown.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Clarifying the active compartment would guide interpretation of the vacuole
+    membrane annotation and connect localization to the mtDNA-viability and
+    morphology phenotypes.
+  resolution: &gt;-
+    Endogenous-level, quantitative localization (e.g. under amino-acid starvation
+    vs. rich medium, and in rho0 cells) and fractionation would establish which
+    pool is functional and under which conditions.
+  provenance:
+  - reference_id: PMID:14504216
+    supporting_text: &gt;-
+      We identified several genes encoding cytosolic proteins, including CCT6,
+      SSB1, ICY1, TIP41, and PBP1, which, when overproduced, rescue the mtDNA
+      dependence of tim18Delta cells.
+suggested_questions:
+- question: &gt;-
+    Does Icy1p have any detectable biochemical activity or a stable protein/RNA
+    partner that would define a molecular function, and does it physically
+    associate with the cytoskeleton as its name implies?
+  experts:
+  - Dunn CD
+  - Jensen RE
+- question: &gt;-
+    Is ICY1&#39;s requirement for viability of rho0 cells due to a direct effect on
+    mitochondrial inner-membrane potential/protein import, or an indirect
+    cytosolic role shared with the co-identified suppressors?
+  experts:
+  - Dunn CD
+  - Jensen RE
+suggested_experiments:
+- hypothesis: &gt;-
+    Icy1p acts as a non-catalytic factor that supports mitochondrial protein
+    import or inner-membrane potential when import is compromised.
+  description: &gt;-
+    Delete and overexpress ICY1 in import-machinery mutant backgrounds (e.g.
+    tim18delta) and measure mitochondrial inner-membrane potential and in vivo/in
+    vitro protein-import efficiency, testing epistasis with the co-identified
+    suppressors CCT6, SSB1, TIP41 and PBP1.
+  experiment_type: genetic and biochemical epistasis / mitochondrial import assay
+- hypothesis: &gt;-
+    Icy1p has one or more stable interaction partners that reveal its molecular
+    function and test the implied cytoskeletal connection.
+  description: &gt;-
+    Affinity-purify tagged Icy1p from cells grown in rich medium and under
+    amino-acid starvation, identify co-purifying proteins by mass spectrometry,
+    and specifically probe for cytoskeletal components; validate top hits by
+    reciprocal co-immunoprecipitation and imaging.
+  experiment_type: affinity purification-mass spectrometry / interaction validation
+- hypothesis: &gt;-
+    The functionally active pool of Icy1p is condition-dependent (cytosolic vs.
+    vacuole membrane).
+  description: &gt;-
+    Quantify endogenous Icy1p localization by live-cell microscopy and subcellular
+    fractionation across rich medium, amino-acid starvation, and rho0 backgrounds
+    to determine which compartment correlates with its phenotypes.
+  experiment_type: quantitative localization / fractionation
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/ILT1/ILT1-ai-review.html
+++ b/genes/yeast/ILT1/ILT1-ai-review.html
@@ -1,0 +1,3303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ILT1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ILT1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q03193" target="_blank" class="term-link">
+                        Q03193
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YDR090C</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ILT1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q03193" data-a="DESCRIPTION: ILT1 (Ionic Liquid Tolerance 1; systematic name YD..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ILT1 (Ionic Liquid Tolerance 1; systematic name YDR090C) is a polytopic plasma-membrane protein of Saccharomyces cerevisiae with no experimentally determined molecular activity. The 310-residue protein has ~6-7 transmembrane helices and two PQ-loop (MtN3/saliva) repeats, placing it in the PQ-loop repeat superfamily that also contains the vacuolar cationic-amino-acid transporters Ypq1/Ypq2/Rtc2 and the lysosomal transporter PQLC2/LAAT-1, although ILT1 belongs to a distinct, uncharacterized subfamily. GFP-fusion studies localize Ilt1 to the plasma membrane. Loss of ILT1 sensitizes cells to imidazolium ionic liquids and to other cationic compounds such as the dye crystal violet, and extra copies increase tolerance, so the protein contributes to survival in the presence of cationic xenobiotics; this effect acts independently of the multidrug efflux pump Sge1 and is background-dependent. Whether Ilt1 itself transports a solute (and if so, what), or acts through another mechanism, has not been established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005774" target="_blank" class="term-link">
+                                    GO:0005774
+                                </a>
+                            </span>
+                            <span class="term-label">vacuolar membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0005774" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level (PAINT/IBA) location inferred from the PQ-loop LAAT-1 superfamily (PTHR16201). This is contradicted by experimental evidence: Ilt1 localizes to the plasma membrane, not the vacuolar membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBD seeds driving this term are the characterized vacuolar transporters of OTHER subfamilies (Ypq1/Ypq2/Rtc2, and lysosomal PQLC2/LAAT-1), not members of ILT1&#39;s own subfamily (PTHR16201:SF37, whose only members are the uncharacterized ILT1 and its S. pombe ortholog). Two independent GFP-localization experiments place Ilt1 at the plasma membrane, directly conflicting with a vacuolar-membrane assignment. This is a paralog over-propagation of location and should not be retained.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005452</span>
+
+                                    &middot; YPQ1 (YOL092W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Vacuolar-membrane lysine exporter; different subfamily from ILT1 (SF37).</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002760</span>
+
+                                    &middot; YPQ2 (YDR352W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Vacuolar-membrane arginine exporter; different subfamily.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000000351</span>
+
+                                    &middot; RTC2/YPQ3 (YBR147W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Putative vacuolar cationic-amino-acid transporter; different subfamily.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034488" target="_blank" class="term-link">
+                                    GO:0034488
+                                </a>
+                            </span>
+                            <span class="term-label">basic amino acid transmembrane export from vacuole</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0034488" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level (PAINT/IBA) process inferred from the vacuolar cationic-amino-acid transporter members of the superfamily. Not supported for ILT1, which acts at the plasma membrane and has no measured amino-acid transport activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Export from vacuole&#34; is incompatible with the experimental plasma-membrane localization of Ilt1, and the transported-substrate (basic amino acids) is a paralog inference from Ypq1/Ypq2/Rtc2/PQLC2 rather than ILT1&#39;s own (uncharacterized) SF37 subfamily. No vacuolar amino-acid-export activity has been demonstrated for Ilt1. Retaining this term would assert both a wrong location and an untested substrate.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000000351</span>
+
+                                    &middot; RTC2/YPQ3 (YBR147W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Vacuolar cationic-amino-acid export seed; ILT1 is in a distinct subfamily and at the plasma membrane.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005452</span>
+
+                                    &middot; YPQ1 (YOL092W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Vacuolar lysine export seed; substrate/site not evidenced for ILT1.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002760</span>
+
+                                    &middot; YPQ2 (YDR352W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Vacuolar arginine export seed; substrate/site not evidenced for ILT1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0080144" target="_blank" class="term-link">
+                                    GO:0080144
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular amino acid homeostasis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0080144" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level (PAINT/IBA) process from the LAAT-1/PQLC2 vacuolar-lysosomal amino-acid recycling role. No experimental support that ILT1 participates in intracellular amino acid homeostasis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This term is inherited from distantly related, characterized subfamily members (vacuolar Ypq transporters; lysosomal PQLC2) and is not evidenced for ILT1. The only characterized ILT1 phenotype is cationic-xenobiotic tolerance at the plasma membrane, not amino-acid homeostasis. The homeostasis role for ILT1 is genuinely unknown (see knowledge_gaps); marking as over-annotated rather than asserting it.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q6ZP29</span>
+
+                                    &middot; PQLC2/LAAT1 (human)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Lysosomal cationic-amino-acid transporter (amino-acid homeostasis); different subfamily from ILT1.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">WB:WBGene00021546</span>
+
+                                    &middot; LAAT-1 (C. elegans)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Lysosomal cationic-amino-acid transporter seed; role not evidenced for ILT1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015174" target="_blank" class="term-link">
+                                    GO:0015174
+                                </a>
+                            </span>
+                            <span class="term-label">basic amino acid transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0015174" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level (PAINT/IBA) molecular function inferred from the PQ-loop superfamily. ILT1 has no measured transport activity or substrate; its own subfamily (SF37) is uncharacterized.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The basic-amino-acid transporter activity is a substrate-specific inference from Ypq1 (lysine), Ypq2 (arginine), Rtc2/Ypq3, and PQLC2 (all in different subfamilies), not from any characterized member of ILT1&#39;s clade. The PQ-loop fold is consistent with a small-molecule transporter or sensor, but ILT1&#39;s actual activity and substrate are undetermined. This is the central molecular-function knowledge gap; the specific basic-amino-acid activity should not be asserted for ILT1.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005452</span>
+
+                                    &middot; YPQ1 (YOL092W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Lysine transporter seed; substrate specificity is a paralog inference not evidenced for ILT1.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000002760</span>
+
+                                    &middot; YPQ2 (YDR352W)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Arginine transporter seed; ILT1 subfamily (SF37) uncharacterized.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q6ZP29</span>
+
+                                    &middot; PQLC2/LAAT1 (human)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Cationic amino acid transporter seed; ILT1 activity/substrate undetermined.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic location from UniProt Subcellular Location mapping (UniProt SUBCELLULAR LOCATION: Cell membrane). Concordant with experimental IDA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plasma-membrane localization is independently supported experimentally (Ilt1-GFP; Huh et al. GFP dataset). This IEA annotation is correct and redundant with the IDA below.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0016020" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic ARBA annotation to the generic &#34;membrane&#34; term, consistent with the multi-pass integral membrane topology of Ilt1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but non-specific; subsumed by the more precise plasma-membrane annotation. Retained as a generic, non-core location term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30045857
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Natural Variation in the Multidrug Efflux Pump SGE1 Underlie...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0005886" data-r="PMID:30045857" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental localization: Ilt1-GFP fusion protein localizes to the plasma membrane. This is the core, well-supported cellular location for Ilt1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by direct fluorescence-microscopy evidence (Ilt1-GFP), and corroborated by the Huh et al. genome-wide GFP-localization study (UniProt SUBCELLULAR LOCATION: Cell membrane, ECO:0000269|PubMed:14562095). This is a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> &#34;No biological data available&#34; root annotation for molecular function. This accurately reflects the state of knowledge: the molecular activity of Ilt1 is genuinely unknown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Despite the family-based IBA transporter annotation, no molecular function has been experimentally established for Ilt1. The ND(MF) annotation honestly reflects this and should stand until a mechanism is demonstrated. See knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> &#34;No biological data available&#34; root annotation for biological process. This is now superseded: experimental deletion/complementation data implicate ILT1 in tolerance to cationic xenobiotics.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND(BP) is no longer accurate: Higgins et al. 2018 provide experimental evidence (deletion sensitivity and complementation for [C2C1im]Cl, [C4C1im]Cl, and crystal violet) that ILT1 participates in the response to cationic/xenobiotic compounds. A specific process term (e.g. response to xenobiotic stimulus) is warranted in place of the root ND term; see proposed core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ILT1 functions in tolerance to a range of cationic toxins in the BY strain background</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009410" target="_blank" class="term-link">
+                                    GO:0009410
+                                </a>
+                            </span>
+                            <span class="term-label">response to xenobiotic stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30045857
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Natural Variation in the Multidrug Efflux Pump SGE1 Underlie...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q03193" data-a="GO:0009410" data-r="PMID:30045857" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation reflecting the experimental phenotype: ilt1 deletion causes sensitivity, and complementation/overexpression confers tolerance, to cationic xenobiotics (imidazolium ionic liquids and cationic dyes).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Higgins et al. 2018 provide mutant-phenotype (IMP) evidence that ILT1 is required for full tolerance to cationic xenobiotics. This is the most specific, defensible biological process term supported by the data, replacing the uninformative ND(BP) root annotation. It does NOT assert a molecular transport mechanism, which remains unknown.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ILT1 functions in tolerance to a range of cationic toxins in the BY strain background</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                        PMID:30045857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The BY ilt1Δ strain transformed with the empty control vector grew significantly slower than the deletion strain complemented with the ILT1 sequence</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Ilt1 is an integral plasma-membrane protein required for full tolerance to cationic xenobiotics (imidazolium ionic liquids and cationic dyes such as crystal violet). Its molecular mechanism is not established; the biological role captured here is participation in the cellular response to these toxic cationic compounds, based on deletion sensitivity and complementation. The molecular_function is left unspecified because no activity or substrate has been demonstrated (recorded as a knowledge gap).</h3>
+                <span class="vote-buttons" data-g="Q03193" data-a="FUNCTION: Ilt1 is an integral plasma-membrane protein requir..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009410" target="_blank" class="term-link">
+                                response to xenobiotic stimulus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                PMID:30045857
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ILT1 functions in tolerance to a range of cationic toxins in the BY strain background</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                                PMID:30045857
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" target="_blank" class="term-link">
+                            PMID:30045857
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Natural Variation in the Multidrug Efflux Pump SGE1 Underlies Ionic Liquid Tolerance in Yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YDR090C was named ILT1 (ionic liquid tolerance 1) because its deletion sensitizes yeast to the imidazolium ionic liquid [C2C1im]Cl; complementation restores tolerance, and the protein also protects against other cationic toxins including crystal violet and [C4C1im]Cl in the BY (S288c) background.</div>
+
+                        <div class="finding-text">"ILT1 functions in tolerance to a range of cationic toxins in the BY strain background"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Ilt1-GFP fusion protein localizes to the plasma membrane, consistent with the independent Huh et al. GFP-localization dataset.</div>
+
+                        <div class="finding-text">"both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Ilt1 directly transport the imidazolium ionic-liquid cation (or a protective solute) across the plasma membrane, or does it act indirectly (e.g. by modulating another transporter or membrane property)?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Trey K. Sato, Audrey P. Gasch</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03193" data-a="Q: Does Ilt1 directly transport the imidazolium ionic..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What accounts for the background-dependence of the ilt1 phenotype (required in BY but not in strain 378)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03193" data-a="Q: What accounts for the background-dependence of the..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute purified Ilt1 into proteoliposomes (or express in a heterologous transport-null system) and assay uptake/efflux of candidate solutes, including the [C2C1im]+ cation, cationic dyes, and cationic amino acids, under a range of pH and ion gradients.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Ilt1 is a plasma-membrane transporter whose substrate is a cation relevant to ionic-liquid/cationic-dye tolerance.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: transport assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03193" data-a="EXPERIMENT: Reconstitute purified Ilt1 into proteoliposomes (o..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure Ilt1 protein level, localization, and PTM state (including the reported Ser229 phosphorylation) with and without [C2C1im]Cl / crystal violet treatment.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Ilt1 abundance or plasma-membrane residence changes upon exposure to cationic xenobiotics.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: quantitative fluorescence microscopy and immunoblotting</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03193" data-a="EXPERIMENT: Measure Ilt1 protein level, localization, and PTM ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of Ilt1 is undetermined. It is unknown whether Ilt1 is itself a transporter/permease (and, if so, what solute it moves and in which direction), a transport-associated or regulatory subunit, or acts through some other membrane-based mechanism. No biochemical transport assay, substrate, or catalytic/transport activity has been reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: Ilt1 is a ~6-7 TM integral plasma-membrane protein with two PQ-loop (MtN3/saliva) repeats, placing it in the PQ-loop repeat superfamily (PTHR16201 / IPR051415 LAAT-1; Pfam PF04193). Its deletion sensitizes cells to cationic xenobiotics and extra copies increase tolerance. The specific &#34;basic amino acid transmembrane transporter activity&#34; attached by IBA is a paralog inference from vacuolar/lysosomal members (Ypq1/Ypq2/Rtc2, PQLC2) of DIFFERENT subfamilies, not from Ilt1&#39;s own uncharacterized subfamily (PTHR16201:SF37).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Ilt1 is a conserved PQ-loop membrane protein of unknown activity whose only characterized role is in tolerance to industrially relevant ionic liquids; resolving its molecular function would clarify a plasma-membrane detoxification/transport mechanism and inform engineering of ionic-liquid-tolerant biofuel strains.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct transport assays (e.g. radiolabelled-substrate uptake/efflux in reconstituted proteoliposomes or heterologous cells) across candidate solutes including the ionic-liquid cation itself and cationic amino acids; substrate screens; and structure-guided identification of the translocation pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"putative PQ-loop motif found in Ypq1, Ypq2, and Rtc2/Ypq3, which are putative vacuolar membrane transporters of cationic amino acids"</em> — PMID:30045857</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The native physiological role of ILT1 is unknown. Ionic liquids are synthetic xenobiotics, so cationic-toxin tolerance is unlikely to be the trait under natural selection; what Ilt1 does for the cell under normal conditions, and why its requirement is background-dependent (needed in BY/S288c but not in the tolerant 378 isolate), is not understood.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: ilt1 deletion causes a growth defect specifically in the presence of cationic compounds in the BY background, is dispensable in the 378 background, and acts independently of the Sge1 efflux pump. No other deletion phenotype or physiological role has been documented.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing an incidental xenobiotic-tolerance effect from a native transport/homeostasis function is required to place ILT1 in a pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic phenotyping (growth across ion/nutrient/stress conditions, metabolomics of ilt1 mutants), genetic-interaction mapping, and testing candidate native substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"suggesting that ILT1 has strain-specific functions"</em> — PMID:30045857</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ILT1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03193" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Research Report: ILT1/YDR090C — An Uncharacterized PQ-Loop Membrane Protein in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">20 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:31:30.971067</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ILT1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="ILT1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-ilt1ydr090c-an-uncharacterized-pq-loop-membrane-protein-in-saccharomyces-cerevisiae">Research Report: ILT1/YDR090C — An Uncharacterized PQ-Loop Membrane Protein in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>ILT1 corresponds to the systematic ORF name YDR090C in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c), encoding a 310-amino-acid uncharacterized membrane protein (UniProt accession Q03193). The protein is annotated with PQ-loop repeat domains (InterPro IPR006603; Pfam PF04193) and an LAAT-1 domain (InterPro IPR051415), placing it within the lysosomal cystine transporter (LCT) family of the Transporter-Opsin-G protein coupled receptor (TOG) superfamily (saudek2012cystinosinmpdu1sweets pages 3-5). A comprehensive bioinformatic survey by Saudek (2012) explicitly listed YDR090C (Q03193) as one of eight PQ-loop family proteins in <em>S. cerevisiae</em>, designating it as an "uncharacterized membrane protein" (saudek2012cystinosinmpdu1sweets pages 3-5). YDR090C also appears in the phylogenetic tree of yeast and human PQ-loop proteins constructed by Jézégou et al. (2012) (jezegou2012heptahelicalproteinpqlc2 pages 4-5).</p>
+<p>Importantly, YDR090C is distinct from the three best-characterized yeast PQ-loop proteins — Ypq1 (YOL092W), Ypq2 (YDR352W), and Ypq3 (YBR147W/RTC2) — which have been functionally characterized as vacuolar basic amino acid transporters (jezegou2012heptahelicalproteinpqlc2 pages 3-4). The following table provides a comprehensive overview of the PQ-loop family in yeast:</p>
+<table>
+<thead>
+<tr>
+<th>UniProt ID</th>
+<th>Systematic name</th>
+<th>Gene name(s)</th>
+<th style="text-align: right;">Length (aa)</th>
+<th>PQ-loop family status in <em>S. cerevisiae</em></th>
+<th>Known / inferred function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Q03193</td>
+<td><strong>YDR090C</strong></td>
+<td><strong>ILT1, YDR090C</strong></td>
+<td style="text-align: right;">310</td>
+<td>PQ-loop family member; distinct from Ypq1–3 (saudek2012cystinosinmpdu1sweets pages 3-5, jezegou2012heptahelicalproteinpqlc2 pages 3-4)</td>
+<td><strong>Uncharacterized membrane protein</strong>. No direct biochemical function established in the retrieved literature. Based on PQ-loop/LAAT-1 domains and family context, it is most plausibly a 7-TM vacuolar/lysosomal transporter-like protein involved in small-solute, likely amino-acid-related, transport or homeostasis, but this remains <strong>inference rather than direct evidence</strong> (saudek2012cystinosinmpdu1sweets pages 3-5, guo2022structureandmechanism pages 3-5, bianchi2019regulationofamino pages 15-17, liu2012laat1isthe pages 3-4).</td>
+</tr>
+<tr>
+<td>Q12010</td>
+<td>YOL092W</td>
+<td>YPQ1, YOL092W</td>
+<td style="text-align: right;">308</td>
+<td>PQ-loop family member; one of the three best-characterized yeast Ypq proteins (llinares2015theap3adaptor pages 1-2, jezegou2012heptahelicalproteinpqlc2 pages 3-4)</td>
+<td>Vacuolar membrane basic amino acid transporter implicated in cationic amino acid homeostasis; reported as a vacuolar lysine/arginine transporter/exporter in different experimental contexts and strongly linked to lysine-responsive vacuolar membrane quality control and degradation (kawanokawada2018transportofamino pages 2-3, jezegou2012heptahelicalproteinpqlc2 pages 4-5, jezegou2012heptahelicalproteinpqlc2 pages 9-10).</td>
+</tr>
+<tr>
+<td>Q06328</td>
+<td>YDR352W</td>
+<td>YPQ2, YDR352W</td>
+<td style="text-align: right;">317</td>
+<td>PQ-loop family member; one of the three best-characterized yeast Ypq proteins (llinares2015theap3adaptor pages 1-2, jezegou2012heptahelicalproteinpqlc2 pages 3-4)</td>
+<td>Vacuolar membrane basic amino acid transporter; functional ortholog of mammalian PQLC2. Best evidence supports arginine export from the vacuole during nitrogen starvation and broader cationic amino acid homeostasis (llinares2015theap3adaptor pages 1-2, cools2020nitrogencoordinatedimport pages 28-29, cools2020nitrogencoordinatedimport pages 21-22).</td>
+</tr>
+<tr>
+<td>P38279</td>
+<td>YBR147W</td>
+<td>RTC2, YPQ3, YBR147W</td>
+<td style="text-align: right;">296</td>
+<td>PQ-loop family member; grouped with Ypq1/2 in yeast vacuolar PQ-loop proteins (jezegou2012heptahelicalproteinpqlc2 pages 3-4, saudek2012cystinosinmpdu1sweets pages 3-5)</td>
+<td>Vacuolar membrane basic amino acid transporter implicated in cationic amino acid homeostasis; evidence suggests a role particularly in histidine and/or lysine-related vacuolar transport, though less directly characterized than Ypq1/2 (kawanokawada2018transportofamino pages 2-3, jezegou2012heptahelicalproteinpqlc2 pages 4-5).</td>
+</tr>
+<tr>
+<td>P17261</td>
+<td>YCR075C</td>
+<td>ERS1, YCR075C</td>
+<td style="text-align: right;">260</td>
+<td>PQ-loop family member; yeast homolog of cystinosin (jezegou2012heptahelicalproteinpqlc2 pages 3-4)</td>
+<td>Functional homolog of human cystinosin by complementation evidence, but native yeast biochemical activity remains incompletely resolved. Reported to localize to vacuole/endosome and proposed to participate in lysosome/vacuole-related transport or trafficking functions (jezegou2012heptahelicalproteinpqlc2 pages 3-4, saudek2012cystinosinmpdu1sweets pages 3-5).</td>
+</tr>
+<tr>
+<td>P18414</td>
+<td>YBL040C</td>
+<td>ERD2, YBL040C</td>
+<td style="text-align: right;">219</td>
+<td>PQ-loop family member in broad family classifications (saudek2012cystinosinmpdu1sweets pages 3-5)</td>
+<td><strong>ER lumen protein-retaining receptor (HDEL receptor)</strong>; a well-established retrieval receptor rather than a vacuolar basic amino acid transporter. Included here because it falls within the broader PQ-loop-related family classification used in comparative analyses (saudek2012cystinosinmpdu1sweets pages 3-5).</td>
+</tr>
+<tr>
+<td>P25565</td>
+<td>YCL002C</td>
+<td>YCL002C, YCL2C</td>
+<td style="text-align: right;">251</td>
+<td>PQ-loop family member in broad family classifications (saudek2012cystinosinmpdu1sweets pages 3-5)</td>
+<td>Putative uncharacterized PQ-loop membrane protein; no direct function established in the retrieved literature (saudek2012cystinosinmpdu1sweets pages 3-5).</td>
+</tr>
+<tr>
+<td>Q03687</td>
+<td>YMR010W</td>
+<td>YMR010W</td>
+<td style="text-align: right;">405</td>
+<td>PQ-loop family member in broad family classifications (saudek2012cystinosinmpdu1sweets pages 3-5)</td>
+<td>Uncharacterized membrane protein; no direct biochemical function established in the retrieved literature (saudek2012cystinosinmpdu1sweets pages 3-5).</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the PQ-loop family proteins reported in </em>Saccharomyces cerevisiae<em>, combining broad family listings with functional evidence where available. It is especially useful for distinguishing the uncharacterized YDR090C/ILT1 protein from the better-studied Ypq1–Ypq3 vacuolar amino acid transporters.</em></p>
+<h2 id="2-domain-architecture-and-structural-inference">2. Domain Architecture and Structural Inference</h2>
+<p>YDR090C possesses the hallmark domains of PQ-loop family proteins: two internal PQ-loop repeats (containing conserved proline-glutamine dipeptides) and predicted seven-transmembrane (7-TM) helical topology (bianchi2019regulationofamino pages 15-17, jezegou2012heptahelicalproteinpqlc2 pages 2-3, kawanokawada2018transportofamino pages 2-3). Structural studies on the closely related family member cystinosin have revealed that PQ-loop proteins adopt a characteristic 3+1+3 architecture, in which two related three-transmembrane-helix bundles (TMs 1–3 and TMs 5–7) are connected by an inversion linker helix (TM4), forming a central substrate binding cavity at the interface of the two bundles (guo2022structureandmechanism pages 3-5, bianchi2019regulationofamino pages 15-17). The conserved PQ motifs are actually located within transmembrane helices TM1 and TM5, rather than in loop regions as originally supposed, and they play essential roles in conformational transitions during the transport cycle (guo2022structureandmechanism pages 9-11).</p>
+<p>PQ-loop transporters operate via an <strong>alternating access mechanism</strong>, oscillating between lumen-open (outward-open) and cytosol-open (inward-open) conformations. This involves rigid-body movements of the two three-helix bundles around the central substrate binding site. Conserved salt bridges on either side of the binding site serve as gates that control access from the luminal and cytosolic sides of the membrane (guo2022structureandmechanism pages 3-5, lobel2022structuralbasisfor pages 6-7, guo2022structureandmechanism pages 9-11). The structural resolution of cystinosin from both <em>Arabidopsis thaliana</em> and humans has firmly established this mechanistic framework for the entire PQ-loop family (guo2022structureandmechanism pages 3-5, lobel2022structuralbasisfor pages 6-7, lobel2022structuralbasisfor pages 3-4).</p>
+<h2 id="3-predicted-function-vacuolar-amino-acid-transporter">3. Predicted Function: Vacuolar Amino Acid Transporter</h2>
+<p>Although YDR090C/ILT1 itself has not been directly characterized biochemically, strong functional predictions can be made based on its domain architecture and the experimentally established functions of its yeast paralogs and orthologs in other organisms.</p>
+<h3 id="31-yeast-paralogs-ypq1-ypq2-and-ypq3">3.1. Yeast Paralogs: Ypq1, Ypq2, and Ypq3</h3>
+<p>The three closest yeast paralogs of YDR090C — Ypq1, Ypq2, and Ypq3 — are all vacuolar membrane proteins that function as <strong>cationic (basic) amino acid transporters</strong>. Ypq1 mediates ATP-dependent uptake of lysine and arginine into vacuolar membrane vesicles (kawanokawada2018transportofamino pages 2-3). Ypq2 functions as an exporter of intravacuolar arginine under nitrogen starvation conditions and has been demonstrated to be a functional ortholog of mammalian PQLC2 (llinares2015theap3adaptor pages 1-2, cools2020nitrogencoordinatedimport pages 21-22). Ypq3 has been implicated in histidine uptake into vacuoles and may also export lysine from the vacuole to the cytosol; its expression is under the control of the Lys14 transcription factor and is repressed by excess lysine (kawanokawada2018transportofamino pages 2-3, jezegou2012heptahelicalproteinpqlc2 pages 4-5). A quadruple mutant lacking all three Ypq proteins plus Avt1 completely lost basic amino acid uptake activity at the vacuolar membrane (kawanokawada2018transportofamino pages 2-3).</p>
+<h3 id="32-metazoan-orthologs-pqlc2-and-laat-1">3.2. Metazoan Orthologs: PQLC2 and LAAT-1</h3>
+<p>The mammalian PQ-loop protein PQLC2 localizes to lysosomes and catalyzes a robust, electrogenic transport selective for cationic amino acids including lysine, arginine, and histidine, and is strongly activated at low extracytosolic pH (jezegou2012heptahelicalproteinpqlc2 pages 2-3, jezegou2012heptahelicalproteinpqlc2 pages 4-5). In <em>Caenorhabditis elegans</em>, the PQ-loop family member LAAT-1 (lysosomal amino acid transporter-1) functions as a lysosomal lysine/arginine transporter essential for amino acid homeostasis: <em>laat-1</em> mutant lysosomes accumulate lysine and arginine at 16-fold and 8-fold higher levels than wild-type, respectively, while cystine levels remain normal (liu2012laat1isthe pages 3-4).</p>
+<h3 id="33-cystinosin-a-functionally-divergent-family-member">3.3. Cystinosin: A Functionally Divergent Family Member</h3>
+<p>Another well-characterized PQ-loop family member is cystinosin (encoded by <em>CTNS</em> in humans, with the yeast homolog being Ers1/YCR075C). Cystinosin is a proton-coupled cystine symporter that exports cystine from the lysosomal lumen; mutations cause cystinosis, a lysosomal storage disease (ruivo2012mechanismofprotonsubstrate pages 1-2). This demonstrates that while most characterized PQ-loop proteins transport basic amino acids, the family can accommodate divergent substrate specificities.</p>
+<p>The following blockquote summarizes the functional inference for YDR090C:</p>
+<blockquote>
+<p>YDR090C/ILT1 is best interpreted as a <strong>PQ-loop family membrane protein</strong> in <em>Saccharomyces cerevisiae</em>, not as one of the experimentally characterized Ypq transporters themselves. It carries the defining PQ-loop/LAAT-1-type architecture associated with <strong>seven transmembrane helices</strong> and membership in the lysosomal cystine transporter/PQ-loop family, but the specific substrate and physiological role of YDR090C have <strong>not yet been established directly</strong> in the available primary literature (saudek2012cystinosinmpdu1sweets pages 3-5, jezegou2012heptahelicalproteinpqlc2 pages 3-4).</p>
+<p>Functional inference comes from better-characterized fungal and metazoan relatives. In budding yeast, the closest characterized paralogs <strong>Ypq1/YOL092W, Ypq2/YDR352W, and Ypq3/YBR147W</strong> are vacuolar PQ-loop proteins involved in <strong>cationic/basic amino-acid homeostasis</strong>, while mammalian <strong>PQLC2</strong> and <em>C. elegans</em> <strong>LAAT-1</strong> mediate lysosomal export of <strong>basic amino acids such as lysine and arginine</strong>; the family founder <strong>cystinosin</strong> instead transports cystine, showing that PQ-loop proteins are transporter-like but can differ in substrate specificity (llinares2015theap3adaptor pages 1-2, jezegou2012heptahelicalproteinpqlc2 pages 4-5, jezegou2012heptahelicalproteinpqlc2 pages 9-10, jezegou2012heptahelicalproteinpqlc2 pages 2-3, liu2012laat1isthe pages 3-4).</p>
+<p>On that basis, the most defensible current model is that YDR090C/ILT1 is a <strong>vacuolar/lysosomal membrane transporter-like protein</strong>, likely participating in <strong>amino-acid efflux or compartmental amino-acid homeostasis</strong>, with <strong>basic amino acids</strong> being a plausible candidate substrate class by analogy to Ypq1-3, PQLC2, and LAAT-1. However, this remains a <strong>prediction from homology and domain architecture</strong>, not an experimentally proven annotation for YDR090C itself (bianchi2019regulationofamino pages 15-17, liu2012laat1isthe pages 3-4, jezegou2012heptahelicalproteinpqlc2 pages 4-5, cools2020nitrogencoordinatedimport pages 21-22).</p>
+<p>Structural work on PQ-loop proteins provides a mechanistic rationale for this inference: these proteins share a <strong>3+1+3 topology</strong>, in which two related <strong>3-transmembrane bundles</strong> form the transport core and move by an <strong>alternating-access mechanism</strong> to expose a central substrate-binding cavity to opposite sides of the membrane. This framework, resolved for cystinosin and generalized across PQ-loop transporters, strongly supports interpreting YDR090C as a <strong>small-solute transporter rather than a soluble regulatory protein</strong>, even though its precise transported substrate remains unknown (guo2022structureandmechanism pages 3-5, lobel2022structuralbasisfor pages 6-7, guo2022structureandmechanism pages 9-11, bianchi2019regulationofamino pages 15-17).</p>
+</blockquote>
+<p><em>Blockquote: This blockquote summarizes the strongest current inference for YDR090C/ILT1 based on PQ-loop family membership, domain architecture, and comparison with characterized paralogs and orthologs. It is useful because direct experimental data on YDR090C are sparse, so function must be inferred cautiously from structural and evolutionary evidence.</em></p>
+<h2 id="4-predicted-subcellular-localization">4. Predicted Subcellular Localization</h2>
+<p>No direct experimental localization data for YDR090C/ILT1 was identified in the primary literature. However, its localization can be inferred from family context. All three yeast Ypq proteins (Ypq1–3) localize to the <strong>vacuolar membrane</strong> and are delivered there via the AP-3 adaptor complex-dependent alkaline phosphatase (ALP) trafficking pathway, utilizing an acidic dileucine motif in their second cytosolic loop (llinares2015theap3adaptor pages 1-2). Similarly, Ers1 (the yeast cystinosin homolog) localizes to the vacuole and endosomes (saudek2012cystinosinmpdu1sweets pages 3-5). In metazoans, PQLC2 localizes to lysosomes and LAAT-1 localizes to lysosomal membranes via a C-terminal dileucine-based sorting motif (liu2012laat1isthe pages 3-4). Given that YDR090C shares the PQ-loop/LAAT-1 domain architecture with these proteins, it is most likely a <strong>vacuolar membrane protein</strong> or associated with endomembrane compartments involved in vacuolar trafficking.</p>
+<h2 id="5-biological-pathways-and-physiological-context">5. Biological Pathways and Physiological Context</h2>
+<h3 id="51-vacuolar-amino-acid-homeostasis">5.1. Vacuolar Amino Acid Homeostasis</h3>
+<p>The yeast vacuole serves as the primary storage compartment for amino acids, accumulating approximately 50% of total cellular amino acids under nutrient-rich conditions (kawanokawada2018transportofamino pages 1-2). The composition of amino acids differs markedly between the vacuolar lumen and the cytosol, reflecting the coordinated action of multiple vacuolar transporters including the Ypq proteins, Vba importers, Avt family transporters, and Vsb1 (kawanokawada2018transportofamino pages 2-3, cools2020nitrogencoordinatedimport pages 21-22, kawanokawada2018transportofamino pages 1-2). Ypq proteins and Vba proteins work in a coordinated manner: Vba1–3 mediate import of cationic amino acids into the vacuole, while Ypq proteins mediate their export to the cytosol (jezegou2012heptahelicalproteinpqlc2 pages 4-5, jezegou2012heptahelicalproteinpqlc2 pages 9-10).</p>
+<h3 id="52-nitrogen-responsive-regulation">5.2. Nitrogen-Responsive Regulation</h3>
+<p>The activity of vacuolar amino acid transporters is regulated by nitrogen availability. Under nitrogen-replete conditions, arginine is actively imported into the vacuole via Vsb1; upon nitrogen starvation, Vsb1 activity is inhibited and Ypq2 exports stored arginine to the cytosol for biosynthetic recycling (cools2020nitrogencoordinatedimport pages 28-29, cools2020nitrogencoordinatedimport pages 21-22). This inverse regulation by nitrogen status represents a key mechanism for adapting amino acid metabolism to nutrient availability.</p>
+<h3 id="53-quality-control-of-vacuolar-membrane-proteins">5.3. Quality Control of Vacuolar Membrane Proteins</h3>
+<p>Ypq1 has emerged as a model substrate for studying ubiquitin-dependent quality control of vacuolar membrane proteins. Upon lysine starvation, Ypq1 is ubiquitinated and sorted into the vacuolar lumen for degradation via the ESCRT (endosomal sorting complexes required for transport) machinery, a process termed the vacuolar membrane recycling and degradation (vReD) pathway (jezegou2012heptahelicalproteinpqlc2 pages 4-5, jezegou2012heptahelicalproteinpqlc2 pages 9-10). Whether YDR090C is similarly subject to starvation-induced or condition-dependent degradation remains unknown.</p>
+<h2 id="6-gene-naming-ilt1-designation">6. Gene Naming: "ILT1" Designation</h2>
+<p>The gene name ILT1 (Ionic Liquid Tolerance 1) for YDR090C appears to originate from studies on yeast tolerance to ionic liquids, which are solvents used in biomass pretreatment. A study by Reed et al. (2019) reported on directed evolution of an ILT1 homolog from <em>Yarrowia lipolytica</em> for improved ionic liquid tolerance in <em>S. cerevisiae</em>. The mechanistic basis for how a PQ-loop membrane protein might contribute to ionic liquid tolerance is not well established, and this phenotypic naming convention should not be conflated with the primary molecular function of the protein, which is more likely related to vacuolar amino acid transport based on domain architecture.</p>
+<h2 id="7-conclusions-and-future-directions">7. Conclusions and Future Directions</h2>
+<p>YDR090C/ILT1 remains an experimentally uncharacterized member of the PQ-loop family of membrane transporters in <em>S. cerevisiae</em>. Based on its domain architecture (PQ-loop repeats, LAAT-1 domain, predicted 7-TM topology) and the well-characterized functions of its yeast paralogs (Ypq1–3) and metazoan orthologs (PQLC2, LAAT-1, cystinosin), YDR090C is most plausibly a <strong>vacuolar membrane transporter</strong> involved in <strong>amino acid efflux or compartmental amino acid homeostasis</strong>, with basic amino acids being a probable substrate class. However, it should be noted that PQ-loop family members can transport different substrates (e.g., cystine for cystinosin), and the specific substrate of YDR090C cannot be definitively assigned without direct biochemical characterization. Structural studies on cystinosin (guo2022structureandmechanism pages 3-5, lobel2022structuralbasisfor pages 6-7) provide a framework for understanding the likely alternating-access transport mechanism of YDR090C. Future work involving heterologous expression, reconstitution into proteoliposomes, and transport assays would be needed to establish the substrate specificity and transport properties of this protein directly.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(saudek2012cystinosinmpdu1sweets pages 3-5): Vladimir Saudek. Cystinosin, mpdu1, sweets and kdelr belong to a well-defined protein family with putative function of cargo receptors involved in vesicle trafficking. PLoS ONE, 7:e30876, Feb 2012. URL: https://doi.org/10.1371/journal.pone.0030876, doi:10.1371/journal.pone.0030876. This article has 63 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jezegou2012heptahelicalproteinpqlc2 pages 4-5): Adrien Jézégou, Elisa Llinares, Christine Anne, Sylvie Kieffer-Jaquinod, Seana O’Regan, Joëlle Aupetit, Allel Chabli, Corinne Sagné, Cécile Debacker, Bernadette Chadefaux-Vekemans, Agnès Journet, Bruno André, and Bruno Gasnier. Heptahelical protein pqlc2 is a lysosomal cationic amino acid exporter underlying the action of cysteamine in cystinosis therapy. Proceedings of the National Academy of Sciences, 109:E3434-E3443, Nov 2012. URL: https://doi.org/10.1073/pnas.1211198109, doi:10.1073/pnas.1211198109. This article has 236 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jezegou2012heptahelicalproteinpqlc2 pages 3-4): Adrien Jézégou, Elisa Llinares, Christine Anne, Sylvie Kieffer-Jaquinod, Seana O’Regan, Joëlle Aupetit, Allel Chabli, Corinne Sagné, Cécile Debacker, Bernadette Chadefaux-Vekemans, Agnès Journet, Bruno André, and Bruno Gasnier. Heptahelical protein pqlc2 is a lysosomal cationic amino acid exporter underlying the action of cysteamine in cystinosis therapy. Proceedings of the National Academy of Sciences, 109:E3434-E3443, Nov 2012. URL: https://doi.org/10.1073/pnas.1211198109, doi:10.1073/pnas.1211198109. This article has 236 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guo2022structureandmechanism pages 3-5): Xue Guo, Philip Schmiege, Tufa E. Assafa, Rong Wang, Yan Xu, Linda Donnelly, Michael Fine, Xiaodan Ni, Jiansen Jiang, Glenn Millhauser, Liang Feng, and Xiaochun Li. Structure and mechanism of human cystine exporter cystinosin. Cell, 185:3739-3752.e18, Sep 2022. URL: https://doi.org/10.1016/j.cell.2022.08.020, doi:10.1016/j.cell.2022.08.020. This article has 60 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bianchi2019regulationofamino pages 15-17): Frans Bianchi, Joury S. van’t Klooster, Stephanie J. Ruiz, and Bert Poolman. Regulation of amino acid transport in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, Nov 2019. URL: https://doi.org/10.1128/mmbr.00024-19, doi:10.1128/mmbr.00024-19. This article has 171 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2012laat1isthe pages 3-4): Bin Liu, Hongwei Du, Rachael Rutkowski, Anton Gartner, and Xiaochen Wang. Laat-1 is the lysosomal lysine/arginine transporter that maintains amino acid homeostasis. Science, 337:351-354, Jul 2012. URL: https://doi.org/10.1126/science.1220281, doi:10.1126/science.1220281. This article has 230 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(llinares2015theap3adaptor pages 1-2): Elisa Llinares, Abdoulaye Oury Barry, and Bruno André. The ap-3 adaptor complex mediates sorting of yeast and mammalian pq-loop-family basic amino acid transporters to the vacuolar/lysosomal membrane. Scientific Reports, Nov 2015. URL: https://doi.org/10.1038/srep16665, doi:10.1038/srep16665. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kawanokawada2018transportofamino pages 2-3): Miyuki Kawano-Kawada, Yoshimi Kakinuma, and Takayuki Sekito. Transport of amino acids across the vacuolar membrane of yeast: its mechanism and physiological role. Biological &amp; pharmaceutical bulletin, 41 10:1496-1501, Oct 2018. URL: https://doi.org/10.1248/bpb.b18-00165, doi:10.1248/bpb.b18-00165. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jezegou2012heptahelicalproteinpqlc2 pages 9-10): Adrien Jézégou, Elisa Llinares, Christine Anne, Sylvie Kieffer-Jaquinod, Seana O’Regan, Joëlle Aupetit, Allel Chabli, Corinne Sagné, Cécile Debacker, Bernadette Chadefaux-Vekemans, Agnès Journet, Bruno André, and Bruno Gasnier. Heptahelical protein pqlc2 is a lysosomal cationic amino acid exporter underlying the action of cysteamine in cystinosis therapy. Proceedings of the National Academy of Sciences, 109:E3434-E3443, Nov 2012. URL: https://doi.org/10.1073/pnas.1211198109, doi:10.1073/pnas.1211198109. This article has 236 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cools2020nitrogencoordinatedimport pages 28-29): Melody Cools, Simon Lissoir, Elisabeth Bodo, Judith Ulloa-Calzonzin, Alexander DeLuna, Isabelle Georis, and Bruno André. Nitrogen coordinated import and export of arginine across the yeast vacuolar membrane. Aug 2020. URL: https://doi.org/10.1371/journal.pgen.1008966, doi:10.1371/journal.pgen.1008966. This article has 29 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cools2020nitrogencoordinatedimport pages 21-22): Melody Cools, Simon Lissoir, Elisabeth Bodo, Judith Ulloa-Calzonzin, Alexander DeLuna, Isabelle Georis, and Bruno André. Nitrogen coordinated import and export of arginine across the yeast vacuolar membrane. Aug 2020. URL: https://doi.org/10.1371/journal.pgen.1008966, doi:10.1371/journal.pgen.1008966. This article has 29 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jezegou2012heptahelicalproteinpqlc2 pages 2-3): Adrien Jézégou, Elisa Llinares, Christine Anne, Sylvie Kieffer-Jaquinod, Seana O’Regan, Joëlle Aupetit, Allel Chabli, Corinne Sagné, Cécile Debacker, Bernadette Chadefaux-Vekemans, Agnès Journet, Bruno André, and Bruno Gasnier. Heptahelical protein pqlc2 is a lysosomal cationic amino acid exporter underlying the action of cysteamine in cystinosis therapy. Proceedings of the National Academy of Sciences, 109:E3434-E3443, Nov 2012. URL: https://doi.org/10.1073/pnas.1211198109, doi:10.1073/pnas.1211198109. This article has 236 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guo2022structureandmechanism pages 9-11): Xue Guo, Philip Schmiege, Tufa E. Assafa, Rong Wang, Yan Xu, Linda Donnelly, Michael Fine, Xiaodan Ni, Jiansen Jiang, Glenn Millhauser, Liang Feng, and Xiaochun Li. Structure and mechanism of human cystine exporter cystinosin. Cell, 185:3739-3752.e18, Sep 2022. URL: https://doi.org/10.1016/j.cell.2022.08.020, doi:10.1016/j.cell.2022.08.020. This article has 60 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lobel2022structuralbasisfor pages 6-7): Mark Löbel, Sacha P. Salphati, Kamel El Omari, Armin Wagner, Stephen J. Tucker, Joanne L. Parker, and Simon Newstead. Structural basis for proton coupled cystine transport by cystinosin. Nature Communications, Aug 2022. URL: https://doi.org/10.1038/s41467-022-32589-2, doi:10.1038/s41467-022-32589-2. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lobel2022structuralbasisfor pages 3-4): Mark Löbel, Sacha P. Salphati, Kamel El Omari, Armin Wagner, Stephen J. Tucker, Joanne L. Parker, and Simon Newstead. Structural basis for proton coupled cystine transport by cystinosin. Nature Communications, Aug 2022. URL: https://doi.org/10.1038/s41467-022-32589-2, doi:10.1038/s41467-022-32589-2. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ruivo2012mechanismofprotonsubstrate pages 1-2): Raquel Ruivo, Gian Carlo Bellenchi, Xiong Chen, Giovanni Zifarelli, Corinne Sagné, Cécile Debacker, Michael Pusch, Stéphane Supplisson, and Bruno Gasnier. Mechanism of proton/substrate coupling in the heptahelical lysosomal transporter cystinosin. Proceedings of the National Academy of Sciences, 109:E210-E217, Jan 2012. URL: https://doi.org/10.1073/pnas.1115581109, doi:10.1073/pnas.1115581109. This article has 68 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kawanokawada2018transportofamino pages 1-2): Miyuki Kawano-Kawada, Yoshimi Kakinuma, and Takayuki Sekito. Transport of amino acids across the vacuolar membrane of yeast: its mechanism and physiological role. Biological &amp; pharmaceutical bulletin, 41 10:1496-1501, Oct 2018. URL: https://doi.org/10.1248/bpb.b18-00165, doi:10.1248/bpb.b18-00165. This article has 42 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ILT1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="ILT1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>guo2022structureandmechanism pages 9-11</li>
+<li>kawanokawada2018transportofamino pages 2-3</li>
+<li>ruivo2012mechanismofprotonsubstrate pages 1-2</li>
+<li>kawanokawada2018transportofamino pages 1-2</li>
+<li>guo2022structureandmechanism pages 3-5</li>
+<li>bianchi2019regulationofamino pages 15-17</li>
+<li>cools2020nitrogencoordinatedimport pages 28-29</li>
+<li>cools2020nitrogencoordinatedimport pages 21-22</li>
+<li>lobel2022structuralbasisfor pages 6-7</li>
+<li>lobel2022structuralbasisfor pages 3-4</li>
+<li>https://doi.org/10.1371/journal.pone.0030876,</li>
+<li>https://doi.org/10.1073/pnas.1211198109,</li>
+<li>https://doi.org/10.1016/j.cell.2022.08.020,</li>
+<li>https://doi.org/10.1128/mmbr.00024-19,</li>
+<li>https://doi.org/10.1126/science.1220281,</li>
+<li>https://doi.org/10.1038/srep16665,</li>
+<li>https://doi.org/10.1248/bpb.b18-00165,</li>
+<li>https://doi.org/10.1371/journal.pgen.1008966,</li>
+<li>https://doi.org/10.1038/s41467-022-32589-2,</li>
+<li>https://doi.org/10.1073/pnas.1115581109,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ILT1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03193" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ilt1-ydr090c-q03193-curation-notes">ILT1 (YDR090C / Q03193) — curation notes</h1>
+<p>Journal-style notes for the AI GO-annotation review of the <em>S. cerevisiae</em> dark gene <strong>ILT1</strong>.<br />
+Standard name ILT1 = "Ionic Liquid Tolerance 1"; systematic name <strong>YDR090C</strong>; UniProt <strong>Q03193</strong>;<br />
+SGD <strong>S000002497</strong>. SGD qualifier: <strong>Verified</strong> ORF.</p>
+<h2 id="identity-provenance">Identity / provenance</h2>
+<ul>
+<li>ILT1 is the SGD standard name assigned in 2018 by Higgins et al.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="we identified SGE1 ... and a previously uncharacterized gene that we named ionic   liquid tolerance 1 (ILT1), which encodes a predicted membrane protein">PMID:30045857</a>.</li>
+<li>SGD one-line description: "Protein of unknown function; deletion confers sensitivity to cationic<br />
+  compounds; green fluorescent protein (GFP)-fusion protein localizes to the plasma membrane."</li>
+<li>UniProt name: "Uncharacterized membrane protein YDR090C". Evidence level PE 1 (protein level).</li>
+</ul>
+<h2 id="sequence-domain-reasoning-inline-from-uniprot-q03193-record">Sequence / domain reasoning (inline, from UniProt Q03193 record)</h2>
+<ul>
+<li>310 aa multi-pass membrane protein. UniProt models 6 TRANSMEM helices (topology from<br />
+  PubMed:12524434 / PubMed:16847258 C-terminal reporter-fusion topology studies); Higgins 2018<br />
+  cite a 7-transmembrane-helix prediction <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="ILT1 encodes a membrane protein with   seven transmembrane helices">PMID:30045857</a>. Either way it is a polytopic ~6–7 TM integral membrane protein.</li>
+<li><strong>PQ-loop repeats</strong>: UniProt annotates two PQ-loop domains (residues 5..69 and 138..194). Pfam<br />
+  PF04193 (PQ-loop), InterPro IPR006603 (PQ-loop_rpt), SMART SM00679 (CTNS, ×2). The PQ-loop /<br />
+  "MtN3/saliva" fold is a duplicated 3-TM unit typical of SWEET-like and PQ-loop transporters/<br />
+  sensors (e.g. cystinosin/CTNS, PQLC2, SWEETs, lysosomal amino-acid transporters).</li>
+<li>InterPro family <strong>IPR051415 = LAAT-1</strong> (Lysosomal/Vacuolar Amino Acid Transporter 1).</li>
+<li>PANTHER: family <strong>PTHR16201</strong> ("SEVEN TRANSMEMBRANE PROTEIN 1-RELATED" / LAAT-1);<br />
+  subfamily <strong>PTHR16201:SF37</strong> = "PQ-LOOP REPEAT-CONTAINING PROTEIN".</li>
+</ul>
+<h2 id="family-orthology-reasoning-the-key-nuance-for-the-iba-annotations">Family / orthology reasoning — the key nuance for the IBA annotations</h2>
+<p>The GOA file carries four IBA (GO_Central / PAINT) annotations propagated from PTHR16201:<br />
+- GO:0005774 vacuolar membrane (C)<br />
+- GO:0015174 basic amino acid transmembrane transporter activity (F)<br />
+- GO:0034488 basic amino acid transmembrane export from vacuole (P)<br />
+- GO:0080144 intracellular amino acid homeostasis (P)</p>
+<p>Inspecting the PANTHER PAINT table (<code>interpro/panther/PTHR16201/PTHR16201-paint.tsv</code>), these IBD<br />
+seeds are the <strong>characterized members of <em>other</em> subfamilies</strong>, not ILT1's own clade:<br />
+- SGD:S000005452 = <strong>YPQ1</strong> (YOL092W) — vacuolar membrane <strong>lysine</strong> exporter<br />
+- SGD:S000002760 = <strong>YPQ2</strong> (YDR352W) — vacuolar membrane <strong>arginine</strong> exporter<br />
+- SGD:S000000351 = <strong>RTC2/YPQ3</strong> (YBR147W) — putative vacuolar cationic-amino-acid transporter<br />
+- WB:WBGene00021546 = <em>C. elegans</em> <strong>LAAT-1</strong> (lysosomal cationic amino acid transporter)<br />
+- UniProtKB:Q6ZP29 = human <strong>PQLC2/LAAT1</strong> (lysosomal cationic amino acid transporter)<br />
+- PomBase:SPAC17C9.10 (S. pombe)</p>
+<p><strong>ILT1 is NOT a PAINT seed</strong> (it is uncharacterized). It sits in subfamily <strong>SF37</strong>, whose only two<br />
+members are ILT1 (Q03193) and the <em>S. pombe</em> SPAC2E12.03c (Q10227) — <strong>both uncharacterized</strong><br />
+(<code>PTHR16201-entries.csv</code>). So the specific "vacuolar basic amino acid export" function attached to<br />
+ILT1 by IBA is inherited from the distantly related YPQ/PQLC2 subfamilies, i.e. it is a<br />
+family-level (paralog) inference, not evidence that ILT1 itself does this.</p>
+<p>Two concrete conflicts with the family-level IBA inference:<br />
+1. <strong>Location.</strong> ILT1 is experimentally at the <strong>plasma membrane</strong>, not the vacuolar membrane:<br />
+   - Huh et al. GFP localization (IDA:SGD; UniProt SUBCELLULAR LOCATION "Cell membrane<br />
+     {ECO:0000269|PubMed:14562095}").<br />
+   - Higgins et al. Ilt1-GFP <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="both Sge1PLL-GFP and Ilt1-GFP fusion proteins      localized to the plasma membrane">PMID:30045857</a>. So the IBA GO:0005774 <em>vacuolar membrane</em> term conflicts<br />
+     with two independent experimental plasma-membrane localizations.<br />
+2. <strong>Process.</strong> The only characterized phenotype is <strong>cationic-toxin tolerance</strong> at the cell<br />
+   surface, not intracellular/vacuolar amino-acid homeostasis.</p>
+<p>Therefore the IBA amino-acid-transport terms are best treated as <strong>over-annotations / uncertain<br />
+paralog inferences</strong> for ILT1: the <em>fold</em> (PQ-loop) is consistent with a small-molecule<br />
+transporter/sensor, but the <em>substrate</em> (basic amino acids) and <em>site</em> (vacuole) are not<br />
+supported for ILT1 and are in fact contradicted (location).</p>
+<h2 id="experimental-knowledge-known-all-from-higgins-et-al-2018-pmid30045857-full-text">Experimental knowledge (KNOWN) — all from Higgins et al. 2018 (PMID:30045857, full text)</h2>
+<ul>
+<li><strong>Deletion phenotype:</strong> <code>ydr090cΔ</code> shows reduced growth at a subtoxic 31 mM [C2C1im]Cl (imidazolium<br />
+  ionic liquid) <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="only ydr090cΔ displayed reduced growth in medium with a subtoxic   31 mM [C2C1im]Cl concentration compared to medium without IIL">PMID:30045857</a>. Basis for the standard-name<br />
+  assignment ILT1.</li>
+<li><strong>Complementation / gain of function:</strong> plasmid ILT1 rescues the <code>ilt1Δ</code> growth defect in<br />
+  [C2C1im]Cl in the BY (S288c-derived) background <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="The BY ilt1Δ strain transformed   with the empty control vector grew significantly slower than the deletion strain complemented   with the ILT1 sequence">PMID:30045857</a>; extra copies increase tolerance.</li>
+<li><strong>Broader cationic-toxin tolerance:</strong> <code>ilt1Δ</code> is sensitive to the cationic dye crystal violet<br />
+  (CV) and to [C4C1im]Cl <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="ILT1 functions in tolerance to a range of cationic toxins   in the BY strain background">PMID:30045857</a>.</li>
+<li><strong>Localization:</strong> Ilt1-GFP at the plasma membrane <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="both Sge1PLL-GFP and Ilt1-GFP   fusion proteins localized to the plasma membrane">PMID:30045857</a>.</li>
+<li><strong>Independent of SGE1:</strong> ILT1 acts independently of the SGE1 efflux pump <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="This   indicated that sge1PLL function does not require ILT1 for IIL tolerance in the BY strain   background">PMID:30045857</a>.</li>
+<li><strong>Strain-specific effect:</strong> no ILT1 requirement in the 378 background (which carries the tolerant<br />
+  SGE1PLL allele) <a href="https://pubmed.ncbi.nlm.nih.gov/30045857" title="no significant differences in cell growth were seen between 378   ilt1Δ/ilt1Δ mutants ... suggesting that ILT1 has strain-specific functions">PMID:30045857</a>.</li>
+<li><strong>PTMs (UniProt large-scale):</strong> Phospho-Ser229 (PubMed:17330950, 19779198); predicted N-glyco at<br />
+  N251, N259.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known / knowledge gaps</h2>
+<ul>
+<li><strong>Molecular function is unknown.</strong> No transport activity, substrate, or mechanism has been<br />
+  measured for Ilt1. It is plausibly a PQ-loop transporter/permease or a transport-associated /<br />
+  regulatory membrane protein, but there is no direct biochemical assay. The IBA MF term (basic<br />
+  amino acid transporter) is a family inference from a <em>different</em> subfamily and is not supported.</li>
+<li><strong>The relevant substrate/transported species (if any) is unknown</strong> — whether Ilt1 exports the<br />
+  ionic-liquid cation, imports something protective, or acts indirectly (e.g. modulating another<br />
+  transporter or membrane property) has not been determined.</li>
+<li><strong>The direct biological role beyond cationic-toxin tolerance is unknown.</strong> Ionic liquids are<br />
+  synthetic xenobiotics; the <em>native</em> physiological function of ILT1 (its selective advantage in<br />
+  the wild) is not established. No growth phenotype other than cationic-compound sensitivity is<br />
+  documented.</li>
+<li><strong>No physical interactors / pathway</strong> are functionally established (BioGRID lists high-throughput<br />
+  interactions only).</li>
+</ul>
+<h2 id="curation-plan-summary">Curation plan (summary)</h2>
+<ul>
+<li>Location: keep <strong>plasma membrane</strong> (IDA, PMID:30045857) as core CC; keep generic "membrane" IEA.</li>
+<li>The IBA <strong>vacuolar membrane</strong> (GO:0005774) location conflicts with two experimental PM<br />
+  localizations → MARK_AS_OVER_ANNOTATED / REMOVE-leaning; treat as non-core paralog inference.</li>
+<li>IBA MF (basic amino acid transporter, GO:0015174) and IBA BP (vacuolar basic amino acid export<br />
+  GO:0034488; intracellular amino acid homeostasis GO:0080144) are unsupported paralog inferences<br />
+  for ILT1's subfamily → MARK_AS_OVER_ANNOTATED (uncertain; do not assert; document in<br />
+  knowledge_gaps).</li>
+<li>ND MF/BP (GO:0003674 / GO:0008150): experimental data now support at least a BP<br />
+  (cationic-compound / xenobiotic tolerance) → the BP-ND is superseded; MF remains genuinely<br />
+  unknown.</li>
+<li>core_functions: minimal — CC plasma membrane; BP response to xenobiotic/toxic cationic compound<br />
+  (defensible from deletion phenotype). MF left as a knowledge gap.</li>
+</ul>
+<h2 id="falcon-deep-research-cross-check-2026-07-05">Falcon deep-research cross-check (2026-07-05)</h2>
+<p>Ran <code>just deep-research-falcon yeast ILT1</code> (Edison; 24.7 min). The report<br />
+(<code>ILT1-deep-research-falcon.md</code>) independently reaches the same core conclusion: YDR090C/ILT1 is a<br />
+PQ-loop family member that is <strong>distinct from the characterized Ypq1-3 vacuolar transporters</strong>, and<br />
+any transport/substrate assignment is <strong>"inference rather than direct evidence"</strong>. It adds useful<br />
+family context (3+1+3 alternating-access fold from cystinosin structures; PQLC2/LAAT-1 lysosomal<br />
+cationic-amino-acid exporters; Ypq2 nitrogen-regulated vacuolar arginine export) — all consistent<br />
+with my paralog-over-annotation reasoning for the IBA terms. Two caveats: (1) the report leans<br />
+toward a "vacuolar transporter" prediction based purely on homology, which conflicts with the two<br />
+experimental plasma-membrane localizations for Ilt1 — I weight the direct evidence higher; (2) the<br />
+report did NOT surface the Higgins et al. 2018 primary experimental paper and instead mentions an<br />
+unverifiable "Reed et al. 2019 Yarrowia lipolytica" study for the ILT1 name — likely a spurious<br />
+citation. I have NOT used that claim; the review's functional/phenotypic claims are all anchored to<br />
+the verified Higgins et al. 2018 full text (PMID:30045857).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q03193
+gene_symbol: ILT1
+aliases:
+- YDR090C
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ILT1 (Ionic Liquid Tolerance 1; systematic name YDR090C) is a polytopic plasma-membrane
+  protein of Saccharomyces cerevisiae with no experimentally determined molecular activity.
+  The 310-residue protein has ~6-7 transmembrane helices and two PQ-loop (MtN3/saliva)
+  repeats, placing it in the PQ-loop repeat superfamily that also contains the vacuolar
+  cationic-amino-acid transporters Ypq1/Ypq2/Rtc2 and the lysosomal transporter PQLC2/LAAT-1,
+  although ILT1 belongs to a distinct, uncharacterized subfamily. GFP-fusion studies localize
+  Ilt1 to the plasma membrane. Loss of ILT1 sensitizes cells to imidazolium ionic liquids and
+  to other cationic compounds such as the dye crystal violet, and extra copies increase
+  tolerance, so the protein contributes to survival in the presence of cationic xenobiotics;
+  this effect acts independently of the multidrug efflux pump Sge1 and is background-dependent.
+  Whether Ilt1 itself transports a solute (and if so, what), or acts through another mechanism,
+  has not been established.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:30045857
+  title: Natural Variation in the Multidrug Efflux Pump SGE1 Underlies Ionic Liquid
+    Tolerance in Yeast.
+  findings:
+  - statement: &gt;-
+      YDR090C was named ILT1 (ionic liquid tolerance 1) because its deletion sensitizes yeast
+      to the imidazolium ionic liquid [C2C1im]Cl; complementation restores tolerance, and the
+      protein also protects against other cationic toxins including crystal violet and
+      [C4C1im]Cl in the BY (S288c) background.
+    supporting_text: &gt;-
+      ILT1 functions in tolerance to a range of cationic toxins in the BY strain background
+    reference_section_type: RESULTS
+  - statement: &gt;-
+      Ilt1-GFP fusion protein localizes to the plasma membrane, consistent with the
+      independent Huh et al. GFP-localization dataset.
+    supporting_text: &gt;-
+      both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text available (PMC6116967). Verified against PubMed; this is the paper that
+      named ILT1/YDR090C and provides the only experimental functional data (deletion
+      sensitivity to cationic compounds, complementation, plasma-membrane localization,
+      SGE1-independence). Supports the tolerance and localization claims verbatim; it does
+      NOT establish a molecular transport function for Ilt1.
+existing_annotations:
+- term:
+    id: GO:0005774
+    label: vacuolar membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Family-level (PAINT/IBA) location inferred from the PQ-loop LAAT-1 superfamily
+      (PTHR16201). This is contradicted by experimental evidence: Ilt1 localizes to the
+      plasma membrane, not the vacuolar membrane.
+    action: REMOVE
+    reason: &gt;-
+      The IBD seeds driving this term are the characterized vacuolar transporters of OTHER
+      subfamilies (Ypq1/Ypq2/Rtc2, and lysosomal PQLC2/LAAT-1), not members of ILT1&#39;s own
+      subfamily (PTHR16201:SF37, whose only members are the uncharacterized ILT1 and its
+      S. pombe ortholog). Two independent GFP-localization experiments place Ilt1 at the
+      plasma membrane, directly conflicting with a vacuolar-membrane assignment. This is a
+      paralog over-propagation of location and should not be retained.
+    supported_by:
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: SGD:S000005452
+        source_label: YPQ1 (YOL092W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Vacuolar-membrane lysine exporter; different subfamily from ILT1 (SF37).
+      - source_id: SGD:S000002760
+        source_label: YPQ2 (YDR352W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Vacuolar-membrane arginine exporter; different subfamily.
+      - source_id: SGD:S000000351
+        source_label: RTC2/YPQ3 (YBR147W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Putative vacuolar cationic-amino-acid transporter; different subfamily.
+- term:
+    id: GO:0034488
+    label: basic amino acid transmembrane export from vacuole
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Family-level (PAINT/IBA) process inferred from the vacuolar cationic-amino-acid
+      transporter members of the superfamily. Not supported for ILT1, which acts at the
+      plasma membrane and has no measured amino-acid transport activity.
+    action: REMOVE
+    reason: &gt;-
+      &#34;Export from vacuole&#34; is incompatible with the experimental plasma-membrane localization
+      of Ilt1, and the transported-substrate (basic amino acids) is a paralog inference from
+      Ypq1/Ypq2/Rtc2/PQLC2 rather than ILT1&#39;s own (uncharacterized) SF37 subfamily. No
+      vacuolar amino-acid-export activity has been demonstrated for Ilt1. Retaining this term
+      would assert both a wrong location and an untested substrate.
+    supported_by:
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: SGD:S000000351
+        source_label: RTC2/YPQ3 (YBR147W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Vacuolar cationic-amino-acid export seed; ILT1 is in a distinct subfamily and at the plasma membrane.
+      - source_id: SGD:S000005452
+        source_label: YPQ1 (YOL092W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Vacuolar lysine export seed; substrate/site not evidenced for ILT1.
+      - source_id: SGD:S000002760
+        source_label: YPQ2 (YDR352W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Vacuolar arginine export seed; substrate/site not evidenced for ILT1.
+- term:
+    id: GO:0080144
+    label: intracellular amino acid homeostasis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Family-level (PAINT/IBA) process from the LAAT-1/PQLC2 vacuolar-lysosomal amino-acid
+      recycling role. No experimental support that ILT1 participates in intracellular amino
+      acid homeostasis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This term is inherited from distantly related, characterized subfamily members
+      (vacuolar Ypq transporters; lysosomal PQLC2) and is not evidenced for ILT1. The only
+      characterized ILT1 phenotype is cationic-xenobiotic tolerance at the plasma membrane,
+      not amino-acid homeostasis. The homeostasis role for ILT1 is genuinely unknown (see
+      knowledge_gaps); marking as over-annotated rather than asserting it.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: UniProtKB:Q6ZP29
+        source_label: PQLC2/LAAT1 (human)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Lysosomal cationic-amino-acid transporter (amino-acid homeostasis); different subfamily from ILT1.
+      - source_id: WB:WBGene00021546
+        source_label: LAAT-1 (C. elegans)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Lysosomal cationic-amino-acid transporter seed; role not evidenced for ILT1.
+- term:
+    id: GO:0015174
+    label: basic amino acid transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Family-level (PAINT/IBA) molecular function inferred from the PQ-loop superfamily. ILT1
+      has no measured transport activity or substrate; its own subfamily (SF37) is
+      uncharacterized.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The basic-amino-acid transporter activity is a substrate-specific inference from Ypq1
+      (lysine), Ypq2 (arginine), Rtc2/Ypq3, and PQLC2 (all in different subfamilies), not from
+      any characterized member of ILT1&#39;s clade. The PQ-loop fold is consistent with a
+      small-molecule transporter or sensor, but ILT1&#39;s actual activity and substrate are
+      undetermined. This is the central molecular-function knowledge gap; the specific
+      basic-amino-acid activity should not be asserted for ILT1.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: SGD:S000005452
+        source_label: YPQ1 (YOL092W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Lysine transporter seed; substrate specificity is a paralog inference not evidenced for ILT1.
+      - source_id: SGD:S000002760
+        source_label: YPQ2 (YDR352W)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Arginine transporter seed; ILT1 subfamily (SF37) uncharacterized.
+      - source_id: UniProtKB:Q6ZP29
+        source_label: PQLC2/LAAT1 (human)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Cationic amino acid transporter seed; ILT1 activity/substrate undetermined.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic location from UniProt Subcellular Location mapping (UniProt SUBCELLULAR
+      LOCATION: Cell membrane). Concordant with experimental IDA.
+    action: ACCEPT
+    reason: &gt;-
+      Plasma-membrane localization is independently supported experimentally (Ilt1-GFP; Huh
+      et al. GFP dataset). This IEA annotation is correct and redundant with the IDA below.
+    supported_by:
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic ARBA annotation to the generic &#34;membrane&#34; term, consistent with the
+      multi-pass integral membrane topology of Ilt1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but non-specific; subsumed by the more precise plasma-membrane annotation.
+      Retained as a generic, non-core location term.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:30045857
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental localization: Ilt1-GFP fusion protein localizes to the plasma
+      membrane. This is the core, well-supported cellular location for Ilt1.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by direct fluorescence-microscopy evidence (Ilt1-GFP), and corroborated by
+      the Huh et al. genome-wide GFP-localization study (UniProt SUBCELLULAR LOCATION: Cell
+      membrane, ECO:0000269|PubMed:14562095). This is a core annotation.
+    supported_by:
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      &#34;No biological data available&#34; root annotation for molecular function. This accurately
+      reflects the state of knowledge: the molecular activity of Ilt1 is genuinely unknown.
+    action: ACCEPT
+    reason: &gt;-
+      Despite the family-based IBA transporter annotation, no molecular function has been
+      experimentally established for Ilt1. The ND(MF) annotation honestly reflects this and
+      should stand until a mechanism is demonstrated. See knowledge_gaps.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      &#34;No biological data available&#34; root annotation for biological process. This is now
+      superseded: experimental deletion/complementation data implicate ILT1 in tolerance to
+      cationic xenobiotics.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The ND(BP) is no longer accurate: Higgins et al. 2018 provide experimental evidence
+      (deletion sensitivity and complementation for [C2C1im]Cl, [C4C1im]Cl, and crystal
+      violet) that ILT1 participates in the response to cationic/xenobiotic compounds. A
+      specific process term (e.g. response to xenobiotic stimulus) is warranted in place of
+      the root ND term; see proposed core_functions.
+    supported_by:
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        ILT1 functions in tolerance to a range of cationic toxins in the BY strain background
+- term:
+    id: GO:0009410
+    label: response to xenobiotic stimulus
+  evidence_type: IMP
+  original_reference_id: PMID:30045857
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed new annotation reflecting the experimental phenotype: ilt1 deletion causes
+      sensitivity, and complementation/overexpression confers tolerance, to cationic
+      xenobiotics (imidazolium ionic liquids and cationic dyes).
+    action: NEW
+    reason: &gt;-
+      Higgins et al. 2018 provide mutant-phenotype (IMP) evidence that ILT1 is required for
+      full tolerance to cationic xenobiotics. This is the most specific, defensible biological
+      process term supported by the data, replacing the uninformative ND(BP) root annotation.
+      It does NOT assert a molecular transport mechanism, which remains unknown.
+    supported_by:
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        ILT1 functions in tolerance to a range of cationic toxins in the BY strain background
+    - reference_id: PMID:30045857
+      supporting_text: &gt;-
+        The BY ilt1Δ strain transformed with the empty control vector grew significantly
+        slower than the deletion strain complemented with the ILT1 sequence
+core_functions:
+- description: &gt;-
+    Ilt1 is an integral plasma-membrane protein required for full tolerance to cationic
+    xenobiotics (imidazolium ionic liquids and cationic dyes such as crystal violet). Its
+    molecular mechanism is not established; the biological role captured here is participation
+    in the cellular response to these toxic cationic compounds, based on deletion sensitivity
+    and complementation. The molecular_function is left unspecified because no activity or
+    substrate has been demonstrated (recorded as a knowledge gap).
+  directly_involved_in:
+  - id: GO:0009410
+    label: response to xenobiotic stimulus
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  supported_by:
+  - reference_id: PMID:30045857
+    supporting_text: &gt;-
+      ILT1 functions in tolerance to a range of cationic toxins in the BY strain background
+  - reference_id: PMID:30045857
+    supporting_text: &gt;-
+      both Sge1PLL-GFP and Ilt1-GFP fusion proteins localized to the plasma membrane
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of Ilt1 is undetermined. It is unknown whether Ilt1 is itself a
+    transporter/permease (and, if so, what solute it moves and in which direction), a
+    transport-associated or regulatory subunit, or acts through some other membrane-based
+    mechanism. No biochemical transport assay, substrate, or catalytic/transport activity has
+    been reported.
+  boundary: &gt;-
+    Established: Ilt1 is a ~6-7 TM integral plasma-membrane protein with two PQ-loop
+    (MtN3/saliva) repeats, placing it in the PQ-loop repeat superfamily (PTHR16201 / IPR051415
+    LAAT-1; Pfam PF04193). Its deletion sensitizes cells to cationic xenobiotics and extra
+    copies increase tolerance. The specific &#34;basic amino acid transmembrane transporter
+    activity&#34; attached by IBA is a paralog inference from vacuolar/lysosomal members
+    (Ypq1/Ypq2/Rtc2, PQLC2) of DIFFERENT subfamilies, not from Ilt1&#39;s own uncharacterized
+    subfamily (PTHR16201:SF37).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Ilt1 is a conserved PQ-loop membrane protein of unknown activity whose only characterized
+    role is in tolerance to industrially relevant ionic liquids; resolving its molecular
+    function would clarify a plasma-membrane detoxification/transport mechanism and inform
+    engineering of ionic-liquid-tolerant biofuel strains.
+  resolution: &gt;-
+    Direct transport assays (e.g. radiolabelled-substrate uptake/efflux in reconstituted
+    proteoliposomes or heterologous cells) across candidate solutes including the ionic-liquid
+    cation itself and cationic amino acids; substrate screens; and structure-guided
+    identification of the translocation pathway.
+  provenance:
+  - reference_id: PMID:30045857
+    supporting_text: &gt;-
+      putative PQ-loop motif found in Ypq1, Ypq2, and Rtc2/Ypq3, which are putative vacuolar
+      membrane transporters of cationic amino acids
+- gap_statement: &gt;-
+    The native physiological role of ILT1 is unknown. Ionic liquids are synthetic xenobiotics,
+    so cationic-toxin tolerance is unlikely to be the trait under natural selection; what Ilt1
+    does for the cell under normal conditions, and why its requirement is background-dependent
+    (needed in BY/S288c but not in the tolerant 378 isolate), is not understood.
+  boundary: &gt;-
+    Established: ilt1 deletion causes a growth defect specifically in the presence of cationic
+    compounds in the BY background, is dispensable in the 378 background, and acts
+    independently of the Sge1 efflux pump. No other deletion phenotype or physiological role
+    has been documented.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing an incidental xenobiotic-tolerance effect from a native transport/homeostasis
+    function is required to place ILT1 in a pathway.
+  resolution: &gt;-
+    Systematic phenotyping (growth across ion/nutrient/stress conditions, metabolomics of
+    ilt1 mutants), genetic-interaction mapping, and testing candidate native substrates.
+  provenance:
+  - reference_id: PMID:30045857
+    supporting_text: &gt;-
+      suggesting that ILT1 has strain-specific functions
+suggested_questions:
+- question: &gt;-
+    Does Ilt1 directly transport the imidazolium ionic-liquid cation (or a protective solute)
+    across the plasma membrane, or does it act indirectly (e.g. by modulating another
+    transporter or membrane property)?
+  experts:
+  - Trey K. Sato
+  - Audrey P. Gasch
+- question: &gt;-
+    What accounts for the background-dependence of the ilt1 phenotype (required in BY but not
+    in strain 378)?
+suggested_experiments:
+- hypothesis: &gt;-
+    Ilt1 is a plasma-membrane transporter whose substrate is a cation relevant to
+    ionic-liquid/cationic-dye tolerance.
+  description: &gt;-
+    Reconstitute purified Ilt1 into proteoliposomes (or express in a heterologous transport-null
+    system) and assay uptake/efflux of candidate solutes, including the [C2C1im]+ cation,
+    cationic dyes, and cationic amino acids, under a range of pH and ion gradients.
+  experiment_type: transport assay
+- hypothesis: &gt;-
+    Ilt1 abundance or plasma-membrane residence changes upon exposure to cationic xenobiotics.
+  description: &gt;-
+    Measure Ilt1 protein level, localization, and PTM state (including the reported Ser229
+    phosphorylation) with and without [C2C1im]Cl / crystal violet treatment.
+  experiment_type: quantitative fluorescence microscopy and immunoblotting
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/LIH1/LIH1-ai-review.html
+++ b/genes/yeast/LIH1/LIH1-ai-review.html
@@ -1,0 +1,2191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LIH1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LIH1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P47145" target="_blank" class="term-link">
+                        P47145
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "LIH1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P47145" data-a="DESCRIPTION: LIH1 (Lipase homolog 1; systematic name YJR107W) i..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>LIH1 (Lipase homolog 1; systematic name YJR107W) is an uncharacterized Saccharomyces cerevisiae protein of the fungal Lipase_3 / alpha-beta hydrolase (AB hydrolase) superfamily. The 328-residue protein retains the canonical serine hydrolase catalytic triad, with the nucleophilic serine (Ser181) located in the conserved GHSLG pentapeptide of the nucleophile elbow, together with an aspartate (Asp253) and histidine (His315) charge-relay pair, and it carries the InterPro fungal-lipase-type and AB-hydrolase-fold signatures. Its functional assignment as a lipase is based entirely on sequence and domain homology: it is the single Saccharomycetaceae relative of the expanded Yarrowia clade lipase (LIP) family, sharing only about 26% sequence identity with Yarrowia lipolytica Lip2, its closest characterized homolog. No catalytic activity, substrate, subcellular localization, or biological role has been experimentally established for the LIH1 protein, and it has no reported loss-of-function phenotype; it is a functionally dark gene whose fold predicts, but does not demonstrate, a carboxylic-ester hydrolase / lipase activity.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004806" target="_blank" class="term-link">
+                                    GO:0004806
+                                </a>
+                            </span>
+                            <span class="term-label">triacylglycerol lipase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P47145" data-a="GO:0004806" data-r="GO_REF:0000120" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic EC-to-GO mapping (EC 3.1.1.3 -&gt; triacylglycerol lipase activity). The EC number is itself a curator/homology inference (UniProt ECO:0000305), not a measured activity. LIH1 has an intact serine-hydrolase catalytic triad (Ser181/Asp253/His315) and belongs to the fungal Lipase_3 family, so a fold-level hydrolase/lipase activity is plausible; however, asserting the specific triacylglycerol substrate over-annotates a protein that has never been assayed and shares only ~26% identity with the nearest characterized lipase (Y. lipolytica Lip2). Generalize to lipase activity (or, most conservatively, carboxylic ester hydrolase activity) and treat as non-core pending biochemical evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The specific triacylglycerol-lipase substrate claim is unsupported by any experimental data for LIH1; the defensible homology-based claim is a fold-level lipase / carboxylic-ester-hydrolase activity.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016298" target="_blank" class="term-link">
+                                    lipase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
+                                    GO:0006629
+                                </a>
+                            </span>
+                            <span class="term-label">lipid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P47145" data-a="GO:0006629" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-domain-based (IPR002921, fungal lipase-type) electronic annotation to the broad process &#34;lipid metabolic process&#34;. This is consistent with the fold and is appropriately general, but the specific physiological role of LIH1 in lipid metabolism has never been demonstrated. Retain as a general, non-core process annotation reflecting the domain inference.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad, domain-consistent BP inference; defensible at this level of generality but not an experimentally established core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P47145" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component with ND (No biological Data) evidence, correctly recording that no subcellular localization is known for LIH1. Accurate placeholder.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root annotation faithfully represents the absence of localization data; no change warranted.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P47145" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with ND evidence, correctly recording that no biological process has been experimentally established for LIH1. Accurate placeholder; note the coexisting IEA BP annotation (lipid metabolic process) is a domain inference, not experimental.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root annotation faithfully represents the absence of experimental process data; no change warranted.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Predicted serine hydrolase of the fungal Lipase_3 / alpha-beta hydrolase family. LIH1 retains an intact, canonically positioned Ser-Asp-His catalytic triad (nucleophilic Ser181 in the GHSLG pentapeptide) and all diagnostic AB-hydrolase signatures, so it is predicted to hydrolyze a carboxylic ester / lipid substrate. No catalytic activity, substrate, or biological role has been experimentally verified; this core function is a fold/homology-based prediction only and is stated at the most defensible level of generality.</h3>
+                <span class="vote-buttons" data-g="P47145" data-a="FUNCTION: Predicted serine hydrolase of the fungal Lipase_3 ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016298" target="_blank" class="term-link">
+                            lipase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26580812" target="_blank" class="term-link">
+                                PMID:26580812
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">All the proteins in this region harbored the conserved serine, aspartic acid, and histidine catalytic triad characteristic of the α/β hydrolase with the catalytic nucleophile serine located in the highly conserved pentapeptide GHS[LFM]G</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26580812" target="_blank" class="term-link">
+                            PMID:26580812
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comprehensive Analysis of a Yeast Lipase Family in the Yarrowia Clade.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">LIH1 (YJR107W) is named as a putative lipase solely on the basis of sequence homology; it is the S. cerevisiae relative of the Yarrowia LIP family and shares only 26% identity (44% similarity) with Y. lipolytica Lip2, its closest relative. It was not biochemically characterized in this study.</div>
+
+                        <div class="finding-text">"This putative lipase in Saccharomyces cerevisiae, called Lih1 and encoded by YJR107W, shares 26% identity and 44% similarity with YlLip2, its closest relative in Y. lipolytica."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Members of this fungal lipase family carry the conserved Ser-Asp-His catalytic triad with the catalytic serine in the GHS[LFM]G pentapeptide, characteristic of the alpha/beta hydrolase fold; this is a family/fold-level bioinformatic argument, consistent with LIH1 retaining an intact triad.</div>
+
+                        <div class="finding-text">"All the proteins in this region harbored the conserved serine, aspartic acid, and histidine catalytic triad characteristic of the α/β hydrolase with the catalytic nucleophile serine located in the highly conserved pentapeptide GHS[LFM]G"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8641269" target="_blank" class="term-link">
+                            PMID:8641269
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Complete nucleotide sequence of Saccharomyces cerevisiae chromosome X.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24374639" target="_blank" class="term-link">
+                            PMID:24374639
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The reference genome sequence of Saccharomyces cerevisiae: Then and now.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is LIH1 a catalytically active hydrolase, and if so what is its natural substrate (triacylglycerol, other acylglycerols, or a non-lipid carboxylic ester)?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Neuvéglise C, Nicaud JM</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="P47145" data-a="Q: Is LIH1 a catalytically active hydrolase, and if s..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Where in the cell does LIH1 act, and is it secreted like many of its Yarrowia clade relatives?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P47145" data-a="Q: Where in the cell does LIH1 act, and is it secrete..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Heterologously express and purify recombinant LIH1 (and a Ser181Ala catalytic mutant) and assay hydrolase activity against a substrate panel spanning tri-, di- and mono-acylglycerols of varying chain length and synthetic p-nitrophenyl esters; loss of activity in the Ser181Ala mutant would confirm triad-dependent catalysis and define substrate preference.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: LIH1 is an active serine hydrolase whose activity depends on the conserved Ser181 nucleophile.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical enzyme assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P47145" data-a="EXPERIMENT: Heterologously express and purify recombinant LIH1..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Profile a lih1-delta deletion strain for growth and lipid-related phenotypes across carbon sources (including fatty acids and triacylglycerol-based media) and stress conditions, combined with transcriptional profiling to identify conditions that induce LIH1 expression.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: LIH1 contributes to lipid metabolism under specific, non-standard conditions.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / phenotypic profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P47145" data-a="EXPERIMENT: Profile a lih1-delta deletion strain for growth an..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The actual catalytic activity of the LIH1 protein is undetermined. Although LIH1 retains an intact serine-hydrolase catalytic triad (Ser181/Asp253/His315) and the GHSLG nucleophile-elbow motif, it has never been expressed, purified, or assayed; whether it hydrolyzes triacylglycerol (as its EC 3.1.1.3 mapping asserts), some other lipid or carboxylic ester, or is catalytically inert in vivo, is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: LIH1 is a member of the fungal Lipase_3 / AB-hydrolase superfamily (Pfam PF01764, InterPro IPR002921/IPR029058, PROSITE PS00120, ESTHER Lipase_3) and its catalytic triad and nucleophile pentapeptide are conserved and correctly positioned. Its only characterized relative is Y. lipolytica Lip2, from which it diverges strongly (~26% identity), and the &#34;triacylglycerol lipase&#34; EC assignment is a curator homology inference (UniProt ECO:0000305), not a measurement.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> LIH1 is the sole Saccharomycetaceae representative of a lipase family that underwent dramatic expansion in the Yarrowia clade; establishing whether this ancestral-type lipase homolog is an active enzyme, and on what substrate, would anchor the functional history of the family and clarify whether S. cerevisiae retains this lipase activity at all.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Heterologous expression and purification of LIH1 followed by in vitro assays against a panel of tri-, di- and mono-acylglycerols and synthetic esters (e.g. p-nitrophenyl esters of varying acyl-chain length) to test for and define hydrolase activity and substrate preference; a catalytically dead Ser181Ala control to confirm triad dependence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This putative lipase in Saccharomyces cerevisiae, called Lih1 and encoded by YJR107W, shares 26% identity and 44% similarity with YlLip2, its closest relative in Y. lipolytica."</em> — PMID:26580812</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of LIH1 is unknown. It is not established whether LIH1 is secreted (as many fungal lipases of this family are), retained intracellularly, or membrane-associated.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The SGD-assigned cellular_component annotation is a root/ND placeholder, i.e. no localization data exist. LIH1 has no annotated signal peptide or transmembrane region in its UniProt record, but this has not been experimentally tested and its Yarrowia relatives include both secreted and non-secreted members.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether LIH1 acts on extracellular lipid substrates (secreted lipase) or in an intracellular compartment is a prerequisite for interpreting any activity and for placing it in a pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous C-terminal fluorescent tagging and microscopy, and/or subcellular fractionation and proteomics, to determine where the protein resides; secretion assays if extracellular activity is suspected.</p>
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process and physiological role of LIH1 are unknown. No loss-of-function phenotype has been reported, the conditions (if any) under which LIH1 is required or induced are undefined, and the assignment to &#34;lipid metabolic process&#34; rests solely on domain inference.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The SGD-assigned biological_process annotation is a root/ND placeholder; the only process annotation (lipid metabolic process) is an InterPro-domain-based IEA. LIH1 appears dispensable under standard laboratory conditions, so any role is likely conditional or redundant.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying a condition-specific phenotype (e.g. growth on particular lipid carbon sources or under lipid stress) would convert LIH1 from a fold-based prediction into an annotated participant in yeast lipid metabolism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotypic profiling of a lih1-delta strain across carbon sources and stress conditions (including lipid/fatty-acid media), expression profiling to find inducing conditions, and genetic-interaction screening to reveal redundancy.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LIH1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P47145" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="lih1-yjr107w-curation-notes">LIH1 (YJR107W) — curation notes</h1>
+<h2 id="deep-research-provenance-note-2026-07-05">Deep-research provenance note (2026-07-05)</h2>
+<p>Automated deep research could not be generated for LIH1. <code>just deep-research-falcon</code><br />
+(falcon provider) timed out twice at 600 s (exit 143/144), and the <code>perplexity-lite</code><br />
+fallback returned HTTP 401 (insufficient_quota — API billing exhausted). Per project<br />
+policy I did NOT fabricate a <code>-deep-research-{provider}.md</code> file. This review is therefore<br />
+grounded directly in: (1) the UniProt record (P47145), (2) the QuickGO GOA export<br />
+(LIH1-goa.tsv), (3) the full text of the sole primary reference PMID:26580812 (fetched to<br />
+publications/, verified by grep), and (4) inline domain/catalytic-triad analysis of the<br />
+deposited sequence (below). This is a genuinely dark gene, so the literature is thin and<br />
+these sources are, in fact, essentially the entire evidence base.</p>
+<p>UniProt: P47145 (LIH1_YEAST). SGD: S000003868. Systematic: YJR107W. ORF: J1983.<br />
+Length 328 aa; 37.2 kDa. Reference proteome (S288c). PE=1 (Evidence at protein level —<br />
+but see caveat below: this is a UniProt "protein level" that rests on peptide detection,<br />
+not on a functional assay).</p>
+<h2 id="bottom-line-dark-gene">Bottom line (dark gene)</h2>
+<p>LIH1 ("Lipase homolog 1") is a <strong>putative</strong> lipase. Its "lipase" identity is an inference<br />
+from sequence homology and domain architecture, NOT from any biochemical characterization of<br />
+the LIH1 protein itself. There is:<br />
+- NO demonstrated enzymatic activity for LIH1.<br />
+- NO known natural substrate.<br />
+- NO reported subcellular localization (SGD MF/BP/CC are ND).<br />
+- NO reported loss-of-function phenotype (BioGRID-ORCS: 0 hits in 10 CRISPR screens; the<br />
+  gene is non-essential and no strong phenotype is on record).<br />
+- NO experimental paper that characterizes LIH1 as an enzyme.</p>
+<p>This is a genuine biology knowledge gap (the unknome): the fold and catalytic machinery are<br />
+present, but what the protein does, where, and why is unknown.</p>
+<h2 id="identity-domain-reasoning-from-lih1-uniprottxt-verified-inline">Identity / domain reasoning (from LIH1-uniprot.txt, verified inline)</h2>
+<ul>
+<li>Family: AB hydrolase superfamily, Lipase family (UniProt SIMILARITY, ECO:0000305).</li>
+<li>Pfam PF01764 (Lipase_3); CDD cd00519 (Lipase_3); InterPro IPR002921 (Fungal lipase-type),<br />
+  IPR029058 (AB hydrolase fold), IPR051299 (AB_hydrolase_lip/est); Gene3D 3.40.50.1820<br />
+  (alpha/beta hydrolase); PROSITE PS00120 (LIPASE_SER).</li>
+<li>ESTHER classification: yeast-yj77, family "Lipase_3".</li>
+<li>PANTHER: PTHR46640 / PTHR46640:SF3 "LIPASE LIH1-RELATED".</li>
+<li>Catalytic triad (by similarity to O59952, a fungal/Rhizomucor-type lipase):</li>
+<li>ACT_SITE Ser181 (Nucleophile) — verified in sequence: sits in the canonical pentapeptide<br />
+<strong>GHSLG</strong> (residues 179–183; I recomputed from the UniProt sequence: positions 179–183 =<br />
+    G-H-S181-L-G). This is the classic filamentous-fungal lipase / α/β-hydrolase catalytic<br />
+    serine motif GHS[LFM]G.</li>
+<li>ACT_SITE Asp253 (charge relay) — verified: context HTG-<strong>D253</strong>-YIP.</li>
+<li>ACT_SITE His315 (charge relay) — verified: context VYE-<strong>H315</strong>-RAY.</li>
+<li>=&gt; The catalytic triad Ser-Asp-His is INTACT. LIH1 is NOT an obvious pseudoenzyme<br />
+    (catalytic residues are conserved), so a fold-level catalytic annotation is defensible;<br />
+    but "intact triad" is necessary, not sufficient, for TAG-lipase activity.</li>
+<li>Sequence version 2 (2011) revised residues 14 and 66 vs the original 1996 chromosome-X<br />
+  sequence (CONFLICTs at 14 P-&gt;L and 66 G-&gt;P in Ref.1) — a common early-yeast-genome artifact.</li>
+</ul>
+<h2 id="literature-verified-against-cached-full-text">Literature (verified against cached full text)</h2>
+<ol>
+<li>PMID:26580812 — Meunchan et al. 2015, PLoS ONE, "Comprehensive Analysis of a Yeast Lipase<br />
+   Family in the Yarrowia Clade." <strong>This is the sole source cited by UniProt for the LIH1<br />
+   name and the EC=3.1.1.3 designation, and both are ECO:0000303 / ECO:0000305 (author<br />
+   statement / curator inference), NOT experimental.</strong></li>
+<li>The paper is about the <em>Yarrowia</em> clade LIP gene family. S. cerevisiae is only mentioned<br />
+     as an outgroup context. The ONLY statement about LIH1 (verbatim):<br />
+     &gt; "A putative lipase was also identified in Sacharomycetaceae. This putative lipase in<br />
+     &gt; Saccharomyces cerevisiae, called Lih1 and encoded by YJR107W, shares 26% identity and<br />
+     &gt; 44% similarity with YlLip2, its closest relative in Y. lipolytica. Lih1 and its<br />
+     &gt; counterparts in other Hemiascomycetes may derive from a common LIP ancestor."</li>
+<li>i.e. LIH1 is named by homology to Y. lipolytica Lip2 (only 26% identity). It was NOT<br />
+     expressed, assayed, or biochemically characterized in this study.</li>
+<li>
+<p>The catalytic-triad / GHS[LFM]G statement in the paper describes the <em>Yarrowia</em> LIP<br />
+     family proteins collectively (verbatim: "All the proteins in this region harbored the<br />
+     conserved serine, aspartic acid, and histidine catalytic triad characteristic of the<br />
+     α/β hydrolase with the catalytic nucleophile serine located in the highly conserved<br />
+     pentapeptide GHS[LFM]G ... This finding confirms that all of these genes encode<br />
+     lipases.") — this is a family/fold-level bioinformatic argument, consistent with LIH1<br />
+     retaining the triad, but does not itself test LIH1.</p>
+</li>
+<li>
+<p>PMID:8641269 — Galibert et al. 1996, EMBO J — complete sequence of chromosome X. Genomic<br />
+   sequencing only; establishes the ORF (YJR107W). Not functional. Abstract-only cached.</p>
+</li>
+<li>
+<p>PMID:24374639 — Engel et al. 2014, G3 — S. cerevisiae reference genome reannotation.<br />
+   Source of the 2011 sequence revision. Not functional.</p>
+</li>
+</ol>
+<h2 id="go-annotation-assessment-goa-lih1-goatsv">GO annotation assessment (GOA, LIH1-goa.tsv)</h2>
+<ul>
+<li>GO:0004806 triacylglycerol lipase activity | IEA | GO_REF:0000120 (RHEA:12044 | EC:3.1.1.3).<br />
+  This is an electronic EC-&gt;GO mapping. The EC number itself (3.1.1.3) is a curator inference<br />
+  (ECO:0000305) from homology, not measured. Asserting the <em>specific TAG substrate</em> is an<br />
+  over-annotation for a protein with only 26% identity to the nearest characterized lipase and<br />
+  no biochemical data. The intact triad supports at most a general fold-level activity.<br />
+  -&gt; MODIFY / generalize toward lipase activity (GO:0016298) or carboxylic ester hydrolase<br />
+     activity (GO:0052689). Keep non-core.</li>
+<li>GO:0006629 lipid metabolic process | IEA | GO_REF:0000002 (InterPro:IPR002921). Broad,<br />
+  domain-based; consistent with the fold. Defensible as a general, non-core BP.</li>
+<li>GO:0005575 cellular_component (root) | ND | GO_REF:0000015. Root/ND placeholder — no CC<br />
+  known. Keep as-is (accurately records "unknown location").</li>
+<li>GO:0008150 biological_process (root) | ND | GO_REF:0000015. Root/ND placeholder — no BP<br />
+  known experimentally. Keep as-is.</li>
+</ul>
+<h2 id="go-term-hierarchy-verified-via-ols">GO term hierarchy (verified via OLS)</h2>
+<ul>
+<li>GO:0052689 carboxylic ester hydrolase activity — "Catalysis of the hydrolysis of a<br />
+  carboxylic ester bond." (most general; matches AB hydrolase fold)</li>
+<li>GO:0016298 lipase activity — "Catalysis of the hydrolysis of a lipid."</li>
+<li>GO:0004806 triacylglycerol lipase activity — "a triacylglycerol + H2O = a diacylglycerol +<br />
+  a fatty acid + H+." (specific substrate; the EC-mapped IEA term)</li>
+</ul>
+<h2 id="known-vs-not-known">KNOWN vs NOT-known</h2>
+<p>KNOWN (bioinformatic / sequence-level):<br />
+- Belongs to the fungal Lipase_3 / AB-hydrolase family (multiple orthogonal signatures).<br />
+- Retains an intact, canonically-positioned Ser181–Asp253–His315 catalytic triad and the<br />
+  GHSLG nucleophile-elbow pentapeptide.<br />
+- Encoded on chr X, YJR107W; 328 aa; expressed at the protein level (peptide evidence).<br />
+- Non-essential (no CRISPR-screen hits; a viable deletion is expected for a lone S. cerevisiae<br />
+  lipase homolog).</p>
+<p>NOT known (the real gaps):<br />
+- Actual catalytic activity of the LIH1 protein (never assayed).<br />
+- Natural / physiological substrate (TAG? di-/mono-acylglycerol? other ester? unknown).<br />
+- Whether it is catalytically active at all in vivo, or a vestigial homolog.<br />
+- Subcellular localization (secreted? intracellular? membrane-associated? unknown).<br />
+- Biological process / physiological role (lipid catabolism is a fold-level guess, unverified).<br />
+- Loss-of-function phenotype / conditions under which it matters.<br />
+- Regulation / expression conditions.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P47145
+gene_symbol: LIH1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  LIH1 (Lipase homolog 1; systematic name YJR107W) is an uncharacterized
+  Saccharomyces cerevisiae protein of the fungal Lipase_3 / alpha-beta hydrolase
+  (AB hydrolase) superfamily. The 328-residue protein retains the canonical serine
+  hydrolase catalytic triad, with the nucleophilic serine (Ser181) located in the
+  conserved GHSLG pentapeptide of the nucleophile elbow, together with an aspartate
+  (Asp253) and histidine (His315) charge-relay pair, and it carries the InterPro
+  fungal-lipase-type and AB-hydrolase-fold signatures. Its functional assignment as
+  a lipase is based entirely on sequence and domain homology: it is the single
+  Saccharomycetaceae relative of the expanded Yarrowia clade lipase (LIP) family,
+  sharing only about 26% sequence identity with Yarrowia lipolytica Lip2, its
+  closest characterized homolog. No catalytic activity, substrate, subcellular
+  localization, or biological role has been experimentally established for the LIH1
+  protein, and it has no reported loss-of-function phenotype; it is a functionally
+  dark gene whose fold predicts, but does not demonstrate, a carboxylic-ester
+  hydrolase / lipase activity.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:26580812
+  title: Comprehensive Analysis of a Yeast Lipase Family in the Yarrowia Clade.
+  findings:
+  - statement: &gt;-
+      LIH1 (YJR107W) is named as a putative lipase solely on the basis of sequence
+      homology; it is the S. cerevisiae relative of the Yarrowia LIP family and
+      shares only 26% identity (44% similarity) with Y. lipolytica Lip2, its
+      closest relative. It was not biochemically characterized in this study.
+    supporting_text: &gt;-
+      This putative lipase in Saccharomyces cerevisiae, called Lih1 and encoded by
+      YJR107W, shares 26% identity and 44% similarity with YlLip2, its closest
+      relative in Y. lipolytica.
+  - statement: &gt;-
+      Members of this fungal lipase family carry the conserved Ser-Asp-His
+      catalytic triad with the catalytic serine in the GHS[LFM]G pentapeptide,
+      characteristic of the alpha/beta hydrolase fold; this is a family/fold-level
+      bioinformatic argument, consistent with LIH1 retaining an intact triad.
+    supporting_text: &gt;-
+      All the proteins in this region harbored the conserved serine, aspartic acid,
+      and histidine catalytic triad characteristic of the α/β hydrolase with the
+      catalytic nucleophile serine located in the highly conserved pentapeptide
+      GHS[LFM]G
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text verified. This is the source UniProt cites (ECO:0000303 /
+      ECO:0000305) for the LIH1 name and the EC 3.1.1.3 designation. Confirms that
+      the lipase assignment for LIH1 is homology-based, not experimental: LIH1 is
+      only mentioned as a distant (26% identity) Saccharomycetaceae relative of the
+      Yarrowia LIP family and was not expressed or assayed.
+- id: PMID:8641269
+  title: Complete nucleotide sequence of Saccharomyces cerevisiae chromosome X.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genomic sequencing of chromosome X that defines the YJR107W ORF; provides no
+      functional information. Cached abstract-only.
+- id: PMID:24374639
+  title: &#34;The reference genome sequence of Saccharomyces cerevisiae: Then and now.&#34;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reference-genome reannotation; source of the 2011 sequence revision at
+      residues 14 and 66. No functional characterization of LIH1.
+existing_annotations:
+- term:
+    id: GO:0004806
+    label: triacylglycerol lipase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic EC-to-GO mapping (EC 3.1.1.3 -&gt; triacylglycerol lipase activity).
+      The EC number is itself a curator/homology inference (UniProt ECO:0000305),
+      not a measured activity. LIH1 has an intact serine-hydrolase catalytic triad
+      (Ser181/Asp253/His315) and belongs to the fungal Lipase_3 family, so a
+      fold-level hydrolase/lipase activity is plausible; however, asserting the
+      specific triacylglycerol substrate over-annotates a protein that has never
+      been assayed and shares only ~26% identity with the nearest characterized
+      lipase (Y. lipolytica Lip2). Generalize to lipase activity (or, most
+      conservatively, carboxylic ester hydrolase activity) and treat as non-core
+      pending biochemical evidence.
+    action: MODIFY
+    reason: &gt;-
+      The specific triacylglycerol-lipase substrate claim is unsupported by any
+      experimental data for LIH1; the defensible homology-based claim is a
+      fold-level lipase / carboxylic-ester-hydrolase activity.
+    proposed_replacement_terms:
+    - id: GO:0016298
+      label: lipase activity
+- term:
+    id: GO:0006629
+    label: lipid metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro-domain-based (IPR002921, fungal lipase-type) electronic annotation
+      to the broad process &#34;lipid metabolic process&#34;. This is consistent with the
+      fold and is appropriately general, but the specific physiological role of
+      LIH1 in lipid metabolism has never been demonstrated. Retain as a general,
+      non-core process annotation reflecting the domain inference.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Broad, domain-consistent BP inference; defensible at this level of generality
+      but not an experimentally established core function.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component with ND (No biological Data) evidence, correctly
+      recording that no subcellular localization is known for LIH1. Accurate
+      placeholder.
+    action: ACCEPT
+    reason: &gt;-
+      ND root annotation faithfully represents the absence of localization data;
+      no change warranted.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process with ND evidence, correctly recording that no
+      biological process has been experimentally established for LIH1. Accurate
+      placeholder; note the coexisting IEA BP annotation (lipid metabolic process)
+      is a domain inference, not experimental.
+    action: ACCEPT
+    reason: &gt;-
+      ND root annotation faithfully represents the absence of experimental
+      process data; no change warranted.
+core_functions:
+- description: &gt;-
+    Predicted serine hydrolase of the fungal Lipase_3 / alpha-beta hydrolase family.
+    LIH1 retains an intact, canonically positioned Ser-Asp-His catalytic triad
+    (nucleophilic Ser181 in the GHSLG pentapeptide) and all diagnostic AB-hydrolase
+    signatures, so it is predicted to hydrolyze a carboxylic ester / lipid substrate.
+    No catalytic activity, substrate, or biological role has been experimentally
+    verified; this core function is a fold/homology-based prediction only and is
+    stated at the most defensible level of generality.
+  molecular_function:
+    id: GO:0016298
+    label: lipase activity
+  supported_by:
+  - reference_id: PMID:26580812
+    supporting_text: &gt;-
+      All the proteins in this region harbored the conserved serine, aspartic acid,
+      and histidine catalytic triad characteristic of the α/β hydrolase with the
+      catalytic nucleophile serine located in the highly conserved pentapeptide
+      GHS[LFM]G
+knowledge_gaps:
+- gap_statement: &gt;-
+    The actual catalytic activity of the LIH1 protein is undetermined. Although LIH1
+    retains an intact serine-hydrolase catalytic triad (Ser181/Asp253/His315) and
+    the GHSLG nucleophile-elbow motif, it has never been expressed, purified, or
+    assayed; whether it hydrolyzes triacylglycerol (as its EC 3.1.1.3 mapping
+    asserts), some other lipid or carboxylic ester, or is catalytically inert in
+    vivo, is unknown.
+  boundary: &gt;-
+    Firmly established: LIH1 is a member of the fungal Lipase_3 / AB-hydrolase
+    superfamily (Pfam PF01764, InterPro IPR002921/IPR029058, PROSITE PS00120,
+    ESTHER Lipase_3) and its catalytic triad and nucleophile pentapeptide are
+    conserved and correctly positioned. Its only characterized relative is
+    Y. lipolytica Lip2, from which it diverges strongly (~26% identity), and the
+    &#34;triacylglycerol lipase&#34; EC assignment is a curator homology inference
+    (UniProt ECO:0000305), not a measurement.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    LIH1 is the sole Saccharomycetaceae representative of a lipase family that
+    underwent dramatic expansion in the Yarrowia clade; establishing whether this
+    ancestral-type lipase homolog is an active enzyme, and on what substrate, would
+    anchor the functional history of the family and clarify whether S. cerevisiae
+    retains this lipase activity at all.
+  resolution: &gt;-
+    Heterologous expression and purification of LIH1 followed by in vitro assays
+    against a panel of tri-, di- and mono-acylglycerols and synthetic esters
+    (e.g. p-nitrophenyl esters of varying acyl-chain length) to test for and define
+    hydrolase activity and substrate preference; a catalytically dead Ser181Ala
+    control to confirm triad dependence.
+  provenance:
+  - reference_id: PMID:26580812
+    supporting_text: &gt;-
+      This putative lipase in Saccharomyces cerevisiae, called Lih1 and encoded by
+      YJR107W, shares 26% identity and 44% similarity with YlLip2, its closest
+      relative in Y. lipolytica.
+- gap_statement: &gt;-
+    The subcellular localization of LIH1 is unknown. It is not established whether
+    LIH1 is secreted (as many fungal lipases of this family are), retained
+    intracellularly, or membrane-associated.
+  boundary: &gt;-
+    The SGD-assigned cellular_component annotation is a root/ND placeholder, i.e.
+    no localization data exist. LIH1 has no annotated signal peptide or
+    transmembrane region in its UniProt record, but this has not been
+    experimentally tested and its Yarrowia relatives include both secreted and
+    non-secreted members.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether LIH1 acts on extracellular lipid substrates (secreted lipase) or in an
+    intracellular compartment is a prerequisite for interpreting any activity and
+    for placing it in a pathway.
+  resolution: &gt;-
+    Endogenous C-terminal fluorescent tagging and microscopy, and/or subcellular
+    fractionation and proteomics, to determine where the protein resides; secretion
+    assays if extracellular activity is suspected.
+- gap_statement: &gt;-
+    The biological process and physiological role of LIH1 are unknown. No
+    loss-of-function phenotype has been reported, the conditions (if any) under
+    which LIH1 is required or induced are undefined, and the assignment to &#34;lipid
+    metabolic process&#34; rests solely on domain inference.
+  boundary: &gt;-
+    The SGD-assigned biological_process annotation is a root/ND placeholder; the
+    only process annotation (lipid metabolic process) is an InterPro-domain-based
+    IEA. LIH1 appears dispensable under standard laboratory conditions, so any role
+    is likely conditional or redundant.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying a condition-specific phenotype (e.g. growth on particular lipid
+    carbon sources or under lipid stress) would convert LIH1 from a fold-based
+    prediction into an annotated participant in yeast lipid metabolism.
+  resolution: &gt;-
+    Phenotypic profiling of a lih1-delta strain across carbon sources and stress
+    conditions (including lipid/fatty-acid media), expression profiling to find
+    inducing conditions, and genetic-interaction screening to reveal redundancy.
+suggested_questions:
+- question: &gt;-
+    Is LIH1 a catalytically active hydrolase, and if so what is its natural
+    substrate (triacylglycerol, other acylglycerols, or a non-lipid carboxylic
+    ester)?
+  experts:
+  - Neuvéglise C
+  - Nicaud JM
+- question: &gt;-
+    Where in the cell does LIH1 act, and is it secreted like many of its Yarrowia
+    clade relatives?
+suggested_experiments:
+- hypothesis: &gt;-
+    LIH1 is an active serine hydrolase whose activity depends on the conserved
+    Ser181 nucleophile.
+  description: &gt;-
+    Heterologously express and purify recombinant LIH1 (and a Ser181Ala catalytic
+    mutant) and assay hydrolase activity against a substrate panel spanning tri-,
+    di- and mono-acylglycerols of varying chain length and synthetic p-nitrophenyl
+    esters; loss of activity in the Ser181Ala mutant would confirm triad-dependent
+    catalysis and define substrate preference.
+  experiment_type: biochemical enzyme assay
+- hypothesis: &gt;-
+    LIH1 contributes to lipid metabolism under specific, non-standard conditions.
+  description: &gt;-
+    Profile a lih1-delta deletion strain for growth and lipid-related phenotypes
+    across carbon sources (including fatty acids and triacylglycerol-based media)
+    and stress conditions, combined with transcriptional profiling to identify
+    conditions that induce LIH1 expression.
+  experiment_type: genetics / phenotypic profiling
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/MCO14/MCO14-ai-review.html
+++ b/genes/yeast/MCO14/MCO14-ai-review.html
@@ -1,0 +1,2272 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCO14 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MCO14</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P38744" target="_blank" class="term-link">
+                        P38744
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YHL018W</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MCO14";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P38744" data-a="DESCRIPTION: MCO14 (systematic name YHL018W) is a small (120 aa..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MCO14 (systematic name YHL018W) is a small (120 aa, ~14 kDa) mitochondrial protein of Saccharomyces cerevisiae belonging to the pterin-4-alpha-carbinolamine dehydratase (PCD/DCoH) family (Pfam PF01329; InterPro IPR001533/IPR036428; PANTHER PTHR12599). It carries the diagnostic PCD catalytic His-His-Pro motif and the PCD-like fold, so it is a predicted 4-alpha-hydroxytetrahydrobiopterin dehydratase (EC 4.2.1.96), the activity that regenerates tetrahydrobiopterin during aromatic amino acid hydroxylation and that additionally, in vertebrate paralogs (DCoH), moonlights as a transcriptional coactivator of HNF1. The protein is localized to mitochondria, where its precursor is imported in a membrane-potential (delta-psi)-dependent manner and assembles into a higher-molecular-weight complex. Its enzymatic activity has not been measured directly in yeast and is annotated as putative; the canonical tetrahydrobiopterin pathway and the aromatic amino acid hydroxylases that generate its expected substrate are largely absent from budding yeast, so the physiological substrate and biological role of MCO14 in yeast are not established. It is non-essential, of moderate abundance, and has no reported deletion phenotype.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006729" target="_blank" class="term-link">
+                                    GO:0006729
+                                </a>
+                            </span>
+                            <span class="term-label">tetrahydrobiopterin biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38744" data-a="GO:0006729" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic InterPro2GO annotation propagated from the PCD/DCoH family signature. The process is biologically questionable in Saccharomyces cerevisiae: budding yeast lacks the BH4-specific biosynthetic enzymes (6-pyruvoyl-tetrahydropterin synthase and sepiapterin reductase) and the aromatic amino acid hydroxylases whose reaction produces the 4a-carbinolamine that PCD regenerates. PCD&#39;s role is in regeneration/recycling during hydroxylation rather than de novo tetrahydrobiopterin biosynthesis per se, and neither the pathway nor its substrate-generating enzymes operate natively in yeast. The term is appropriate for the family but its pathway context is absent in this organism, so it is over-annotated here.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagated IEA whose metazoan/bacterial pathway context (BH4 biosynthesis and aromatic amino acid hydroxylation) is largely absent from S. cerevisiae; kept as family-level context rather than removed because the fold/motif are genuinely PCD-type.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008124" target="_blank" class="term-link">
+                                    GO:0008124
+                                </a>
+                            </span>
+                            <span class="term-label">4-alpha-hydroxytetrahydrobiopterin dehydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38744" data-a="GO:0008124" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (EC/RHEA/InterPro-based) molecular-function annotation. MCO14 has the PCD-like fold and retains the diagnostic catalytic His-His-Pro motif, so this is the single best-supported functional hypothesis for the protein and is retained as its (predicted) core molecular function. The important caveat, recorded in the knowledge_gaps, is that UniProt flags the activity as &#34;Putative&#34; (no enzyme assay of the yeast protein has been reported) and the physiological substrate in yeast is unknown; the annotation therefore rests on family/domain inference, not direct evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Defensible domain/family-based MF prediction (conserved PCD catalytic motif) and the only informative functional hypothesis for the protein; accepted as the predicted core molecular function while its putative, unproven-in-yeast status is captured in the knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38744" data-a="GO:0005739" data-r="PMID:14562095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial localization from the genome-wide GFP-fusion dataset (Huh et al. 2003, assigned by SGD). Independently corroborated by the high-confidence mitochondrial proteome study of Morgenstern et al. 2017 (PMID:28658629), which additionally showed that the Mco14 precursor is imported in a membrane-potential-dependent manner and forms a high-molecular-weight complex. This is the best-supported and core localization for the protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported by two independent high-throughput datasets (GFP localization and quantitative mitochondrial proteomics with import assays).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P38744" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function annotation with the ND (no biological data) evidence code, recorded by SGD to indicate that no experimental molecular-function data are available for this protein. This accurately reflects the curation state: the dehydratase activity is only a family-based electronic prediction. The ND root placeholder is superseded by the more informative (if putative) GO:0008124 IEA annotation and carries no specific information.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root-term placeholder; a specific (electronic) molecular-function annotation (GO:0008124) now exists, making the ND root redundant.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P38744" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process annotation with the ND (no biological data) evidence code. This honestly reflects that the biological role of MCO14 in yeast is not experimentally established. It is an uninformative root placeholder and conveys no specific process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root-term placeholder; the genuine unknown biological role is captured in the knowledge_gaps section rather than by a root ND annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Predicted pterin-4-alpha-carbinolamine (4a-hydroxytetrahydrobiopterin) dehydratase. MCO14 has the PCD/DCoH fold and retains the diagnostic catalytic His-His-Pro motif conserved with characterized family members (e.g. human PCBD1), so a dehydratase activity (EC 4.2.1.96) is the leading molecular-function hypothesis. This is a family/domain-based inference only: UniProt annotates the activity as putative, no enzyme assay of the yeast protein has been reported, and the physiological substrate in yeast is unknown. The protein is mitochondrial.</h3>
+                <span class="vote-buttons" data-g="P38744" data-a="FUNCTION: Predicted pterin-4-alpha-carbinolamine (4a-hydroxy..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008124" target="_blank" class="term-link">
+                            4-alpha-hydroxytetrahydrobiopterin dehydratase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProtKB:P38744
+
+                        </span>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28658629" target="_blank" class="term-link">
+                                PMID:28658629
+                            </a>
+
+                        </span>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP-fusion localization study of budding yeast; the source of the SGD high-throughput (HDA) mitochondrial localization assignment for YHL018W/MCO14. The cached entry is abstract-only; the per-ORF localization is in the study&#39;s supplementary dataset.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28658629" target="_blank" class="term-link">
+                            PMID:28658629
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Definition of a High-Confidence Mitochondrial Proteome at Quantitative Scale.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-confidence yeast mitochondrial proteome study that named MCO14 (the MCO &#34;mitochondrial class one&#34; series). Mco14 is a high-confidence mitochondrial protein whose radiolabeled precursor is imported in a membrane-potential (delta-psi)-dependent manner and assembles into a distinct high-molecular-weight complex, indicating an inner-membrane / matrix-facing location. The study assigns no molecular function to Mco14.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProtKB:P38744
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P38744 (PHS_YEAST): Putative pterin-4-alpha-carbinolamine dehydratase</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt reviewed (Swiss-Prot) entry. RecName &#34;Putative pterin-4-alpha-carbinolamine dehydratase&#34; (EC 4.2.1.96); assigns the protein to the pterin-4-alpha-carbinolamine dehydratase family (Pfam PF01329; InterPro IPR001533/IPR036428; CDD cd00488) and notes &#34;Present with 752 molecules/cell in log phase SD medium&#34;. The &#34;Putative&#34; designation reflects that the catalytic activity is a family-based inference, not a measured activity for the yeast protein.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is MCO14 a catalytically active pterin-4-alpha-carbinolamine dehydratase in yeast, and what is its physiological substrate given that yeast lacks the canonical tetrahydrobiopterin pathway?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38744" data-a="Q: Is MCO14 a catalytically active pterin-4-alpha-car..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the composition of the membrane-potential-dependent high-molecular-weight complex that Mco14 assembles into after mitochondrial import?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38744" data-a="Q: What is the composition of the membrane-potential-..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant P38744 and assay dehydratase activity in vitro against 4a-hydroxytetrahydrobiopterin / 4a-hydroxytetrahydropterin substrates (spectrophotometric or coupled assay), comparing to a catalytic-His mutant.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MCO14 has 4a-hydroxytetrahydropterin dehydratase activity.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzyme assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38744" data-a="EXPERIMENT: Express and purify recombinant P38744 and assay de..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform affinity purification-mass spectrometry of chromosomally tagged Mco14 from purified mitochondria under membrane-potential-permissive conditions to identify stoichiometric complex partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MCO14 functions within a defined mitochondrial complex.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-MS</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38744" data-a="EXPERIMENT: Perform affinity purification-mass spectrometry of..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Profile the growth/fitness of an mco14-delta strain across respiratory, oxidative-stress, amino-acid-limitation, and pterin/folate-perturbation conditions, and measure mitochondrial pteridine metabolite levels versus wild type.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MCO14 is required under a specific physiological condition.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: phenotypic profiling / metabolomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38744" data-a="EXPERIMENT: Profile the growth/fitness of an mco14-delta strai..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process in which MCO14 participates in yeast mitochondria is unknown. The family-derived tetrahydrobiopterin pathway is largely absent from S. cerevisiae, so the process the protein actually serves (metabolic, structural, or regulatory) is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: MCO14 is a mitochondrial protein whose precursor is imported in a membrane-potential-dependent manner and forms a high-molecular-weight complex. Not established: any pathway membership; yeast lacks the BH4-specific enzymes (PTS/PTPS, sepiapterin reductase) and aromatic amino acid hydroxylases that define the family&#39;s canonical process, and no deletion or conditional phenotype has been reported (SGD lists no phenotypes).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> MCO14 is a conserved-but-dark mitochondrial protein; establishing its process would connect a widespread PCD-family fold to a defined mitochondrial function and clarify what, if anything, the pterin-dehydratase chemistry does in an organism thought to lack the pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotypic profiling of mco14-delta under diverse conditions (respiratory/oxidative/pterin stress), affinity-purification of the membrane-potential-dependent complex to identify partners, and mitochondrial pteridine metabolomics.</p>
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The composition of the high-molecular-weight, membrane-potential-dependent complex that Mco14 assembles into is unknown; no specific interaction partner has been curated.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: blue-native and import assays show Mco14 forms a distinct high-molecular-weight complex after inner-membrane import. Not established: the identity of the partner subunit(s); the ~97 SGD interactions are high-throughput and non-specific.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying complex partners would place MCO14 in a functional module and is the most tractable route to its in-vivo role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reciprocal affinity purification-MS of tagged Mco14 from isolated mitochondria under membrane-potential-permissive conditions.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MCO14-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38744" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mco14-yhl018w-p38744-review-notes">MCO14 (YHL018W / P38744) review notes</h1>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li><strong>Standard name:</strong> MCO14 (SGD). Name description at SGD: "Mitochondrial Class One protein of 14 kDa".<br />
+  The <code>MCO</code> prefix = "Mitochondrial Class One" protein, a naming series introduced by Morgenstern et al.<br />
+  2017 for high-confidence mitochondrial proteins of previously unknown function<br />
+  [PMID:28658629, "The mitochondrial class 1 protein of 10 kDa (Mco10)..."]. MCO14 was named in the same<br />
+  study; the trailing number encodes the ~kDa mass (Mco14 ≈ 14 kDa).</li>
+<li><strong>Systematic name:</strong> YHL018W (chromosome VIII). <strong>SGDID:</strong> S000001010. <strong>UniProt:</strong> P38744 (PHS_YEAST),<br />
+  120 aa, 14 kDa, "Evidence at protein level" (PE1).</li>
+<li><strong>UniProt RecName:</strong> "<strong>Putative</strong> pterin-4-alpha-carbinolamine dehydratase" (EC 4.2.1.96); AltNames<br />
+  "4-alpha-hydroxy-tetrahydropterin dehydratase", "Pterin carbinolamine dehydratase (PCD)". The word<br />
+<em>Putative</em> is important: the enzymatic activity is a <strong>family-based inference</strong>, not measured in yeast.</li>
+<li>Verified via SGD REST (<code>/backend/locus/MCO14</code>): gene_name MCO14, uniprot_id P38744, feature YHL018W,<br />
+  qualifier "Verified" ORF.</li>
+</ul>
+<h2 id="domain-family-inline-analysis-of-mco14-uniprottxt">Domain / family (inline analysis of MCO14-uniprot.txt)</h2>
+<ul>
+<li>Belongs to the <strong>pterin-4-alpha-carbinolamine dehydratase (PCD/DCoH) family</strong> (UniProt SIMILARITY,<br />
+  ECO:0000305). Domain hits in the UniProt record:</li>
+<li>Pfam <strong>PF01329</strong> (Pterin_4a)</li>
+<li>InterPro <strong>IPR001533</strong> (Pterin dehydratase), <strong>IPR036428</strong> (PCD superfamily)</li>
+<li>CDD <strong>cd00488</strong> (PCD_DCoH)</li>
+<li>PANTHER <strong>PTHR12599</strong> / <strong>PTHR12599:SF0</strong> (PTERIN-4-ALPHA-CARBINOLAMINE DEHYDRATASE)</li>
+<li>Gene3D 3.30.1360.20 "Transcriptional coactivator/pterin dehydratase"; SUPFAM SSF55248 PCD-like.</li>
+<li><strong>Catalytic-motif conservation (inline sequence analysis).</strong> MCO14 sequence<br />
+<code>...VSMRSHLWG​HHPLIH...</code> contains the diagnostic PCD catalytic <strong>HHP</strong> motif. Aligning to human PCBD1<br />
+  (P61457), whose UniProt BINDING sites are residues 61-63 (<code>DHH</code>, containing the catalytic His pair) and<br />
+  78-81, the human catalytic motif <code>DHHPEW</code> aligns to MCO14 <code>GHHPLIH</code> — the <strong>His-His-Pro core is<br />
+  conserved</strong>, and the upstream <code>TRV</code> (human <code>TRVAL</code> / yeast <code>TRVSM</code>) is conserved. So MCO14 <strong>retains the<br />
+  PCD catalytic signature</strong> and is a plausible (not obviously defunct) dehydratase — but note this is a<br />
+  distant homolog (~30% local identity around the catalytic window), and no direct enzyme assay exists for<br />
+  the yeast protein.</li>
+<li>CDD/Gene3D also flag the shared fold with the <strong>DCoH transcriptional-coactivator (dimerization cofactor<br />
+  of HNF1)</strong> moonlighting activity known for the vertebrate paralogs. There is no evidence for a<br />
+  transcription-factor partner in yeast (yeast has no HNF1 ortholog), so that moonlighting role is not<br />
+  expected here.</li>
+</ul>
+<h2 id="localization-known">Localization (KNOWN)</h2>
+<ul>
+<li><strong>Mitochondrion.</strong> GOA: GO:0005739 mitochondrion, HDA, assigned by SGD from the genome-wide GFP<br />
+  localization dataset [PMID:14562095, Huh et al. 2003] (per-ORF localization is in that study's<br />
+  supplement; the cached entry is abstract-only).</li>
+<li>Independently confirmed by the high-confidence mitochondrial proteome study [PMID:28658629,<br />
+  Morgenstern et al. 2017], which included Mco14 among high-confidence mitochondrial proteins and studied<br />
+  its import/complex formation. In their blue-native + import assays, complex formation was<br />
+  membrane-potential (Δψ)-dependent: "<em>the precursor proteins were translocated into or across the inner<br />
+  membrane to form a complex (shown here for Dpa10, Mco14, Dpi29, and Dpi34)</em>" — indicating an<br />
+  inner-membrane/matrix-facing location rather than the outer membrane/IMS. Blue-native analysis also<br />
+  showed Mco14 forms "<em>distinct high-molecular-weight complexes</em>".</li>
+</ul>
+<h2 id="molecular-function-what-is-known-vs-not">Molecular function — what is known vs not</h2>
+<ul>
+<li><strong>KNOWN (family inference):</strong> PCD-family fold with conserved catalytic HHP motif → predicted<br />
+  4-alpha-hydroxytetrahydrobiopterin dehydratase (EC 4.2.1.96). This is the single most-supported<br />
+  functional hypothesis, but is IEA/IBA only and flagged "Putative" by UniProt.</li>
+<li><strong>NOT KNOWN:</strong> No direct enzymatic assay of P38744; no measured substrate; no in-vivo function; no<br />
+  deletion phenotype (SGD phenotype_details returns 0 phenotypes); no genetic pathway placement. GOA has<br />
+  the ND (no-data) root annotations GO:0003674 and GO:0008150 recorded by SGD — an explicit statement<br />
+  that curators could not assign specific function/process from experiment.</li>
+</ul>
+<h2 id="biological-process-the-bh4-pathway-is-largely-absent-in-yeast-key-reviewer-point">Biological process — the BH4 pathway is largely ABSENT in yeast (key reviewer point)</h2>
+<ul>
+<li>The IEA BP annotation GO:0006729 "tetrahydrobiopterin biosynthetic process" (InterPro2GO, GO_REF:0000002)<br />
+  carries a <strong>metazoan/bacterial pathway context that S. cerevisiae mostly lacks</strong>:</li>
+<li>Yeast has GTP cyclohydrolase I (<strong>FOL2/GCH1</strong>), but that enzyme feeds <strong>folate</strong> biosynthesis; the<br />
+    downstream <strong>BH4-specific</strong> enzymes 6-pyruvoyl-tetrahydropterin synthase (PTS/PTPS) and sepiapterin<br />
+    reductase (SPR) are <strong>not present natively</strong> — heterologous PTS and SPR must be introduced to make BH4<br />
+    in yeast (Germann et al. 2016, <em>Biotechnol J</em>, PMC5066760: "GCH1/Fol2 is natively present in wild-type<br />
+    S. cerevisiae, whereas heterologous PTS and SPR were introduced to enable BH4 production").</li>
+<li>Yeast also lacks the aromatic amino acid hydroxylases (PAH/TH/TPH) whose reaction generates the<br />
+    4a-carbinolamine substrate that PCD/DCoH regenerates. PCD's canonical role is <strong>regeneration/recycling</strong><br />
+    of BH4 during aromatic amino acid hydroxylation, not de novo BH4 <em>biosynthesis</em> — and neither the<br />
+    substrate-producing hydroxylases nor de novo BH4 synthesis operate natively in budding yeast.</li>
+<li>Reactome maps P38744 to "Phenylalanine metabolism" (R-SCE-8964208) purely by family orthology; there<br />
+    is no evidence yeast runs Phe hydroxylation.<br />
+  → The BH4-biosynthesis BP is therefore an over-propagation in this organism (PATHWAY_CONTEXT_IGNORED).<br />
+  Marked MARK_AS_OVER_ANNOTATED (not a flat REMOVE: the term is family-appropriate; it is the yeast<br />
+  pathway context that is missing).</li>
+</ul>
+<h2 id="interactions-abundance">Interactions / abundance</h2>
+<ul>
+<li>Abundance: "<em>Present with 752 molecules/cell in log phase SD medium</em>" (UniProt MISCELLANEOUS, from<br />
+  PMID:14562106). SGD lists 97 physical/genetic interactions, essentially all high-throughput; no<br />
+  curated functional complex partner. BioGRID-ORCS: 0 hits in 10 CRISPR screens (non-essential, no strong<br />
+  fitness signal).</li>
+</ul>
+<h2 id="summary-of-known-vs-not-known-for-knowledge_gaps">Summary of KNOWN vs NOT-known (for knowledge_gaps)</h2>
+<ul>
+<li>KNOWN: mitochondrial protein (dual proteomic evidence); ~14 kDa; PCD/DCoH fold with conserved catalytic<br />
+  HHP motif; imported in a Δψ-dependent manner and part of a high-MW complex; non-essential; moderate<br />
+  abundance.</li>
+<li>NOT KNOWN: the actual biochemical substrate and whether MCO14 is catalytically active in vivo; its<br />
+  physiological mitochondrial role/process; any deletion or conditional phenotype; whether the annotated<br />
+  BH4/pterin chemistry occurs at all in yeast mitochondria; its complex partners; any regulatory or<br />
+  moonlighting function.</li>
+</ul>
+<h2 id="provenance-log">Provenance log</h2>
+<ul>
+<li>SGD REST <code>/backend/locus/MCO14</code> and <code>/S000001010/phenotype_details</code>, <code>/interaction_details</code> (2026-07-05).</li>
+<li>UniProt P38744 (cached MCO14-uniprot.txt); human PCBD1 P61457 (rest.uniprot.org, for catalytic-residue<br />
+  comparison).</li>
+<li>PMID:28658629 (Morgenstern 2017, full text cached) — mitochondrial proteome, MCO naming, Mco14 import.</li>
+<li>PMID:14562095 (Huh 2003, abstract cached) — GFP localization source for the mitochondrion annotation.</li>
+<li>Germann et al. 2016 (PMC5066760, WebFetch) — yeast lacks native PTS/SPR for BH4.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P38744
+gene_symbol: MCO14
+aliases:
+- YHL018W
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  MCO14 (systematic name YHL018W) is a small (120 aa, ~14 kDa) mitochondrial
+  protein of Saccharomyces cerevisiae belonging to the pterin-4-alpha-carbinolamine
+  dehydratase (PCD/DCoH) family (Pfam PF01329; InterPro IPR001533/IPR036428;
+  PANTHER PTHR12599). It carries the diagnostic PCD catalytic His-His-Pro motif and
+  the PCD-like fold, so it is a predicted 4-alpha-hydroxytetrahydrobiopterin
+  dehydratase (EC 4.2.1.96), the activity that regenerates tetrahydrobiopterin during
+  aromatic amino acid hydroxylation and that additionally, in vertebrate paralogs
+  (DCoH), moonlights as a transcriptional coactivator of HNF1. The protein is
+  localized to mitochondria, where its precursor is imported in a membrane-potential
+  (delta-psi)-dependent manner and assembles into a higher-molecular-weight complex.
+  Its enzymatic activity has not been measured directly in yeast and is annotated as
+  putative; the canonical tetrahydrobiopterin pathway and the aromatic amino acid
+  hydroxylases that generate its expected substrate are largely absent from budding
+  yeast, so the physiological substrate and biological role of MCO14 in yeast are not
+  established. It is non-essential, of moderate abundance, and has no reported
+  deletion phenotype.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:14562095
+  title: Global analysis of protein localization in budding yeast.
+  findings:
+  - statement: &gt;-
+      Genome-wide GFP-fusion localization study of budding yeast; the source of the
+      SGD high-throughput (HDA) mitochondrial localization assignment for YHL018W/MCO14.
+      The cached entry is abstract-only; the per-ORF localization is in the study&#39;s
+      supplementary dataset.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified GFP localization dataset (Huh et al. 2003, Nature). Basis for the
+      mitochondrion CC annotation; the mitochondrial localization is independently
+      confirmed by Morgenstern et al. 2017 (PMID:28658629).
+- id: PMID:28658629
+  title: Definition of a High-Confidence Mitochondrial Proteome at Quantitative Scale.
+  findings:
+  - statement: &gt;-
+      High-confidence yeast mitochondrial proteome study that named MCO14 (the MCO
+      &#34;mitochondrial class one&#34; series). Mco14 is a high-confidence mitochondrial
+      protein whose radiolabeled precursor is imported in a membrane-potential
+      (delta-psi)-dependent manner and assembles into a distinct high-molecular-weight
+      complex, indicating an inner-membrane / matrix-facing location. The study assigns
+      no molecular function to Mco14.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text read and verified (cached). Establishes and names MCO14 as a
+      mitochondrial protein, corroborates the mitochondrion CC, and provides
+      import/complex evidence. Verbatim from the full text: &#34;the precursor proteins were
+      translocated into or across the inner membrane to form a complex (shown here for
+      Dpa10, Mco14, Dpi29, and Dpi34)&#34; and blue-native analysis &#34;revealing distinct
+      high-molecular-weight complexes&#34;.
+- id: UniProtKB:P38744
+  title: &#34;UniProtKB entry P38744 (PHS_YEAST): Putative pterin-4-alpha-carbinolamine dehydratase&#34;
+  findings:
+  - statement: &gt;-
+      UniProt reviewed (Swiss-Prot) entry. RecName &#34;Putative pterin-4-alpha-carbinolamine
+      dehydratase&#34; (EC 4.2.1.96); assigns the protein to the pterin-4-alpha-carbinolamine
+      dehydratase family (Pfam PF01329; InterPro IPR001533/IPR036428; CDD cd00488) and
+      notes &#34;Present with 752 molecules/cell in log phase SD medium&#34;. The &#34;Putative&#34;
+      designation reflects that the catalytic activity is a family-based inference, not a
+      measured activity for the yeast protein.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Source of the family assignment, the (putative) EC 4.2.1.96 activity, and the
+      abundance datum; used as provenance for the predicted molecular function.
+existing_annotations:
+- term:
+    id: GO:0006729
+    label: tetrahydrobiopterin biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic InterPro2GO annotation propagated from the PCD/DCoH family signature.
+      The process is biologically questionable in Saccharomyces cerevisiae: budding
+      yeast lacks the BH4-specific biosynthetic enzymes (6-pyruvoyl-tetrahydropterin
+      synthase and sepiapterin reductase) and the aromatic amino acid hydroxylases whose
+      reaction produces the 4a-carbinolamine that PCD regenerates. PCD&#39;s role is in
+      regeneration/recycling during hydroxylation rather than de novo tetrahydrobiopterin
+      biosynthesis per se, and neither the pathway nor its substrate-generating enzymes
+      operate natively in yeast. The term is appropriate for the family but its pathway
+      context is absent in this organism, so it is over-annotated here.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Over-propagated IEA whose metazoan/bacterial pathway context (BH4 biosynthesis and
+      aromatic amino acid hydroxylation) is largely absent from S. cerevisiae; kept as
+      family-level context rather than removed because the fold/motif are genuinely
+      PCD-type.
+- term:
+    id: GO:0008124
+    label: 4-alpha-hydroxytetrahydrobiopterin dehydratase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (EC/RHEA/InterPro-based) molecular-function annotation. MCO14 has the
+      PCD-like fold and retains the diagnostic catalytic His-His-Pro motif, so this is
+      the single best-supported functional hypothesis for the protein and is retained as
+      its (predicted) core molecular function. The important caveat, recorded in the
+      knowledge_gaps, is that UniProt flags the activity as &#34;Putative&#34; (no enzyme assay of
+      the yeast protein has been reported) and the physiological substrate in yeast is
+      unknown; the annotation therefore rests on family/domain inference, not direct
+      evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Defensible domain/family-based MF prediction (conserved PCD catalytic motif) and the
+      only informative functional hypothesis for the protein; accepted as the predicted
+      core molecular function while its putative, unproven-in-yeast status is captured in
+      the knowledge_gaps.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:14562095
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Mitochondrial localization from the genome-wide GFP-fusion dataset (Huh et al.
+      2003, assigned by SGD). Independently corroborated by the high-confidence
+      mitochondrial proteome study of Morgenstern et al. 2017 (PMID:28658629), which
+      additionally showed that the Mco14 precursor is imported in a
+      membrane-potential-dependent manner and forms a high-molecular-weight complex.
+      This is the best-supported and core localization for the protein.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported by two independent high-throughput datasets (GFP localization and
+      quantitative mitochondrial proteomics with import assays).
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function annotation with the ND (no biological data) evidence code,
+      recorded by SGD to indicate that no experimental molecular-function data are
+      available for this protein. This accurately reflects the curation state: the
+      dehydratase activity is only a family-based electronic prediction. The ND root
+      placeholder is superseded by the more informative (if putative) GO:0008124 IEA
+      annotation and carries no specific information.
+    action: REMOVE
+    reason: &gt;-
+      Uninformative root-term placeholder; a specific (electronic) molecular-function
+      annotation (GO:0008124) now exists, making the ND root redundant.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process annotation with the ND (no biological data) evidence code.
+      This honestly reflects that the biological role of MCO14 in yeast is not
+      experimentally established. It is an uninformative root placeholder and conveys no
+      specific process.
+    action: REMOVE
+    reason: &gt;-
+      Uninformative root-term placeholder; the genuine unknown biological role is
+      captured in the knowledge_gaps section rather than by a root ND annotation.
+core_functions:
+- description: &gt;-
+    Predicted pterin-4-alpha-carbinolamine (4a-hydroxytetrahydrobiopterin) dehydratase.
+    MCO14 has the PCD/DCoH fold and retains the diagnostic catalytic His-His-Pro motif
+    conserved with characterized family members (e.g. human PCBD1), so a dehydratase
+    activity (EC 4.2.1.96) is the leading molecular-function hypothesis. This is a
+    family/domain-based inference only: UniProt annotates the activity as putative, no
+    enzyme assay of the yeast protein has been reported, and the physiological substrate
+    in yeast is unknown. The protein is mitochondrial.
+  molecular_function:
+    id: GO:0008124
+    label: 4-alpha-hydroxytetrahydrobiopterin dehydratase activity
+  locations:
+  - id: GO:0005739
+    label: mitochondrion
+  supported_by:
+  - reference_id: UniProtKB:P38744
+  - reference_id: PMID:28658629
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      Whether MCO14 is a catalytically active dehydratase in yeast, and if so its true
+      physiological substrate, is undetermined; the annotated 4a-carbinolamine
+      dehydratase activity is a family/motif-based prediction (UniProt &#34;Putative&#34;) with
+      no direct enzyme assay of P38744.
+    boundary: &gt;-
+      Established: MCO14 has the PCD/DCoH fold, retains the conserved catalytic His-His-Pro
+      motif, and is mitochondrial. Not established: any measured catalytic activity, kcat,
+      or substrate for the yeast protein.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Determines whether MCO14 is a genuine pterin-recycling enzyme in yeast mitochondria
+      or a fold-retaining protein repurposed for another (e.g. structural or moonlighting)
+      role, as seen for the DCoH branch of the family.
+    resolution: &gt;-
+      In vitro dehydratase assay of recombinant P38744 with 4a-hydroxytetrahydropterin
+      substrates; targeted metabolomics of pterin/pteridine species in wild-type vs
+      mco14-delta mitochondria.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The biological process in which MCO14 participates in yeast mitochondria is unknown.
+    The family-derived tetrahydrobiopterin pathway is largely absent from S. cerevisiae,
+    so the process the protein actually serves (metabolic, structural, or regulatory) is
+    undetermined.
+  boundary: &gt;-
+    Established: MCO14 is a mitochondrial protein whose precursor is imported in a
+    membrane-potential-dependent manner and forms a high-molecular-weight complex. Not
+    established: any pathway membership; yeast lacks the BH4-specific enzymes (PTS/PTPS,
+    sepiapterin reductase) and aromatic amino acid hydroxylases that define the family&#39;s
+    canonical process, and no deletion or conditional phenotype has been reported (SGD
+    lists no phenotypes).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    MCO14 is a conserved-but-dark mitochondrial protein; establishing its process would
+    connect a widespread PCD-family fold to a defined mitochondrial function and clarify
+    what, if anything, the pterin-dehydratase chemistry does in an organism thought to
+    lack the pathway.
+  resolution: &gt;-
+    Phenotypic profiling of mco14-delta under diverse conditions
+    (respiratory/oxidative/pterin stress), affinity-purification of the
+    membrane-potential-dependent complex to identify partners, and mitochondrial
+    pteridine metabolomics.
+- gap_statement: &gt;-
+    The composition of the high-molecular-weight, membrane-potential-dependent complex
+    that Mco14 assembles into is unknown; no specific interaction partner has been
+    curated.
+  boundary: &gt;-
+    Established: blue-native and import assays show Mco14 forms a distinct
+    high-molecular-weight complex after inner-membrane import. Not established: the
+    identity of the partner subunit(s); the ~97 SGD interactions are high-throughput and
+    non-specific.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Identifying complex partners would place MCO14 in a functional module and is the most
+    tractable route to its in-vivo role.
+  resolution: &gt;-
+    Reciprocal affinity purification-MS of tagged Mco14 from isolated mitochondria under
+    membrane-potential-permissive conditions.
+suggested_questions:
+- question: &gt;-
+    Is MCO14 a catalytically active pterin-4-alpha-carbinolamine dehydratase in yeast,
+    and what is its physiological substrate given that yeast lacks the canonical
+    tetrahydrobiopterin pathway?
+  experts: []
+- question: &gt;-
+    What is the composition of the membrane-potential-dependent high-molecular-weight
+    complex that Mco14 assembles into after mitochondrial import?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    MCO14 has 4a-hydroxytetrahydropterin dehydratase activity.
+  description: &gt;-
+    Express and purify recombinant P38744 and assay dehydratase activity in vitro against
+    4a-hydroxytetrahydrobiopterin / 4a-hydroxytetrahydropterin substrates
+    (spectrophotometric or coupled assay), comparing to a catalytic-His mutant.
+  experiment_type: enzyme assay
+- hypothesis: &gt;-
+    MCO14 functions within a defined mitochondrial complex.
+  description: &gt;-
+    Perform affinity purification-mass spectrometry of chromosomally tagged Mco14 from
+    purified mitochondria under membrane-potential-permissive conditions to identify
+    stoichiometric complex partners.
+  experiment_type: affinity purification-MS
+- hypothesis: &gt;-
+    MCO14 is required under a specific physiological condition.
+  description: &gt;-
+    Profile the growth/fitness of an mco14-delta strain across respiratory,
+    oxidative-stress, amino-acid-limitation, and pterin/folate-perturbation conditions,
+    and measure mitochondrial pteridine metabolite levels versus wild type.
+  experiment_type: phenotypic profiling / metabolomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/MNN14/MNN14-ai-review.html
+++ b/genes/yeast/MNN14/MNN14-ai-review.html
@@ -1,0 +1,2960 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MNN14 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MNN14</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P40355" target="_blank" class="term-link">
+                        P40355
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MNN14";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P40355" data-a="DESCRIPTION: MNN14 (systematic name YJR061W) encodes a 935-resi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MNN14 (systematic name YJR061W) encodes a 935-residue single-pass type II membrane protein of the Golgi apparatus in Saccharomyces cerevisiae. It is a paralog of MNN4 and belongs to the MNN4 family within the LicD/fukutin-related nucleotidyltransferase superfamily (Pfam PF04991 LicD; InterPro IPR007074 and IPR009644; PANTHER PTHR15407 fukutin-related), a divalent-cation-dependent phosphoryl-transferase fold distinct from the KRE2/MNT1 (GT15) mannosyltransferases. MNN14 is a mannosylphosphorylation enzyme: recombinant soluble MNN14 transfers mannosyl-phosphate from GDP-mannose to high-mannose N-glycans (e.g. Man8GlcNAc2 and the Man7-9GlcNAc2 glycans of a therapeutic protein), producing mono- and bis-mannosyl- phosphorylated glycans in an Mn2+-dependent reaction. It acts partially redundantly with MNN4 in vivo: single deletions leave residual mannosylphosphate, whereas simultaneous deletion of MNN4 and MNN14 abolishes N-glycan mannosylphosphorylation. Mannosylphosphorylation adds mannose-1-phosphate to the mannans of fungal glycoproteins, contributing negative surface charge, and is fungal-specific, so loss of MNN4 plus MNN14 is used in yeast glyco-engineering to make human-compatible glycoproteins. The protein carries a conserved DXD motif (498-500) typical of divalent-cation- dependent transferases. The in-vivo division of labour between the intrinsic catalytic activity of MNN14 and MNN4 (curated as a regulator of the Mnn6/Ktr6 mannosylphosphate transferase), the acceptor-position specificity of MNN14, and the basis of the MNN4/MNN14 redundancy remain to be resolved.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009101" target="_blank" class="term-link">
+                                    GO:0009101
+                                </a>
+                            </span>
+                            <span class="term-label">glycoprotein biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40355" data-a="GO:0009101" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) biological-process annotation from the MNN4-family tree, whose panel includes the paralog MNN4 (SGD:S000001684). MNN14 acts in N-glycan mannosylphosphorylation, which adds mannose-1-phosphate to glycoprotein-linked mannans and is part of glycoprotein biosynthesis, so the BP is correct. It is more general than the experimentally supported N-glycan-processing annotation below and is retained as a valid but non-core parent process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but generic BP consistent with the gene&#39;s role; superseded for specificity by the experimental GO:0006491 annotation. Retained per GO conventions as a valid IBA inference.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" target="_blank" class="term-link">
+                                        PMID:28101612
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">essential for N-glycan mannosylphosphorylation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40355" data-a="GO:0000139" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Subcellular-location annotation supported by the UniProt SUBCELLULAR LOCATION (Golgi apparatus membrane) and by the protein&#39;s single-pass type II membrane topology (cytoplasmic 1-21; signal-anchor TM 22-42; lumenal 43-935). Golgi localization is expected for an enzyme/regulator acting on outer-chain mannan maturation and is consistent with the MNN4 paralog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain/topology- and SubCell-supported cellular component; the correct and informative localization for this Golgi mannosylphosphorylation factor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P40355
+
+                                </span>
+
+                                <div class="support-text">Golgi apparatus membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P40355
+
+                                </span>
+
+                                <div class="support-text">Signal-anchor for type II membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006491" target="_blank" class="term-link">
+                                    GO:0006491
+                                </a>
+                            </span>
+                            <span class="term-label">N-glycan processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28101612
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abolishment of N-glycan mannosylphosphorylation in glyco-eng...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P40355" data-a="GO:0006491" data-r="PMID:28101612" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IGI) annotation curated by SGD from the genetic interaction with MNN4 (with/from SGD:S000001684). Kim et al. 2017 showed that MNN14 is required for full N-glycan mannosylphosphorylation and that the MNN4+MNN14 double deletion eliminates it, placing MNN14 in N-glycan outer-chain maturation. GO:0006491 (conversion of N-linked glycan to a mature form by glycosidases/glycosyltransferases) appropriately captures this outer-chain modification step. This is the best-supported process annotation and the core biological role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally grounded (IGI) core biological process directly supported by the double-deletion phenotype; the single defensible functional placement for this otherwise dark gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" target="_blank" class="term-link">
+                                        PMID:28101612
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">essential for N-glycan mannosylphosphorylation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" target="_blank" class="term-link">
+                                        PMID:28101612
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Double disruption of MNN4 and MNN14 genes was enough to eliminate N-glycan</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P40355" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder assigned by SGD with the ND (No biological Data) code, reflecting that no molecular-function had been curated for MNN14. This is now superseded by direct biochemical evidence: recombinant soluble MNN14 transfers mannosyl-phosphate from GDP-mannose to high-mannose N-glycans in vitro (Kang et al. 2021), establishing a mannosylphosphate transferase activity (GO:0000031). The ND root should be replaced by that specific MF (proposed as a NEW annotation below and used as the core molecular function).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND placeholder is no longer accurate: an experimental (in-vitro) MF for MNN14 now exists. GO:0000031 (mannosylphosphate transferase activity) is the specific, evidence-supported molecular function and should replace the uninformative root term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000031" target="_blank" class="term-link">
+                                    mannosylphosphate transferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                                        PMID:33144549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in vitro mannosyl-phosphorylation of high-mannose type N-glycans that utilizes a recombinant Mnn14 protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                                        PMID:33144549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">2 mM GDP-mannose (donor substrate)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000031" target="_blank" class="term-link">
+                                    GO:0000031
+                                </a>
+                            </span>
+                            <span class="term-label">mannosylphosphate transferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33144549
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In Vitro N-Glycan Mannosyl-Phosphorylation of a Therapeutic ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P40355" data-a="GO:0000031" data-r="PMID:33144549" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed NEW molecular-function annotation not currently in GOA. Recombinant soluble MNN14 (rMnn14 77-935) directly transfers mannosyl-phosphate from the donor GDP-mannose to high-mannose N-glycan acceptors, producing mono- and bis-mannosyl-phosphorylated glycans in an Mn2+-dependent reaction optimal at pH 7.5 / 30 C (Kang et al. 2021). GO:0000031 exactly matches this reaction (GDP-mannose + mannose-acceptor -&gt; phosphorylated glycan + GMP) and is the intrinsic catalytic activity of MNN14. The assay used the soluble catalytic domain expressed in P. pastoris, consistent with an intrinsic (not merely regulatory) activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported (in-vitro biochemical, IDA-equivalent) molecular function for MNN14 that is missing from GOA; this is the core catalytic function of the gene product.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                                        PMID:33144549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a strategy is established here for the in vitro mannosyl-phosphorylation of high-mannose type N-glycans</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                                        PMID:33144549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a recombinant Mnn14 protein derived from Saccharomyces cerevisiae</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                                        PMID:33144549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the main MPEs in Saccharomyces cerevisiae</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P40355" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level placeholder assigned by SGD with the ND code. It is superseded by the more informative Golgi membrane (GO:0000139) annotation above, which is supported by SubCell and the type II membrane topology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative root placeholder retained per GO conventions; the specific localization is already captured by the Golgi membrane annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Golgi-membrane mannosylphosphate transferase (mannosylphosphorylation enzyme) that transfers mannosyl-phosphate from GDP-mannose to high-mannose N-glycans, producing mono- and bis-mannosyl-phosphorylated glycans; the activity is demonstrated in vitro for recombinant soluble MNN14 and is Mn2+-dependent. In vivo MNN14 acts in N-glycan mannosylphosphorylation partially redundantly with its paralog MNN4.</h3>
+                <span class="vote-buttons" data-g="P40355" data-a="FUNCTION: Golgi-membrane mannosylphosphate transferase (mann..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000031" target="_blank" class="term-link">
+                            mannosylphosphate transferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006491" target="_blank" class="term-link">
+                                N-glycan processing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                Golgi membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                                PMID:33144549
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">in vitro mannosyl-phosphorylation of high-mannose type N-glycans that utilizes a recombinant Mnn14 protein</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" target="_blank" class="term-link">
+                                PMID:28101612
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">essential for N-glycan mannosylphosphorylation</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" target="_blank" class="term-link">
+                            PMID:28101612
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Abolishment of N-glycan mannosylphosphorylation in glyco-engineered Saccharomyces cerevisiae by double disruption of MNN4 and MNN14 genes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33144549" target="_blank" class="term-link">
+                            PMID:33144549
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In Vitro N-Glycan Mannosyl-Phosphorylation of a Therapeutic Enzyme by Using Recombinant Mnn14 Produced from Pichia pastoris.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12509465" target="_blank" class="term-link">
+                            PMID:12509465
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The transcription factor Rim101p governs ion tolerance and cell differentiation by direct repression of the regulatory genes NRG1 and SMP1 in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9459307" target="_blank" class="term-link">
+                            PMID:9459307
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mannosylphosphate transfer to cell wall mannan is regulated by the transcriptional level of the MNN4 gene in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:P40355
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MNN14 - Mannosyltransferase regulator 14 - Saccharomyces cerevisiae</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:P36044
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MNN4 - Protein MNN4 - Saccharomyces cerevisiae</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Given that MNN14 has intrinsic mannosylphosphate transferase activity in vitro while MNN4 is curated as a regulator of Mnn6/Ktr6, how are catalysis and regulation partitioned between MNN14 and MNN4 in vivo?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40355" data-a="Q: Given that MNN14 has intrinsic mannosylphosphate t..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the conserved DXD motif of MNN14 support catalysis, and is it required for MNN14 function in vivo?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40355" data-a="Q: Does the conserved DXD motif of MNN14 support cata..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Introduce DXD-motif catalytic point mutations into chromosomal MNN14 (and MNN4) and score the N-glycan mannosylphosphate profile in single and double mutants; complement mnn4 mnn14 double deletions with wild-type versus DXD-mutant alleles; and test whether MNN14/MNN4 stimulate purified Mnn6/Ktr6 activity in a reconstituted reaction.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The DXD motif is required for the in-vivo mannosylphosphate transferase activity of MNN14, and MNN14 contributes catalysis (not only regulation) to cellular mannosylphosphorylation.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function / reconstitution</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40355" data-a="EXPERIMENT: Introduce DXD-motif catalytic point mutations into..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform quantitative N-glycan and mannan structural analysis (mass spectrometry) of cell-wall mannoproteins and a secreted reporter glycoprotein from wild-type, mnn4, mnn14, and mnn4 mnn14 strains to map which mannosylphosphate positions depend on each paralog.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MNN14 and MNN4 act on distinct acceptor positions or substrate classes, explaining their partial redundancy.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative glycomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40355" data-a="EXPERIMENT: Perform quantitative N-glycan and mannan structura..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The in-vivo division of labour between MNN14 and its paralog MNN4 is unresolved. MNN14 has intrinsic mannosylphosphate transferase activity in vitro, yet MNN4 is curated as a positive regulator (enzyme activator) of the Mnn6/Ktr6 mannosylphosphate transferase, not a catalyst. It is unknown whether, in the cell, MNN14 acts primarily as a catalyst, MNN4 primarily as a regulator, and how the two models are reconciled for two closely related paralogs.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: recombinant soluble MNN14 catalyzes mannosyl-phosphate transfer from GDP-mannose to high-mannose N-glycans in vitro (Mn2+-dependent), so MNN14 has intrinsic transferase activity (GO:0000031); and genetically both MNN4 and MNN14 are required for full N-glycan mannosylphosphorylation. Also established, classically, is that Mnn6/Ktr6 (KRE2/MNT1 family) is a mannosylphosphate transferase and that MNN4 is a positive regulator whose transcript/protein level is rate-limiting; MNN4&#39;s curated molecular function is enzyme activator activity (GO:0008047).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifying whether MNN14 (and MNN4) contribute catalysis, regulation, or both in vivo would resolve an apparent contradiction between the in-vitro enzymology and the classical regulator model, and would sharpen the mannosylphosphorylation pathway model that underpins yeast glyco-engineering.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In-vivo structure-function analysis (DXD-motif catalytic mutants of MNN14 and MNN4 assayed for the glycan phenotype), reconstitution tests of whether MNN14/MNN4 stimulate Mnn6/Ktr6, and quantitative comparison of the catalytic contribution of each paralog in single and double mutants.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the main MPEs in Saccharomyces cerevisiae"</em> — PMID:33144549</li>
+
+                <li><em>"Mannosylphosphate transfer to cell wall mannan is regulated by the transcriptional level of the MNN4 gene"</em> — PMID:9459307</li>
+
+                <li><em>"partially redundant function with MNN4"</em> — UniProt:P40355</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The acceptor-position specificity of MNN14 in vivo is unknown: which mannose residues/positions on N-linked (and possibly O-linked) glycans MNN14 phosphorylates in the cell, and whether MNN4 and MNN14 act on the same or different positions.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In vitro, MNN14 mannosyl-phosphorylates high-mannose N-glycans (Man8GlcNAc2 and Man7-9GlcNAc2 on rhGAA), producing mono- and bis-mannosyl-phosphorylated products; genetically, N-glycan mannosylphosphorylation is abolished only when both MNN4 and MNN14 are deleted. The precise in-vivo acceptor positions and whether the two paralogs are position-selective have not been mapped.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Mapping acceptor positions would convert the pathway placement into a fully defined molecular reaction and explain why two paralogs are maintained.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structural mannan/N-glycan analysis (e.g. by mass spectrometry) of defined acceptors in wild-type versus mnn14 single and mnn4 mnn14 double mutants, combined with in-vitro reactions on candidate acceptor substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"essential for N-glycan mannosylphosphorylation"</em> — PMID:28101612</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The basis of the functional redundancy between MNN14 and MNN4, and any distinct or condition-specific role of MNN14, are unknown. There is no described standalone loss-of-function phenotype for an mnn14 single mutant beyond the residual mannosylphosphate profile.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: single deletion of either MNN4 or MNN14 leaves residual N-glycan mannosylphosphorylation, and only the double deletion eliminates it, so the two paralogs have overlapping but individually non-essential activities. MNN14 is a non-essential gene, and its expression is repressed by RIM101.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Understanding whether MNN14 and MNN4 differ in acceptor specificity, substrate class (N- vs O-linked; core vs outer chain), or expression context would explain why two paralogs are maintained and would sharpen the mannosylphosphorylation model relevant to glyco-engineering.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Comparative glycan profiling and genetic-interaction/expression analyses of mnn4 and mnn14 single mutants under varied growth conditions, and tests of RIM101-dependent regulation of MNN14 relative to MNN4.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Double disruption of MNN4 and MNN14 genes was enough to eliminate N-glycan"</em> — PMID:28101612</li>
+
+                <li><em>"partially redundant function with MNN4"</em> — UniProt:P40355</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MNN14-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40355" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: MNN14 (YJR061W) — A Mannosylphosphorylation Enzyme in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">18 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:28:54.050515</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="MNN14-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="MNN14-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-mnn14-yjr061w-a-mannosylphosphorylation-enzyme-in-saccharomyces-cerevisiae">Comprehensive Research Report: MNN14 (YJR061W) — A Mannosylphosphorylation Enzyme in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-geneprotein-identity-and-verification">1. Gene/Protein Identity and Verification</h2>
+<p>MNN14 (systematic name YJR061W; UniProt P40355) encodes a 935-amino acid protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The protein is annotated as "Mannosyltransferase regulator 14" and belongs to the MNN4/fukutin protein family. Gene disruption and complementation experiments have established MNN14 as one of the main mannosylphosphorylation enzymes (MPEs) in <em>S. cerevisiae</em> (kang2021invitronglycan pages 2-3, kang2021invitronglycan pages 1-2). The gene was definitively characterized in the study by Kim et al. (2017, <em>Appl. Microbiol. Biotechnol.</em> 101:2979–2989), which demonstrated that double disruption of <em>MNN4</em> and <em>MNN14</em> abolished N-glycan mannosylphosphorylation in glyco-engineered <em>S. cerevisiae</em> (kang2021invitronglycan pages 7-8).</p>
+<h2 id="2-protein-structure-and-domain-architecture">2. Protein Structure and Domain Architecture</h2>
+<p>Mnn14 is a type II membrane protein containing two principal functional regions (kang2021invitronglycan pages 3-5):</p>
+<ul>
+<li><strong>Transmembrane (TM) domain</strong> (residues 24–46): A single-pass transmembrane segment characteristic of Golgi-resident glycosyltransferases. This domain anchors the protein in the Golgi membrane, with a short N-terminal cytoplasmic tail and a large C-terminal lumenal catalytic region.</li>
+<li><strong>LicD domain</strong> (residues 470–720): The catalytic domain belonging to the nucleotidyltransferase fold protein family (Pfam PF04991). This domain is the hallmark of the fukutin/MNN4 family and is responsible for the phosphoryl-ligand transfer activity.</li>
+</ul>
+<p>The fukutin family is defined by a conserved motif with the sequence G[TS]hhGhhx₄hhxaxxDxD, where 'h' denotes hydrophobic residues and 'a' aromatic residues (harnett2010howdonematodes pages 2-4). The characteristic DxD motif and a distal aspartic acid residue are predicted to coordinate a divalent cation, consistent with the experimentally demonstrated requirement for Mn²⁺ in Mnn14 catalysis (harnett2010howdonematodes pages 2-4, kang2021invitronglycan pages 2-3). On SDS-PAGE, the recombinant soluble form of Mnn14 (rMnn14₇₇₋₉₃₅) migrates at approximately 100 kDa (kang2021invitronglycan pages 3-5).</p>
+<p>The following table summarizes the key properties of MNN14:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+<th>Evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>MNN14</strong>; ordered locus <strong>YJR061W</strong></td>
+<td>(kang2021invitronglycan pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P40355</strong></td>
+<td>(kang2021invitronglycan pages 1-2)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Saccharomyces cerevisiae</strong> (baker's yeast)</td>
+<td>(kang2021invitronglycan pages 2-3, kang2021invitronglycan pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein length</td>
+<td><strong>935 aa</strong></td>
+<td>(kang2021invitronglycan pages 3-5)</td>
+</tr>
+<tr>
+<td>Apparent molecular weight</td>
+<td>Recombinant soluble Mnn14 was detected at <strong>~100 kDa by SDS-PAGE</strong></td>
+<td>(kang2021invitronglycan pages 3-5)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td>Member of the <strong>MNN4/fukutin-related phospho-ligand transferase family</strong>; MNN4 is the close paralog in yeast</td>
+<td>(pakhomova2026alterationsinprotein pages 2-3, harnett2010howdonematodes pages 2-4)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td><strong>Type II membrane protein</strong> with <strong>transmembrane domain residues 24–46</strong> and <strong>LicD domain residues 470–720</strong></td>
+<td>(kang2021invitronglycan pages 3-5)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Golgi apparatus</strong>; normally a <strong>Golgi-resident type II membrane protein</strong></td>
+<td>(kang2021invitronglycan pages 3-5)</td>
+</tr>
+<tr>
+<td>Enzymatic activity</td>
+<td><strong>Mannosylphosphorylation enzyme / mannosylphosphotransferase</strong> that converts Man8GlcNAc2 to mono- and bis-mannosyl-phosphorylated products</td>
+<td>(kang2021invitronglycan pages 3-5, kang2021invitronglycan pages 1-2)</td>
+</tr>
+<tr>
+<td>Donor substrate</td>
+<td><strong>GDP-mannose</strong></td>
+<td>(kang2021invitronglycan pages 2-3)</td>
+</tr>
+<tr>
+<td>Acceptor substrate</td>
+<td><strong>High-mannose type N-glycans</strong>, including <strong>Man8GlcNAc2</strong> and glycans on proteins such as <strong>Man7-9GlcNAc2</strong> on rhGAA</td>
+<td>(kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 3-5, kang2021invitronglycan pages 7-8)</td>
+</tr>
+<tr>
+<td>Metal ion requirement</td>
+<td>Requires <strong>Mn2+</strong> for optimal activity; consistent with a divalent-cation-dependent DxD-type phosphotransferase family</td>
+<td>(kang2021invitronglycan pages 2-3, harnett2010howdonematodes pages 2-4)</td>
+</tr>
+<tr>
+<td>Optimal pH</td>
+<td><strong>pH 7.5</strong></td>
+<td>(kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 3-5, kang2021invitronglycan pages 2-3)</td>
+</tr>
+<tr>
+<td>Optimal temperature</td>
+<td><strong>30°C</strong></td>
+<td>(kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 2-3)</td>
+</tr>
+<tr>
+<td>Biological function</td>
+<td>Adds <strong>mannosyl-phosphate</strong> to yeast glycoprotein glycans; this modification contributes negative charge to cell-surface mannoproteins and is thought to <strong>strengthen the yeast cell wall</strong></td>
+<td>(kang2021invitronglycan pages 7-8, pakhomova2026alterationsinprotein pages 2-3)</td>
+</tr>
+<tr>
+<td>Key paralog</td>
+<td><strong>MNN4</strong>; MNN14 is described as an <strong>MNN4 paralog</strong> in S. cerevisiae</td>
+<td>(pakhomova2026alterationsinprotein pages 2-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core biochemical, structural, and cellular properties of the yeast MNN14 (YJR061W) protein based on the available evidence. It is useful as a compact reference for its annotation, catalytic activity, localization, and pathway role.</em></p>
+<h2 id="3-enzymatic-activity-and-reaction-mechanism">3. Enzymatic Activity and Reaction Mechanism</h2>
+<h3 id="31-primary-function">3.1 Primary Function</h3>
+<p>Mnn14 functions as a mannosylphosphotransferase (mannosylphosphorylation enzyme, MPE). It catalyzes the transfer of mannosyl-phosphate from GDP-mannose (donor substrate) to mannose residues on high-mannose type N-glycans (acceptor substrate), creating mannose-1-phospho-6-mannose (ManP) phosphodiester linkages (kang2021invitronglycan pages 1-2, kang2021invitronglycan pages 3-5).</p>
+<blockquote>
+<p>Mnn14 is a Golgi-resident mannosylphosphorylation enzyme that transfers mannosyl-phosphate from GDP-mannose to mannose residues on high-mannose type N-glycans, generating mannose-1-phospho-6-mannose (ManP) modifications on glycoprotein N-glycans (kang2021invitronglycan pages 3-5, kang2021invitronglycan pages 2-3)</p>
+<p>In vitro, recombinant Mnn14 converts Man8GlcNAc2 into both mono-mannosyl-phosphorylated ManP-Man8GlcNAc2 and bis-mannosyl-phosphorylated Man2P2-Man8GlcNAc2 products, showing that the enzyme can install one or two phosphomannose caps on suitable high-mannose acceptors (kang2021invitronglycan pages 3-5)</p>
+<p>The enzyme also efficiently modifies protein-linked high-mannose glycans such as Man7-9GlcNAc2 on recombinant human acid α-glucosidase, and the dominant products can be bis-mannosyl-phosphorylated under optimized conditions (kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 7-8)</p>
+<p>Catalysis requires GDP-mannose as the donor substrate and Mn2+ as an activating divalent cation, with reported optimal assay conditions around pH 7.5 and 30°C (kang2021invitronglycan pages 2-3)</p>
+<p>Available evidence further indicates that a minimal acceptor requirement is the presence of at least one α(1,2)-linked mannose outside the phosphorylation site, helping explain Mnn14 selectivity for high-mannose yeast-type N-glycans (kang2021invitronglycan pages 7-8)</p>
+</blockquote>
+<p><em>Blockquote: This blockquote summarizes the core enzymatic activity of yeast Mnn14, including donor and acceptor specificity, reaction products, and catalytic requirements. It is useful as a concise functional annotation of the protein’s primary biochemical role.</em></p>
+<h3 id="32-substrate-specificity">3.2 Substrate Specificity</h3>
+<p>The enzyme acts on high-mannose type N-glycans, with Man₈GlcNAc₂ serving as a well-characterized substrate. It also efficiently modifies Man₇₋₉GlcNAc₂ glycans attached to proteins (kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 7-8). The minimal substrate requirement for the enzyme is the presence of at least one α(1,2)-linked mannose residue outside the mannosyl-phosphorylation site (kang2021invitronglycan pages 7-8). In addition to N-linked glycans, MPEs in yeast are reported to add mannosyl-phosphate to O-mannose residues on glycoproteins (kang2021invitronglycan pages 7-8).</p>
+<h3 id="33-reaction-products">3.3 Reaction Products</h3>
+<p>From the Man₈GlcNAc₂ substrate, Mnn14 produces both mono-mannosyl-phosphorylated (ManP-Man₈GlcNAc₂) and bis-mannosyl-phosphorylated (Man₂P₂-Man₈GlcNAc₂) glycan products (kang2021invitronglycan pages 3-5). When applied to the high-mannose N-glycans on recombinant human lysosomal alpha-glucosidase (rhGAA) under optimized conditions, 74% of the glycans were converted to bis-mannosyl-phosphorylated forms (kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 7-8).</p>
+<h3 id="34-optimal-reaction-conditions">3.4 Optimal Reaction Conditions</h3>
+<p>In vitro characterization of a recombinant soluble form (rMnn14₇₇₋₉₃₅) established the following optimal conditions: pH 7.5 in Tris-HCl buffer, 30°C, and 10 mM MnCl₂ with 2 mM GDP-mannose as the donor substrate (kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 2-3). The buffer compound has a stronger effect on activity than pH itself; sodium phosphate buffer dramatically reduces activity at the same pH, possibly due to competition with the phosphotransferase reaction (kang2021invitronglycan pages 7-8, kang2021invitronglycan pages 3-5). The enzyme is absolutely dependent on divalent cations, with Mn²⁺ being far superior to other ions tested (kang2021invitronglycan pages 2-3).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>Mnn14 is a Golgi-resident enzyme. As a type II membrane protein with a single transmembrane segment (residues 24–46), it is anchored in the Golgi membrane with its catalytic LicD domain facing the Golgi lumen (kang2021invitronglycan pages 3-5). This localization is consistent with the broader N-glycan processing pathway in <em>S. cerevisiae</em>, in which sequential modifications of N-glycans occur as glycoproteins transit through different Golgi compartments: α-1,6-mannosylation in the cis-Golgi, α-1,2-mannosylation in the medial compartment, and α-1,3-mannosylation and phosphomannosylation in later compartments (fabre2014mannosylationoffungal pages 2-3).</p>
+<h2 id="5-biological-pathway-and-functional-context">5. Biological Pathway and Functional Context</h2>
+<h3 id="51-n-glycan-mannosylphosphate-modification-pathway">5.1 N-Glycan Mannosylphosphate Modification Pathway</h3>
+<p>In <em>S. cerevisiae</em>, the modification of N-linked and O-linked glycans with mannosylphosphate is an important post-translational modification. This process creates negatively charged phosphodiester-linked mannose residues on cell wall mannoproteins, which contributes to the overall negative charge of the yeast cell surface and can be detected by Alcian blue staining (pakhomova2026alterationsinprotein pages 2-3). The mannosylphosphate modification is thought to strengthen the cell wall of the yeast (kang2021invitronglycan pages 7-8).</p>
+<h3 id="52-relationship-to-mnn4-and-mnn6">5.2 Relationship to MNN4 and MNN6</h3>
+<p>MNN14 is a paralog of MNN4 in the <em>S. cerevisiae</em> genome (pakhomova2026alterationsinprotein pages 2-3). Both belong to the fukutin protein family and presumably catalyze mannosylphosphate transfer from GDP-mannose (pakhomova2026alterationsinprotein pages 2-3). In the classical model of yeast mannosylphosphorylation, MNN4 was described as a putative positive regulator of MNN6 (also known as KTR6), which was identified as the actual mannosylphosphate transferase (jigami2008yeastglycobiologyand pages 4-6). MNN6 belongs to the KRE2/MNT1 family and is involved in mannosylphosphate transfer to α-1,2-mannose side chains (fabre2014mannosylationoffungal pages 7-7). However, more recent biochemical studies have demonstrated that Mnn14 itself possesses strong, direct mannosylphosphorylation activity, establishing it as a bona fide MPE rather than merely a regulator (kang2021invitronglycan pages 1-2, kang2021invitronglycan pages 3-5, kang2021invitronglycan pages 2-3).</p>
+<p>Despite both MNN4 and MNN14 being paralogs, MNN4 appears to play the dominant role in mannosylphosphorylation under normal conditions: disruption of MNN4 alone is sufficient to abolish Alcian blue staining, suggesting that MNN14 may play a minor or partially redundant role in vivo (pakhomova2026alterationsinprotein pages 2-3). Nevertheless, double disruption of <em>MNN4</em> and <em>MNN14</em> was required to completely abolish N-glycan mannosylphosphorylation in glyco-engineered strains, confirming that MNN14 contributes to this modification (kang2021invitronglycan pages 7-8).</p>
+<h3 id="53-evolutionary-and-structural-context">5.3 Evolutionary and Structural Context</h3>
+<p>The fukutin/LicD protein family to which MNN14 belongs encompasses a diverse group of phosphoryl-ligand transferases found across bacteria, fungi, and metazoans. In bacteria, LicD gene products (e.g., in <em>Streptococcus pneumoniae</em> and <em>Haemophilus influenzae</em>) transfer phosphorylcholine to carbohydrates on teichoic acid and lipopolysaccharide, respectively (harnett2010howdonematodes pages 2-4). In mammals, the fukutin (FKTN) and fukutin-related protein (FKRP) are involved in the post-translational modification of α-dystroglycan, and mutations in these genes cause forms of muscular dystrophy (dystroglycanopathies) (yoshidamoriguchi2015matriglycananovel pages 7-9). The conservation of the DxD motif and the divalent-cation-dependent phosphotransferase mechanism across these diverse family members supports the classification of MNN14 as a phosphoryl-ligand transferase (harnett2010howdonematodes pages 2-4).</p>
+<h2 id="6-biotechnological-applications">6. Biotechnological Applications</h2>
+<p>A major area of applied interest for MNN14 is its use in glyco-engineering strategies for the production of therapeutic enzymes for lysosomal storage diseases (LSDs). Enzyme replacement therapy for LSDs requires recombinant enzymes containing mannose-6-phosphate (M6P) glycans for efficient cellular uptake via M6P receptors and lysosomal targeting (kang2021invitronglycan pages 1-2). The mannosyl-phosphorylated glycans produced by Mnn14 can be converted to M6P glycans through subsequent in vitro uncapping (removal of the outer mannose) and trimming reactions (kang2021invitronglycan pages 2-3, kang2021invitronglycan pages 1-2).</p>
+<p>A recombinant soluble form of Mnn14 (rMnn14₇₇₋₉₃₅), engineered by deleting the N-terminal 76 amino acids including the transmembrane domain and part of the stem region, was successfully produced as a secreted protein in <em>Pichia pastoris</em> and demonstrated high mannosylphosphorylation activity (kang2021invitronglycan pages 1-2, kang2021invitronglycan pages 3-5). This recombinant enzyme was used to mannosyl-phosphorylate rhGAA with 74% conversion efficiency, predominantly yielding bis-mannosyl-phosphorylated glycans that can be converted to bis-M6P glycans with superior lysosomal targeting capability (kang2021invitronglycan pages 5-7, kang2021invitronglycan pages 7-8). This in vitro approach offers advantages over mammalian GlcNAc-1-phosphotransferase because Mnn14 is a single-chain enzyme (rather than a multi-subunit complex) and does not discriminate between lysosomal and non-lysosomal protein substrates (kang2021invitronglycan pages 7-8).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>MNN14 (YJR061W) encodes a Golgi-resident, type II membrane mannosylphosphotransferase in <em>S. cerevisiae</em> that catalyzes the transfer of mannosyl-phosphate from GDP-mannose to high-mannose type N-glycans. The enzyme contains a LicD domain characteristic of the fukutin/MNN4 family of phosphoryl-ligand transferases, requires Mn²⁺ for catalysis, and produces both mono- and bis-mannosyl-phosphorylated glycan products. Its biological function is to add negatively charged phosphomannose modifications to cell wall glycoproteins, contributing to cell wall integrity. MNN14 is a paralog of MNN4 and plays a contributory role in the overall mannosylphosphorylation capacity of <em>S. cerevisiae</em>. Biotechnologically, recombinant Mnn14 has been developed as a tool for in vitro generation of mannose-6-phosphate glycans on therapeutic enzymes for the treatment of lysosomal storage diseases.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(kang2021invitronglycan pages 2-3): Ji-Yeon Kang, Hong-Yeol Choi, Dong-Il Kim, Ohsuk Kwon, and Doo-Byoung Oh. In vitro <i>n</i>-glycan mannosyl-phosphorylation of a therapeutic enzyme by using recombinant mnn14 produced from <i>pichia pastoris</i>. Journal of Microbiology and Biotechnology, 31:163-170, Jan 2021. URL: https://doi.org/10.4014/jmb.2010.10033, doi:10.4014/jmb.2010.10033. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kang2021invitronglycan pages 1-2): Ji-Yeon Kang, Hong-Yeol Choi, Dong-Il Kim, Ohsuk Kwon, and Doo-Byoung Oh. In vitro <i>n</i>-glycan mannosyl-phosphorylation of a therapeutic enzyme by using recombinant mnn14 produced from <i>pichia pastoris</i>. Journal of Microbiology and Biotechnology, 31:163-170, Jan 2021. URL: https://doi.org/10.4014/jmb.2010.10033, doi:10.4014/jmb.2010.10033. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kang2021invitronglycan pages 7-8): Ji-Yeon Kang, Hong-Yeol Choi, Dong-Il Kim, Ohsuk Kwon, and Doo-Byoung Oh. In vitro <i>n</i>-glycan mannosyl-phosphorylation of a therapeutic enzyme by using recombinant mnn14 produced from <i>pichia pastoris</i>. Journal of Microbiology and Biotechnology, 31:163-170, Jan 2021. URL: https://doi.org/10.4014/jmb.2010.10033, doi:10.4014/jmb.2010.10033. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kang2021invitronglycan pages 3-5): Ji-Yeon Kang, Hong-Yeol Choi, Dong-Il Kim, Ohsuk Kwon, and Doo-Byoung Oh. In vitro <i>n</i>-glycan mannosyl-phosphorylation of a therapeutic enzyme by using recombinant mnn14 produced from <i>pichia pastoris</i>. Journal of Microbiology and Biotechnology, 31:163-170, Jan 2021. URL: https://doi.org/10.4014/jmb.2010.10033, doi:10.4014/jmb.2010.10033. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(harnett2010howdonematodes pages 2-4): William Harnett, Justyna Rzepecka, and Katrina M. Houston. How do nematodes transfer phosphorylcholine to carbohydrates? Trends in parasitology, 26 3:114-8, Mar 2010. URL: https://doi.org/10.1016/j.pt.2009.12.003, doi:10.1016/j.pt.2009.12.003. This article has 25 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pakhomova2026alterationsinprotein pages 2-3): Maria Pakhomova, Azamat Karginov, Maria Kulakova, Polina Vladimirova, Olga Mitkevich, and Michael Agaphonov. Alterations in protein n-glycosylation confer vanadate resistance in ogataea polymorpha mutants defective in phosphomannosylation. Frontiers in Molecular Biosciences, Jan 2026. URL: https://doi.org/10.3389/fmolb.2026.1741711, doi:10.3389/fmolb.2026.1741711. This article has 0 citations.</p>
+</li>
+<li>
+<p>(kang2021invitronglycan pages 5-7): Ji-Yeon Kang, Hong-Yeol Choi, Dong-Il Kim, Ohsuk Kwon, and Doo-Byoung Oh. In vitro <i>n</i>-glycan mannosyl-phosphorylation of a therapeutic enzyme by using recombinant mnn14 produced from <i>pichia pastoris</i>. Journal of Microbiology and Biotechnology, 31:163-170, Jan 2021. URL: https://doi.org/10.4014/jmb.2010.10033, doi:10.4014/jmb.2010.10033. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fabre2014mannosylationoffungal pages 2-3): Emeline Fabre, Thomas Hurtaux, and Chantal Fradin. Mannosylation of fungal glycoconjugates in the golgi apparatus. Current opinion in microbiology, 20:103-10, Aug 2014. URL: https://doi.org/10.1016/j.mib.2014.05.008, doi:10.1016/j.mib.2014.05.008. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jigami2008yeastglycobiologyand pages 4-6): Yoshifumi JIGAMI. Yeast glycobiology and its application. Bioscience, Biotechnology, and Biochemistry, 72:637-648, Mar 2008. URL: https://doi.org/10.1271/bbb.70725, doi:10.1271/bbb.70725. This article has 54 citations.</p>
+</li>
+<li>
+<p>(fabre2014mannosylationoffungal pages 7-7): Emeline Fabre, Thomas Hurtaux, and Chantal Fradin. Mannosylation of fungal glycoconjugates in the golgi apparatus. Current opinion in microbiology, 20:103-10, Aug 2014. URL: https://doi.org/10.1016/j.mib.2014.05.008, doi:10.1016/j.mib.2014.05.008. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yoshidamoriguchi2015matriglycananovel pages 7-9): T. Yoshida-Moriguchi and K. P. Campbell. Matriglycan: a novel polysaccharide that links dystroglycan to the basement membrane. Glycobiology, 25:702-713, Apr 2015. URL: https://doi.org/10.1093/glycob/cwv021, doi:10.1093/glycob/cwv021. This article has 262 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="MNN14-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="MNN14-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kang2021invitronglycan pages 7-8</li>
+<li>kang2021invitronglycan pages 3-5</li>
+<li>harnett2010howdonematodes pages 2-4</li>
+<li>kang2021invitronglycan pages 1-2</li>
+<li>kang2021invitronglycan pages 2-3</li>
+<li>pakhomova2026alterationsinprotein pages 2-3</li>
+<li>fabre2014mannosylationoffungal pages 2-3</li>
+<li>jigami2008yeastglycobiologyand pages 4-6</li>
+<li>fabre2014mannosylationoffungal pages 7-7</li>
+<li>yoshidamoriguchi2015matriglycananovel pages 7-9</li>
+<li>kang2021invitronglycan pages 5-7</li>
+<li>TS</li>
+<li>https://doi.org/10.4014/jmb.2010.10033,</li>
+<li>https://doi.org/10.1016/j.pt.2009.12.003,</li>
+<li>https://doi.org/10.3389/fmolb.2026.1741711,</li>
+<li>https://doi.org/10.1016/j.mib.2014.05.008,</li>
+<li>https://doi.org/10.1271/bbb.70725,</li>
+<li>https://doi.org/10.1093/glycob/cwv021,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MNN14-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40355" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mnn14-yjr061w-p40355-curation-notes">MNN14 (YJR061W, P40355) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> MNN14.<br />
+Understudied ("dark") gene. Primary deliverable is a rigorous knowledge_gaps section.<br />
+Every assertion below carries inline provenance.</p>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li>UniProt: <strong>P40355</strong> (MNN14_YEAST), 935 aa, MW 108,427.</li>
+<li>SGD: S000003822; systematic/ordered-locus name <strong>YJR061W</strong>; ORF name J1736.</li>
+<li>RefSeq NP_012595.1.</li>
+<li>Protein name in UniProt: "Mannosyltransferase regulator 14"<br />
+  [ECO:0000303|PubMed:28101612]. The <em>name</em> was coined in the 2017 glyco-engineering<br />
+  paper; it does NOT itself establish a mannosyltransferase catalytic activity.</li>
+</ul>
+<h2 id="family-domains-important-attribution-point">Family / domains — IMPORTANT attribution point</h2>
+<p>The task brief anticipated a GT15/MNN1 alpha-1,3-mannosyltransferase. <strong>This is not what<br />
+the record shows.</strong> MNN14 is NOT in the MNN1/GT15 family.</p>
+<ul>
+<li>UniProt SIMILARITY: "Belongs to the <strong>MNN4 family</strong>." [UniProt P40355, "SIMILARITY: Belongs to the MNN4 family."]</li>
+<li>Pfam: <strong>PF04991 (LicD)</strong> — a nucleotidyl-/phosphotransferase-type domain<br />
+  [UniProt P40355, "Pfam; PF04991; LicD; 1."].</li>
+<li>InterPro: <strong>IPR007074</strong> (LicD/FKTN/FKRP nucleotidyltransferase) and<br />
+<strong>IPR009644</strong> (FKTN/MNN4/W02B3.4-1)<br />
+  [UniProt P40355, "InterPro; IPR007074; LicD/FKTN/FKRP_NTP_transf." and<br />
+  "InterPro; IPR009644; FKTN/MNN4/W02B3.4-1."].</li>
+<li>PANTHER: PTHR15407 (FUKUTIN-RELATED)<br />
+  [UniProt P40355, "PANTHER; PTHR15407; FUKUTIN-RELATED; 1."].</li>
+</ul>
+<p>So the fold is the LicD/fukutin-related nucleotidyltransferase superfamily, shared by MNN4<br />
+and the metazoan fukutin (FKTN)/FKRP ribitol-phosphate transferases — a phosphotransferase-type<br />
+architecture, distinct from the KRE2/MNT1/GT15 mannosyltransferases.</p>
+<h3 id="topology-type-ii-golgi-membrane-protein">Topology (type II Golgi membrane protein)</h3>
+<ul>
+<li>TOPO_DOM 1..21 Cytoplasmic; TRANSMEM 22..42 (signal-anchor, type II); TOPO_DOM 43..935 Lumenal.<br />
+  [UniProt P40355 FT lines]. Consistent with a Golgi-lumen-acting glycan-modifying protein.</li>
+<li>KW: Golgi apparatus; Membrane; Signal-anchor; Transmembrane.</li>
+</ul>
+<h3 id="dxd-motif-catalytic-motif-reasoning">DXD motif (catalytic-motif reasoning)</h3>
+<ul>
+<li>MOTIF 498..500 "DXD" [ECO:0000250|UniProtKB:P36044] — inferred by similarity to MNN4 (P36044).</li>
+<li>UniProt DOMAIN comment: "The conserved DXD motif is essential for the function, which could<br />
+  be an indication that MNN14 has transferase activity." [UniProt P40355,<br />
+  "The conserved DXD motif is essential for the function, which could be an indication that MNN14 has transferase activity."]</li>
+<li>DXD motifs coordinate a divalent cation and the nucleotide-sugar in many GT-A / phosphotransferase<br />
+  enzymes. Its presence is <em>consistent with</em>, but does NOT prove, a catalytic transferase role for<br />
+  MNN14 — see knowledge gap. The same wording is used for MNN4, whose curated MF is <em>regulator</em>,<br />
+  not transferase (below).</li>
+</ul>
+<h2 id="function-known-vs-not-known">Function — KNOWN vs NOT known</h2>
+<h3 id="known-experimentally-pmid28101612-abstract-only-in-cache-igi-in-goa">KNOWN (experimentally, PMID:28101612 — abstract-only in cache; IGI in GOA)</h3>
+<ul>
+<li>MNN14 is an <strong>MNN4 paralog</strong> required for full <strong>N-glycan mannosylphosphorylation</strong> in<br />
+<em>S. cerevisiae</em>. <a href="https://pubmed.ncbi.nlm.nih.gov/28101612" title="MNN14 gene, an MNN4 paralog with unknown function, is essential   for N-glycan mannosylphosphorylation">PMID:28101612</a></li>
+<li><strong>Partial redundancy with MNN4:</strong> single deletions leave residual mannosylphosphate; the<br />
+<strong>MNN4+MNN14 double deletion</strong> abolishes N-glycan mannosylphosphorylation.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28101612" title="Double disruption of MNN4 and MNN14 genes was enough to eliminate N-glycan   mannosylphosphorylation.">PMID:28101612</a></li>
+<li>Biotechnology relevance: eliminating mannosylphosphate (an och1Δmnn1Δmnn4Δmnn14Δ strain) is a<br />
+  step toward human-compatible glycoproteins in yeast. [PMID:28101612 abstract]</li>
+<li>INDUCTION: expression is repressed by RIM101 [UniProt P40355, "Expression is repressed by RIM101."],<br />
+  from PMID:12509465 (Lamb &amp; Mitchell 2003; Rim101 represses NRG1/SMP1). This is a regulatory-network<br />
+  observation, not a molecular function.</li>
+<li>Localization: <strong>Golgi apparatus membrane</strong> (ECO:0000305; by SubCell + topology; IEA in GOA).<br />
+  [UniProt P40355, "SUBCELLULAR LOCATION: Golgi apparatus membrane"]</li>
+</ul>
+<h3 id="not-known-the-real-gaps">NOT known (the real gaps)</h3>
+<ul>
+<li><strong>Molecular function is undetermined.</strong> MNN14 has NO curated MF term other than the ND root.<br />
+  The two live hypotheses, neither established for MNN14:</li>
+<li><strong>Enzyme regulator/activator</strong> of the mannosylphosphate transferase — the role its paralog<br />
+     MNN4 is assigned. In yeast the actual catalytic <strong>mannosylphosphate transferase is<br />
+     Mnn6/Ktr6</strong> (KRE2/MNT1 family), and <strong>MNN4 is its positive regulator</strong> whose amount is<br />
+     rate-limiting [Odani et al. 1997, PMID:9459307 "Mannosylphosphate transfer to cell wall<br />
+     mannan is regulated by the transcriptional level of the MNN4 gene"; Wang et al., MNN6=KTR6<br />
+     is the mannosylphosphate transferase]. MNN4's curated MF is <strong>enzyme activator activity<br />
+     (GO:0008047, IMP:SGD)</strong>; UniProt (P36044) states "While MNN4 seems to have a regulatory role<br />
+     in N-glycan mannosylphosphorylation, a transferase activity of MNN4 cannot be ruled out."</li>
+<li><strong>Transferase activity</strong> of its own — suggested only by the conserved DXD motif (by similarity).</li>
+<li><strong>Direct acceptor substrate / exact reaction of MNN14 is unknown</strong> (which mannan/glycan position;<br />
+  whether it transfers mannose-1-phosphate at all vs. regulates the enzyme that does).</li>
+<li><strong>Basis of the MNN4/MNN14 redundancy</strong> is unknown (paralog sub-/neo-functionalization;<br />
+  condition-, substrate-, or acceptor-position specificity).</li>
+<li><strong>Standalone loss-of-function phenotype</strong> beyond the glyco-profile is uncharacterized; MNN14 is<br />
+  non-essential and there is no described growth/stress phenotype for mnn14Δ alone.</li>
+</ul>
+<h2 id="goa-annotations-to-review-5">GOA annotations to review (5)</h2>
+<ol>
+<li>GO:0009101 glycoprotein biosynthetic process — IBA (GO_REF:0000033); IBA panel includes<br />
+   SGD:S000001684 (MNN4). BP is correct (mannosylphosphorylation is glycoprotein biosynthesis);<br />
+   generic but defensible. Not the <em>most</em> specific but IBA-appropriate. -&gt; KEEP_AS_NON_CORE / ACCEPT.</li>
+<li>GO:0000139 Golgi membrane — IEA (SubCell). Supported by topology + SubCell. -&gt; ACCEPT.</li>
+<li>GO:0006491 N-glycan processing — IGI (PMID:28101612), with SGD:S000001684 (MNN4). This is the<br />
+   experimental genetic-interaction annotation matching the double-deletion result. -&gt; ACCEPT (core BP).</li>
+<li>GO:0003674 molecular_function — ND (root). MF genuinely unknown. -&gt; KEEP_AS_NON_CORE.</li>
+<li>GO:0005575 cellular_component — ND (root). Superseded by Golgi membrane; but ND placeholder. -&gt; KEEP_AS_NON_CORE.</li>
+</ol>
+<p>Note: GO:0006491 "N-glycan processing" is defined as conversion of N-linked glycan to mature form by<br />
+glycosidases/glycosyltransferases [OLS GO:0006491]. Mannosylphosphorylation is an N-glycan<br />
+outer-chain maturation/modification, so this is an appropriate (if slightly generic) BP.</p>
+<h2 id="candidate-mf-terms-considered-not-asserted-as-mnn14-core">Candidate MF terms considered (NOT asserted as MNN14 core)</h2>
+<ul>
+<li>GO:0000031 mannosylphosphate transferase activity — this is the <em>catalytic</em> activity of Mnn6/Ktr6;<br />
+  assigning it to MNN14 would be over-annotation because (a) MNN14's own catalytic activity is unproven<br />
+  and (b) its paralog MNN4 is curated as a <em>regulator</em>, not a transferase. Listed only in knowledge_gaps.</li>
+<li>GO:0008047 enzyme activator activity — the MF of the paralog MNN4 (IMP:SGD); a plausible-by-orthology<br />
+  hypothesis for MNN14 but not experimentally shown for MNN14. Listed only in knowledge_gaps.</li>
+</ul>
+<h2 id="references-gathered">References gathered</h2>
+<ul>
+<li>PMID:28101612 — Kim et al. 2017, Appl Microbiol Biotechnol. Primary experimental (abstract-only cache).<br />
+  The single functional paper directly on MNN14; source of IGI GO:0006491.</li>
+<li>PMID:12509465 — Lamb &amp; Mitchell 2003 (RIM101 represses NRG1/SMP1). Source of the INDUCTION note;<br />
+  MNN14 mentioned as a Rim101-repressed target. Secondary/regulatory context.</li>
+<li>PMID:9459307 — Odani et al. 1997, FEBS Lett. MNN4 = positive regulator of mannosylphosphorylation;<br />
+  establishes the MNN4-family regulator paradigm (background for the MF gap).</li>
+<li>UniProt:P40355 — domain/family/topology/DXD evidence.</li>
+<li>UniProt:P36044 — MNN4 paralog record (regulator MF; DXD ambiguity) for attribution.</li>
+</ul>
+<h2 id="web-verification-log">Web verification log</h2>
+<ul>
+<li>rest.uniprot.org P40355 (full record downloaded to MNN14-uniprot.txt): family=MNN4, Pfam LicD,<br />
+  DXD 498-500, type II Golgi, FUNCTION = "role in N-glycan mannosylphosphorylation... partially<br />
+  redundant with MNN4."</li>
+<li>rest.uniprot.org P36044 (MNN4): MF enzyme activator activity (IMP:SGD); "seems to have a<br />
+  regulatory role... transferase activity cannot be ruled out."</li>
+<li>WebSearch (Odani 1997 PMID:9459307; Wang MNN6=KTR6): MNN6/Ktr6 = the mannosylphosphate transferase;<br />
+  MNN4 = its positive regulator, Mnn4p amount rate-limiting.</li>
+<li>OLS: GO:0006491, GO:0009101, GO:0000031, GO:0008047 definitions confirmed.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P40355
+gene_symbol: MNN14
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  MNN14 (systematic name YJR061W) encodes a 935-residue single-pass type II
+  membrane protein of the Golgi apparatus in Saccharomyces cerevisiae. It is a
+  paralog of MNN4 and belongs to the MNN4 family within the
+  LicD/fukutin-related nucleotidyltransferase superfamily (Pfam PF04991 LicD;
+  InterPro IPR007074 and IPR009644; PANTHER PTHR15407 fukutin-related), a
+  divalent-cation-dependent phosphoryl-transferase fold distinct from the
+  KRE2/MNT1 (GT15) mannosyltransferases. MNN14 is a mannosylphosphorylation
+  enzyme: recombinant soluble MNN14 transfers mannosyl-phosphate from
+  GDP-mannose to high-mannose N-glycans (e.g. Man8GlcNAc2 and the Man7-9GlcNAc2
+  glycans of a therapeutic protein), producing mono- and bis-mannosyl-
+  phosphorylated glycans in an Mn2+-dependent reaction. It acts partially
+  redundantly with MNN4 in vivo: single deletions leave residual
+  mannosylphosphate, whereas simultaneous deletion of MNN4 and MNN14 abolishes
+  N-glycan mannosylphosphorylation. Mannosylphosphorylation adds
+  mannose-1-phosphate to the mannans of fungal glycoproteins, contributing
+  negative surface charge, and is fungal-specific, so loss of MNN4 plus MNN14 is
+  used in yeast glyco-engineering to make human-compatible glycoproteins. The
+  protein carries a conserved DXD motif (498-500) typical of divalent-cation-
+  dependent transferases. The in-vivo division of labour between the intrinsic
+  catalytic activity of MNN14 and MNN4 (curated as a regulator of the Mnn6/Ktr6
+  mannosylphosphate transferase), the acceptor-position specificity of MNN14,
+  and the basis of the MNN4/MNN14 redundancy remain to be resolved.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: PMID:28101612
+    title: Abolishment of N-glycan mannosylphosphorylation in glyco-engineered Saccharomyces cerevisiae by double disruption of MNN4 and MNN14 genes.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified primary research article (Kim et al. 2017, Appl Microbiol
+        Biotechnol; cached abstract-only, full_text_available: false). This is the
+        single functional study directly on MNN14 and the source of the SGD IGI
+        annotation to GO:0006491. It establishes, by genetic-interaction/
+        deletion analysis, that MNN14 (an MNN4 paralog) is required for full
+        N-glycan mannosylphosphorylation and that the MNN4+MNN14 double deletion
+        abolishes it. It does NOT assay a molecular activity for MNN14, so it does
+        not distinguish a transferase from a regulator role.
+  - id: PMID:33144549
+    title: In Vitro N-Glycan Mannosyl-Phosphorylation of a Therapeutic Enzyme by Using Recombinant Mnn14 Produced from Pichia pastoris.
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed/PMC-verified primary research (Kang et al. 2021, J Microbiol
+        Biotechnol; full text available, PMC9705852). This is the decisive
+        molecular-function paper: recombinant soluble MNN14 (rMnn14 77-935)
+        secreted from Pichia pastoris directly transfers mannosyl-phosphate from
+        GDP-mannose to high-mannose N-glycans (Man8GlcNAc2 and the Man7-9GlcNAc2
+        glycans of rhGAA), producing mono- and bis-mannosyl-phosphorylated
+        products, requires Mn2+, and is optimal at pH 7.5 / 30 C. It establishes
+        an intrinsic mannosylphosphate transferase (mannosylphosphorylation
+        enzyme, MPE) activity for MNN14 in vitro, and (with its companion Kim
+        et al. 2017) that MNN14 is a main MPE in S. cerevisiae. It does not
+        resolve the in-vivo division of labour between MNN14 and MNN4.
+  - id: PMID:12509465
+    title: The transcription factor Rim101p governs ion tolerance and cell differentiation by direct repression of the regulatory genes NRG1 and SMP1 in Saccharomyces cerevisiae.
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Lamb &amp; Mitchell 2003). Cited by UniProt as the source of
+        the INDUCTION statement that MNN14 expression is repressed by RIM101. This
+        is regulatory-network context, not a molecular function of MNN14; included
+        for completeness of the UniProt-cited literature.
+  - id: PMID:9459307
+    title: Mannosylphosphate transfer to cell wall mannan is regulated by the transcriptional level of the MNN4 gene in Saccharomyces cerevisiae.
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Odani et al. 1997, FEBS Lett). Not about MNN14 directly,
+        but load-bearing for the molecular-function reasoning: it establishes the
+        MNN4-family paradigm in which MNN4 is a positive regulator whose amount is
+        rate-limiting for mannosylphosphorylation, while the catalytic
+        mannosylphosphate transferase is a separate enzyme (Mnn6/Ktr6). This is
+        the basis for treating MNN14&#39;s own transferase-vs-regulator activity as an
+        open molecular-function gap rather than assigning it the transferase term.
+  - id: UniProt:P40355
+    title: MNN14 - Mannosyltransferase regulator 14 - Saccharomyces cerevisiae
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        UniProtKB reviewed entry (MNN14_YEAST), protein existence level 1. Source
+        of the domain/family/topology evidence used here: MNN4-family membership,
+        Pfam PF04991 (LicD)/InterPro IPR007074/IPR009644 nucleotidyltransferase
+        fold, single-pass type II Golgi membrane topology, and the conserved DXD
+        motif (498-500, by similarity to MNN4/P36044) whose functional
+        significance is explicitly hedged (&#34;could be an indication that MNN14 has
+        transferase activity&#34;).
+  - id: UniProt:P36044
+    title: MNN4 - Protein MNN4 - Saccharomyces cerevisiae
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        UniProtKB reviewed entry for the MNN4 paralog, used for cross-attribution.
+        MNN4&#39;s curated molecular function is enzyme activator activity (GO:0008047,
+        IMP:SGD) and UniProt states that while MNN4 has a regulatory role in
+        N-glycan mannosylphosphorylation, a transferase activity cannot be ruled
+        out. This regulator-vs-catalyst distinction relative to the intrinsic
+        in-vitro catalytic activity of the paralogous DXD-containing MNN14 is the
+        basis of the in-vivo division-of-labour knowledge gap.
+existing_annotations:
+  - term:
+      id: GO:0009101
+      label: glycoprotein biosynthetic process
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Phylogenetically inferred (IBA) biological-process annotation from the
+        MNN4-family tree, whose panel includes the paralog MNN4 (SGD:S000001684).
+        MNN14 acts in N-glycan mannosylphosphorylation, which adds
+        mannose-1-phosphate to glycoprotein-linked mannans and is part of
+        glycoprotein biosynthesis, so the BP is correct. It is more general than
+        the experimentally supported N-glycan-processing annotation below and is
+        retained as a valid but non-core parent process.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Correct but generic BP consistent with the gene&#39;s role; superseded for
+        specificity by the experimental GO:0006491 annotation. Retained per GO
+        conventions as a valid IBA inference.
+      supported_by:
+        - reference_id: PMID:28101612
+          supporting_text: &#34;essential for N-glycan mannosylphosphorylation&#34;
+  - term:
+      id: GO:0000139
+      label: Golgi membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Subcellular-location annotation supported by the UniProt SUBCELLULAR
+        LOCATION (Golgi apparatus membrane) and by the protein&#39;s single-pass type
+        II membrane topology (cytoplasmic 1-21; signal-anchor TM 22-42; lumenal
+        43-935). Golgi localization is expected for an enzyme/regulator acting on
+        outer-chain mannan maturation and is consistent with the MNN4 paralog.
+      action: ACCEPT
+      reason: &gt;-
+        Domain/topology- and SubCell-supported cellular component; the correct and
+        informative localization for this Golgi mannosylphosphorylation factor.
+      supported_by:
+        - reference_id: UniProt:P40355
+          supporting_text: &#34;Golgi apparatus membrane&#34;
+        - reference_id: UniProt:P40355
+          supporting_text: &#34;Signal-anchor for type II membrane protein&#34;
+  - term:
+      id: GO:0006491
+      label: N-glycan processing
+    evidence_type: IGI
+    original_reference_id: PMID:28101612
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Experimental (IGI) annotation curated by SGD from the genetic interaction
+        with MNN4 (with/from SGD:S000001684). Kim et al. 2017 showed that MNN14 is
+        required for full N-glycan mannosylphosphorylation and that the MNN4+MNN14
+        double deletion eliminates it, placing MNN14 in N-glycan outer-chain
+        maturation. GO:0006491 (conversion of N-linked glycan to a mature form by
+        glycosidases/glycosyltransferases) appropriately captures this outer-chain
+        modification step. This is the best-supported process annotation and the
+        core biological role.
+      action: ACCEPT
+      reason: &gt;-
+        Experimentally grounded (IGI) core biological process directly supported
+        by the double-deletion phenotype; the single defensible functional
+        placement for this otherwise dark gene.
+      supported_by:
+        - reference_id: PMID:28101612
+          supporting_text: &#34;essential for N-glycan mannosylphosphorylation&#34;
+        - reference_id: PMID:28101612
+          supporting_text: &#34;Double disruption of MNN4 and MNN14 genes was enough to eliminate N-glycan&#34;
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root-level placeholder assigned by SGD with the ND (No biological Data)
+        code, reflecting that no molecular-function had been curated for MNN14.
+        This is now superseded by direct biochemical evidence: recombinant
+        soluble MNN14 transfers mannosyl-phosphate from GDP-mannose to
+        high-mannose N-glycans in vitro (Kang et al. 2021), establishing a
+        mannosylphosphate transferase activity (GO:0000031). The ND root should
+        be replaced by that specific MF (proposed as a NEW annotation below and
+        used as the core molecular function).
+      action: MODIFY
+      proposed_replacement_terms:
+        - id: GO:0000031
+          label: mannosylphosphate transferase activity
+      reason: &gt;-
+        The ND placeholder is no longer accurate: an experimental (in-vitro) MF
+        for MNN14 now exists. GO:0000031 (mannosylphosphate transferase activity)
+        is the specific, evidence-supported molecular function and should replace
+        the uninformative root term.
+      supported_by:
+        - reference_id: PMID:33144549
+          supporting_text: &#34;in vitro mannosyl-phosphorylation of high-mannose type N-glycans that utilizes a recombinant Mnn14 protein&#34;
+        - reference_id: PMID:33144549
+          supporting_text: &#34;2 mM GDP-mannose (donor substrate)&#34;
+  - term:
+      id: GO:0000031
+      label: mannosylphosphate transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:33144549
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Proposed NEW molecular-function annotation not currently in GOA.
+        Recombinant soluble MNN14 (rMnn14 77-935) directly transfers
+        mannosyl-phosphate from the donor GDP-mannose to high-mannose N-glycan
+        acceptors, producing mono- and bis-mannosyl-phosphorylated glycans in an
+        Mn2+-dependent reaction optimal at pH 7.5 / 30 C (Kang et al. 2021).
+        GO:0000031 exactly matches this reaction (GDP-mannose + mannose-acceptor
+        -&gt; phosphorylated glycan + GMP) and is the intrinsic catalytic activity
+        of MNN14. The assay used the soluble catalytic domain expressed in
+        P. pastoris, consistent with an intrinsic (not merely regulatory)
+        activity.
+      action: NEW
+      reason: &gt;-
+        Experimentally supported (in-vitro biochemical, IDA-equivalent) molecular
+        function for MNN14 that is missing from GOA; this is the core catalytic
+        function of the gene product.
+      supported_by:
+        - reference_id: PMID:33144549
+          supporting_text: &#34;a strategy is established here for the in vitro mannosyl-phosphorylation of high-mannose type N-glycans&#34;
+        - reference_id: PMID:33144549
+          supporting_text: &#34;a recombinant Mnn14 protein derived from Saccharomyces cerevisiae&#34;
+        - reference_id: PMID:33144549
+          supporting_text: &#34;the main MPEs in Saccharomyces cerevisiae&#34;
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Root-level placeholder assigned by SGD with the ND code. It is superseded
+        by the more informative Golgi membrane (GO:0000139) annotation above,
+        which is supported by SubCell and the type II membrane topology.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Uninformative root placeholder retained per GO conventions; the specific
+        localization is already captured by the Golgi membrane annotation.
+core_functions:
+  - description: &gt;-
+      Golgi-membrane mannosylphosphate transferase (mannosylphosphorylation
+      enzyme) that transfers mannosyl-phosphate from GDP-mannose to high-mannose
+      N-glycans, producing mono- and bis-mannosyl-phosphorylated glycans; the
+      activity is demonstrated in vitro for recombinant soluble MNN14 and is
+      Mn2+-dependent. In vivo MNN14 acts in N-glycan mannosylphosphorylation
+      partially redundantly with its paralog MNN4.
+    supported_by:
+      - reference_id: PMID:33144549
+        supporting_text: &#34;in vitro mannosyl-phosphorylation of high-mannose type N-glycans that utilizes a recombinant Mnn14 protein&#34;
+      - reference_id: PMID:28101612
+        supporting_text: &#34;essential for N-glycan mannosylphosphorylation&#34;
+    molecular_function:
+      id: GO:0000031
+      label: mannosylphosphate transferase activity
+    directly_involved_in:
+      - id: GO:0006491
+        label: N-glycan processing
+    locations:
+      - id: GO:0000139
+        label: Golgi membrane
+proposed_new_terms: []
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The in-vivo division of labour between MNN14 and its paralog MNN4 is
+      unresolved. MNN14 has intrinsic mannosylphosphate transferase activity in
+      vitro, yet MNN4 is curated as a positive regulator (enzyme activator) of
+      the Mnn6/Ktr6 mannosylphosphate transferase, not a catalyst. It is unknown
+      whether, in the cell, MNN14 acts primarily as a catalyst, MNN4 primarily as
+      a regulator, and how the two models are reconciled for two closely related
+      paralogs.
+    boundary: &gt;-
+      Firmly established: recombinant soluble MNN14 catalyzes mannosyl-phosphate
+      transfer from GDP-mannose to high-mannose N-glycans in vitro
+      (Mn2+-dependent), so MNN14 has intrinsic transferase activity (GO:0000031);
+      and genetically both MNN4 and MNN14 are required for full N-glycan
+      mannosylphosphorylation. Also established, classically, is that Mnn6/Ktr6
+      (KRE2/MNT1 family) is a mannosylphosphate transferase and that MNN4 is a
+      positive regulator whose transcript/protein level is rate-limiting; MNN4&#39;s
+      curated molecular function is enzyme activator activity (GO:0008047).
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: NARROWING
+    significance: &gt;-
+      Clarifying whether MNN14 (and MNN4) contribute catalysis, regulation, or
+      both in vivo would resolve an apparent contradiction between the in-vitro
+      enzymology and the classical regulator model, and would sharpen the
+      mannosylphosphorylation pathway model that underpins yeast
+      glyco-engineering.
+    resolution: &gt;-
+      In-vivo structure-function analysis (DXD-motif catalytic mutants of MNN14
+      and MNN4 assayed for the glycan phenotype), reconstitution tests of whether
+      MNN14/MNN4 stimulate Mnn6/Ktr6, and quantitative comparison of the
+      catalytic contribution of each paralog in single and double mutants.
+    provenance:
+      - reference_id: PMID:33144549
+        supporting_text: &#34;the main MPEs in Saccharomyces cerevisiae&#34;
+      - reference_id: PMID:9459307
+        supporting_text: &#34;Mannosylphosphate transfer to cell wall mannan is regulated by the transcriptional level of the MNN4 gene&#34;
+      - reference_id: UniProt:P40355
+        supporting_text: &#34;partially redundant function with MNN4&#34;
+  - gap_statement: &gt;-
+      The acceptor-position specificity of MNN14 in vivo is unknown: which
+      mannose residues/positions on N-linked (and possibly O-linked) glycans
+      MNN14 phosphorylates in the cell, and whether MNN4 and MNN14 act on the
+      same or different positions.
+    boundary: &gt;-
+      In vitro, MNN14 mannosyl-phosphorylates high-mannose N-glycans
+      (Man8GlcNAc2 and Man7-9GlcNAc2 on rhGAA), producing mono- and
+      bis-mannosyl-phosphorylated products; genetically, N-glycan
+      mannosylphosphorylation is abolished only when both MNN4 and MNN14 are
+      deleted. The precise in-vivo acceptor positions and whether the two
+      paralogs are position-selective have not been mapped.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Mapping acceptor positions would convert the pathway placement into a fully
+      defined molecular reaction and explain why two paralogs are maintained.
+    resolution: &gt;-
+      Structural mannan/N-glycan analysis (e.g. by mass spectrometry) of defined
+      acceptors in wild-type versus mnn14 single and mnn4 mnn14 double mutants,
+      combined with in-vitro reactions on candidate acceptor substrates.
+    provenance:
+      - reference_id: PMID:28101612
+        supporting_text: &#34;essential for N-glycan mannosylphosphorylation&#34;
+  - gap_statement: &gt;-
+      The basis of the functional redundancy between MNN14 and MNN4, and any
+      distinct or condition-specific role of MNN14, are unknown. There is no
+      described standalone loss-of-function phenotype for an mnn14 single mutant
+      beyond the residual mannosylphosphate profile.
+    boundary: &gt;-
+      Established: single deletion of either MNN4 or MNN14 leaves residual
+      N-glycan mannosylphosphorylation, and only the double deletion eliminates
+      it, so the two paralogs have overlapping but individually non-essential
+      activities. MNN14 is a non-essential gene, and its expression is repressed
+      by RIM101.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Understanding whether MNN14 and MNN4 differ in acceptor specificity,
+      substrate class (N- vs O-linked; core vs outer chain), or expression
+      context would explain why two paralogs are maintained and would sharpen the
+      mannosylphosphorylation model relevant to glyco-engineering.
+    resolution: &gt;-
+      Comparative glycan profiling and genetic-interaction/expression analyses of
+      mnn4 and mnn14 single mutants under varied growth conditions, and tests of
+      RIM101-dependent regulation of MNN14 relative to MNN4.
+    provenance:
+      - reference_id: PMID:28101612
+        supporting_text: &#34;Double disruption of MNN4 and MNN14 genes was enough to eliminate N-glycan&#34;
+      - reference_id: UniProt:P40355
+        supporting_text: &#34;partially redundant function with MNN4&#34;
+suggested_questions:
+  - question: &gt;-
+      Given that MNN14 has intrinsic mannosylphosphate transferase activity in
+      vitro while MNN4 is curated as a regulator of Mnn6/Ktr6, how are catalysis
+      and regulation partitioned between MNN14 and MNN4 in vivo?
+  - question: &gt;-
+      Does the conserved DXD motif of MNN14 support catalysis, and is it required
+      for MNN14 function in vivo?
+suggested_experiments:
+  - hypothesis: &gt;-
+      The DXD motif is required for the in-vivo mannosylphosphate transferase
+      activity of MNN14, and MNN14 contributes catalysis (not only regulation) to
+      cellular mannosylphosphorylation.
+    description: &gt;-
+      Introduce DXD-motif catalytic point mutations into chromosomal MNN14 (and
+      MNN4) and score the N-glycan mannosylphosphate profile in single and double
+      mutants; complement mnn4 mnn14 double deletions with wild-type versus
+      DXD-mutant alleles; and test whether MNN14/MNN4 stimulate purified
+      Mnn6/Ktr6 activity in a reconstituted reaction.
+    experiment_type: structure-function / reconstitution
+  - hypothesis: &gt;-
+      MNN14 and MNN4 act on distinct acceptor positions or substrate classes,
+      explaining their partial redundancy.
+    description: &gt;-
+      Perform quantitative N-glycan and mannan structural analysis (mass
+      spectrometry) of cell-wall mannoproteins and a secreted reporter
+      glycoprotein from wild-type, mnn4, mnn14, and mnn4 mnn14 strains to map
+      which mannosylphosphate positions depend on each paralog.
+    experiment_type: comparative glycomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/NVJ3/NVJ3-ai-review.html
+++ b/genes/yeast/NVJ3/NVJ3-ai-review.html
@@ -1,0 +1,2826 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NVJ3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>NVJ3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q03983" target="_blank" class="term-link">
+                        Q03983
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YDR179W-A</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "NVJ3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q03983" data-a="DESCRIPTION: NVJ3 (YDR179W-A) is a soluble Saccharomyces cerevi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>NVJ3 (YDR179W-A) is a soluble Saccharomyces cerevisiae protein that resides at the nucleus-vacuole junction (NVJ), the membrane contact site where the nuclear endoplasmic reticulum apposes the vacuole. It is a paralog of the ER-anchored tether Mdm1 (the yeast member of the SNX13/14/19/25 sorting-nexin family) and shares with Mdm1 a single recognizable domain, the Phox-associated (PXA) domain; unlike Mdm1 it lacks a transmembrane anchor and a phosphoinositide-binding PX domain. Nvj3 is recruited to ER-vacuole contacts by direct association with Mdm1 and, in cells lacking Mdm1, redistributes to the cytoplasm; its contact-site localization does not require the canonical NVJ tether Nvj1. Functionally, Nvj3 acts together with Mdm1 in neutral-lipid (triacylglycerol) metabolism and lipid-droplet dynamics at ER-vacuole contacts, particularly during nutritional stress: loss of NVJ3 (with MDM1) increases triacylglycerol and lipid-droplet content in a manner dependent on the fatty acyl-CoA synthetase Faa1. Its own biochemical (molecular) activity has not been established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
+                                    GO:0006629
+                                </a>
+                            </span>
+                            <span class="term-label">lipid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29146766" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29146766
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Lipid droplet biogenesis is spatially coordinated at ER-vacu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03983" data-a="GO:0006629" data-r="PMID:29146766" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported by loss-of-function evidence: deletion of NVJ3 (together with MDM1) increases triacylglycerol and lipid-droplet content, an effect suppressed by deletion of the fatty acyl-CoA synthetase Faa1. Nvj3 therefore participates in NVJ-associated neutral-lipid metabolism. The term is general but correctly reflects the demonstrated biological process, and the acts_upstream_of_or_within qualifier is appropriate for a modulatory role established genetically. Retained as a core biological process; the specific molecular step remains a gap.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29146766" target="_blank" class="term-link">
+                                        PMID:29146766
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold increase in TAG</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29146766" target="_blank" class="term-link">
+                                        PMID:29146766
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we see in the mdm1 Δ nvj3 Δ double knockout</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071561" target="_blank" class="term-link">
+                                    GO:0071561
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus-vacuole junction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26283797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mdm1/Snx13 is a novel ER-endolysosomal interorganelle tether...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03983" data-a="GO:0071561" data-r="PMID:26283797" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Well supported by direct imaging: GFP-tagged Nvj3 localizes to the nucleus-vacuole junction and colocalizes with Mdm1 there. This is a core, experimentally established localization of the protein.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                        PMID:26283797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098853" target="_blank" class="term-link">
+                                    GO:0098853
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum-vacuole membrane contact site</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26283797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mdm1/Snx13 is a novel ER-endolysosomal interorganelle tether...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q03983" data-a="GO:0098853" data-r="PMID:26283797" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Well supported and more precise than the NVJ term for the underlying structure. Nvj3 localizes to the ER-vacuole membrane contact site, retaining this localization even in nvj1-deletion cells, where it is enriched at the tips of ER tubules contacting the vacuole. Core localization annotation.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                        PMID:26283797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both Mdm1 and Nvj3 retained ER–vacuole MCS localizations in nvj1Δ yeast but were no longer restricted to NVJ patches</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                        PMID:26283797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Nvj3 was clearly enriched at the tips of ER tubules making contact with the vacuole, confirming ER–vacuole tethering does not require Nvj1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032266" target="_blank" class="term-link">
+                                    GO:0032266
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol-3-phosphate binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26283797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mdm1/Snx13 is a novel ER-endolysosomal interorganelle tether...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q03983" data-a="GO:0032266" data-r="PMID:26283797" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is an ISS annotation transferred from the paralog Mdm1 (with/from SGD:S000004572). The sequence basis for the transfer is weak: in Mdm1 the high-affinity PI3P-binding activity is a property of its C-terminal PX domain, whereas the source paper states that the PXA domain is the ONLY domain shared between Mdm1 and Nvj3. Nvj3 has no PX domain (InterPro/Pfam for Q03983 returns only the PXA domain, PF02194) and is predicted to be soluble with no transmembrane anchor (max Kyte-Doolittle hydropathy ~1.1, below a TM threshold). There is no direct biochemical evidence that Nvj3 itself binds PI3P, and the domain that would confer that activity is absent, so this is likely an over-annotation by similarity. A specific molecular function for Nvj3 remains undetermined (see knowledge_gaps).
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                        PMID:26283797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the PXA domain is the only domain shared between Mdm1 and Nvj3</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                        PMID:26283797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">its C-terminal PX domain, which binds PI3P with high affinity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Resident protein of the nucleus-vacuole junction / ER-vacuole membrane contact site. Nvj3 is a soluble paralog of the ER-anchored tether Mdm1 and is recruited to ER-vacuole contacts through direct association with Mdm1 (it becomes cytoplasmic in mdm1-deletion cells); its contact-site localization is independent of the canonical NVJ tether Nvj1. No autonomous molecular activity has been demonstrated, so no molecular_function term is asserted here (see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="Q03983" data-a="FUNCTION: Resident protein of the nucleus-vacuole junction /..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071561" target="_blank" class="term-link">
+                                nucleus-vacuole junction
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098853" target="_blank" class="term-link">
+                                endoplasmic reticulum-vacuole membrane contact site
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                PMID:26283797
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                                PMID:26283797
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Nvj3-GFP redistributed into the cytoplasm in mdm1Δ cells, suggesting Nvj3 interacts directly with Mdm1 at NVJs</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Participates, together with its paralog Mdm1, in neutral-lipid (triacylglycerol) metabolism and lipid-droplet dynamics at ER-vacuole contact sites, a role that is pronounced under nutritional stress. Genetic loss of NVJ3 (with MDM1) raises triacylglycerol and lipid-droplet content in a manner suppressible by deletion of the fatty acyl-CoA synthetase Faa1, placing Nvj3 in lipid-droplet production downstream of fatty acyl-CoA activation. The molecular step Nvj3 performs in this process is not established.</h3>
+                <span class="vote-buttons" data-g="Q03983" data-a="FUNCTION: Participates, together with its paralog Mdm1, in n..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
+                                lipid metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098853" target="_blank" class="term-link">
+                                endoplasmic reticulum-vacuole membrane contact site
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29146766" target="_blank" class="term-link">
+                                PMID:29146766
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold increase in TAG</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29146766" target="_blank" class="term-link">
+                                PMID:29146766
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we see in the mdm1 Δ nvj3 Δ double knockout</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" target="_blank" class="term-link">
+                            PMID:26283797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mdm1/Snx13 is a novel ER-endolysosomal interorganelle tethering protein.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nvj3 (Ydr179w-a) is a novel paralog of Mdm1 that localizes to the nucleus-vacuole junction / ER-vacuole membrane contact site, independently of the canonical tether Nvj1.</div>
+
+                        <div class="finding-text">"both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nvj3 is predicted to be soluble and requires Mdm1 for its NVJ localization, redistributing to the cytoplasm in mdm1-deletion cells.</div>
+
+                        <div class="finding-text">"Nvj3-GFP redistributed into the cytoplasm in mdm1Δ cells, suggesting Nvj3 interacts directly with Mdm1 at NVJs"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The PXA domain is the only domain shared between Mdm1 and Nvj3; the PI3P-binding activity of Mdm1 resides in its separate PX domain.</div>
+
+                        <div class="finding-text">"the PXA domain is the only domain shared between Mdm1 and Nvj3"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29146766" target="_blank" class="term-link">
+                            PMID:29146766
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Lipid droplet biogenesis is spatially coordinated at ER-vacuole contacts under nutritional stress.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion of MDM1, NVJ3, or both causes lipid-droplet accumulation and a ~2-fold increase in triacylglycerol, implicating Nvj3 in NVJ-associated neutral-lipid metabolism.</div>
+
+                        <div class="finding-text">"deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold increase in TAG"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The triacylglycerol increase in the mdm1 nvj3 double mutant is suppressed by deletion of the fatty acyl-CoA synthetase Faa1, linking Mdm1/Nvj3 to lipid droplet production downstream of fatty acyl-CoA activation.</div>
+
+                        <div class="finding-text">"Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we see in the mdm1 Δ nvj3 Δ double knockout"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41542480" target="_blank" class="term-link">
+                            PMID:41542480
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Nvj3 regulates Dga1-mediated triacylglycerol synthesis and lipid droplet formation at ER contact sites.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Nvj3 bind or transfer a specific lipid through its PXA domain, or does it act solely as an Mdm1-recruited scaffold at ER-vacuole contacts?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: W. Mike Henne</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03983" data-a="Q: Does Nvj3 bind or transfer a specific lipid throug..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the mechanistic step by which Nvj3 couples Dga1-dependent triacylglycerol synthesis to efficient lipid-droplet packaging?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: W. Mike Henne</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03983" data-a="Q: What is the mechanistic step by which Nvj3 couples..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant Nvj3 (and its isolated PXA domain) and perform protein-lipid overlay, liposome flotation/co-sedimentation, and lipid-transfer assays against a panel of phospholipids, phosphoinositides, DAG, and sterols to identify any direct lipid ligand or transfer activity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The Nvj3 PXA domain binds a specific lipid that contributes to its function at ER-vacuole contacts.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro lipid-binding/transfer biochemistry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03983" data-a="EXPERIMENT: Express and purify recombinant Nvj3 (and its isola..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Combine quantitative lipidomics of nvj3Δ and PXA-domain point/deletion mutants with live-cell imaging of DAG and lipid-droplet biogenesis during diauxic shift or glucose depletion to map Nvj3&#39;s step in TAG synthesis and lipid-droplet packaging.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Nvj3 organizes DAG/TAG conversion at ER-vacuole contacts and its PXA domain is required for this role.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics + lipidomics + live-cell imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03983" data-a="EXPERIMENT: Combine quantitative lipidomics of nvj3Δ and PXA-d..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct molecular/biochemical activity of Nvj3 is undetermined: it is unknown whether Nvj3 binds or transfers a specific lipid, senses a lipid, or acts purely as a scaffold/adaptor recruited by Mdm1. Its only recognizable domain is the PXA (Phox-associated) domain, whose biochemical function is itself uncharacterized.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Nvj3&#39;s localization (NVJ / ER-vacuole contact site) and its genetic contribution to triacylglycerol/lipid-droplet homeostasis are experimentally established, and it is known to depend on Mdm1 for recruitment; but no in vitro activity, ligand, or catalytic step has been assigned to the protein or its PXA domain. (Fatty-acid binding has been shown for the PXA domains of the paralog Mdm1 and of human SNX14, but not for Nvj3 itself.)</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Nvj3 is the only yeast protein besides Mdm1 to carry a PXA domain; defining its activity would clarify the function of the conserved PXA domain and the mechanism by which ER-vacuole contacts regulate neutral-lipid metabolism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of recombinant Nvj3 and its PXA domain (lipid-binding / lipid-transfer assays, ligand identification) and structure determination, combined with separation-of-function alleles tested for lipid-droplet phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"All Mdm1 homologues encode an uncharacterized PXA domain"</em> — PMID:26283797</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether Nvj3 itself possesses membrane-tethering activity, or is only a passenger recruited to Mdm1-formed ER-vacuole contacts, is unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Mdm1 is an ER-anchored transmembrane protein that tethers the ER to the vacuole via its PI3P-binding PX domain; Nvj3 is predicted soluble, lacks a PX domain, and requires Mdm1 for contact-site localization. Independent tethering by Nvj3 alone has not been demonstrated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing tether from passenger determines whether Nvj3 should be annotated with a contact-site tether activity or an accessory/adaptor role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test ER-vacuole contact formation and reconstituted tethering with Nvj3 in the absence of Mdm1 (e.g. synthetic tethering assays, in vitro membrane binding).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Because Nvj3 is predicted to be soluble, we hypothesized that it required Mdm1 for its NVJ localization"</em> — PMID:26283797</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular step by which Nvj3 influences triacylglycerol synthesis and lipid-droplet packaging is unknown, as is the physiological consequence of its loss beyond a mild neutral-lipid imbalance.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> nvj3Δ (with mdm1Δ) increases TAG and lipid droplets in an Faa1-dependent manner, and a 2026 preprint links Nvj3 to Dga1-dependent TAG synthesis and DAG localization; but no peer-reviewed mechanism, direct partner in TAG synthesis, or robust growth phenotype has been reported (no hits in 10 CRISPR screens per BioGRID-ORCS).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving the step would connect ER-vacuole contact-site biology to the enzymology of lipid-droplet biogenesis and to the conserved SNX13/14-family lipid roles in mammals.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Peer-reviewed, mechanistic dissection of the Nvj3-Dga1/DAG relationship (e.g. the findings reported in the preprint PMID:41542480), with lipidomics and separation-of-function alleles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold increase in TAG"</em> — PMID:29146766</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NVJ3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03983" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">26 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:05:54.687139</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="NVJ3-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="NVJ3-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-on-nvj3-ydr179w-a-in-saccharomyces-cerevisiae">Comprehensive Research Report on NVJ3 (YDR179W-A) in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="1-gene-identity-verification">1. Gene Identity Verification</h3>
+<p>NVJ3 (systematic name YDR179W-A; UniProt Q03983) encodes a protein in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c) that was originally annotated as an uncharacterized open reading frame. It has since been identified as a component of the nucleus-vacuole junction (NVJ) and designated NVJ3 based on its localization and functional context (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24). The protein contains a Phox-associated (PXA) domain (IPR003114 / PF02194), which is consistent with its classification as a paralog of the sorting nexin-related protein Mdm1 (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24). The gene identity is confirmed across multiple independent studies.</p>
+<h3 id="2-protein-description-and-domain-architecture">2. Protein Description and Domain Architecture</h3>
+<p>Nvj3 is a <strong>soluble protein</strong> and a paralog of the ER membrane protein Mdm1 (vladimir2019investigatingsphingolipidmetabolism pages 21-24). Unlike Mdm1, which possesses a full multi-domain architecture consisting of an N-terminal transmembrane domain (for ER anchoring), a PXA domain, an RGS (regulator of G-protein signaling) domain, a PX (Phox homology) domain (for vacuolar PI3P binding), and a C-terminal nexin/PXC domain (bohnert2020tetheringfattethers pages 2-3, bandyopadhyay2024lysosomalmembranecontact pages 3-4, bandyopadhyay2024lysosomalmembranecontact pages 4-6), Nvj3 retains primarily the PXA domain but lacks the integral membrane domains and the PX domain that anchor Mdm1 in the ER membrane and target it to the vacuole, respectively (vladimir2019investigatingsphingolipidmetabolism pages 21-24).</p>
+<p>The PXA domain is a critical functional element shared among sorting nexin-RGS family members (Mdm1 in yeast; SNX13, SNX14, SNX19, and SNX25 in mammals) (amatya2021snxpxargspxcsubfamilyof pages 5-7, bandyopadhyay2024lysosomalmembranecontact pages 3-4). Structural studies on the mammalian orthologs reveal that the PXA domain, together with the PXC domain, forms a tightly intertwined tunnel-like structure approximately 80 Å in length with a hydrophobic interior lined by residues from both domains (bandyopadhyay2024lysosomalmembranecontact pages 3-4, bandyopadhyay2024lysosomalmembranecontact pages 4-6). In Mdm1, the PXA domain binds free fatty acids <em>in vitro</em> and is sufficient on its own to drive lipid droplet (LD) targeting and biogenesis (vladimir2019investigatingsphingolipidmetabolism pages 21-24, bohnert2020tetheringfattethers pages 2-3). The mammalian ortholog Snx14 similarly requires its PXA domain for fatty acid binding and proper saturated fatty acid metabolism; deletion of the PXA domain abrogates Snx14's ability to rescue cell viability following palmitate exposure (datta2020snx14proximitylabeling pages 10-11). Given that Nvj3 possesses a PXA domain, it is inferred to have the capacity for lipid or fatty acid binding at the NVJ, though direct biochemical characterization of Nvj3's PXA domain has not been reported.</p>
+<p>The following table summarizes the key properties of NVJ3:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>NVJ3 summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>NVJ3</strong> (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24)</td>
+</tr>
+<tr>
+<td>Systematic name</td>
+<td><strong>YDR179W-A</strong>; corresponds to the UniProt target protein for <em>S. cerevisiae</em> S288c described in the research context (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>Q03983</strong></td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c), budding yeast (kohler2020closingthegap pages 3-5, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+</tr>
+<tr>
+<td>Protein type</td>
+<td><strong>Soluble protein</strong>; described as a soluble paralog of the ER membrane protein Mdm1 (vladimir2019investigatingsphingolipidmetabolism pages 21-24)</td>
+</tr>
+<tr>
+<td>Key domain</td>
+<td><strong>PXA / Phox-associated domain</strong>; by family inference, PXA domains in Mdm1/SNX14-family proteins are lipid-associated and linked to fatty-acid handling (bohnert2020tetheringfattethers pages 2-3, datta2020snx14proximitylabeling pages 10-11, bandyopadhyay2024lysosomalmembranecontact pages 3-4, bandyopadhyay2024lysosomalmembranecontact pages 4-6)</td>
+</tr>
+<tr>
+<td>Paralog</td>
+<td><strong>Mdm1</strong> (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Nucleus-vacuole junction (NVJ)</strong>, an ER-vacuole/nuclear envelope-vacuole membrane contact site (karnebeck2019newinsightsinto pages 36-40, santanasosa2023ayeastmitotic pages 9-11, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+</tr>
+<tr>
+<td>Localization dependency</td>
+<td><strong>Mdm1-dependent, Nvj1-independent</strong>: Nvj3 localizes to NVJs independently of Nvj1, but in <strong>mdm1Δ</strong> cells it redistributes from the NVJ to the cytoplasm (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td><strong>Accessory NVJ protein / tether-associated factor</strong> implicated in <strong>lipid droplet biogenesis</strong> and lipid metabolic organization at a subset of NVJs, rather than being the core structural tether itself (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 3-5)</td>
+</tr>
+<tr>
+<td>NOT involved in</td>
+<td><strong>Piecemeal microautophagy of the nucleus (PMN)</strong>; Nvj3-containing NVJs are described as distinct from PMN-active Nvj1-Vac8 junctions (santanasosa2023ayeastmitotic pages 9-11)</td>
+</tr>
+<tr>
+<td>Broader pathway context</td>
+<td>Part of a larger NVJ protein network that can include <strong>Nvj1, Vac8, Nvj2, Mdm1, Osh1, Tsc13, Lam5, Lam6, and Vps13</strong> and contributes to lipid/sterol/FA organization at ER-vacuole contacts (kohler2020closingthegap pages 3-5, karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+</tr>
+<tr>
+<td>Phenotype/context from broader NVJ loss</td>
+<td>In a <strong>nvj1Δ nvj2Δ nvj3Δ mdm1Δ</strong> mutant, ER-vacuole contacts are lost by EM, while cells still grow comparably to wild type under the tested conditions; altered ceramide-related lipid flux was also reported (vladimir2019investigatingsphingolipidmetabolism pages 75-81)</td>
+</tr>
+<tr>
+<td>Related mammalian orthologs of Mdm1</td>
+<td>The Mdm1/SNX-RGS family is represented in mammals by <strong>SNX13, SNX14, SNX19, and SNX25</strong>; these are relevant evolutionary comparators for inferring PXA-family function, not direct demonstrated orthologs of yeast Nvj3 (bandyopadhyay2024lysosomalmembranecontact pages 3-4, amatya2021snxpxargspxcsubfamilyof pages 5-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, localization, inferred molecular role, and pathway context of yeast NVJ3/YDR179W-A. It is useful as a compact reference because the direct literature on NVJ3 is limited and much of its function is inferred from its Mdm1 relationship and PXA-domain family biology.</em></p>
+<h3 id="3-subcellular-localization">3. Subcellular Localization</h3>
+<p>Nvj3 localizes to the <strong>nucleus-vacuole junction (NVJ)</strong>, the membrane contact site formed between the nuclear envelope (outer nuclear membrane/perinuclear ER) and the vacuolar membrane in budding yeast (karnebeck2019newinsightsinto pages 36-40, santanasosa2023ayeastmitotic pages 9-11, vladimir2019investigatingsphingolipidmetabolism pages 21-24). This localization was initially reported by Henne et al. (2015) and has been confirmed in multiple subsequent studies.</p>
+<p>Critically, Nvj3's localization to the NVJ is <strong>Mdm1-dependent but Nvj1-independent</strong> (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24). In wild-type cells, Nvj3 is found concentrated at NVJ contact sites. However, in <em>mdm1Δ</em> cells, Nvj3 redistributes from the NVJ to the cytoplasm, indicating that Mdm1 serves as the anchor or recruitment factor that retains Nvj3 at the ER-vacuole interface (karnebeck2019newinsightsinto pages 36-40). By contrast, deletion of NVJ1 does not affect Nvj3 localization, demonstrating that the Mdm1-Nvj3 module operates independently of the canonical Nvj1-Vac8 NVJ tethering system (vladimir2019investigatingsphingolipidmetabolism pages 21-24).</p>
+<h3 id="4-function-lipid-droplet-biogenesis-at-nvj-contact-sites">4. Function: Lipid Droplet Biogenesis at NVJ Contact Sites</h3>
+<p>A central finding is that Nvj3, together with Mdm1 and Nvj2, is associated with a <strong>subset of NVJ contact sites that are specifically dedicated to lipid droplet (LD) biogenesis in response to nutrient stress</strong> (santanasosa2023ayeastmitotic pages 9-11). These LD biogenesis-associated NVJs are functionally and spatially <strong>distinct from the NVJs involved in piecemeal microautophagy of the nucleus (PMN)</strong>, which are established through the canonical Nvj1-Vac8 interaction (santanasosa2023ayeastmitotic pages 9-11).</p>
+<p>Mdm1 functions as the primary tri-organellar molecular tether at these sites, connecting the ER, the vacuole, and lipid droplets (choudhary2021auniquejunctional pages 7-9). It is anchored to the ER through its N-terminal integral membrane domain, targets the vacuolar membrane via its PX domain binding to phosphatidylinositol 3-phosphate (PI3P), and associates with lipid droplets through its PXA domain (vladimir2019investigatingsphingolipidmetabolism pages 21-24, choudhary2021auniquejunctional pages 7-9). Mdm1 recruits the fatty acyl-CoA synthetase Faa1, linking it to the conversion of free fatty acids into storage-competent neutral lipids and thereby promoting LD formation (vladimir2019investigatingsphingolipidmetabolism pages 21-24). As a soluble Mdm1 paralog that is recruited to the NVJ by Mdm1, Nvj3 likely functions as an <strong>accessory factor</strong> in this lipid metabolic hub, potentially contributing to fatty acid handling or lipid organization through its PXA domain (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 3-5).</p>
+<h3 id="5-relationship-to-piecemeal-microautophagy-of-the-nucleus-pmn">5. Relationship to Piecemeal Microautophagy of the Nucleus (PMN)</h3>
+<p>Despite its localization at the NVJ — the site where PMN occurs — Nvj3 is <strong>not involved in piecemeal microautophagy of the nucleus</strong>. The NVJ contact sites at which Nvj3, Mdm1, and Nvj2 are found do not participate in the PMN autophagy pathway (santanasosa2023ayeastmitotic pages 9-11). PMN instead depends on the Nvj1-Vac8 interaction, with additional contributions from Osh1 (essential for proper PMN bleb formation) and Tsc13 (whose absence reduces PMN bleb size) (kohler2020closingthegap pages 9-11, karnebeck2019newinsightsinto pages 36-40). This functional segregation underscores that the NVJ is not a monolithic structure but rather comprises functionally distinct subdomains.</p>
+<h3 id="6-loss-of-function-phenotype">6. Loss-of-Function Phenotype</h3>
+<p>The quadruple deletion mutant <em>nvj1Δ nvj2Δ nvj3Δ mdm1Δ</em> (ΔNVJ) was found to grow normally under standard conditions, comparable to wild-type cells (vladimir2019investigatingsphingolipidmetabolism pages 75-81). However, electron microscopy confirmed that this ΔNVJ mutant completely lacks ER-vacuole contacts (vladimir2019investigatingsphingolipidmetabolism pages 75-81). Analysis of sphingolipid metabolism in the quadruple mutant revealed reduced levels of PHC-B ceramide species and lower mean amounts of C17-ceramides and C17-IPCs at certain time points, suggesting that the collective loss of NVJ proteins affects ceramide metabolism and lipid flux between the ER and vacuole (vladimir2019investigatingsphingolipidmetabolism pages 75-81). In a separate study examining α-synuclein toxicity in yeast, Nvj3 was described as "a protein of unknown function" that is a paralog of Mdm1 and localizes to the NVJ depending on Mdm1 (vecchio2023multipletethersof pages 3-4).</p>
+<h3 id="7-nvj-protein-network-context">7. NVJ Protein Network Context</h3>
+<p>Nvj3 operates within a larger network of NVJ-resident proteins that collectively coordinate lipid metabolism, sterol transport, and interorganellar communication at the nuclear envelope-vacuole interface. The following table summarizes the major NVJ proteins and their functional roles:</p>
+<table>
+<thead>
+<tr>
+<th>Protein name</th>
+<th>Membrane association</th>
+<th>Primary function at NVJ</th>
+<th>Role in PMN</th>
+<th>Role in LD biogenesis</th>
+<th>Key domains/features</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Nvj1</td>
+<td>Integral membrane protein of the outer nuclear membrane / perinuclear ER</td>
+<td>Core NVJ tether with Vac8; organizes canonical nucleus-vacuole junctions and recruits PMN-related factors (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 3-5, kohler2020closingthegap pages 9-11)</td>
+<td>Direct, essential structural component of PMN sites (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 9-11)</td>
+<td>Not the main LD-biogenesis factor; distinct from Mdm1/Nvj2/Nvj3 LD-producing NVJs (santanasosa2023ayeastmitotic pages 9-11)</td>
+<td>Transmembrane tether; binds Vac8; interacts with Osh1 and Tsc13 functionally at NVJs (kohler2020closingthegap pages 3-5, kohler2020closingthegap pages 9-11)</td>
+</tr>
+<tr>
+<td>Vac8</td>
+<td>Vacuolar membrane-associated, highly palmitoylated protein</td>
+<td>Core vacuolar-side NVJ tether with Nvj1; scaffold for vacuole contact organization (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 3-5, kohler2020closingthegap pages 9-11)</td>
+<td>Direct, essential structural component of PMN sites; conformational state linked to PMN/Cvt functions (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 9-11)</td>
+<td>Not the principal LD-biogenesis determinant, though present at NVJ-related contact systems (diep2024thevacuolelipid pages 2-3, kohler2020closingthegap pages 9-11)</td>
+<td>Armadillo-repeat scaffold; palmitoylated vacuolar surface protein (kohler2020closingthegap pages 3-5, kohler2020closingthegap pages 9-11)</td>
+</tr>
+<tr>
+<td>Nvj2</td>
+<td>Accessory NVJ protein; membrane-associated SMP protein at NE-vacuole contacts</td>
+<td>Accessory/regulatory NVJ factor that adapts contact abundance and function; part of a subset of NVJs linked to lipid handling (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 3-5, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+<td>Not defined as a core PMN factor; PMN mainly depends on Nvj1-Vac8 (santanasosa2023ayeastmitotic pages 9-11, kohler2020closingthegap pages 3-5)</td>
+<td>Yes, associated with LD-biogenesis NVJs together with Mdm1 and Nvj3 (santanasosa2023ayeastmitotic pages 9-11)</td>
+<td>SMP lipid-transfer domain (vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+</tr>
+<tr>
+<td>Nvj3</td>
+<td>Soluble protein; Mdm1-dependent peripheral resident at NVJ</td>
+<td>Accessory NVJ factor and soluble paralog of Mdm1; likely supports lipid/fatty-acid handling at a subset of NVJs (karnebeck2019newinsightsinto pages 36-40, vladimir2019investigatingsphingolipidmetabolism pages 21-24)</td>
+<td>No clear evidence for direct PMN role; Nvj3-positive NVJs are described as distinct from PMN junctions (santanasosa2023ayeastmitotic pages 9-11)</td>
+<td>Yes, associated with LD-biogenesis NVJs under nutrient stress (santanasosa2023ayeastmitotic pages 9-11)</td>
+<td>PXA domain; lacks the ER-anchoring/TM and PX architecture described for Mdm1, consistent with being soluble (vladimir2019investigatingsphingolipidmetabolism pages 21-24, bohnert2020tetheringfattethers pages 2-3, bandyopadhyay2024lysosomalmembranecontact pages 3-4)</td>
+</tr>
+<tr>
+<td>Mdm1</td>
+<td>ER/nuclear ER integral membrane protein with vacuole-binding PX domain</td>
+<td>Interorganelle tether at NVJ and ER-vacuole contacts; recruits lipid-metabolic machinery and organizes FA/ceramide handling (vladimir2019investigatingsphingolipidmetabolism pages 21-24, choudhary2021auniquejunctional pages 7-9)</td>
+<td>Not the canonical PMN tether; Mdm1-positive NVJs can be distinct from PMN-active junctions (santanasosa2023ayeastmitotic pages 9-11)</td>
+<td>Major positive regulator of LD biogenesis; tri-organellar tether linking ER, vacuole, and LDs (vladimir2019investigatingsphingolipidmetabolism pages 21-24, choudhary2021auniquejunctional pages 7-9)</td>
+<td>N-terminal membrane anchor, PXA domain, RGS domain, PX domain binding PI3P, C-terminal nexin/PXC region (choudhary2021auniquejunctional pages 7-9, bohnert2020tetheringfattethers pages 2-3, bandyopadhyay2024lysosomalmembranecontact pages 3-4, bandyopadhyay2024lysosomalmembranecontact pages 4-6)</td>
+</tr>
+<tr>
+<td>Osh1</td>
+<td>Peripheral lipid-transfer protein recruited to NVJ/PMN blebs</td>
+<td>Sterol/oxysterol transport factor at NVJ; links Nvj1 to lipid trafficking (vladimir2019investigatingsphingolipidmetabolism pages 21-24, kohler2020closingthegap pages 3-5, kohler2020closingthegap pages 9-11)</td>
+<td>Yes; essential for proper PMN vesicle/bleb formation (kohler2020closingthegap pages 9-11, karnebeck2019newinsightsinto pages 36-40)</td>
+<td>No specific direct LD-biogenesis role established here (vladimir2019investigatingsphingolipidmetabolism pages 21-24, kohler2020closingthegap pages 9-11)</td>
+<td>Oxysterol-binding protein family member (OSBP-related protein) (vladimir2019investigatingsphingolipidmetabolism pages 21-24, karnebeck2019newinsightsinto pages 36-40)</td>
+</tr>
+<tr>
+<td>Tsc13</td>
+<td>Integral ER membrane enzyme enriched at NVJ</td>
+<td>Very-long-chain fatty acid elongation enzyme contributing to NVJ lipid environment and membrane properties (vladimir2019investigatingsphingolipidmetabolism pages 21-24, kohler2020closingthegap pages 3-5, karnebeck2019newinsightsinto pages 36-40)</td>
+<td>Supports PMN efficiency; loss reduces PMN bleb size rather than abolishing PMN (karnebeck2019newinsightsinto pages 36-40)</td>
+<td>Indirect/supportive via FA elongation and local lipid metabolism, not established as a dedicated LD tether (vladimir2019investigatingsphingolipidmetabolism pages 21-24, karnebeck2019newinsightsinto pages 36-40)</td>
+<td>Enoyl-CoA reductase of VLCFA synthesis pathway (vladimir2019investigatingsphingolipidmetabolism pages 21-24, karnebeck2019newinsightsinto pages 36-40)</td>
+</tr>
+<tr>
+<td>Lam5/Lam6</td>
+<td>Lipid-transfer/contact-site proteins associated with NVJ and other MCSs</td>
+<td>Accessory sterol-transfer/contact expansion factors at NVJ; Lam6 especially linked to MCS expansion (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+<td>No direct PMN-specific role established in gathered evidence (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+<td>Potential indirect role through sterol organization and contact remodeling; no direct dedicated LD-biogenesis function shown here (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+<td>StART-like sterol-transfer proteins / contact-site regulators (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+</tr>
+<tr>
+<td>Vps13</td>
+<td>Large peripheral lipid transporter recruited to NVJ</td>
+<td>Bulk lipid transporter at NVJ and other contact sites; contributes to lipid exchange and contact-site function (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+<td>No direct PMN-core role established in gathered evidence (karnebeck2019newinsightsinto pages 36-40)</td>
+<td>Possible indirect role through lipid supply/transport at NVJ, but not identified here as the principal LD-biogenesis factor (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+<td>Large Vps13-family bridge-like lipid transport protein (karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares major nucleus-vacuole junction proteins in budding yeast, emphasizing which proteins form the core PMN tether versus those associated with lipid-droplet biogenesis and lipid handling. It is useful for placing NVJ3 in the broader NVJ functional network.</em></p>
+<p>Key interacting partners and co-residents at the NVJ include: Nvj1 and Vac8 (core tethers), Osh1 (oxysterol-binding protein for sterol transport), Tsc13 (enoyl-CoA reductase for very-long-chain fatty acid biosynthesis), Nvj2 (SMP domain lipid transfer protein), Lam5 and Lam6 (sterol transport proteins), and Vps13 (bulk lipid transporter) (kohler2020closingthegap pages 3-5, karnebeck2019newinsightsinto pages 36-40, vrijsen2022interorganellarcommunicationin pages 7-8). NVJ contacts are known to expand upon nutrient stress, and this expansion is associated with increased lipid droplet formation at adjacent ER subdomains (choudhary2021auniquejunctional pages 7-9, kohler2020closingthegap pages 3-5).</p>
+<h3 id="8-evolutionary-context">8. Evolutionary Context</h3>
+<p>Mdm1, the functional partner of Nvj3, belongs to the SNX-PXA-RGS-PXC subfamily of sorting nexins (amatya2021snxpxargspxcsubfamilyof pages 5-7, bandyopadhyay2024lysosomalmembranecontact pages 3-4). The mammalian orthologs of Mdm1 include SNX13 (involved in endolysosomal cholesterol export), SNX14 (linked to SCAR20 cerebellar ataxia disease when mutated), SNX19, and SNX25 (amatya2021snxpxargspxcsubfamilyof pages 5-7, datta2020snx14proximitylabeling pages 10-11, bandyopadhyay2024lysosomalmembranecontact pages 3-4). The <em>Drosophila</em> homolog Snazarus similarly regulates lipid droplet populations at plasma membrane-droplet contacts in adipocytes (bohnert2020tetheringfattethers pages 2-3). Nvj3 appears to be a yeast-specific soluble derivative of this sorting nexin family, retaining the PXA domain but having lost the membrane-anchoring and vacuole-targeting domains present in Mdm1. No direct mammalian ortholog of Nvj3 has been identified.</p>
+<h3 id="9-summary">9. Summary</h3>
+<p>NVJ3 (YDR179W-A) encodes a soluble, PXA domain-containing protein that functions as an accessory component of the nucleus-vacuole junction in <em>S. cerevisiae</em>. It is a paralog of the ER membrane tether Mdm1 and depends on Mdm1 for its localization to the NVJ, but is independent of the canonical NVJ tether Nvj1. Nvj3 resides at a subset of NVJ contact sites that are dedicated to lipid droplet biogenesis under nutrient stress, rather than at those involved in piecemeal microautophagy of the nucleus. Through its PXA domain — which in the related Mdm1 and SNX14 proteins has been shown to bind free fatty acids and promote lipid droplet formation — Nvj3 is inferred to participate in fatty acid handling or lipid organization at the ER-vacuole interface. Collectively, the NVJ proteins including Nvj3 maintain ER-vacuole contacts that are essential for ceramide metabolism and lipid homeostasis. The precise biochemical function of Nvj3 remains incompletely characterized, and much of its functional annotation is inferred from its domain architecture, localization, and relationship to the better-studied Mdm1.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(karnebeck2019newinsightsinto pages 36-40): Stefanie Karnebeck. New insights into nucleophagy in s. cerevisiae. Unknown journal, 2019. URL: https://doi.org/10.53846/goediss-7339, doi:10.53846/goediss-7339.</p>
+</li>
+<li>
+<p>(vladimir2019investigatingsphingolipidmetabolism pages 21-24): Vladimir Girik. Investigating sphingolipid metabolism in budding yeast using stable isotope-labeled and caged vacuole-specific probes. ArXiv, 2019. URL: https://doi.org/10.13097/archive-ouverte/unige:125912, doi:10.13097/archive-ouverte/unige:125912. This article has 0 citations.</p>
+</li>
+<li>
+<p>(bohnert2020tetheringfattethers pages 2-3): Maria Bohnert. Tethering fat: tethers in lipid droplet contact sites. Contact, 3:251525642090814, Mar 2020. URL: https://doi.org/10.1177/2515256420908142, doi:10.1177/2515256420908142. This article has 27 citations.</p>
+</li>
+<li>
+<p>(bandyopadhyay2024lysosomalmembranecontact pages 3-4): Sumit Bandyopadhyay, Daniel Adebayo, Eseiwi Obaseki, and Hanaa Hariri. Lysosomal membrane contact sites: integrative hubs for cellular communication and homeostasis. Current topics in membranes, 93:85-116, Jul 2024. URL: https://doi.org/10.1016/bs.ctm.2024.07.001, doi:10.1016/bs.ctm.2024.07.001. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bandyopadhyay2024lysosomalmembranecontact pages 4-6): Sumit Bandyopadhyay, Daniel Adebayo, Eseiwi Obaseki, and Hanaa Hariri. Lysosomal membrane contact sites: integrative hubs for cellular communication and homeostasis. Current topics in membranes, 93:85-116, Jul 2024. URL: https://doi.org/10.1016/bs.ctm.2024.07.001, doi:10.1016/bs.ctm.2024.07.001. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(amatya2021snxpxargspxcsubfamilyof pages 5-7): Bibhas Amatya, Hewang Lee, Laureano D. Asico, Prasad Konkalmatt, Ines Armando, Robin A. Felder, and Pedro A. Jose. Snx-pxa-rgs-pxc subfamily of snxs in the regulation of receptor-mediated signaling and membrane trafficking. International Journal of Molecular Sciences, 22:2319, Feb 2021. URL: https://doi.org/10.3390/ijms22052319, doi:10.3390/ijms22052319. This article has 25 citations.</p>
+</li>
+<li>
+<p>(datta2020snx14proximitylabeling pages 10-11): Sanchari Datta, Jade Bowerman, Hanaa Hariri, Rupali Ugrankar, Kaitlyn M. Eckert, Chase Corley, Gonçalo Vale, Jeffrey G. McDonald, and W. Mike Henne. Snx14 proximity labeling reveals a role in saturated fatty acid metabolism and er homeostasis defective in scar20 disease. Dec 2020. URL: https://doi.org/10.1073/pnas.2011124117, doi:10.1073/pnas.2011124117. This article has 29 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kohler2020closingthegap pages 3-5): Verena Kohler, Andreas Aufschnaiter, and Sabrina Büttner. Closing the gap: membrane contact sites in the regulation of autophagy. Cells, 9:1184, May 2020. URL: https://doi.org/10.3390/cells9051184, doi:10.3390/cells9051184. This article has 49 citations.</p>
+</li>
+<li>
+<p>(vrijsen2022interorganellarcommunicationin pages 7-8): Stephanie Vrijsen, Céline Vrancx, Mara Del Vecchio, Johannes V. Swinnen, Patrizia Agostinis, Joris Winderickx, Peter Vangheluwe, and Wim Annaert. Inter-organellar communication in parkinson's and alzheimer's disease: looking beyond endoplasmic reticulum-mitochondria contact sites. Frontiers in Neuroscience, Jun 2022. URL: https://doi.org/10.3389/fnins.2022.900338, doi:10.3389/fnins.2022.900338. This article has 48 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(santanasosa2023ayeastmitotic pages 9-11): Silvia Santana-Sosa, Emiliano Matos-Perdomo, Jessel Ayra-Plasencia, and Félix Machín. A yeast mitotic tale for the nucleus and the vacuoles to embrace. International Journal of Molecular Sciences, 24:9829, Jun 2023. URL: https://doi.org/10.3390/ijms24129829, doi:10.3390/ijms24129829. This article has 5 citations.</p>
+</li>
+<li>
+<p>(vladimir2019investigatingsphingolipidmetabolism pages 75-81): Vladimir Girik. Investigating sphingolipid metabolism in budding yeast using stable isotope-labeled and caged vacuole-specific probes. ArXiv, 2019. URL: https://doi.org/10.13097/archive-ouverte/unige:125912, doi:10.13097/archive-ouverte/unige:125912. This article has 0 citations.</p>
+</li>
+<li>
+<p>(choudhary2021auniquejunctional pages 7-9): Vineet Choudhary and Roger Schneiter. A unique junctional interface at contact sites between the endoplasmic reticulum and lipid droplets. Frontiers in Cell and Developmental Biology, Apr 2021. URL: https://doi.org/10.3389/fcell.2021.650186, doi:10.3389/fcell.2021.650186. This article has 45 citations.</p>
+</li>
+<li>
+<p>(kohler2020closingthegap pages 9-11): Verena Kohler, Andreas Aufschnaiter, and Sabrina Büttner. Closing the gap: membrane contact sites in the regulation of autophagy. Cells, 9:1184, May 2020. URL: https://doi.org/10.3390/cells9051184, doi:10.3390/cells9051184. This article has 49 citations.</p>
+</li>
+<li>
+<p>(vecchio2023multipletethersof pages 3-4): Mara Del Vecchio, Lucia Amado, Alexandra P. Cogan, Els Meert, Joelle Rosseels, Vanessa Franssens, Sander K. Govers, Joris Winderickx, and Ayelén González Montoro. Multiple tethers of organelle contact sites are involved in α-synuclein toxicity in yeast. Molecular Biology of the Cell, Jul 2023. URL: https://doi.org/10.1091/mbc.e23-01-0029, doi:10.1091/mbc.e23-01-0029. This article has 4 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diep2024thevacuolelipid pages 2-3): Duy Trong Vien Diep and Maria Bohnert. The vacuole lipid droplet contact site vclip. Contact, Jan 2024. URL: https://doi.org/10.1177/25152564241308722, doi:10.1177/25152564241308722. This article has 3 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="NVJ3-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="NVJ3-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>vladimir2019investigatingsphingolipidmetabolism pages 21-24</li>
+<li>santanasosa2023ayeastmitotic pages 9-11</li>
+<li>vladimir2019investigatingsphingolipidmetabolism pages 75-81</li>
+<li>karnebeck2019newinsightsinto pages 36-40</li>
+<li>choudhary2021auniquejunctional pages 7-9</li>
+<li>vecchio2023multipletethersof pages 3-4</li>
+<li>vrijsen2022interorganellarcommunicationin pages 7-8</li>
+<li>bohnert2020tetheringfattethers pages 2-3</li>
+<li>bandyopadhyay2024lysosomalmembranecontact pages 3-4</li>
+<li>bandyopadhyay2024lysosomalmembranecontact pages 4-6</li>
+<li>amatya2021snxpxargspxcsubfamilyof pages 5-7</li>
+<li>kohler2020closingthegap pages 3-5</li>
+<li>kohler2020closingthegap pages 9-11</li>
+<li>diep2024thevacuolelipid pages 2-3</li>
+<li>https://doi.org/10.53846/goediss-7339,</li>
+<li>https://doi.org/10.13097/archive-ouverte/unige:125912,</li>
+<li>https://doi.org/10.1177/2515256420908142,</li>
+<li>https://doi.org/10.1016/bs.ctm.2024.07.001,</li>
+<li>https://doi.org/10.3390/ijms22052319,</li>
+<li>https://doi.org/10.1073/pnas.2011124117,</li>
+<li>https://doi.org/10.3390/cells9051184,</li>
+<li>https://doi.org/10.3389/fnins.2022.900338,</li>
+<li>https://doi.org/10.3390/ijms24129829,</li>
+<li>https://doi.org/10.3389/fcell.2021.650186,</li>
+<li>https://doi.org/10.1091/mbc.e23-01-0029,</li>
+<li>https://doi.org/10.1177/25152564241308722,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NVJ3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03983" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="nvj3-ydr179w-a-q03983-curation-notes">NVJ3 (YDR179W-A / Q03983) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> NVJ3<br />
+("Nucleus-Vacuole Junction 3"). Understudied / dark gene. Provenance is recorded inline as<br />
+<code>[PMID:xxxx "verbatim quote"]</code>.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>SGD standard name <strong>NVJ3</strong>; systematic name <strong>YDR179W-A</strong>; UniProt <strong>Q03983</strong> (YD179_YEAST),<br />
+  463 aa. Confirmed via SGD locus API: <code>systematic: YDR179W-A | standard: NVJ3</code>, and via UniProt<br />
+  cross-references (<code>SGD; S000002587; YDR179W-A</code>).</li>
+<li>SGD one-line description: "Protein involved in lipid metabolism; localizes to endoplasmic<br />
+  reticulum-vacuole membrane contact sites at the nucleus-vacuole junction in an Mdm1p-dependent<br />
+  manner; contains a lipid-binding PXA domain."</li>
+<li><code>just fetch-gene yeast NVJ3</code> failed because UniProt does not carry <code>NVJ3</code> as a gene name<br />
+  (gene name = ORF <code>YDR179W-A</code>); fetched with <code>--uniprot-id Q03983</code>.</li>
+</ul>
+<h2 id="domain-architecture-bioinformatics-done-inline">Domain architecture / bioinformatics (done inline)</h2>
+<ul>
+<li>InterPro/Pfam for Q03983 returns ONLY the <strong>PXA domain</strong> (Pfam PF02194 / IPR003114<br />
+  "Phox-associated domain"). No PX (PF00787) domain, no annotated transmembrane region.<br />
+  (Queried InterPro API <code>entry/all/protein/uniprot/Q03983</code>.)</li>
+<li>UniProt feature table lists only <code>CHAIN 1..463</code> — no TRANSMEM, no SIGNAL. Consistent with a<br />
+  soluble, peripherally-recruited protein rather than an integral membrane protein.</li>
+<li>Inline Kyte–Doolittle hydropathy scan (window 19) of the full sequence: max mean hydropathy<br />
+  = <strong>1.14</strong> (pos ~422), below the ~1.6 threshold typically indicative of a candidate TM helix.<br />
+  Supports the "predicted soluble" characterization (no strong TM segment).</li>
+<li>This matters for the annotations: <strong>the only domain Nvj3 shares with its paralog Mdm1 is the<br />
+  PXA domain.</strong> The PI3P-binding activity that anchors Mdm1 to the vacuole is a property of<br />
+  Mdm1's separate <strong>PX</strong> domain, which Nvj3 does NOT possess.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="In yeast, the PXA domain is the only domain shared between Mdm1 and Nvj3 and is unique to these proteins">PMID:26283797</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="its C-terminal PX domain, which binds PI3P with high affinity">PMID:26283797</a></li>
+</ul>
+<h2 id="what-is-known">What is KNOWN</h2>
+<h3 id="localization-well-supported-experimental">Localization (well supported, experimental)</h3>
+<ul>
+<li>Nvj3 was discovered as a novel paralog of Mdm1 and named in PMID:26283797.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="We also characterize a novel Mdm1 paralogue Ydr179w-a, which we name Nvj3, and show that both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner.">PMID:26283797</a></li>
+<li>GFP-tagged Nvj3 localizes to the nucleus–vacuole junction (NVJ) / ER–vacuole membrane contact<br />
+  site (basis of GO:0071561 IDA and GO:0098853 IDA).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="To determine its localization, we GFP tagged the YDR179W-A locus and observed that Ydr179w-a–GFP also localized to NVJs">PMID:26283797</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="A tBFP2-tagged Ydr179w-a colocalized with Mdm1-GFP, confirming its NVJ localization, and thus we name it Nvj3">PMID:26283797</a></li>
+<li>NVJ / ER–vacuole localization is <strong>independent of the canonical tether Nvj1</strong>.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="Remarkably, both Mdm1 and Nvj3 retained ER–vacuole MCS localizations in nvj1Δ yeast but were no longer restricted to NVJ patches.">PMID:26283797</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="In some cells, Nvj3 was clearly enriched at the tips of ER tubules making contact with the vacuole, confirming ER–vacuole tethering does not require Nvj1">PMID:26283797</a></li>
+</ul>
+<h3 id="recruitment-by-mdm1-well-supported">Recruitment by Mdm1 (well supported)</h3>
+<ul>
+<li>Nvj3 is predicted soluble and requires Mdm1 for NVJ localization; in mdm1Δ it goes cytosolic.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="Because Nvj3 is predicted to be soluble, we hypothesized that it required Mdm1 for its NVJ localization.">PMID:26283797</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="Consistent with this, Nvj3-GFP redistributed into the cytoplasm in mdm1Δ cells, suggesting Nvj3 interacts directly with Mdm1 at NVJs">PMID:26283797</a></li>
+<li>Mdm1 co-purifies with Nvj3.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29146766" title="we show that Mdm1 co‐purifies with Faa1 and Fas1/2 in addition to Mdm1 paralog Nvj3">PMID:29146766</a></li>
+<li>SGD interaction data: physical partners include MDM1 (paralog/recruiter) and SEC61 (ER<br />
+  translocon); other partners are high-throughput (NAM7, MPT5, DHH1, CCR4, PUP1, HSC82).</li>
+</ul>
+<h3 id="lipid-neutral-lipid-metabolism-biological-process-experimental-imp">Lipid / neutral-lipid metabolism (biological process; experimental IMP)</h3>
+<ul>
+<li>Deleting MDM1, NVJ3, or both causes lipid-droplet accumulation and ~2-fold TAG increase;<br />
+  suppressed by Faa1 loss (basis of GO:0006629 IMP, PMID:29146766).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29146766" title="deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold increase in TAG, implying a functional role for Mdm1 and Nvj3 in NVJ‐associated LD dynamics">PMID:29146766</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29146766" title="Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we see in the mdm1 Δ nvj3 Δ double knockout">PMID:29146766</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29146766" title="our results are consistent with a role for Mdm1/Nvj3 in LD production following fatty acyl‐CoA activation">PMID:29146766</a></li>
+<li>Nvj3 is NOT required for piecemeal microautophagy of the nucleus (PMN).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="Nvj1-mCherry–positive PMN vesicles formed even in the absence of Mdm1 and Nvj3, suggesting they are not required for yeast PMN">PMID:26283797</a></li>
+</ul>
+<h3 id="newer-preprint-not-peer-reviewed-treat-cautiously">Newer (preprint, NOT peer-reviewed — treat cautiously)</h3>
+<ul>
+<li>PMID:41542480 (bioRxiv 2026): "Nvj3 regulates Dga1-mediated triacylglycerol synthesis and lipid<br />
+  droplet formation at ER contact sites." Abstract: Nvj3 induced by glucose depletion; recruited<br />
+  to LD-associated ER domains; required to couple Dga1-dependent TAG synthesis to LD formation;<br />
+  nvj3Δ → TAG accumulates but is inefficiently packaged into LDs, with altered phospholipid<br />
+  remodeling and DAG mislocalization. This corroborates the lipid role and adds a DAG/Dga1 axis,<br />
+  but assigns no direct biochemical (molecular-function) activity to Nvj3. Preprint → do not use<br />
+  as sole basis for a positive core molecular-function claim; used only to frame knowledge gaps.</li>
+</ul>
+<h2 id="what-is-not-known-the-primary-deliverable-knowledge-gaps">What is NOT known (the primary deliverable — knowledge gaps)</h2>
+<ol>
+<li><strong>Molecular function is undetermined (MF-dark).</strong> No direct biochemical activity has been<br />
+   demonstrated for Nvj3. It carries only a PXA domain (function of the PXA domain itself is<br />
+   uncharacterized: <a href="https://pubmed.ncbi.nlm.nih.gov/26283797" title="All Mdm1 homologues encode an uncharacterized PXA domain.">PMID:26283797</a>).<br />
+   Whether Nvj3 transfers lipids, binds/senses a specific lipid, or acts purely as a<br />
+   scaffold/adaptor recruited by Mdm1 is unknown.</li>
+<li><strong>The PI3P-binding (GO:0032266) annotation is ISS, transferred from Mdm1</strong> (with/from<br />
+   SGD:S000004572 = MDM1). But the PI3P-binding activity in Mdm1 resides in its <strong>PX</strong> domain,<br />
+   which Nvj3 lacks; Nvj3 shares only the PXA domain. So the sequence basis for transferring<br />
+   PI3P binding to Nvj3 is weak. This is flagged as a likely over-annotation / MODIFY-to-gap.</li>
+<li><strong>Is Nvj3 itself a tether, or a passenger?</strong> Nvj3 is recruited to ER–vacuole MCSs by Mdm1<br />
+   and is predicted soluble; independent tethering activity of Nvj3 alone has not been shown.</li>
+<li><strong>Loss-of-function phenotype is subtle.</strong> Single nvj3Δ has mild neutral-lipid phenotypes;<br />
+   there is no reported growth phenotype and 0 hits in 10 CRISPR screens (UniProt DR BioGRID-ORCS),<br />
+   consistent with redundancy with Mdm1 and a modulatory role.</li>
+</ol>
+<h2 id="annotation-by-annotation-plan">Annotation-by-annotation plan</h2>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Evidence</th>
+<th>Ref</th>
+<th>Action</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0071561 nucleus-vacuole junction (CC)</td>
+<td>IDA</td>
+<td>PMID:26283797</td>
+<td>ACCEPT</td>
+<td>GFP colocalization at NVJ; core localization</td>
+</tr>
+<tr>
+<td>GO:0098853 ER-vacuole membrane contact site (CC)</td>
+<td>IDA</td>
+<td>PMID:26283797</td>
+<td>ACCEPT</td>
+<td>direct imaging; ER-vacuole MCS</td>
+</tr>
+<tr>
+<td>GO:0006629 lipid metabolic process (BP)</td>
+<td>IMP</td>
+<td>PMID:29146766</td>
+<td>ACCEPT (core, but consider specificity)</td>
+<td>nvj3Δ neutral-lipid/TAG phenotype</td>
+</tr>
+<tr>
+<td>GO:0032266 PI3P binding (MF)</td>
+<td>ISS</td>
+<td>PMID:26283797 (from MDM1)</td>
+<td>MARK_AS_OVER_ANNOTATED</td>
+<td>activity is Mdm1-PX-domain-specific; Nvj3 lacks PX; only PXA is shared</td>
+</tr>
+</tbody>
+</table>
+<h2 id="core_functions-plan">core_functions plan</h2>
+<ul>
+<li>CC/localization: NVJ / ER-vacuole MCS resident, Mdm1-recruited (supported).</li>
+<li>BP: participates in neutral-lipid (TAG/LD) metabolism at ER-vacuole contacts (IMP-supported).</li>
+<li>MF: NO confident positive MF term (dark). Do not assert PI3P binding or lipid transfer.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<ul>
+<li>falcon deep-research launched via <code>just deep-research-falcon yeast NVJ3 --fallback perplexity-lite</code>.</li>
+<li>Independently grounded review in UniProt + GOA + cached primary literature (PMID:26283797,<br />
+  PMID:29146766) + PubMed metadata for the 2026 preprint (PMID:41542480). No fabrication.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q03983
+gene_symbol: NVJ3
+product_type: PROTEIN
+aliases:
+- YDR179W-A
+status: DRAFT
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  NVJ3 (YDR179W-A) is a soluble Saccharomyces cerevisiae protein that resides at the
+  nucleus-vacuole junction (NVJ), the membrane contact site where the nuclear
+  endoplasmic reticulum apposes the vacuole. It is a paralog of the ER-anchored tether
+  Mdm1 (the yeast member of the SNX13/14/19/25 sorting-nexin family) and shares with
+  Mdm1 a single recognizable domain, the Phox-associated (PXA) domain; unlike Mdm1 it
+  lacks a transmembrane anchor and a phosphoinositide-binding PX domain. Nvj3 is
+  recruited to ER-vacuole contacts by direct association with Mdm1 and, in cells
+  lacking Mdm1, redistributes to the cytoplasm; its contact-site localization does not
+  require the canonical NVJ tether Nvj1. Functionally, Nvj3 acts together with Mdm1 in
+  neutral-lipid (triacylglycerol) metabolism and lipid-droplet dynamics at ER-vacuole
+  contacts, particularly during nutritional stress: loss of NVJ3 (with MDM1) increases
+  triacylglycerol and lipid-droplet content in a manner dependent on the fatty
+  acyl-CoA synthetase Faa1. Its own biochemical (molecular) activity has not been
+  established.
+references:
+- id: PMID:26283797
+  title: &#34;Mdm1/Snx13 is a novel ER-endolysosomal interorganelle tethering protein.&#34;
+  findings:
+  - statement: &gt;-
+      Nvj3 (Ydr179w-a) is a novel paralog of Mdm1 that localizes to the
+      nucleus-vacuole junction / ER-vacuole membrane contact site, independently of
+      the canonical tether Nvj1.
+    supporting_text: &gt;-
+      both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner
+  - statement: &gt;-
+      Nvj3 is predicted to be soluble and requires Mdm1 for its NVJ localization,
+      redistributing to the cytoplasm in mdm1-deletion cells.
+    supporting_text: &gt;-
+      Nvj3-GFP redistributed into the cytoplasm in mdm1Δ cells, suggesting Nvj3
+      interacts directly with Mdm1 at NVJs
+  - statement: &gt;-
+      The PXA domain is the only domain shared between Mdm1 and Nvj3; the PI3P-binding
+      activity of Mdm1 resides in its separate PX domain.
+    supporting_text: &gt;-
+      the PXA domain is the only domain shared between Mdm1 and Nvj3
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (J Cell Biol 2015) that discovered and named Nvj3
+      (Ydr179w-a). It is the source for the NVJ (GO:0071561) and ER-vacuole MCS
+      (GO:0098853) IDA localizations and the ISS PI3P-binding transfer from Mdm1.
+      Full text available and used for verbatim supporting quotes.
+- id: PMID:29146766
+  title: &#34;Lipid droplet biogenesis is spatially coordinated at ER-vacuole contacts under nutritional stress.&#34;
+  findings:
+  - statement: &gt;-
+      Deletion of MDM1, NVJ3, or both causes lipid-droplet accumulation and a ~2-fold
+      increase in triacylglycerol, implicating Nvj3 in NVJ-associated neutral-lipid
+      metabolism.
+    supporting_text: &gt;-
+      deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold
+      increase in TAG
+  - statement: &gt;-
+      The triacylglycerol increase in the mdm1 nvj3 double mutant is suppressed by
+      deletion of the fatty acyl-CoA synthetase Faa1, linking Mdm1/Nvj3 to lipid
+      droplet production downstream of fatty acyl-CoA activation.
+    supporting_text: &gt;-
+      Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we
+      see in the mdm1 Δ nvj3 Δ double knockout
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (EMBO Rep 2018). Source for the GO:0006629 lipid
+      metabolic process IMP annotation: nvj3Δ (with mdm1Δ) increases TAG/LDs, Faa1-
+      dependent. Full text available; quotes verified verbatim.
+- id: PMID:41542480
+  title: &#34;Nvj3 regulates Dga1-mediated triacylglycerol synthesis and lipid droplet formation at ER contact sites.&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      bioRxiv preprint (2026), NOT peer-reviewed; full text not cached. Metadata and
+      abstract verified via PubMed (PMID:41542480). Used only to frame knowledge gaps
+      around the DAG/Dga1 axis of lipid-droplet biogenesis; NOT used as the basis for
+      any positive core-function claim. No verbatim full-text quote is available.
+existing_annotations:
+- term:
+    id: GO:0006629
+    label: lipid metabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:29146766
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      Supported by loss-of-function evidence: deletion of NVJ3 (together with MDM1)
+      increases triacylglycerol and lipid-droplet content, an effect suppressed by
+      deletion of the fatty acyl-CoA synthetase Faa1. Nvj3 therefore participates in
+      NVJ-associated neutral-lipid metabolism. The term is general but correctly
+      reflects the demonstrated biological process, and the acts_upstream_of_or_within
+      qualifier is appropriate for a modulatory role established genetically. Retained
+      as a core biological process; the specific molecular step remains a gap.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:29146766
+      supporting_text: &gt;-
+        deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold
+        increase in TAG
+    - reference_id: PMID:29146766
+      supporting_text: &gt;-
+        Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we
+        see in the mdm1 Δ nvj3 Δ double knockout
+- term:
+    id: GO:0071561
+    label: nucleus-vacuole junction
+  evidence_type: IDA
+  original_reference_id: PMID:26283797
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Well supported by direct imaging: GFP-tagged Nvj3 localizes to the
+      nucleus-vacuole junction and colocalizes with Mdm1 there. This is a core,
+      experimentally established localization of the protein.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:26283797
+      supporting_text: &gt;-
+        both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner
+- term:
+    id: GO:0098853
+    label: endoplasmic reticulum-vacuole membrane contact site
+  evidence_type: IDA
+  original_reference_id: PMID:26283797
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Well supported and more precise than the NVJ term for the underlying structure.
+      Nvj3 localizes to the ER-vacuole membrane contact site, retaining this
+      localization even in nvj1-deletion cells, where it is enriched at the tips of ER
+      tubules contacting the vacuole. Core localization annotation.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:26283797
+      supporting_text: &gt;-
+        both Mdm1 and Nvj3 retained ER–vacuole MCS localizations in nvj1Δ yeast but
+        were no longer restricted to NVJ patches
+    - reference_id: PMID:26283797
+      supporting_text: &gt;-
+        Nvj3 was clearly enriched at the tips of ER tubules making contact with the
+        vacuole, confirming ER–vacuole tethering does not require Nvj1
+- term:
+    id: GO:0032266
+    label: phosphatidylinositol-3-phosphate binding
+  evidence_type: ISS
+  original_reference_id: PMID:26283797
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is an ISS annotation transferred from the paralog Mdm1 (with/from
+      SGD:S000004572). The sequence basis for the transfer is weak: in Mdm1 the
+      high-affinity PI3P-binding activity is a property of its C-terminal PX domain,
+      whereas the source paper states that the PXA domain is the ONLY domain shared
+      between Mdm1 and Nvj3. Nvj3 has no PX domain (InterPro/Pfam for Q03983 returns
+      only the PXA domain, PF02194) and is predicted to be soluble with no
+      transmembrane anchor (max Kyte-Doolittle hydropathy ~1.1, below a TM threshold).
+      There is no direct biochemical evidence that Nvj3 itself binds PI3P, and the
+      domain that would confer that activity is absent, so this is likely an
+      over-annotation by similarity. A specific molecular function for Nvj3 remains
+      undetermined (see knowledge_gaps).
+    action: MARK_AS_OVER_ANNOTATED
+    supported_by:
+    - reference_id: PMID:26283797
+      supporting_text: &gt;-
+        the PXA domain is the only domain shared between Mdm1 and Nvj3
+    - reference_id: PMID:26283797
+      supporting_text: &gt;-
+        its C-terminal PX domain, which binds PI3P with high affinity
+core_functions:
+- description: &gt;-
+    Resident protein of the nucleus-vacuole junction / ER-vacuole membrane contact
+    site. Nvj3 is a soluble paralog of the ER-anchored tether Mdm1 and is recruited to
+    ER-vacuole contacts through direct association with Mdm1 (it becomes cytoplasmic in
+    mdm1-deletion cells); its contact-site localization is independent of the canonical
+    NVJ tether Nvj1. No autonomous molecular activity has been demonstrated, so no
+    molecular_function term is asserted here (see knowledge_gaps).
+  locations:
+  - id: GO:0071561
+    label: nucleus-vacuole junction
+  - id: GO:0098853
+    label: endoplasmic reticulum-vacuole membrane contact site
+  supported_by:
+  - reference_id: PMID:26283797
+    supporting_text: &gt;-
+      both it and Mdm1 localize specifically to NVJs in an Nvj1-independent manner
+  - reference_id: PMID:26283797
+    supporting_text: &gt;-
+      Nvj3-GFP redistributed into the cytoplasm in mdm1Δ cells, suggesting Nvj3
+      interacts directly with Mdm1 at NVJs
+- description: &gt;-
+    Participates, together with its paralog Mdm1, in neutral-lipid (triacylglycerol)
+    metabolism and lipid-droplet dynamics at ER-vacuole contact sites, a role that is
+    pronounced under nutritional stress. Genetic loss of NVJ3 (with MDM1) raises
+    triacylglycerol and lipid-droplet content in a manner suppressible by deletion of
+    the fatty acyl-CoA synthetase Faa1, placing Nvj3 in lipid-droplet production
+    downstream of fatty acyl-CoA activation. The molecular step Nvj3 performs in this
+    process is not established.
+  directly_involved_in:
+  - id: GO:0006629
+    label: lipid metabolic process
+  locations:
+  - id: GO:0098853
+    label: endoplasmic reticulum-vacuole membrane contact site
+  supported_by:
+  - reference_id: PMID:29146766
+    supporting_text: &gt;-
+      deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold
+      increase in TAG
+  - reference_id: PMID:29146766
+    supporting_text: &gt;-
+      Deletion of Faa1 in addition to Mdm1 and Nvj3 suppresses the increase in TAG we
+      see in the mdm1 Δ nvj3 Δ double knockout
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct molecular/biochemical activity of Nvj3 is undetermined: it is unknown
+    whether Nvj3 binds or transfers a specific lipid, senses a lipid, or acts purely as
+    a scaffold/adaptor recruited by Mdm1. Its only recognizable domain is the PXA
+    (Phox-associated) domain, whose biochemical function is itself uncharacterized.
+  boundary: &gt;-
+    Nvj3&#39;s localization (NVJ / ER-vacuole contact site) and its genetic contribution to
+    triacylglycerol/lipid-droplet homeostasis are experimentally established, and it is
+    known to depend on Mdm1 for recruitment; but no in vitro activity, ligand, or
+    catalytic step has been assigned to the protein or its PXA domain. (Fatty-acid
+    binding has been shown for the PXA domains of the paralog Mdm1 and of human SNX14,
+    but not for Nvj3 itself.)
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Nvj3 is the only yeast protein besides Mdm1 to carry a PXA domain; defining its
+    activity would clarify the function of the conserved PXA domain and the mechanism by
+    which ER-vacuole contacts regulate neutral-lipid metabolism.
+  resolution: &gt;-
+    Biochemical characterization of recombinant Nvj3 and its PXA domain (lipid-binding /
+    lipid-transfer assays, ligand identification) and structure determination, combined
+    with separation-of-function alleles tested for lipid-droplet phenotypes.
+  provenance:
+  - reference_id: PMID:26283797
+    supporting_text: &gt;-
+      All Mdm1 homologues encode an uncharacterized PXA domain
+- gap_statement: &gt;-
+    Whether Nvj3 itself possesses membrane-tethering activity, or is only a passenger
+    recruited to Mdm1-formed ER-vacuole contacts, is unresolved.
+  boundary: &gt;-
+    Mdm1 is an ER-anchored transmembrane protein that tethers the ER to the vacuole via
+    its PI3P-binding PX domain; Nvj3 is predicted soluble, lacks a PX domain, and
+    requires Mdm1 for contact-site localization. Independent tethering by Nvj3 alone has
+    not been demonstrated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing tether from passenger determines whether Nvj3 should be annotated
+    with a contact-site tether activity or an accessory/adaptor role.
+  resolution: &gt;-
+    Test ER-vacuole contact formation and reconstituted tethering with Nvj3 in the
+    absence of Mdm1 (e.g. synthetic tethering assays, in vitro membrane binding).
+  provenance:
+  - reference_id: PMID:26283797
+    supporting_text: &gt;-
+      Because Nvj3 is predicted to be soluble, we hypothesized that it required Mdm1 for
+      its NVJ localization
+- gap_statement: &gt;-
+    The specific molecular step by which Nvj3 influences triacylglycerol synthesis and
+    lipid-droplet packaging is unknown, as is the physiological consequence of its loss
+    beyond a mild neutral-lipid imbalance.
+  boundary: &gt;-
+    nvj3Δ (with mdm1Δ) increases TAG and lipid droplets in an Faa1-dependent manner, and
+    a 2026 preprint links Nvj3 to Dga1-dependent TAG synthesis and DAG localization; but
+    no peer-reviewed mechanism, direct partner in TAG synthesis, or robust growth
+    phenotype has been reported (no hits in 10 CRISPR screens per BioGRID-ORCS).
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: NARROWING
+  significance: &gt;-
+    Resolving the step would connect ER-vacuole contact-site biology to the enzymology
+    of lipid-droplet biogenesis and to the conserved SNX13/14-family lipid roles in
+    mammals.
+  resolution: &gt;-
+    Peer-reviewed, mechanistic dissection of the Nvj3-Dga1/DAG relationship (e.g. the
+    findings reported in the preprint PMID:41542480), with lipidomics and
+    separation-of-function alleles.
+  provenance:
+  - reference_id: PMID:29146766
+    supporting_text: &gt;-
+      deleting MDM1, NVJ3, or both causes accumulation of LDs in yeast, and a ~2‐fold
+      increase in TAG
+suggested_questions:
+- question: &gt;-
+    Does Nvj3 bind or transfer a specific lipid through its PXA domain, or does it act
+    solely as an Mdm1-recruited scaffold at ER-vacuole contacts?
+  experts:
+  - W. Mike Henne
+- question: &gt;-
+    What is the mechanistic step by which Nvj3 couples Dga1-dependent triacylglycerol
+    synthesis to efficient lipid-droplet packaging?
+  experts:
+  - W. Mike Henne
+suggested_experiments:
+- hypothesis: &gt;-
+    The Nvj3 PXA domain binds a specific lipid that contributes to its function at
+    ER-vacuole contacts.
+  description: &gt;-
+    Express and purify recombinant Nvj3 (and its isolated PXA domain) and perform
+    protein-lipid overlay, liposome flotation/co-sedimentation, and lipid-transfer
+    assays against a panel of phospholipids, phosphoinositides, DAG, and sterols to
+    identify any direct lipid ligand or transfer activity.
+  experiment_type: in vitro lipid-binding/transfer biochemistry
+- hypothesis: &gt;-
+    Nvj3 organizes DAG/TAG conversion at ER-vacuole contacts and its PXA domain is
+    required for this role.
+  description: &gt;-
+    Combine quantitative lipidomics of nvj3Δ and PXA-domain point/deletion mutants with
+    live-cell imaging of DAG and lipid-droplet biogenesis during diauxic shift or
+    glucose depletion to map Nvj3&#39;s step in TAG synthesis and lipid-droplet packaging.
+  experiment_type: genetics + lipidomics + live-cell imaging
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/ROF1/ROF1-ai-review.html
+++ b/genes/yeast/ROF1/ROF1-ai-review.html
@@ -1,0 +1,2741 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ROF1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ROF1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P38867" target="_blank" class="term-link">
+                        P38867
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YHR177W</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ROF1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P38867" data-a="DESCRIPTION: ROF1 (YHR177W) is a putative sequence-specific DNA..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ROF1 (YHR177W) is a putative sequence-specific DNA-binding transcription factor of the fungal Gti1/Pac2 (WOPR-domain) family. Its N-terminal WOPR domain (residues ~6-201) has been crystallized in complex with a preferred DNA site, establishing it as a bona fide sequence-specific DNA-binding protein, and the protein is a paralog of the S. cerevisiae pseudohyphal-growth regulator Mit1 and an ortholog of the Candida albicans white-opaque master regulator Wor1. Rof1 acts in the nucleus as a regulator of the transcriptional program controlling filamentous/pseudohyphal growth and complex (biofilm-like &#34;fluffy&#34;) colony morphology: its overexpression represses the FLO11/flocculin and filamentation-MAPK regulon and flattens complex colony structure, while its deletion can increase colony structure. The direction of its transcriptional effect on direct targets, and its physiological trigger, remain incompletely defined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                                    GO:0003700
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0003700" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation from the Gti1/Pac2 (WOPR) family. Family members (Wor1, Mit1, Ryp1) are sequence-specific DNA-binding transcription factors, and the ROF1 WOPR domain has been crystallized bound to DNA (PMID:24994900). Domain- and structure-defensible core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22095082" target="_blank" class="term-link">
+                                        PMID:22095082
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognize the same DNA sequence</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization is expected for a sequence-specific DNA-binding transcription factor and is consistent with the curator IC nucleus annotation. Retained as the core site of action.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043565" target="_blank" class="term-link">
+                                    GO:0043565
+                                </a>
+                            </span>
+                            <span class="term-label">sequence-specific DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0043565" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Directly supported by the co-crystal structure of the ROF1 WOPR domain with a preferred DNA site (PMID:24994900) and by the shared sequence-specific recognition of the Wor1/Mit1/Ryp1 family. Core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22095082" target="_blank" class="term-link">
+                                        PMID:22095082
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognize the same DNA sequence</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                    GO:0045944
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0045944" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ROF1 is a transcriptional regulator, so involvement in regulation of RNA polymerase II transcription is well supported. However, the POSITIVE direction is not established for ROF1 in S. cerevisiae: the direct budding-yeast data show ROF1 overexpression REPRESSING the FLO11/flocculin and filamentation-MAPK program, and the IBA/ISS positive direction derives from the C. albicans activator Wor1. The regulatory role is real but its direction on direct targets is a knowledge gap; kept as non-core, and a direction-neutral parent term is proposed as a better fit.
+                        </div>
+
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    regulation of transcription by RNA polymerase II
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" target="_blank" class="term-link">
+                                        PMID:28673928
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">as regulators of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
+                                    GO:0003677
+                                </a>
+                            </span>
+                            <span class="term-label">DNA binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24994900
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of a new DNA-binding domain which regulates pathog...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0003677" data-r="PMID:24994900" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence: the ROF1 WOPR domain (PDB 4M8B, residues 6-201 of P38867) was crystallized in complex with its preferred DNA sequence. GO:0043565 (sequence-specific DNA binding) is the more precise term for the same activity; this general parent is retained as accurate.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" target="_blank" class="term-link">
+                                        PMID:24994900
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">WOPR-domain proteins are found throughout the fungal kingdom where they function</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24994900
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of a new DNA-binding domain which regulates pathog...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0005634" data-r="PMID:24994900" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator inference (IC) of nuclear localization from the transcription-factor role. Appropriate for a sequence-specific DNA-binding transcription factor; the core cellular location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                    GO:0045944
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24994900
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of a new DNA-binding domain which regulates pathog...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:0045944" data-r="PMID:24994900" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS from C. albicans Wor1 (with/from UniProtKB:Q5AP80), an activator of opaque-phase genes. The orthology is genuine (both are WOPR-family regulators), but the transferred POSITIVE direction is Wor1-specific; ROF1 experimental data in S. cerevisiae point to repression of the filamentation/FLO11 program. Not removed (well-grounded curator ISS), but the direction is uncertain, so kept as non-core and flagged in knowledge_gaps.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22095082" target="_blank" class="term-link">
+                                        PMID:22095082
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognize the same DNA sequence</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1900428" target="_blank" class="term-link">
+                                    GO:1900428
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of filamentous growth of a population of unicellular organisms</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28673928
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Transcriptional Profiling of Biofilm Regulators Identified b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P38867" data-a="GO:1900428" data-r="PMID:28673928" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed NEW annotation not currently in GOA. ROF1 was identified in an overexpression screen as a regulator of complex (&#34;fluffy&#34;) colony morphology: overexpression reduces, and deletion increases, complex colony structure, and the overexpression transcriptional profile represses the FLO11/flocculin and filamentation-MAPK regulon. This establishes ROF1 as a regulator of the filamentous/pseudohyphal growth program in S. cerevisiae. A direction-neutral term is used because the direct-target direction (activation vs repression) is a knowledge gap.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" target="_blank" class="term-link">
+                                        PMID:28673928
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">as regulators of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Sequence-specific DNA-binding transcription factor (Gti1/Pac2/WOPR family) acting in the nucleus to regulate the RNA polymerase II transcriptional program governing filamentous/pseudohyphal growth and complex (&#34;fluffy&#34;) colony morphology. The WOPR domain provides sequence-specific DNA recognition (co-crystal with DNA); in budding yeast ROF1 modulates the FLO11/flocculin and filamentation-MAPK regulon shared with its paralog Mit1.</h3>
+                <span class="vote-buttons" data-g="P38867" data-a="FUNCTION: Sequence-specific DNA-binding transcription factor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                            DNA-binding transcription factor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1900428" target="_blank" class="term-link">
+                                regulation of filamentous growth of a population of unicellular organisms
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" target="_blank" class="term-link">
+                                PMID:24994900
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">WOPR-domain proteins are found throughout the fungal kingdom where they function</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" target="_blank" class="term-link">
+                                PMID:28673928
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">as regulators of</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" target="_blank" class="term-link">
+                            PMID:24994900
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of a new DNA-binding domain which regulates pathogenesis in a wide variety of fungi.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" target="_blank" class="term-link">
+                            PMID:28673928
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transcriptional Profiling of Biofilm Regulators Identified by an Overexpression Screen in Saccharomyces cerevisiae.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22095082" target="_blank" class="term-link">
+                            PMID:22095082
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A conserved transcriptional regulator governs fungal morphology in widely diverged species.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Rof1 bind the FLO11 promoter directly, or does it act indirectly through shared targets with its paralog Mit1?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38867" data-a="Q: Does Rof1 bind the FLO11 promoter directly, or doe..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Under what physiological condition is Rof1 activity required, and is it functionally antagonistic, redundant, or parallel to Mit1?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38867" data-a="Q: Under what physiological condition is Rof1 activit..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Genome-wide ChIP-seq/CUT&amp;RUN of epitope-tagged Rof1 under filamentation-inducing conditions, integrated with RNA-seq of rof1 deletion and overexpression, and compared to Mit1 binding maps, to define direct targets and the activation/repression direction.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P38867" data-a="EXPERIMENT: Genome-wide ChIP-seq/CUT&amp;RUN of epitope-tagged Rof..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Epistasis and expression analysis of rof1, mit1, and rof1 mit1 mutants across colony-morphology conditions and strain backgrounds to resolve the paralog relationship and a clean loss-of-function phenotype.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P38867" data-a="EXPERIMENT: Epistasis and expression analysis of rof1, mit1, a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct in vivo target genes of Rof1 in S. cerevisiae are undetermined. No genome-wide Rof1 ChIP dataset has been reported (unlike its paralog Mit1); the available data are downstream expression changes from overexpression, not direct binding, and SGD lists zero known targets.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Rof1 is established as a sequence-specific DNA-binding protein (WOPR domain co-crystallized with DNA) and its paralog Mit1 binds the control regions of known pseudohyphal-growth regulators and flocculin genes, so a plausible target space is the FLO11/filamentation regulon - but ROF1&#39;s own direct binding sites are unmapped.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without direct targets, ROF1&#39;s placement in the filamentous-growth regulatory network (and whether it acts on FLO11 directly or via Mit1-shared sites) cannot be fixed.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Genome-wide ChIP-seq / CUT&amp;RUN for tagged Rof1 under filamentation-inducing conditions, compared with Mit1 binding maps.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"recognize the same DNA sequence"</em> — PMID:22095082</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether Rof1 functions as a transcriptional activator or repressor of its direct targets in S. cerevisiae is unresolved. GO annotations encode positive regulation (transferred from the C. albicans activator Wor1), yet the budding-yeast phenotypic and expression data indicate repression of the complex-colony/FLO11 program.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that ROF1 overexpression reduces complex &#34;fluffy&#34; colony morphology and that its deletion can increase colony structure, and that the overexpression profile is dominated by repression of FLO11, FLO10 and TEC1. The mechanistic direction on genes it binds directly is not established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Activator-vs-repressor identity determines how ROF1 is wired into the filamentous-growth circuit and how it relates functionally to the activator paralog Mit1 and to Wor1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct-target reporter/expression assays with DNA-binding-competent vs -defective Rof1 alleles, and Rof1 ChIP integrated with target expression.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"as master regulators of cell morphology and pathogenesis"</em> — PMID:24994900</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Rof1 has no penetrant, condition-independent loss-of-function phenotype, and the physiological signal or condition that activates it is unknown. Single-deletion effects on colony morphology are strain-background dependent and conflicting between studies.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Deletion increases colony structure in one background and suppresses hog1-driven hyper-filamentation in another, and overexpression reduces complex colony morphology; but a clean, condition-independent single-deletion phenotype has not been established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A defined activating condition and a clean phenotype are prerequisites for placing ROF1 in a specific signaling pathway (HOG / filamentation-MAPK / cAMP-PKA) rather than the broad morphology network.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic phenotyping of rof1 deletion (and rof1 mit1 double mutants) across nutrient/stress conditions and strain backgrounds; identification of upstream regulators.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"adaptive morphological"</em> — PMID:28673928</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ROF1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38867" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">16 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:08:35.709396</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="ROF1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-rof1yhr177w-in-saccharomyces-cerevisiae">Comprehensive Research Report: ROF1/YHR177W in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="gene-identity-and-symbol-disambiguation">Gene Identity and Symbol Disambiguation</h3>
+<p><strong>Important note on gene symbol ambiguity:</strong> The symbol "ROF1" is used in <em>Arabidopsis thaliana</em> to designate an FKBP-type immunophilin (AtFKBP62), which is entirely unrelated to the yeast protein discussed here. In <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c), ROF1 (Regulator of Fluffy 1) corresponds to the systematic open reading frame <strong>YHR177W</strong> (UniProt: P38867). This protein was initially annotated as uncharacterized but has since been functionally characterized as a WOPR-domain transcription factor belonging to the fungal-specific Gti1/Pac2 family (luo2024therolesof pages 2-4, luo2024therolesof pages 1-2, arita2021agenome‐scaleyeast pages 8-10).</p>
+<p>The key characteristics of ROF1/YHR177W are summarized in the following table:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene Name</td>
+<td><strong>ROF1</strong> (Regulator of Fluffy 1); also referred to as <strong>YHR177W</strong> in the yeast systematic nomenclature; identified as the <strong>Pac2 ortholog</strong> in <em>S. cerevisiae</em> (luo2024therolesof pages 2-4, luo2024therolesof pages 1-2)</td>
+</tr>
+<tr>
+<td>Systematic Name</td>
+<td><strong>YHR177W</strong> (luo2024therolesof pages 2-4, luo2024therolesof pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>P38867</strong> (user-provided target identity)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Saccharomyces cerevisiae</strong> (strain ATCC 204508 / S288c), baker's yeast (luo2024therolesof pages 2-4)</td>
+</tr>
+<tr>
+<td>Protein Family</td>
+<td><strong>Gti1/Pac2 family</strong>; fungal-specific <strong>WOPR-domain transcription factor</strong> family (luo2024therolesof pages 1-2, luo2024therolesof pages 4-5)</td>
+</tr>
+<tr>
+<td>Domain(s)</td>
+<td>Conserved N-terminal <strong>Gti1/Pac2 (WOPR) domain</strong> corresponding to PF09729/IPR018608; WOPR domain comprises <strong>WOPRa</strong> and <strong>WOPRb</strong> globular subdomains required for DNA binding (luo2024therolesof pages 1-2, tollot2016thewoprprotein pages 2-4, luo2024therolesof pages 4-5)</td>
+</tr>
+<tr>
+<td>DNA Binding Motif</td>
+<td>Promoters repressed by Rof1 are enriched for a <strong>WOPR-like motif</strong>: <strong>[A/T]TTAAACTTT</strong> (arita2021agenome‐scaleyeast pages 8-10)</td>
+</tr>
+<tr>
+<td>Primary Function</td>
+<td><strong>Sequence-specific transcriptional repressor</strong> that regulates gene expression programs linked to colony morphology/biofilm-related traits and broader transcription-factor networks; it is not an enzyme or transporter, but a <strong>fungal transcriptional regulator</strong> (arita2021agenome‐scaleyeast pages 8-10, arita2021agenome‐scaleyeast pages 10-12)</td>
+</tr>
+<tr>
+<td>Paralog</td>
+<td><strong>MIT1</strong>, the <em>S. cerevisiae</em> <strong>Gti1 ortholog</strong> and Wor1 homolog; Rof1 and Mit1 share overlapping DNA-binding regions and regulate many of the same genes (luo2024therolesof pages 2-4)</td>
+</tr>
+<tr>
+<td>Subcellular Localization</td>
+<td>Most likely <strong>nuclear</strong>, based on family-level evidence that Gti1/Pac2 proteins are nuclear-localizing transcriptional regulators with NLS features; direct YHR177W-specific localization evidence was not found in the gathered literature, so this is an inference rather than a direct experimental localization claim here (luo2024therolesof pages 6-7, luo2024therolesof pages 4-5)</td>
+</tr>
+<tr>
+<td>Key Phenotypes (deletion and overexpression)</td>
+<td><strong>Deletion:</strong> YHR177W deletion alone had <strong>no clear effect on morphological switching/vegetative growth</strong>, but deletion suppresses the <strong>hog1Δ hyper-filamentous/complex colony/invasive growth phenotype</strong> in diploids; YHR177W is also described as required for <strong>biofilm formation</strong> in review-level synthesis (luo2024therolesof pages 7-7, luo2024therolesof pages 2-4, furukawa2011efficientconstructionof pages 5-6). <strong>Overexpression:</strong> reduces expression of a subset of target genes, causes <strong>fitness defects</strong>, <strong>prevents fluffy colony morphology</strong>, and <strong>reduces colony structure complexity</strong> (luo2024therolesof pages 4-5, arita2021agenome‐scaleyeast pages 8-10, arita2021agenome‐scaleyeast pages 10-12)</td>
+</tr>
+<tr>
+<td>Regulon (key repressed genes)</td>
+<td>Rof1-repressed genes include transcription factors <strong>MOT3, CUP9, PHD1, YAP6, NRG1, GAT2, TBS1, ACA1, GCN4, CIN5, and MIT1</strong>; repressed gene sets are enriched for <strong>water transport</strong>, <strong>siderophore transmembrane transport</strong>, and <strong>transcription factor binding</strong> functions (arita2021agenome‐scaleyeast pages 8-10)</td>
+</tr>
+<tr>
+<td>Genetic Interactions</td>
+<td><strong>264 synthetic dosage lethality interactions</strong> were identified upon ROF1 overexpression; strongest interactions involve the <strong>cell wall integrity (CWI) pathway</strong> (<strong>SLT2, BCK1, PKC1</strong>) and cell wall biosynthesis genes (<strong>GFA1, QRI1</strong>), plus chromatin/transcription regulators including <strong>SWR1, INO80, Rpd3L, NuA4, and COMPASS</strong> components (arita2021agenome‐scaleyeast pages 10-12)</td>
+</tr>
+<tr>
+<td>Signaling Pathway Connections</td>
+<td>Connected most clearly to <strong>morphogenesis/filamentation regulatory networks</strong> and genetically to the <strong>cell wall integrity (PKC1-BCK1-SLT2/Mpk1) MAPK pathway</strong>; YHR177W also emerges in <strong>hog1Δ suppressor</strong> screens, linking it indirectly to HOG-dependent control of filamentous growth. At the family level, Gti1/Pac2 proteins are associated with <strong>PKA</strong> and <strong>MAPK</strong> regulatory logic in fungi (arita2021agenome‐scaleyeast pages 10-12, luo2024therolesof pages 2-4, luo2024therolesof pages 6-7, furukawa2011efficientconstructionof pages 5-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key molecular, functional, and phenotypic characteristics of the yeast gene ROF1/YHR177W from the gathered evidence. It is useful as a compact reference for identity verification, inferred function, regulatory targets, and pathway connections.</em></p>
+<h3 id="1-primary-function-sequence-specific-transcriptional-repressor">1. Primary Function: Sequence-Specific Transcriptional Repressor</h3>
+<p>ROF1 encodes a sequence-specific DNA-binding transcriptional repressor. When Rof1 expression is induced (using the YETI inducible expression system), it rapidly reduces the expression of a defined subset of target genes (arita2021agenome‐scaleyeast pages 8-10). This repressive activity is mediated through its WOPR DNA-binding domain, which recognizes promoter sequences enriched for the motif <strong>[A/T]TTAAACTTT</strong> (arita2021agenome‐scaleyeast pages 8-10). Rof1 is not an enzyme or transporter; rather, it functions as a transcriptional regulator that modulates gene expression programs related to colony morphology, biofilm formation, and broader transcription factor networks.</p>
+<p>The Rof1 regulon, identified by transcriptomic analysis following rapid induction, includes genes functionally enriched for water transport, siderophore transmembrane transport, and transcription factor binding activity (arita2021agenome‐scaleyeast pages 8-10). Notably, Rof1 represses the expression of numerous transcription factor genes, including <strong>MOT3, CUP9, PHD1, YAP6, NRG1, GAT2, TBS1, ACA1, GCN4, CIN5</strong>, and <strong>MIT1</strong> (its own paralog) (arita2021agenome‐scaleyeast pages 8-10). This highly interconnected nature—a transcription factor that represses other transcription factors—positions Rof1 as a potential upstream modulator of multiple regulatory circuits.</p>
+<h3 id="2-domain-architecture-and-structural-features">2. Domain Architecture and Structural Features</h3>
+<p>ROF1 belongs to the <strong>Gti1/Pac2 protein family</strong>, also known as the WOPR (Wor1, Pac2, Ryp1) transcription factor family, which is fungal-specific (luo2024therolesof pages 1-2). The defining structural feature is a conserved N-terminal <strong>Gti1/Pac2 domain</strong> (Pfam PF09729 / InterPro IPR018608). This domain consists of two globular subdomains, <strong>WOPRa</strong> and <strong>WOPRb</strong>, separated by a linker region of variable length and sequence (tollot2016thewoprprotein pages 2-4, luo2024therolesof pages 4-5). Both subdomains are required for DNA binding activity—neither alone is sufficient (tollot2016thewoprprotein pages 2-4). The N-terminal Gti1/Pac2 domain also contains a conserved <strong>protein kinase A (Pka1) phosphorylation site</strong>, suggesting regulation by PKA-dependent signaling (luo2024therolesof pages 2-4, luo2024therolesof pages 1-2).</p>
+<p>Structural modeling has confirmed that key amino acids critical for WOPR motif binding are highly conserved across WOPR family members. Crystal structures of the WOPR domain from Wor1 in <em>Candida albicans</em> and YHR177W from <em>S. cerevisiae</em> have been used as structural templates for comparative modeling (duttke2022decodingtranscriptionregulatory pages 7-8), indicating that the structural basis for DNA binding is conserved across the family.</p>
+<p>The C-terminal region of Rof1, in contrast to the conserved N-terminal domain, is divergent and variable among Gti1/Pac2 family members, and this divergence may contribute to the functional differences between the two paralogs in <em>S. cerevisiae</em> (luo2024therolesof pages 5-6).</p>
+<h3 id="3-relationship-with-paralog-mit1-and-the-morphogenesis-regulatory-network">3. Relationship with Paralog Mit1 and the Morphogenesis Regulatory Network</h3>
+<p><em>S. cerevisiae</em> possesses two WOPR-family paralogs: <strong>Mit1</strong> (the Gti1/Wor1 ortholog) and <strong>ROF1/YHR177W</strong> (the Pac2 ortholog) (luo2024therolesof pages 2-4). These two proteins share substantial functional overlap: over 50% of YHR177W-bound intergenic regions overlap with Mit1-bound regions, indicating shared DNA-binding specificities and co-regulation of many of the same target genes (luo2024therolesof pages 2-4). Despite this overlap, the two paralogs have distinct phenotypic consequences. Mit1 is a central regulator of morphological transitions—its absence prevents diploid pseudohyphal growth and haploid invasive growth—whereas deletion of YHR177W alone has no clear effect on morphological switching or vegetative growth (luo2024therolesof pages 2-4, luo2024therolesof pages 7-7). Instead, YHR177W is required for biofilm formation and complex colony structure (luo2024therolesof pages 2-4).</p>
+<p>Intriguingly, deletion of <em>MIT1</em> substantially increases <em>YHR177W</em> expression levels, suggesting a regulatory feedback loop between the two paralogs (luo2024therolesof pages 2-4). Both Rof1 and Mit1 are integrated into a broader morphogenesis transcriptional network that includes Phd1, Sok2, Mga1, Flo8, Tec1, and Ste12 (luo2024therolesof pages 2-4). The Rof1 overexpression regulon also includes Mit1 itself as a repressed target, further underscoring the interconnectedness of these regulatory circuits (arita2021agenome‐scaleyeast pages 8-10).</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>Although direct experimental localization data specific to YHR177W/Rof1 (e.g., from GFP fusion imaging) were not identified in the primary literature gathered here, the protein is predicted to localize to the <strong>nucleus</strong>. This inference is strongly supported by multiple lines of evidence: (i) Gti1/Pac2 family proteins across fungal species contain nuclear localization signals (NLS) and have been characterized as nuclear-localizing transcriptional regulators (luo2024therolesof pages 2-4, luo2024therolesof pages 6-7); (ii) Rof1 possesses a sequence-specific DNA-binding domain and functions as a transcription factor, which necessitates nuclear localization; and (iii) the Saccharomyces Genome Database annotates Rof1 localization as nuclear. These converging lines of evidence strongly support a nuclear site of action.</p>
+<h3 id="5-role-in-filamentous-growth-and-colony-morphology">5. Role in Filamentous Growth and Colony Morphology</h3>
+<p>Rof1 plays a defined role in the complex colony morphology and filamentous growth programs of <em>S. cerevisiae</em>. In a genetic screen for suppressors of the hyper-filamentous phenotype caused by deletion of the Hog1 MAPK in diploid Σ1278b strains, <em>YHR177W</em> was identified as one of 30 genes whose insertion/deletion significantly suppressed enhanced morphological developments, including hyper-filamentous growth, agar invasion, and complex colony morphology (luo2024therolesof pages 2-4, furukawa2011efficientconstructionof pages 5-6). This screen categorized YHR177W as being involved in control of cell cycle or cell division, although the precise mechanistic basis for suppression was not elucidated (furukawa2011efficientconstructionof pages 5-6).</p>
+<p>Overexpression of ROF1, conversely, reduces the complexity of colony structure and prevents the formation of "fluffy" colony morphology, a phenotype associated with biofilm-like growth (luo2024therolesof pages 4-5, arita2021agenome‐scaleyeast pages 10-12). This is consistent with Rof1's role as a transcriptional repressor of genes involved in morphological complexity.</p>
+<h3 id="6-genetic-interactions-and-pathway-connections">6. Genetic Interactions and Pathway Connections</h3>
+<p>A genome-wide synthetic dosage lethality (SDL) screen using the YETI system identified <strong>264 genes</strong> with synthetic genetic interactions upon ROF1 overexpression (arita2021agenome‐scaleyeast pages 10-12). The strongest interactions were with components of the <strong>cell wall integrity (CWI) signaling pathway</strong>, specifically <strong>SLT2</strong> (the MAPK), <strong>BCK1</strong> (MAPKKK), and <strong>PKC1</strong> (protein kinase C), as well as cell wall biosynthesis genes <strong>GFA1</strong> and <strong>QRI1</strong> (arita2021agenome‐scaleyeast pages 10-12). This genetic connection to the CWI pathway suggests that Rof1 overexpression imposes cell wall stress or reduces cell wall integrity, such that cells become dependent on the CWI pathway for survival.</p>
+<p>Additionally, ROF1 displayed synthetic interactions with genes encoding components of multiple chromatin remodeling and transcriptional regulation complexes, including the <strong>SWR1 complex</strong>, <strong>INO80 complex</strong>, <strong>Rpd3L histone deacetylase complex</strong>, <strong>NuA4 histone acetyltransferase complex</strong>, and the <strong>COMPASS (Set1) histone methyltransferase complex</strong> (arita2021agenome‐scaleyeast pages 10-12). These interactions are consistent with Rof1's function as a transcriptional repressor that may require proper chromatin architecture for its activity or whose repressive effects create a cellular dependency on chromatin-mediated gene regulation.</p>
+<h3 id="7-evolutionary-context-the-gti1pac2-wopr-family">7. Evolutionary Context: The Gti1/Pac2 (WOPR) Family</h3>
+<p>The Gti1/Pac2 family is a well-conserved, fungal-specific transcription factor family found throughout the fungal kingdom (luo2024therolesof pages 1-2, luo2024therolesof pages 7-8). Most fungal genomes encode two paralogous WOPR proteins—one Gti1-type (e.g., Wor1 in <em>Candida albicans</em>, Ryp1 in <em>Histoplasma capsulatum</em>, Sge1 in <em>Fusarium</em> species, Mit1 in <em>S. cerevisiae</em>) and one Pac2-type (e.g., ROF1/YHR177W in <em>S. cerevisiae</em>, Pac2 in <em>Schizosaccharomyces pombe</em>) (luo2024therolesof pages 2-4, luo2024therolesof pages 5-6). The Gti1 orthologs have been more extensively studied and are generally considered master regulators of morphological switching and virulence in pathogenic fungi, while the Pac2 orthologs tend to play more minor or modulatory roles (luo2024therolesof pages 5-6, luo2024therolesof pages 7-8).</p>
+<p>In <em>S. pombe</em>, the founding member Pac2 controls the onset of sexual development through a pathway independent of the cAMP cascade, specifically in response to nitrogen starvation (luo2024therolesof pages 2-4, luo2024therolesof pages 1-2). Gti1 in <em>S. pombe</em> functions as a downstream target of the Wis1-Sty1 MAPK (HOG) pathway and promotes gluconate uptake during glucose starvation (luo2024therolesof pages 2-4, luo2024therolesof pages 6-7). This family-level context—regulation by MAPK and PKA pathways and involvement in nutrient-responsive developmental decisions—provides a framework for understanding Rof1's role in <em>S. cerevisiae</em> as a regulator positioned at the intersection of nutrient sensing and morphological development.</p>
+<h3 id="8-summary">8. Summary</h3>
+<p>ROF1/YHR177W encodes a fungal-specific WOPR-domain transcription factor that functions primarily as a <strong>transcriptional repressor</strong> in <em>S. cerevisiae</em>. It binds DNA through its conserved WOPRa/WOPRb domain to the motif [A/T]TTAAACTTT and represses a regulon of genes including multiple transcription factors, as well as genes involved in water transport and siderophore transport. Rof1 is the Pac2 ortholog in the Gti1/Pac2 family, paralogous to Mit1 (the Gti1/Wor1 ortholog), and the two share &gt;50% of their DNA-binding targets. While deletion of Rof1 alone does not abolish morphological transitions, it is required for biofilm formation and was identified as a positive regulator of the hyper-filamentous growth phenotype in <em>hog1Δ</em> diploids. Its overexpression suppresses fluffy colony morphology and creates a genetic dependency on the cell wall integrity MAPK pathway. Rof1 is predicted to function in the <strong>nucleus</strong> as a DNA-binding transcriptional regulator, consistent with its family-level properties including conserved nuclear localization signals and its demonstrated capacity for sequence-specific DNA binding.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(luo2024therolesof pages 2-4): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+<li>
+<p>(luo2024therolesof pages 1-2): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+<li>
+<p>(arita2021agenome‐scaleyeast pages 8-10): Yuko Arita, Griffin Kim, Zhijian Li, Helena Friesen, Gina Turco, Rebecca Y Wang, Dale Climie, Matej Usaj, Manuel Hotz, Emily H Stoops, Anastasia Baryshnikova, Charles Boone, David Botstein, Brenda J Andrews, and R Scott McIsaac. A genome‐scale yeast library with inducible expression of individual genes. Molecular Systems Biology, Jun 2021. URL: https://doi.org/10.15252/msb.202110207, doi:10.15252/msb.202110207. This article has 77 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(luo2024therolesof pages 4-5): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+<li>
+<p>(tollot2016thewoprprotein pages 2-4): Marie Tollot, Daniela Assmann, Christian Becker, Janine Altmüller, Julien Y. Dutheil, Carl-Eric Wegner, and Regine Kahmann. The wopr protein ros1 is a master regulator of sporogenesis and late effector gene expression in the maize pathogen ustilago maydis. PLOS Pathogens, 12:e1005697, Jun 2016. URL: https://doi.org/10.1371/journal.ppat.1005697, doi:10.1371/journal.ppat.1005697. This article has 106 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(arita2021agenome‐scaleyeast pages 10-12): Yuko Arita, Griffin Kim, Zhijian Li, Helena Friesen, Gina Turco, Rebecca Y Wang, Dale Climie, Matej Usaj, Manuel Hotz, Emily H Stoops, Anastasia Baryshnikova, Charles Boone, David Botstein, Brenda J Andrews, and R Scott McIsaac. A genome‐scale yeast library with inducible expression of individual genes. Molecular Systems Biology, Jun 2021. URL: https://doi.org/10.15252/msb.202110207, doi:10.15252/msb.202110207. This article has 77 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(luo2024therolesof pages 6-7): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+<li>
+<p>(luo2024therolesof pages 7-7): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+<li>
+<p>(furukawa2011efficientconstructionof pages 5-6): Kentaro Furukawa, Takako Furukawa, and Stefan Hohmann. Efficient construction of homozygous diploid strains identifies genes required for the hyper-filamentous phenotype in saccharomyces cerevisiae. PLoS ONE, 6:e26584, Oct 2011. URL: https://doi.org/10.1371/journal.pone.0026584, doi:10.1371/journal.pone.0026584. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duttke2022decodingtranscriptionregulatory pages 7-8): Sascha H. Duttke, Sinem Beyhan, Rajendra Singh, Sonya Neal, Suganya Viriyakosol, Joshua Fierer, Theo N. Kirkland, Jason E. Stajich, Christopher Benner, and Aaron F. Carlin. Decoding transcription regulatory mechanisms associated with <i>coccidioides immitis</i> phase transition using total rna. mSystems, Feb 2022. URL: https://doi.org/10.1128/msystems.01404-21, doi:10.1128/msystems.01404-21. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(luo2024therolesof pages 5-6): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+<li>
+<p>(luo2024therolesof pages 7-8): Zheng Luo, Dianguang Xiong, and Chengming Tian. The roles of gti1/pac2 family proteins in fungal growth, morphogenesis, stress response, and pathogenicity. Molecular Plant-Microbe Interactions®, 37:488-497, Jun 2024. URL: https://doi.org/10.1094/mpmi-11-23-0198-cr, doi:10.1094/mpmi-11-23-0198-cr. This article has 9 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="ROF1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>luo2024therolesof pages 2-4</li>
+<li>luo2024therolesof pages 1-2</li>
+<li>tollot2016thewoprprotein pages 2-4</li>
+<li>duttke2022decodingtranscriptionregulatory pages 7-8</li>
+<li>luo2024therolesof pages 5-6</li>
+<li>furukawa2011efficientconstructionof pages 5-6</li>
+<li>luo2024therolesof pages 4-5</li>
+<li>luo2024therolesof pages 6-7</li>
+<li>luo2024therolesof pages 7-7</li>
+<li>luo2024therolesof pages 7-8</li>
+<li>A/T</li>
+<li>https://doi.org/10.1094/mpmi-11-23-0198-cr,</li>
+<li>https://doi.org/10.15252/msb.202110207,</li>
+<li>https://doi.org/10.1371/journal.ppat.1005697,</li>
+<li>https://doi.org/10.1371/journal.pone.0026584,</li>
+<li>https://doi.org/10.1128/msystems.01404-21,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ROF1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38867" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="rof1-yhr177w-s-cerevisiae-curation-notes">ROF1 (YHR177W) — S. cerevisiae — Curation Notes</h1>
+<p>Journal for the AI GO-annotation review of ROF1. Provenance recorded inline as<br />
+<code>[PMID:xxxx "verbatim supporting text"]</code> or <code>[SGD]</code> / <code>[UniProt]</code> where appropriate.</p>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li><strong>Standard name:</strong> ROF1 (SGD standard name description = <strong>"Regulator Of Fluffy"</strong>, verified via SGD API for locus S000001220). NOTE: the task hint "Repressor Of Filamentation" is NOT the SGD name; the SGD-verified expansion is "Regulator Of Fluffy 1" <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" title="we have given YHR177W the name ROF1 (Regulator Of Fluffy1)">PMID:28673928</a>. The two are conceptually related (ROF1 represses the fluffy/filamentous colony program), but I use the SGD-verified name.</li>
+<li><strong>Systematic name / ORF:</strong> YHR177W (Verified ORF, chromosome VIII).</li>
+<li><strong>UniProt:</strong> P38867 (YHX7_YEAST), reviewed Swiss-Prot, 453 aa, PE=1 (evidence at protein level). [UniProt]</li>
+<li><strong>SGD:</strong> S000001220.</li>
+<li><strong>NCBI Taxon:</strong> 559292 (S. cerevisiae S288C).</li>
+</ul>
+<h2 id="domain-structure-inline-domain-analysis">Domain / structure (inline domain analysis)</h2>
+<ul>
+<li><strong>Pfam PF09729 (Gti1_Pac2); InterPro IPR018608 (Gti1/Pac2)</strong> — this is the <strong>WOPR domain</strong>, the DNA-binding domain of the Wor1/Mit1/Ryp1/Gti1/Pac2/Sge1 family of fungal transcriptional regulators. [UniProt DR lines]</li>
+<li><strong>PANTHER PTHR28027 "TRANSCRIPTIONAL REGULATOR MIT1"</strong>, subfamily SF2. Family members include ROF1 (P38867), its S. cerevisiae paralog <strong>MIT1 (P40002)</strong>, C. albicans <strong>Wor1 (Q5AP80)</strong>, S. pombe <strong>Gti1/Pac2</strong>, Fusarium/Verticillium <strong>Sge1</strong>, and H. capsulatum <strong>Ryp1</strong>. [interpro/panther/PTHR28027/PTHR28027-entries.csv]</li>
+<li><strong>PDB 4M8B</strong> — 2.6 Å crystal structure of the WOPR domain of YHR177W (residues <strong>6–201</strong>) bound to an optimized 19-bp DNA site <a href="https://pubmed.ncbi.nlm.nih.gov/24994900" title="the 2.6-Å crystal structure of a WOPR domain in complex with its preferred DNA sequence">PMID:24994900</a>. The paper's abstract describes the fold as "two highly conserved regions, separated by an unconserved linker, form an interdigitated β-sheet that is tilted into the major groove of DNA" and notes minor-groove contacts "primarily through a deeply penetrating arginine residue." This is the structural basis for ROF1 being a bona fide sequence-specific DNA-binding protein.</li>
+<li>UniProt features: two disordered regions (183–210, 428–453), a basic-residue compositional bias (198–207) just C-terminal to the structured WOPR domain — consistent with a nuclear TF (DNA-binding domain + disordered activation/regulatory tail). [UniProt FT]</li>
+</ul>
+<p>Domain reasoning: The WOPR domain is a <em>demonstrated</em> DNA-binding fold (co-crystal with DNA for this exact protein fragment). Sequence-specific DNA binding and nuclear localization are therefore domain-defensible. Family membership (Wor1/Mit1) makes "transcription regulator" a well-supported functional class.</p>
+<h2 id="what-is-known-experimental-structural">What is KNOWN (experimental / structural)</h2>
+<ol>
+<li>
+<p><strong>Sequence-specific DNA binding (WOPR domain).</strong> The YHR177W WOPR domain (res 6–201) was crystallized bound to its preferred DNA site <a href="https://pubmed.ncbi.nlm.nih.gov/24994900">PMID:24994900</a>. → supports GO:0003677 DNA binding (IDA, SGD) and GO:0043565 sequence-specific DNA binding (domain-defensible). Cromie: "YHR177W has been shown to encode a protein having DNA-binding properties (Cain et al. 2012)" <a href="https://pubmed.ncbi.nlm.nih.gov/28673928">PMID:28673928</a>.</p>
+</li>
+<li>
+<p><strong>Negative regulator of complex ("fluffy") colony morphology / biofilm formation.</strong> In an overexpression screen for genes that reduce fluffy colony structure, ROF1/YHR177W was one of the verified hits <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" title="five genes were verified: SAN1, TOS8, YHR177W, HEK2, and SFL1">PMID:28673928</a>. Overexpression REDUCES fluffy morphology and DELETION INCREASES colony structure [PMID:28673928 "Increase in copy number of DIG1, SFL1, HEK2, ROF1/YHR177W, SAN1, and TOS8 leads to a reduction in fluffy morphology in strain F45" ; "Deletion of DIG1, SFL1, HEK2, ROF1/YHR177W, SAN1, and TOS8 leads to an increase in fluffy morphology in strain F13"]. This defines ROF1 as a <strong>repressor</strong> of the biofilm/complex-colony program.</p>
+</li>
+<li>
+<p><strong>Overexpression represses the FLO11/filamentation-MAPK regulon.</strong> The ROF1 overexpression transcriptional profile is part of a "common factor" shared with SFL1/HEK2/SAN1 in which FLO11, FLO10, TEC1 and filamentation-MAPK/mating genes are repressed <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" title="TEC1 itself was also one of the genes commonly repressed, as were the flocculin genes FLO10 and FLO11 that are known to be effectors of complex colony phenotypes">PMID:28673928</a>. The ROF1 overexpression profile correlated most strongly with SAN1 (R = 0.84).</p>
+</li>
+<li>
+<p><strong>Overexpression cell-cycle phenotype.</strong> SGD description: "overexpression causes a cell cycle delay or arrest" [SGD; underlying screens PMID:16455487 (Sopko 2006), PMID:18617996 (Niu 2008)].</p>
+</li>
+<li>
+<p><strong>Family / orthology:</strong> paralog of MIT1 (S. cerevisiae master regulator of pseudohyphal growth) and ortholog of C. albicans WOR1 [PMID:28673928 "YHR177W is a paralog of MIT1 ... and is an ortholog of WOR1, a master regulator of the white-opaque phenotypic switch in Candida albicans"; PMID:22095082 for Mit1 being a master regulator of pseudohyphal growth]. Cain 2012 showed Wor1/Mit1/Ryp1 recognize the same DNA sequence but control largely non-overlapping gene sets between species <a href="https://pubmed.ncbi.nlm.nih.gov/22095082" title="the genes controlled by the orthologous regulators overlap only slightly ... despite the fact that the DNA binding specificity of the regulators has remained largely unchanged">PMID:22095082</a>.</p>
+</li>
+</ol>
+<h2 id="what-is-not-known-knowledge-gaps">What is NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>Direct in vivo target genes of Rof1 in S. cerevisiae.</strong> Genome-wide ChIP for Rof1 (as done for Mit1 in PMID:22095082) has not, to my knowledge, been reported; the overexpression RNA-seq (PMID:28673928) reports downstream expression changes, not direct binding. SGD lists "0 known targets."</li>
+<li><strong>Activator vs repressor direction.</strong> The GO annotation set encodes GO:0045944 <strong>positive</strong> regulation of transcription (ISS from C. albicans Wor1, which is an activator of white-opaque genes). However, the S. cerevisiae experimental data (PMID:28673928) show ROF1 behaving as a <strong>repressor</strong> of the FLO11/filamentation program (overexpression represses; deletion de-represses colony structure). WOPR proteins can act as activators or repressors depending on target/context (Wor1 activates opaque genes; Sfl1 is a repressor in the same regulon). The physiological direction of Rof1's transcriptional effect on its own direct targets in budding yeast is unresolved.</li>
+<li><strong>Loss-of-function phenotype is background-dependent / conflicting.</strong> Deletion reduced complex colony morphology in one study (Furukawa et al. 2011) but had little effect in another (Cain et al. 2012), per Cromie <a href="https://pubmed.ncbi.nlm.nih.gov/28673928" title="deletion reducing complex colony morphology in one study (Furukawa et al. 2011) but having little effect in another (Cain et al. 2012)">PMID:28673928</a>. There is no clean, penetrant single-deletion phenotype under standard laboratory conditions.</li>
+<li><strong>Physiological condition / signal that activates Rof1.</strong> Unknown upstream signal; WOPR-family members respond to nutrient/morphogenic cues, but the S. cerevisiae Rof1 trigger is uncharacterized.</li>
+<li><strong>Whether Rof1 and its paralog Mit1 act antagonistically, redundantly, or on distinct regulons</strong> in budding yeast is not established.</li>
+</ul>
+<h2 id="annotation-by-annotation-reasoning-7-goa-rows">Annotation-by-annotation reasoning (7 GOA rows)</h2>
+<p>GOA source: genes/yeast/ROF1/ROF1-goa.tsv (7 annotations).</p>
+<ol>
+<li>
+<p><strong>GO:0003700 DNA-binding transcription factor activity — IBA (GO_REF:0000033), enables.</strong><br />
+   PANTHER IBA from the WOPR/Mit1/Wor1 family. Family members are DNA-binding transcription factors; the WOPR domain is a demonstrated DNA-binding fold and Mit1/Wor1 are TFs. Domain-defensible. ACCEPT (this is a strong, family-supported MF; the specific <em>activity</em> subtype—activator vs repressor—is the open question, but "DNA-binding transcription factor activity" is the correct parent). Core MF.</p>
+</li>
+<li>
+<p><strong>GO:0005634 nucleus — IBA (GO_REF:0000033), is_active_in.</strong> Nuclear localization expected for a DNA-binding TF; consistent with IC nucleus below. ACCEPT.</p>
+</li>
+<li>
+<p><strong>GO:0043565 sequence-specific DNA binding — IBA (GO_REF:0000033), enables.</strong> Directly supported by the co-crystal structure with a specific DNA site <a href="https://pubmed.ncbi.nlm.nih.gov/24994900">PMID:24994900</a> and family DNA-binding specificity <a href="https://pubmed.ncbi.nlm.nih.gov/22095082">PMID:22095082</a>. ACCEPT. Core MF.</p>
+</li>
+<li>
+<p><strong>GO:0045944 positive regulation of transcription by RNA polymerase II — IBA (GO_REF:0000033), involved_in.</strong> IBA-propagated from the family; but note the <em>direction</em> (positive) is not established for Rof1 in S. cerevisiae and the direct budding-yeast experimental data point to repression of the FLO11 program. The safe, defensible statement is that Rof1 is involved in <strong>regulation</strong> of Pol II transcription; the specific positive direction is a knowledge gap. KEEP_AS_NON_CORE (regulatory role is real but non-core given uncertain direction / no direct targets), and flag the directionality gap. Consider that a more neutral term (regulation of transcription by RNA polymerase II) better reflects current evidence — but per guidance I will not rewrite the GOA id; I will note this in the review reason and knowledge_gaps and propose the neutral parent as a replacement suggestion.</p>
+</li>
+<li>
+<p><strong>GO:0003677 DNA binding — IDA (PMID:24994900), enables.</strong> Directly from the crystal structure of the YHR177W WOPR domain bound to DNA. Strong experimental support. ACCEPT. (GO:0043565 is the more specific term; this is the general parent — both are fine to retain, keep IDA general one as ACCEPT.)</p>
+</li>
+<li>
+<p><strong>GO:0005634 nucleus — IC (PMID:24994900), located_in.</strong> Inferred by curator (IC) from the transcription-factor role. Reasonable for a sequence-specific DNA-binding TF. ACCEPT. Core location.</p>
+</li>
+<li>
+<p><strong>GO:0045944 positive regulation of transcription by RNA polymerase II — ISS (PMID:24994900, with/from UniProtKB:Q5AP80 = C. albicans Wor1), involved_in.</strong> ISS from Wor1, an <em>activator</em> of opaque-phase genes. The inference transfers "regulates Pol II transcription" but the <em>positive</em> direction is Wor1-specific; S. cerevisiae Rof1 experimental data (PMID:28673928) indicate repression of FLO11/filamentation genes. Do NOT REMOVE (experimental/curator ISS grounded in real orthology), but mark the directionality as uncertain. KEEP_AS_NON_CORE with a note that direction is a knowledge gap.</p>
+</li>
+</ol>
+<h2 id="core-functions-defensible">Core functions (defensible)</h2>
+<ul>
+<li>MF: sequence-specific DNA-binding transcription factor activity (WOPR domain; co-crystal with DNA). Domain- and structure-supported.</li>
+<li>CC: nucleus.</li>
+<li>BP: regulation of transcription by RNA polymerase II, in the context of the FLO11/filamentous-growth (complex colony / biofilm) regulon — experimentally a repressor of that program on overexpression. Direction of effect on direct targets is unresolved; treat BP role as a regulator of the filamentous-growth transcriptional program.</li>
+</ul>
+<h2 id="references-gathered">References gathered</h2>
+<ul>
+<li>PMID:24994900 (Lohse 2014) — WOPR domain crystal structure + DNA binding (GO source; abstract-only cache, full_text_available:false).</li>
+<li>PMID:28673928 (Cromie 2017) — biofilm-regulator overexpression screen; ROF1 naming; repressor of fluffy/FLO11 program (FULL TEXT cached).</li>
+<li>PMID:22095082 (Cain 2012) — Mit1/Wor1/Ryp1 conserved regulator; YHR177W DNA-binding; paralog relationship (abstract-only cache).</li>
+<li>PMID:16455487 (Sopko 2006) — systematic overexpression phenotypes (abstract-only) — overexpression cell-cycle phenotype context.</li>
+<li>PMID:18617996 (Niu 2008) — cell cycle control by overexpression (full text cached) — overexpression phenotype context.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P38867
+gene_symbol: ROF1
+aliases:
+- YHR177W
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ROF1 (YHR177W) is a putative sequence-specific DNA-binding transcription factor
+  of the fungal Gti1/Pac2 (WOPR-domain) family. Its N-terminal WOPR domain (residues
+  ~6-201) has been crystallized in complex with a preferred DNA site, establishing
+  it as a bona fide sequence-specific DNA-binding protein, and the protein is a paralog
+  of the S. cerevisiae pseudohyphal-growth regulator Mit1 and an ortholog of the
+  Candida albicans white-opaque master regulator Wor1. Rof1 acts in the nucleus as a
+  regulator of the transcriptional program controlling filamentous/pseudohyphal growth
+  and complex (biofilm-like &#34;fluffy&#34;) colony morphology: its overexpression represses
+  the FLO11/flocculin and filamentation-MAPK regulon and flattens complex colony
+  structure, while its deletion can increase colony structure. The direction of its
+  transcriptional effect on direct targets, and its physiological trigger, remain
+  incompletely defined.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+- id: PMID:24994900
+  title: Structure of a new DNA-binding domain which regulates pathogenesis in a wide
+    variety of fungi.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Reports the 2.6 A co-crystal structure of the WOPR domain bound
+      to DNA (PDB 4M8B is the YHR177W/ROF1 WOPR domain, residues 6-201, per UniProt),
+      the direct experimental basis for the IDA DNA-binding annotation. Cached record
+      is abstract-only (full_text_available:false); the structural assay of the ROF1
+      fragment is in the full text and is trusted per curator IDA.
+- id: PMID:28673928
+  title: Transcriptional Profiling of Biofilm Regulators Identified by an Overexpression
+    Screen in Saccharomyces cerevisiae.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified, full text available. Names YHR177W as ROF1 (Regulator Of Fluffy
+      1), identifies it as a repressor of complex/fluffy colony morphology
+      (overexpression reduces, deletion increases colony structure), and shows the
+      overexpression profile represses FLO11/FLO10/TEC1 and filamentation-MAPK genes.
+      Establishes the S. cerevisiae biological-process context and the paralog (MIT1)/
+      ortholog (WOR1) relationships.
+- id: PMID:22095082
+  title: A conserved transcriptional regulator governs fungal morphology in widely
+    diverged species.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; cached record abstract-only. Establishes the Wor1/Mit1/Ryp1
+      WOPR family as sequence-specific transcriptional regulators recognizing the same
+      DNA motif and that Mit1 (ROF1&#39;s paralog) is a master regulator of pseudohyphal
+      growth. Cited by Cromie 2017 for YHR177W/ROF1 DNA-binding properties. Directly
+      about the paralog Mit1, so relevance to ROF1 itself is corroborative rather than
+      primary.
+existing_annotations:
+- term:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation from the Gti1/Pac2 (WOPR) family. Family members
+      (Wor1, Mit1, Ryp1) are sequence-specific DNA-binding transcription factors, and
+      the ROF1 WOPR domain has been crystallized bound to DNA (PMID:24994900). Domain-
+      and structure-defensible core molecular function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:22095082
+      supporting_text: recognize the same DNA sequence
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Nuclear localization is expected for a sequence-specific DNA-binding
+      transcription factor and is consistent with the curator IC nucleus annotation.
+      Retained as the core site of action.
+    action: ACCEPT
+- term:
+    id: GO:0043565
+    label: sequence-specific DNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Directly supported by the co-crystal structure of the ROF1 WOPR domain with a
+      preferred DNA site (PMID:24994900) and by the shared sequence-specific
+      recognition of the Wor1/Mit1/Ryp1 family. Core molecular function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:22095082
+      supporting_text: recognize the same DNA sequence
+- term:
+    id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ROF1 is a transcriptional regulator, so involvement in regulation of RNA
+      polymerase II transcription is well supported. However, the POSITIVE direction is
+      not established for ROF1 in S. cerevisiae: the direct budding-yeast data show ROF1
+      overexpression REPRESSING the FLO11/flocculin and filamentation-MAPK program, and
+      the IBA/ISS positive direction derives from the C. albicans activator Wor1. The
+      regulatory role is real but its direction on direct targets is a knowledge gap;
+      kept as non-core, and a direction-neutral parent term is proposed as a better fit.
+    action: KEEP_AS_NON_CORE
+    proposed_replacement_terms:
+    - id: GO:0006357
+      label: regulation of transcription by RNA polymerase II
+    supported_by:
+    - reference_id: PMID:28673928
+      supporting_text: as regulators of
+- term:
+    id: GO:0003677
+    label: DNA binding
+  evidence_type: IDA
+  original_reference_id: PMID:24994900
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental evidence: the ROF1 WOPR domain (PDB 4M8B, residues 6-201 of
+      P38867) was crystallized in complex with its preferred DNA sequence. GO:0043565
+      (sequence-specific DNA binding) is the more precise term for the same activity;
+      this general parent is retained as accurate.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:24994900
+      supporting_text: WOPR-domain proteins are found throughout the fungal kingdom
+        where they function
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IC
+  original_reference_id: PMID:24994900
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Curator inference (IC) of nuclear localization from the transcription-factor
+      role. Appropriate for a sequence-specific DNA-binding transcription factor; the
+      core cellular location.
+    action: ACCEPT
+- term:
+    id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
+  evidence_type: ISS
+  original_reference_id: PMID:24994900
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS from C. albicans Wor1 (with/from UniProtKB:Q5AP80), an activator of
+      opaque-phase genes. The orthology is genuine (both are WOPR-family regulators),
+      but the transferred POSITIVE direction is Wor1-specific; ROF1 experimental data in
+      S. cerevisiae point to repression of the filamentation/FLO11 program. Not removed
+      (well-grounded curator ISS), but the direction is uncertain, so kept as non-core
+      and flagged in knowledge_gaps.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:22095082
+      supporting_text: recognize the same DNA sequence
+- term:
+    id: GO:1900428
+    label: regulation of filamentous growth of a population of unicellular organisms
+  evidence_type: IMP
+  original_reference_id: PMID:28673928
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed NEW annotation not currently in GOA. ROF1 was identified in an
+      overexpression screen as a regulator of complex (&#34;fluffy&#34;) colony morphology:
+      overexpression reduces, and deletion increases, complex colony structure, and the
+      overexpression transcriptional profile represses the FLO11/flocculin and
+      filamentation-MAPK regulon. This establishes ROF1 as a regulator of the
+      filamentous/pseudohyphal growth program in S. cerevisiae. A direction-neutral term
+      is used because the direct-target direction (activation vs repression) is a
+      knowledge gap.
+    action: NEW
+    supported_by:
+    - reference_id: PMID:28673928
+      supporting_text: as regulators of
+core_functions:
+- description: &gt;-
+    Sequence-specific DNA-binding transcription factor (Gti1/Pac2/WOPR family) acting
+    in the nucleus to regulate the RNA polymerase II transcriptional program governing
+    filamentous/pseudohyphal growth and complex (&#34;fluffy&#34;) colony morphology. The WOPR
+    domain provides sequence-specific DNA recognition (co-crystal with DNA); in budding
+    yeast ROF1 modulates the FLO11/flocculin and filamentation-MAPK regulon shared with
+    its paralog Mit1.
+  molecular_function:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  directly_involved_in:
+  - id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  - id: GO:1900428
+    label: regulation of filamentous growth of a population of unicellular organisms
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: PMID:24994900
+    supporting_text: WOPR-domain proteins are found throughout the fungal kingdom where
+      they function
+  - reference_id: PMID:28673928
+    supporting_text: as regulators of
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct in vivo target genes of Rof1 in S. cerevisiae are undetermined. No
+    genome-wide Rof1 ChIP dataset has been reported (unlike its paralog Mit1); the
+    available data are downstream expression changes from overexpression, not direct
+    binding, and SGD lists zero known targets.
+  boundary: &gt;-
+    Rof1 is established as a sequence-specific DNA-binding protein (WOPR domain
+    co-crystallized with DNA) and its paralog Mit1 binds the control regions of known
+    pseudohyphal-growth regulators and flocculin genes, so a plausible target space is
+    the FLO11/filamentation regulon - but ROF1&#39;s own direct binding sites are unmapped.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Without direct targets, ROF1&#39;s placement in the filamentous-growth regulatory
+    network (and whether it acts on FLO11 directly or via Mit1-shared sites) cannot be
+    fixed.
+  resolution: &gt;-
+    Genome-wide ChIP-seq / CUT&amp;RUN for tagged Rof1 under filamentation-inducing
+    conditions, compared with Mit1 binding maps.
+  provenance:
+  - reference_id: PMID:22095082
+    supporting_text: recognize the same DNA sequence
+- gap_statement: &gt;-
+    Whether Rof1 functions as a transcriptional activator or repressor of its direct
+    targets in S. cerevisiae is unresolved. GO annotations encode positive regulation
+    (transferred from the C. albicans activator Wor1), yet the budding-yeast phenotypic
+    and expression data indicate repression of the complex-colony/FLO11 program.
+  boundary: &gt;-
+    It is firmly established that ROF1 overexpression reduces complex &#34;fluffy&#34; colony
+    morphology and that its deletion can increase colony structure, and that the
+    overexpression profile is dominated by repression of FLO11, FLO10 and TEC1. The
+    mechanistic direction on genes it binds directly is not established.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Activator-vs-repressor identity determines how ROF1 is wired into the
+    filamentous-growth circuit and how it relates functionally to the activator paralog
+    Mit1 and to Wor1.
+  resolution: &gt;-
+    Direct-target reporter/expression assays with DNA-binding-competent vs -defective
+    Rof1 alleles, and Rof1 ChIP integrated with target expression.
+  provenance:
+  - reference_id: PMID:24994900
+    supporting_text: as master regulators of cell morphology and pathogenesis
+- gap_statement: &gt;-
+    Rof1 has no penetrant, condition-independent loss-of-function phenotype, and the
+    physiological signal or condition that activates it is unknown. Single-deletion
+    effects on colony morphology are strain-background dependent and conflicting between
+    studies.
+  boundary: &gt;-
+    Deletion increases colony structure in one background and suppresses hog1-driven
+    hyper-filamentation in another, and overexpression reduces complex colony
+    morphology; but a clean, condition-independent single-deletion phenotype has not
+    been established.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A defined activating condition and a clean phenotype are prerequisites for placing
+    ROF1 in a specific signaling pathway (HOG / filamentation-MAPK / cAMP-PKA) rather
+    than the broad morphology network.
+  resolution: &gt;-
+    Systematic phenotyping of rof1 deletion (and rof1 mit1 double mutants) across
+    nutrient/stress conditions and strain backgrounds; identification of upstream
+    regulators.
+  provenance:
+  - reference_id: PMID:28673928
+    supporting_text: adaptive morphological
+suggested_questions:
+- question: &gt;-
+    Does Rof1 bind the FLO11 promoter directly, or does it act indirectly through
+    shared targets with its paralog Mit1?
+- question: &gt;-
+    Under what physiological condition is Rof1 activity required, and is it functionally
+    antagonistic, redundant, or parallel to Mit1?
+suggested_experiments:
+- description: &gt;-
+    Genome-wide ChIP-seq/CUT&amp;RUN of epitope-tagged Rof1 under filamentation-inducing
+    conditions, integrated with RNA-seq of rof1 deletion and overexpression, and
+    compared to Mit1 binding maps, to define direct targets and the activation/repression
+    direction.
+- description: &gt;-
+    Epistasis and expression analysis of rof1, mit1, and rof1 mit1 mutants across
+    colony-morphology conditions and strain backgrounds to resolve the paralog
+    relationship and a clean loss-of-function phenotype.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/SDD3/SDD3-ai-review.html
+++ b/genes/yeast/SDD3/SDD3-ai-review.html
@@ -1,0 +1,2903 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SDD3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SDD3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q12496" target="_blank" class="term-link">
+                        Q12496
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YOL098C</span>
+
+                    <span class="badge">HRF1037</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SDD3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q12496" data-a="DESCRIPTION: SDD3 (systematic name YOL098C) is a ~1037-residue ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SDD3 (systematic name YOL098C) is a ~1037-residue cytoplasmic protein of the peptidase M16 family (pitrilysin/inverzincin clan ME). It contains the two characteristic M16 domains (Pfam Peptidase_M16 N-terminal catalytic domain and Peptidase_M16_C C-terminal domain; MEROPS M16.A04) and retains the family&#39;s inverted zinc-binding catalytic motif HxxEH near its N-terminus, so it is predicted to be a zinc-dependent metalloendopeptidase; a genome-wide zinc-proteome survey computationally classified it as a zinc-binding protein. Despite the intact catalytic motif, no proteolytic activity, substrate, or cleavage specificity has been experimentally demonstrated for SDD3 or for any member of its uncharacterized ortholog group (PANTHER subfamily PTHR43016:SF16, with orthologs in fission yeast, worm and filamentous fungi), so it remains a putative metalloprotease. The protein localizes to the cytoplasm. The only reported phenotype comes from overexpression: multicopy expression of SDD3 suppresses the degenerative cell death caused by the dominant mitochondrial ADP/ATP carrier allele AAC2(A128P), placing it in a large cytosolic network that counteracts stress from over-accumulated, unimported mitochondrial precursor proteins. Its normal (loss-of-function) biological role and its physiological substrate remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12496" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic metal ion binding, inferred electronically from the InterPro M16 metalloenzyme signature (IPR011249). Consistent with the domain and with the more specific zinc ion binding annotation, but uninformative on its own.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain-consistent (SDD3 carries the M16 inverted zincin fold) but this is the generic parent of the more specific GO:0008270 zinc ion binding term already present, and it is electronic. Retain as supporting, non-core; the specific zinc term better captures the predicted cofactor.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    GO:0008270
+                                </a>
+                            </span>
+                            <span class="term-label">zinc ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12496" data-a="GO:0008270" data-r="PMID:30358795" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Zinc ion binding predicted by a proteome-wide zinc-proteome bioinformatic survey and independently consistent with the retained M16 HxxEH zincin motif (His60/Glu63/His64). Not a direct experimental binding measurement for SDD3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Defensible as a domain- and prediction-supported molecular-function hypothesis: the M16 fold uses a zinc cofactor and the catalytic motif is intact. However the evidence is computational (RCA zinc-proteome prediction) with no biochemical validation for SDD3 specifically, so it is kept as non-core. Zinc binding, if real, would be in service of the (still-undemonstrated) metalloendopeptidase activity rather than being the biological point of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                        PMID:30358795
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identified using a bioinformatics analysis that combined global domain searches with local motif searches</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14562095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global analysis of protein localization in budding yeast.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12496" data-a="GO:0005737" data-r="PMID:14562095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization determined experimentally by genome-wide GFP-fusion microscopy, and independently consistent with the report that the anti-degenerative suppressor network (which includes SDD3) is cytosolic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (HDA) evidence from a canonical high-coverage yeast localization dataset; corroborated by the Wang &amp; Chen 2015 statement that all suppressors are located in the cytosol. This is the single most solid annotation for SDD3 and represents its established subcellular location. The more precise term GO:0005829 (cytosol) is used in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26192197" target="_blank" class="term-link">
+                                        PMID:26192197
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the suppressors are located in the cytosol, suggesting that they prevent cell death via pathways that operate in the cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12496" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with ND (no data) evidence — a placeholder indicating that no biological process has been experimentally assigned to SDD3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This ND root annotation honestly reflects the current state of knowledge: the normal biological role of SDD3 is undetermined. The only reported phenotype is an overexpression suppression of AAC2(A128P) cell death, a gain-of-function genetic observation rather than a loss-of-function process assignment; inventing a specific BP term (e.g. proteostasis or protein catabolism) would over-annotate. Retain the ND placeholder rather than remove.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Knowledge gap:</div>
+
+                            <div class="support-item">
+                                <div>The normal (loss-of-function) biological process in which SDD3 participates is unknown; no SDD3 deletion phenotype has been reported that would assign it to a specific pathway.
+                                    <span class="badge">OPEN</span>
+                                    <span class="badge">BIOLOGY</span>
+                                    <span class="badge">BP_DARK</span>
+                                </div>
+
+                                <div class="support-text"><strong>Resolve:</strong> Phenotype an sdd3 deletion (and sdd3 deletion combined with mPOS-inducing lesions such as yme1 deletion or AAC2(A128P)); test whether endogenous SDD3 is required for, or induced by, mPOS.</div>
+
+
+
+                                <div class="support-text"><em>"The remaining eight include the uncharacterized YEL057C, YMR074C, YOL098C and the truncated YPR022C that are named SDD1-4 (Suppressor of Degenerative Death) respectively"</em> — PMID:26192197</div>
+
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26192197" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26192197
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A cytosolic network suppressing mitochondria-mediated proteo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q12496" data-a="GO:0005829" data-r="PMID:26192197" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> More precise refinement of the experimental cytoplasm localization: SDD3 is a soluble cytosolic protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proposed as a more specific child of the accepted GO:0005737 (cytoplasm) experimental annotation. Supported by the genome-wide GFP localization (cytoplasm) and by the report that the anti-degenerative suppressor network including SDD3 is cytosolic.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26192197" target="_blank" class="term-link">
+                                        PMID:26192197
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the suppressors are located in the cytosol, suggesting that they prevent cell death via pathways that operate in the cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30358795
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cellular economy of the Saccharomyces cerevisiae zinc pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q12496" data-a="GO:0004222" data-r="PMID:30358795" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed domain-inferred molecular function: SDD3 is a peptidase M16 family protein retaining the canonical HxxEH zincin catalytic motif, so it is predicted to be a zinc-dependent metalloendopeptidase. Not experimentally demonstrated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Added as a hypothesis grounded in domain architecture (Pfam Peptidase_M16 + Peptidase_M16_C; MEROPS M16.A04; intact HxxEH motif at His60-Glu63-His64) and SGD&#39;s &#34;putative metalloprotease&#34; description, not as an asserted function. No catalytic activity or substrate has been measured for SDD3 or its SF16 subfamily; see the associated knowledge_gaps. Recorded so the predicted activity is explicit and testable rather than hidden.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                        PMID:30358795
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identified using a bioinformatics analysis that combined global domain searches with local motif searches</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cytoplasmic localization is the one experimentally established property of SDD3; the protein is a soluble cytoplasmic component and any biochemical role it performs is executed in the cytoplasm/cytosol.</h3>
+                <span class="vote-buttons" data-g="Q12496" data-a="FUNCTION: Cytoplasmic localization is the one experimentally..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26192197" target="_blank" class="term-link">
+                                PMID:26192197
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">All of the suppressors are located in the cytosol, suggesting that they prevent cell death via pathways that operate in the cytosol</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Putative (domain-inferred, not experimentally demonstrated) zinc-dependent metalloendopeptidase activity. SDD3 belongs to the M16 peptidase family and retains the canonical inverted zincin catalytic motif HxxEH (His60-Thr-Leu-Glu63-His64), giving it the sequence hallmarks of a zinc metalloendopeptidase, and it is predicted to bind zinc. No proteolytic activity, substrate, or cleavage specificity has been measured for SDD3 or any member of its uncharacterized SF16 subfamily, so this is a hypothesis grounded in domain architecture rather than a demonstrated function; see knowledge_gaps.</h3>
+                <span class="vote-buttons" data-g="Q12496" data-a="FUNCTION: Putative (domain-inferred, not experimentally demo..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                            metalloendopeptidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                                PMID:30358795
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">identified using a bioinformatics analysis that combined global domain searches with local motif searches</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curatorial statement evidence.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
+                            PMID:14562095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide GFP-fusion localization study; SDD3/YOL098C was scored as cytoplasmic, the basis for the experimental cytoplasm annotation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
+                            PMID:30358795
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Proteome-wide bioinformatic identification of the yeast zinc proteome using domain plus motif searches; SDD3/YOL098C was among the predicted zinc-binding proteins, consistent with the M16 zincin motif.</div>
+
+                        <div class="finding-text">"identified using a bioinformatics analysis that combined global domain searches with local motif searches"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26192197" target="_blank" class="term-link">
+                            PMID:26192197
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A cytosolic network suppressing mitochondria-mediated proteostatic stress and cell death.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">YOL098C was recovered as a multicopy (overexpression) suppressor of AAC2(A128P)-induced degenerative cell death and named SDD3 (Suppressor of Degenerative Death 3), one of a large cytosolic anti-mPOS network whose members are cytosolic.</div>
+
+                        <div class="finding-text">"The remaining eight include the uncharacterized YEL057C, YMR074C, YOL098C and the truncated YPR022C that are named SDD1-4 (Suppressor of Degenerative Death) respectively"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is SDD3 a catalytically active zinc metalloendopeptidase, and what is its physiological substrate?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Xin Jie Chen</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12496" data-a="Q: Is SDD3 a catalytically active zinc metalloendopep..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does endogenous SDD3 have a loss-of-function role in cytosolic proteostasis or in clearing over-accumulated mitochondrial precursor proteins (mPOS), or is the suppression phenotype purely a high-copy gain-of-function effect?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Xin Jie Chen</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12496" data-a="Q: Does endogenous SDD3 have a loss-of-function role ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant SDD3, assay metalloendopeptidase activity (zinc dependence, chelator sensitivity) against candidate M16-type peptide substrates, and compare wild-type with a catalytic HxxEH-motif mutant.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SDD3 is a zinc-dependent metalloendopeptidase whose activity requires the intact HxxEH motif.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro enzyme assay with catalytic-residue mutagenesis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12496" data-a="EXPERIMENT: Express and purify recombinant SDD3, assay metallo..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Delete SDD3 and test for phenotypes in mPOS-sensitized backgrounds (e.g. yme1 deletion or AAC2(A128P)); use N-terminomics/degradomics and affinity-purification mass spectrometry in SDD3 over- vs under-expressing cells to identify substrates and interaction partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SDD3 acts in cytosolic clearance of over-accumulated mitochondrial precursors.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics plus interaction/degradomics proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12496" data-a="EXPERIMENT: Delete SDD3 and test for phenotypes in mPOS-sensit..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> SDD3 has no experimentally demonstrated molecular function. Its assignment as a zinc metalloendopeptidase rests entirely on the presence of the M16 family fold and the intact HxxEH zincin motif plus a computational zinc-proteome prediction; no catalytic activity, substrate, cofactor binding, or physical interaction partner has been measured for the SDD3 protein.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly known: SDD3 (YOL098C) is a verified, ~1037-aa, cytoplasmically localized (experimental GFP) protein of the peptidase M16 family that retains the canonical catalytic zincin motif, and whose multicopy overexpression suppresses AAC2(A128P)-induced degenerative cell death.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> SDD3 is a conserved-but-dark member of the M16 peptidase family: its ortholog group (PANTHER subfamily PTHR43016:SF16 - fission yeast, worm, and filamentous fungi) is uniformly uncharacterized, so closing this gap would define function for a whole conserved subfamily rather than a single gene.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstitute and assay the predicted metalloendopeptidase activity in vitro (with catalytic-motif controls), identify substrates by degradomics, and map physical interactors by affinity-purification mass spectrometry.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The remaining eight include the uncharacterized YEL057C, YMR074C, YOL098C and the truncated YPR022C that are named SDD1-4 (Suppressor of Degenerative Death) respectively"</em> — PMID:26192197</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether SDD3&#39;s recovery as an overexpression suppressor of mitochondria-mediated cell death reflects a genuine endogenous role in cytosolic proteostasis / clearance of over-accumulated mitochondrial precursors, or an indirect gain-of-function effect of high-copy expression.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> SDD3 was identified only through multicopy overexpression suppression of AAC2(A128P)-induced death and belongs to a large cytosolic network the authors link to relief of mitochondrial Precursor Over-accumulation Stress (mPOS); the network as a whole acts by modulating cytosolic translation, mRNA turnover, and protein chaperoning/turnover, and all its members are cytosolic.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The distinction matters for whether SDD3 should ultimately be annotated to a proteostasis / protein-catabolism process and for understanding the crosstalk between mitochondrial dysfunction and cytosolic protein homeostasis relevant to neurodegeneration and ageing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test the endogenous requirement (deletion and conditional depletion) in mPOS-sensitized backgrounds; measure whether SDD3 protein or transcript is induced under mPOS and whether it associates with, or degrades, accumulated mitochondrial precursor proteins.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"All of the suppressors are located in the cytosol, suggesting that they prevent cell death via pathways that operate in the cytosol"</em> — PMID:26192197</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SDD3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12496" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Research Report: YOL098C (SDD3) in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">24 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T13:16:40.391291</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="SDD3-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-yol098c-sdd3-in-saccharomyces-cerevisiae">Research Report: YOL098C (SDD3) in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="critical-gene-symbol-ambiguity-notice">⚠️ Critical Gene Symbol Ambiguity Notice</h2>
+<p>The gene symbol "SDD3" is <strong>ambiguous</strong> and refers to multiple distinct proteins across different organisms and contexts. Literature searches revealed at least two unrelated uses of this symbol: (1) "Sdd3" as a single-stranded DNA deaminase identified through AlphaFold2-based structural clustering of deaminase proteins, used in cytosine base editing applications (huang2023discoveryofdeaminase pages 11-13, huang2024discoveringdeaminasesusing pages 1-2); and (2) "Sdd3" as a regulator of biofilm formation in <em>Candida albicans</em> acting through the Rho1-PKC-MAPK signaling pathway (wu2026thepathogenicityand pages 18-19). <strong>Neither of these proteins corresponds to the target gene YOL098C in <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c).</strong> The following report is based strictly on information pertaining to the UniProt Q12496 entry for YOL098C and functional inferences drawn from its conserved domain architecture.</p>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>YOL098C (also designated HRF1037) is an open reading frame on chromosome XV of <em>S. cerevisiae</em> (strain S288c). According to UniProt (accession Q12496), it encodes an <strong>uncharacterized protein</strong> with no experimentally validated standard gene name. The protein contains the following InterPro domains:</p>
+<ul>
+<li><strong>Metalloenz_LuxS/M16 (IPR011249)</strong> — a broad superfamily fold shared by M16 metallopeptidases</li>
+<li><strong>Pept_M16_N (IPR011765)</strong> — the N-terminal catalytic half of M16 metallopeptidases</li>
+<li><strong>Peptidase_M16_C (IPR007863)</strong> — the C-terminal regulatory half of M16 metallopeptidases</li>
+<li><strong>Pfam domains: Peptidase_M16 (PF00675) and Peptidase_M16_C (PF05193)</strong></li>
+</ul>
+<p>These domain annotations place YOL098C squarely within the <strong>M16 family of metalloendopeptidases</strong> (clan ME in the MEROPS classification). No primary literature was identified that directly characterizes the function, substrate specificity, localization, or biological role of YOL098C.</p>
+<h2 id="2-m16-metallopeptidase-family-structural-and-functional-context">2. M16 Metallopeptidase Family: Structural and Functional Context</h2>
+<p>The M16 family of metallopeptidases are zinc-dependent endopeptidases characterized by several shared features (jarzab2025ittakestwo pages 2-5, jarzab2025ittakestwo pages 7-9):</p>
+<ul>
+<li>A distinctive <strong>clamshell-like architecture</strong> composed of two halves, each containing two structurally homologous domains (D1–D4), enclosing a central catalytic chamber.</li>
+<li>An <strong>inverted zinc-binding motif (HXXEH)</strong>, in which two histidine residues and a distal glutamate coordinate a catalytic zinc ion. The glutamate within the HXXEH motif activates a water molecule for nucleophilic attack on the substrate peptide bond (jarzab2025ittakestwo pages 7-9).</li>
+<li>An <strong>R/Y (arginine/tyrosine) pair motif</strong> located in the C-terminal half (D4) that is critical for substrate binding and transition state stabilization (jarzab2025ittakestwo pages 7-9).</li>
+<li>Two principal functional conformations: an <strong>open</strong> state for substrate uptake/product release and a <strong>closed</strong> state associated with catalytic activity (jarzab2025ittakestwo pages 2-5).</li>
+</ul>
+<p>The M16 family is subdivided into three subfamilies (jarzab2025ittakestwo pages 2-5):</p>
+<ul>
+<li><strong>M16A</strong> — Monomeric enzymes (~100 kDa) including pitrilysin, insulin-degrading enzyme (IDE), and the yeast proteins Axl1 and Ste23. These act as "peptidasomes," degrading peptides of 30–70 amino acid residues.</li>
+<li><strong>M16B</strong> — Heterodimeric processing peptidases (~50 kDa subunits) including the mitochondrial processing peptidase (MPP), which cleaves N-terminal targeting presequences from imported mitochondrial precursor proteins.</li>
+<li><strong>M16C</strong> — Monomeric enzymes (~100 kDa) including the presequence protease PreP (human PITRM1) and yeast Cym1. These also function as peptidasomes, degrading cleaved presequence peptides and other aggregation-prone peptides.</li>
+</ul>
+<p>M16A and M16C members share similar molecular organization and degrade various peptides with chain lengths in the range of 30–70 amino acid residues. They are referred to as "peptidasomes" by analogy with proteasomes (jarzab2025ittakestwo pages 2-5). In contrast, M16B members function specifically as processing peptidases that cut short N-terminal targeting sequences.</p>
+<p>Given that YOL098C possesses both PF00675 (Peptidase_M16, the N-terminal catalytic half) and PF05193 (Peptidase_M16_C, the C-terminal regulatory half), it is predicted to be a <strong>monomeric M16 metalloendopeptidase</strong> belonging to either the M16A or M16C subfamily. This domain architecture is consistent with a peptidasome-type function — i.e., degradation of peptide substrates within an enclosed catalytic chamber.</p>
+<h2 id="3-yol098c-in-the-context-of-yeast-m16-family-members">3. YOL098C in the Context of Yeast M16 Family Members</h2>
+<p><em>S. cerevisiae</em> encodes several characterized M16 family members, providing context for the uncharacterized YOL098C. The following table summarizes these proteins:</p>
+<table>
+<thead>
+<tr>
+<th>Protein / gene</th>
+<th>Systematic name</th>
+<th>M16 subfamily / architecture</th>
+<th>Known or inferred function</th>
+<th>Localization</th>
+<th>Evidence / notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>YOL098C (target; UniProt Q12496)</td>
+<td>YOL098C / HRF1037</td>
+<td>Likely M16A or M16C-like monomeric M16 metallopeptidase; contains Peptidase_M16 and Peptidase_M16_C domains</td>
+<td>Uncharacterized; domain architecture supports a zinc-dependent metalloendopeptidase/peptidasome-like role, but no specific substrate, reaction, or pathway has been experimentally established</td>
+<td>Not securely established; no confirmed localization from the retrieved literature</td>
+<td>The queried symbol “SDD3” is ambiguous and literature is limited for this specific protein. UniProt/domain annotation supports M16-family membership, but direct functional studies were not found. M16A/C enzymes are generally monomeric ~100 kDa peptidasomes with four-domain “clamshell” architecture and HXXEH zinc-binding motif (jarzab2025ittakestwo pages 2-5, jarzab2025ittakestwo pages 7-9)</td>
+</tr>
+<tr>
+<td>MPP α subunit (Mas2)</td>
+<td>MAS2</td>
+<td>M16B heterodimeric processing peptidase</td>
+<td>Mitochondrial processing peptidase subunit involved in cleavage of N-terminal targeting presequences from imported mitochondrial precursor proteins</td>
+<td>Mitochondrial matrix / import-processing machinery</td>
+<td>Eukaryotic M16B peptidases act as processing peptidases for organelle-targeting sequences; yeast MPP is a canonical M16B member. The glycine-rich loop in the α-subunit contributes to substrate binding (jarzab2025ittakestwo pages 2-5, jarzab2025ittakestwo pages 7-9, jarzab2025ittakestwo pages 5-7)</td>
+</tr>
+<tr>
+<td>MPP β subunit (Mas1)</td>
+<td>MAS1</td>
+<td>M16B heterodimeric processing peptidase</td>
+<td>Catalytic MPP subunit; participates with Mas2 in primary cleavage of mitochondrial presequences during protein import</td>
+<td>Mitochondrial matrix / import-processing machinery</td>
+<td>Yeast MPP is an M16B metallopeptidase complex; M16B members function as processing peptidases rather than general peptidasomes (jarzab2025ittakestwo pages 2-5, jarzab2025ittakestwo pages 5-7)</td>
+</tr>
+<tr>
+<td>Cym1</td>
+<td>CYM1</td>
+<td>M16C (PreP/PITRM1-type)</td>
+<td>Presequence peptide degradation after MPP cleavage; prevents feedback inhibition of MPP by clearing released targeting peptides</td>
+<td>Mitochondrial matrix</td>
+<td>Cym1 is the yeast homolog of human PITRM1/PreP. Loss of Cym1 causes accumulation of cleaved presequences and feedback inhibition of MPP (gala2021mitochondrialproteasesin pages 7-8, gala2021mitochondrialproteasesin pages 6-7)</td>
+</tr>
+<tr>
+<td>Axl1</td>
+<td>AXL1</td>
+<td>M16A</td>
+<td>Processing of the a-factor mating pheromone precursor</td>
+<td>Cytosol / mating pathway-associated processing</td>
+<td>Yeast Axl1 is an M16A peptidase with a well-established role in a-factor production; M16A peptidases are monomeric peptidasomes (jarzab2025ittakestwo pages 9-10, jarzab2025ittakestwo pages 2-5)</td>
+</tr>
+<tr>
+<td>Ste23</td>
+<td>STE23</td>
+<td>M16A</td>
+<td>Broadly peptidase-like; implicated in efficient degradation of mitochondrial presequence peptides downstream of MPP; also reported to cleave insulin and amyloid-β in heterologous/biochemical contexts</td>
+<td>Mitochondrial matrix (for presequence-degradation role)</td>
+<td>Ste23 is described as a novel mitochondrial matrix protease important for presequence degradation/processing in yeast; it is also grouped with Axl1 as a yeast M16A peptidase (jarzab2025ittakestwo pages 9-10, jarzab2025ittakestwo pages 27-28)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the characterized M16 metallopeptidase family members in Saccharomyces cerevisiae and places the uncharacterized target YOL098C in that family context. It is useful for distinguishing the ambiguous target from better-studied yeast M16 proteins and for inferring likely function from conserved domain architecture.</em></p>
+<p>The key characterized yeast M16 members include:</p>
+<p><strong>MPP (Mas1/Mas2, M16B):</strong> The essential mitochondrial processing peptidase that cleaves N-terminal targeting presequences from nuclear-encoded mitochondrial precursor proteins upon their import into the matrix (jarzab2025ittakestwo pages 5-7, gala2021mitochondrialproteasesin pages 7-8).</p>
+<p><strong>Cym1 (YDR430C, M16C):</strong> The yeast ortholog of human PITRM1/PreP. Cym1 is a mitochondrial matrix peptidase responsible for degrading cleaved presequence peptides after MPP processing. Loss of Cym1 results in accumulation of presequence peptides, which causes <strong>feedback inhibition of MPP</strong>, thereby impairing mitochondrial protein import (gala2021mitochondrialproteasesin pages 7-8, gala2021mitochondrialproteasesin pages 6-7). Deletion of CYM1 has also been reported to decrease proteolytic activity and improve secretion of recombinant proteins in yeast expression systems (berlec2013currentstateand pages 8-9).</p>
+<p><strong>Axl1 and Ste23 (M16A):</strong> Axl1 is involved in the production of the a-factor mating pheromone. Ste23 has been characterized as a mitochondrial matrix protease that is required for efficient degradation of presequence peptides generated by MPP and can cleave insulin and amyloid-β peptides in biochemical assays (jarzab2025ittakestwo pages 9-10, jarzab2025ittakestwo pages 27-28).</p>
+<p>YOL098C represents an additional, uncharacterized M16 family member in the yeast genome. Its function has not been experimentally determined, and it is not known whether it is functionally redundant with Cym1, Ste23, or Axl1, or whether it has a distinct role.</p>
+<h2 id="4-predicted-function-based-on-domain-architecture">4. Predicted Function Based on Domain Architecture</h2>
+<p>Based on the presence of both N-terminal and C-terminal M16 metallopeptidase domains, YOL098C is predicted to:</p>
+<ol>
+<li><strong>Catalyze zinc-dependent endoproteolytic cleavage</strong> of peptide substrates within an enclosed clamshell-like catalytic chamber, consistent with the "peptidasome" model described for M16A and M16C family members (jarzab2025ittakestwo pages 2-5).</li>
+<li><strong>Utilize the HXXEH inverted zinc-binding motif</strong> for catalysis, with the conserved glutamate acting as a general base to activate a water molecule for nucleophilic attack on the scissile peptide bond (jarzab2025ittakestwo pages 7-9).</li>
+<li>Potentially function in <strong>peptide degradation pathways</strong>, possibly degrading targeting peptides, signaling peptides, or other short peptide substrates.</li>
+</ol>
+<p>The M16C subfamily member PreP (human PITRM1) and its yeast ortholog Cym1 provide particularly informative models. PreP is a ~105 kDa zinc-dependent metallopeptidase that specifically degrades targeting peptides, including those from mitochondrial ATP synthase F1β and chloroplastic small subunit of Rubisco (ghifari2019thepeptidasesinvolved pages 6-7). PreP preferentially cleaves positively charged residues at the P'1 position and serine or neutral amino acids at the P1 position (ghifari2019thepeptidasesinvolved pages 7-8). The catalytic mechanism involves hinge-bending motions that transition the enzyme from open to closed states upon substrate binding, bringing critical C-terminal residues (the R/Y pair) to the active site to stabilize the transition state (jarzab2025ittakestwo pages 18-19).</p>
+<p>Whether YOL098C shares these substrate preferences or catalytic properties remains to be determined experimentally.</p>
+<h2 id="5-subcellular-localization">5. Subcellular Localization</h2>
+<p>The subcellular localization of YOL098C has not been conclusively established in the retrieved literature. Many M16 family peptidases function in the mitochondrial matrix (e.g., MPP, Cym1, Ste23) (gala2021mitochondrialproteasesin pages 7-8, jarzab2025ittakestwo pages 27-28), suggesting that YOL098C may also localize to mitochondria. However, other M16 family members (e.g., Axl1, IDE) function in the cytosol (jarzab2025ittakestwo pages 9-10). Without experimental localization data specific to YOL098C, its compartmentalization remains uncertain. Systematic approaches such as the Huh et al. (2003) GFP localization study and the more recent bi-genomic split-GFP assay (bykov2025asystematicbigenomic pages 1-2, bykov2025asystematicbigenomic pages 3-5) have been applied to the yeast proteome, but no data specifically confirming YOL098C's mitochondrial or cytosolic localization was found in the papers retrieved.</p>
+<h2 id="6-biological-pathways-and-processes">6. Biological Pathways and Processes</h2>
+<p>Given its M16 domain architecture, YOL098C may participate in one or more of the following pathways:</p>
+<ul>
+<li><strong>Mitochondrial protein import and presequence processing:</strong> M16 peptidases in yeast (MPP, Cym1, Ste23) form a coordinated system for processing and degrading mitochondrial targeting peptides. MPP performs the initial cleavage, and downstream peptidases (Cym1, Ste23) degrade the released presequence fragments. Failure in this degradation pathway leads to feedback inhibition of MPP and impaired mitochondrial biogenesis (gala2021mitochondrialproteasesin pages 7-8, gala2021mitochondrialproteasesin pages 6-7). YOL098C could potentially function in this pathway as an additional or specialized presequence peptidase.</li>
+<li><strong>General peptide quality control:</strong> M16A/C peptidasomes degrade various peptides that could be cytotoxic if allowed to accumulate. In humans, PITRM1/PreP also degrades amyloid-β peptides in mitochondria, and its saturation has been implicated in Alzheimer's disease pathogenesis (gala2021mitochondrialproteasesin pages 6-7).</li>
+<li><strong>Mating pheromone processing or other signaling peptide degradation:</strong> By analogy with Axl1's role in a-factor pheromone processing (jarzab2025ittakestwo pages 9-10).</li>
+</ul>
+<h2 id="7-limitations-and-conclusions">7. Limitations and Conclusions</h2>
+<p>This report must be interpreted with the following limitations:</p>
+<ol>
+<li><strong>No primary literature was found that directly characterizes YOL098C.</strong> All functional inferences are based on domain architecture and analogy with characterized M16 family members.</li>
+<li><strong>The gene symbol "SDD3" is ambiguous</strong> and primarily refers to unrelated proteins in the recent literature — a deaminase tool for base editing (huang2023discoveryofdeaminase pages 11-13, huang2024discoveringdeaminasesusing pages 1-2) and a biofilm regulator in <em>C. albicans</em> (wu2026thepathogenicityand pages 18-19). Neither is the same as YOL098C.</li>
+<li><strong>The protein is classified as "uncharacterized" in UniProt</strong>, reflecting the absence of experimental functional data.</li>
+</ol>
+<p>In summary, YOL098C encodes a putative M16 metalloendopeptidase in <em>S. cerevisiae</em> with the hallmark domain architecture of this enzyme family. By structural inference, it is predicted to function as a zinc-dependent peptidasome that degrades peptide substrates of approximately 30–70 residues within an enclosed catalytic chamber. Its precise substrate specificity, subcellular localization, and biological role await experimental characterization. The most informative functional model derives from characterized yeast M16 family members — particularly Cym1 (M16C, presequence peptidase) and Ste23/Axl1 (M16A, pheromone processing/presequence degradation) — which collectively suggest a role in peptide degradation, potentially within the mitochondrial protein import pathway or in cellular peptide quality control.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(huang2023discoveryofdeaminase pages 11-13): Jiaying Huang, Qiupeng Lin, Hongyuan Fei, Zixin He, Hu Xu, Yunjia Li, Kunli Qu, Peng Han, Qiang Gao, Boshu Li, Guanwen Liu, Lixiao Zhang, Jiacheng Hu, Rui Zhang, Erwei Zuo, Yonglun Luo, Yidong Ran, Jin-Long Qiu, Kevin Tianmeng Zhao, and Caixia Gao. Discovery of deaminase functions by structure-based protein clustering. Jul 2023. URL: https://doi.org/10.1016/j.cell.2023.05.041, doi:10.1016/j.cell.2023.05.041. This article has 270 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huang2024discoveringdeaminasesusing pages 1-2): Yongye Huang, Jianxin Jiang, and Min Wu. Discovering deaminases using alphafold2: a strategy to search for tool proteins for gene editing. Signal Transduction and Targeted Therapy, Feb 2024. URL: https://doi.org/10.1038/s41392-024-01737-z, doi:10.1038/s41392-024-01737-z. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2026thepathogenicityand pages 18-19): Jiadi Wu, Chenyang Jiang, Hui Wang, Tongbin Chen, Xi Chen, and Wenyue Da. The pathogenicity and future treatment strategies of candida albicans. Frontiers in Cellular and Infection Microbiology, Feb 2026. URL: https://doi.org/10.3389/fcimb.2026.1752304, doi:10.3389/fcimb.2026.1752304. This article has 6 citations.</p>
+</li>
+<li>
+<p>(jarzab2025ittakestwo pages 2-5): Miroslaw Jarzab and Joanna Skorko-Glonek. It takes two to tango: current understanding of the role of m16 family of proteases and their structural properties. Biomolecules, 15:1697, Dec 2025. URL: https://doi.org/10.3390/biom15121697, doi:10.3390/biom15121697. This article has 0 citations.</p>
+</li>
+<li>
+<p>(jarzab2025ittakestwo pages 7-9): Miroslaw Jarzab and Joanna Skorko-Glonek. It takes two to tango: current understanding of the role of m16 family of proteases and their structural properties. Biomolecules, 15:1697, Dec 2025. URL: https://doi.org/10.3390/biom15121697, doi:10.3390/biom15121697. This article has 0 citations.</p>
+</li>
+<li>
+<p>(jarzab2025ittakestwo pages 5-7): Miroslaw Jarzab and Joanna Skorko-Glonek. It takes two to tango: current understanding of the role of m16 family of proteases and their structural properties. Biomolecules, 15:1697, Dec 2025. URL: https://doi.org/10.3390/biom15121697, doi:10.3390/biom15121697. This article has 0 citations.</p>
+</li>
+<li>
+<p>(gala2021mitochondrialproteasesin pages 7-8): Maria Gomez‐Fabra Gala and Friederike‐Nora Vögtle. Mitochondrial proteases in human diseases. FEBS Letters, 595:1205-1222, Feb 2021. URL: https://doi.org/10.1002/1873-3468.14039, doi:10.1002/1873-3468.14039. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gala2021mitochondrialproteasesin pages 6-7): Maria Gomez‐Fabra Gala and Friederike‐Nora Vögtle. Mitochondrial proteases in human diseases. FEBS Letters, 595:1205-1222, Feb 2021. URL: https://doi.org/10.1002/1873-3468.14039, doi:10.1002/1873-3468.14039. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jarzab2025ittakestwo pages 9-10): Miroslaw Jarzab and Joanna Skorko-Glonek. It takes two to tango: current understanding of the role of m16 family of proteases and their structural properties. Biomolecules, 15:1697, Dec 2025. URL: https://doi.org/10.3390/biom15121697, doi:10.3390/biom15121697. This article has 0 citations.</p>
+</li>
+<li>
+<p>(jarzab2025ittakestwo pages 27-28): Miroslaw Jarzab and Joanna Skorko-Glonek. It takes two to tango: current understanding of the role of m16 family of proteases and their structural properties. Biomolecules, 15:1697, Dec 2025. URL: https://doi.org/10.3390/biom15121697, doi:10.3390/biom15121697. This article has 0 citations.</p>
+</li>
+<li>
+<p>(berlec2013currentstateand pages 8-9): Aleš Berlec and Borut Štrukelj. Current state and recent advances in biopharmaceutical production in <i>escherichia coli</i>, yeasts and mammalian cells. Journal of Industrial Microbiology and Biotechnology, 40:257-274, Apr 2013. URL: https://doi.org/10.1007/s10295-013-1235-0, doi:10.1007/s10295-013-1235-0. This article has 348 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ghifari2019thepeptidasesinvolved pages 6-7): Abi S Ghifari, Shaobai Huang, and Monika W Murcha. The peptidases involved in plant mitochondrial protein import. Journal of experimental botany, 70 21:6005-6018, Nov 2019. URL: https://doi.org/10.1093/jxb/erz365, doi:10.1093/jxb/erz365. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ghifari2019thepeptidasesinvolved pages 7-8): Abi S Ghifari, Shaobai Huang, and Monika W Murcha. The peptidases involved in plant mitochondrial protein import. Journal of experimental botany, 70 21:6005-6018, Nov 2019. URL: https://doi.org/10.1093/jxb/erz365, doi:10.1093/jxb/erz365. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jarzab2025ittakestwo pages 18-19): Miroslaw Jarzab and Joanna Skorko-Glonek. It takes two to tango: current understanding of the role of m16 family of proteases and their structural properties. Biomolecules, 15:1697, Dec 2025. URL: https://doi.org/10.3390/biom15121697, doi:10.3390/biom15121697. This article has 0 citations.</p>
+</li>
+<li>
+<p>(bykov2025asystematicbigenomic pages 1-2): Yury S Bykov, Solène Zuttion, Bruno Senger, Ofir Klein, Yeynit Asraf, Hadar Meyer, Hubert D Becker, Róża Kucharczyk, and Maya Schuldiner. A systematic bi-genomic split-gfp assay illuminates the mitochondrial matrix proteome and protein targeting routes. ArXiv, Jul 2025. URL: https://doi.org/10.7554/elife.98889, doi:10.7554/elife.98889. This article has 3 citations.</p>
+</li>
+<li>
+<p>(bykov2025asystematicbigenomic pages 3-5): Yury S Bykov, Solène Zuttion, Bruno Senger, Ofir Klein, Yeynit Asraf, Hadar Meyer, Hubert D Becker, Róża Kucharczyk, and Maya Schuldiner. A systematic bi-genomic split-gfp assay illuminates the mitochondrial matrix proteome and protein targeting routes. ArXiv, Jul 2025. URL: https://doi.org/10.7554/elife.98889, doi:10.7554/elife.98889. This article has 3 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="SDD3-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>wu2026thepathogenicityand pages 18-19</li>
+<li>jarzab2025ittakestwo pages 7-9</li>
+<li>jarzab2025ittakestwo pages 2-5</li>
+<li>berlec2013currentstateand pages 8-9</li>
+<li>ghifari2019thepeptidasesinvolved pages 6-7</li>
+<li>ghifari2019thepeptidasesinvolved pages 7-8</li>
+<li>jarzab2025ittakestwo pages 18-19</li>
+<li>jarzab2025ittakestwo pages 9-10</li>
+<li>gala2021mitochondrialproteasesin pages 6-7</li>
+<li>huang2023discoveryofdeaminase pages 11-13</li>
+<li>huang2024discoveringdeaminasesusing pages 1-2</li>
+<li>jarzab2025ittakestwo pages 5-7</li>
+<li>gala2021mitochondrialproteasesin pages 7-8</li>
+<li>jarzab2025ittakestwo pages 27-28</li>
+<li>bykov2025asystematicbigenomic pages 1-2</li>
+<li>bykov2025asystematicbigenomic pages 3-5</li>
+<li>https://doi.org/10.1016/j.cell.2023.05.041,</li>
+<li>https://doi.org/10.1038/s41392-024-01737-z,</li>
+<li>https://doi.org/10.3389/fcimb.2026.1752304,</li>
+<li>https://doi.org/10.3390/biom15121697,</li>
+<li>https://doi.org/10.1002/1873-3468.14039,</li>
+<li>https://doi.org/10.1007/s10295-013-1235-0,</li>
+<li>https://doi.org/10.1093/jxb/erz365,</li>
+<li>https://doi.org/10.7554/elife.98889,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SDD3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12496" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sdd3-yol098c-q12496-curation-notes">SDD3 (YOL098C / Q12496) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of the understudied ("dark") <em>S. cerevisiae</em><br />
+gene <strong>SDD3</strong>. Provenance recorded inline as <code>[PMID:xxxx "verbatim text"]</code>.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>SGD standard name <strong>SDD3</strong> = systematic name <strong>YOL098C</strong>; SGD:S000005458; UniProt <strong>Q12496</strong><br />
+  (entry name YO098_YEAST). 1037 aa. Status at SGD: <strong>Verified</strong> (a real protein-coding gene,<br />
+  not a dubious ORF).</li>
+<li>The UniProt record still labels it "Uncharacterized protein YOL098C" with gene names<br />
+<code>YOL098C</code> / ORF <code>HRF1037</code>; the SGD standard name SDD3 (from Wang &amp; Chen 2015) has not yet<br />
+  propagated to the UniProt <code>GN</code> line — this is why <code>just fetch-gene yeast SDD3</code> failed on the<br />
+  symbol and the gene had to be fetched via the systematic name YOL098C. Files were then<br />
+  consolidated under <code>genes/yeast/SDD3/</code>.</li>
+<li>SGD name description: <strong>"Suppressor of Degenerative Death"</strong>.</li>
+<li>SGD one-line description: <em>"Putative metalloprotease; overproduction suppresses lethality due<br />
+  to expression of the dominant PET9 allele AAC2-A128P"</em> (SGD locus S000005458, sourced to Wang<br />
+  &amp; Chen 2015, PMID:26192197).</li>
+</ul>
+<h2 id="domain-architecture-inline-bioinformatics-from-sdd3-uniprottxt">Domain architecture / inline bioinformatics (from SDD3-uniprot.txt)</h2>
+<ul>
+<li><strong>Peptidase M16 family (pitrilysin/inverzincin clan ME)</strong>. UniProt cross-refs:</li>
+<li>Pfam <code>PF00675</code> Peptidase_M16 (N-terminal catalytic domain) + <code>PF05193</code> Peptidase_M16_C<br />
+    (C-terminal domain).</li>
+<li>MEROPS <code>M16.A04</code>.</li>
+<li>InterPro <code>IPR011249</code> (Metalloenzyme LuxS/M16), <code>IPR011765</code> (Pept_M16_N), <code>IPR007863</code><br />
+    (Peptidase_M16_C).</li>
+<li>Gene3D <code>3.30.830.10</code> ×3 (Metalloenzyme, LuxS/M16 peptidase-like fold).</li>
+<li>PANTHER family <code>PTHR43016</code> "PRESEQUENCE PROTEASE"; subfamily <code>PTHR43016:SF16</code><br />
+    "METALLOPROTEASE, PUTATIVE (AFU_ORTHOLOGUE AFUA_4G07610)-RELATED".</li>
+<li><strong>Catalytic-motif check (done inline on the sequence):</strong> the M16 family inverted zincin<br />
+  signature <strong>HxxEH</strong> is present at residues <strong>60-64 = H-T-L-E-H</strong> (His60, Glu63, His64). In M16<br />
+  peptidases the two His residues coordinate the catalytic Zn²⁺ and the Glu is the general base; a<br />
+  candidate third metal ligand Glu lies ~70 residues downstream (E135, "…TEVYHID…"). So SDD3 <strong>retains the<br />
+  canonical catalytic apparatus at the primary-sequence level</strong> — it is NOT an obvious<br />
+  pseudo-protease (no gross loss of the HxxEH motif). This is sequence-level evidence of the<br />
+<em>potential</em> for zinc metalloendopeptidase activity; it is NOT a demonstration of catalytic<br />
+  activity.</li>
+<li>The broad PTHR43016 family contains PreP/pitrilysin-type presequence proteases (mitochondrial<br />
+  MPP, PreP, cytosolic pitrilysin/insulysin relatives). However, SDD3 sits in the small,<br />
+  uncharacterized subfamily <strong>SF16</strong>, whose only reviewed members are all "putative" and<br />
+  uncharacterized (see orthology below). No SDD3-specific substrate, cleavage specificity, or<br />
+  catalytic assay exists.</li>
+</ul>
+<h2 id="orthology-from-interpropantherpthr43016pthr43016-entriescsv-subfamily-sf16">Orthology (from interpro/panther/PTHR43016/PTHR43016-entries.csv, subfamily SF16)</h2>
+<p>Reviewed SF16 members (a small, uniformly uncharacterized subfamily):<br />
+- <em>S. cerevisiae</em> YOL098C / SDD3 (Q12496, 1037 aa) — this gene.<br />
+- <em>S. pombe</em> SPAC3H1.02c (Q10068, 1036 aa) — near-identical length, clear ortholog; also<br />
+  "Uncharacterized". (SGD alias list for SDD3 explicitly includes <code>SPAC3H1.02c</code>.)<br />
+- <em>C. elegans</em> C05D11.1 (P48053, 995 aa) — "Uncharacterized".<br />
+- <em>A. fumigatus</em> AFUA_4G07610 — the PANTHER subfamily name is anchored to this ortholog.</p>
+<p>Interpretation: SF16 is a <strong>conserved-but-dark M16 subfamily</strong> — orthologs from yeast to worm,<br />
+none functionally characterized. This is a textbook conserved-unknome situation.</p>
+<h2 id="known-experimental-literature-evidence">Known experimental / literature evidence</h2>
+<h3 id="pmid26192197-wang-x-chen-xj-2015-nature-a-cytosolic-network-suppressing-mitochondria-mediated-proteostatic-stress-and-cell-death-full-text-cached">PMID:26192197 — Wang X &amp; Chen XJ (2015) Nature. "A cytosolic network suppressing mitochondria-mediated proteostatic stress and cell death." (full text cached)</h3>
+<ul>
+<li>YOL098C was recovered in a <strong>multicopy (overexpression) suppressor screen</strong> for genes that,<br />
+  when over-expressed, inhibit AAC2^A128P-induced degenerative cell death. It is one of 40<br />
+  suppressors and one of eight uncharacterized ones named <strong>SDD1-4</strong>: <em>"The remaining eight<br />
+  include the uncharacterized YEL057C, YMR074C, YOL098C and the truncated YPR022C that are named<br />
+  SDD1-4 (Suppressor of Degenerative Death) respectively"</em> <a href="https://pubmed.ncbi.nlm.nih.gov/26192197">PMID:26192197</a>. YOL098C is <strong>SDD3</strong><br />
+  (third of the four).</li>
+<li>General mechanism of the network (not SDD3-specific): the suppressors relieve "mitochondrial<br />
+  Precursor Over-accumulation Stress" (mPOS) — cytosolic accumulation/aggregation of unimported<br />
+  mitochondrial precursors — largely by modulating cytosolic translation, mRNA turnover, and<br />
+  protein chaperoning/turnover: <em>"We also discover a large network of genes that suppress mPOS,<br />
+  by modulating ribosomal biogenesis, messenger RNA decapping, transcript-specific translation,<br />
+  protein chaperoning and turnover"</em> <a href="https://pubmed.ncbi.nlm.nih.gov/26192197">PMID:26192197</a>.</li>
+<li>Localization of the network: <em>"All of the suppressors are located in the cytosol, suggesting<br />
+  that they prevent cell death via pathways that operate in the cytosol"</em> <a href="https://pubmed.ncbi.nlm.nih.gov/26192197">PMID:26192197</a>.</li>
+<li><strong>Curation caveat:</strong> this is an <em>overexpression / gain-of-function genetic</em> phenotype in a<br />
+  screen, not a demonstration of SDD3's normal cellular role or of any biochemical activity.<br />
+  SDD3 was named but NOT individually characterized (no deletion phenotype, no substrate, no<br />
+  mechanism assigned to SDD3 specifically in this paper). Its recovery is fully consistent with,<br />
+  but does not prove, a proteostasis/protein-turnover role.</li>
+</ul>
+<h3 id="pmid14562095-huh-wk-et-al-2003-nature-global-analysis-of-protein-localization-in-budding-yeast-abstract-only-cache">PMID:14562095 — Huh WK et al. (2003) Nature. "Global analysis of protein localization in budding yeast." (abstract-only cache)</h3>
+<ul>
+<li>Source of the GOA <code>GO:0005737 cytoplasm</code> HDA annotation (GFP-fusion localization study,<br />
+  ~75% of the proteome). SDD3-GFP was scored cytoplasmic. Consistent with the "all suppressors<br />
+  are cytosolic" statement above. (Note GOA cites PMID:14562095 for the CC term; the UniProt DR<br />
+  line lists the cytoplasm GO term as <code>HDA:SGD</code>.)</li>
+</ul>
+<h3 id="pmid30358795-wang-y-et-al-2018-metallomics-the-cellular-economy-of-the-s-cerevisiae-zinc-proteome-abstract-only-cache">PMID:30358795 — Wang Y et al. (2018) Metallomics. "The cellular economy of the S. cerevisiae zinc proteome." (abstract-only cache)</h3>
+<ul>
+<li>Source of the GOA <code>GO:0008270 zinc ion binding</code> <strong>RCA</strong> annotation. This is a <strong>proteome-wide<br />
+  computational prediction</strong>: <em>"The yeast zinc proteome of 582 known or potential zinc-binding<br />
+  proteins was identified using a bioinformatics analysis that combined global domain searches<br />
+  with local motif searches"</em> <a href="https://pubmed.ncbi.nlm.nih.gov/30358795">PMID:30358795</a>. SDD3/YOL098C was among the predicted zinc<br />
+  proteins — consistent with the M16 HxxEH zincin motif, but this is a prediction, not a direct<br />
+  binding measurement for SDD3.</li>
+</ul>
+<h2 id="known-vs-not-known-summary">KNOWN vs NOT-known summary</h2>
+<p>KNOWN (defensible):<br />
+- Real, verified protein-coding gene; ~1037-aa cytoplasmic protein (experimental GFP<br />
+  localization, PMID:14562095; corroborated by PMID:26192197).<br />
+- Belongs to the M16 peptidase family (pitrilysin clan) and retains the canonical HxxEH catalytic<br />
+  zincin motif (sequence-level; UniProt/Pfam/InterPro/MEROPS + inline motif check).<br />
+- Predicted zinc-binding protein (computational, PMID:30358795), consistent with the domain.<br />
+- Overexpression suppresses AAC2^A128P-induced degenerative cell death (genetic gain-of-function;<br />
+  member of the anti-mPOS cytosolic proteostasis network, PMID:26192197).</p>
+<p>NOT known (the real gaps):<br />
+- No demonstrated <strong>catalytic (metalloendopeptidase) activity</strong> for SDD3 or any SF16 ortholog;<br />
+  no substrate, no cleavage specificity, no in-vitro assay. "Putative metalloprotease" only.<br />
+- No demonstrated <strong>direct zinc binding</strong> for the SDD3 protein (RCA prediction only).<br />
+- No <strong>loss-of-function</strong> phenotype defining a normal biological role (the only phenotype is<br />
+  overexpression suppression). Whether SDD3 normally participates in cytosolic proteostasis /<br />
+  mitochondrial-precursor clearance, or does something else entirely, is undetermined.<br />
+- No physical <strong>interaction partner or substrate</strong> identified.<br />
+- The entire conserved <strong>SF16 subfamily</strong> (yeast→worm) is functionally uncharacterized.</p>
+<h2 id="annotation-by-annotation-plan">Annotation-by-annotation plan</h2>
+<ol>
+<li><code>GO:0046872 metal ion binding</code> (IEA, InterPro/IPR011249) — domain-consistent but generic;<br />
+   KEEP_AS_NON_CORE (the more specific zinc term already exists). Generic parent of zinc binding.</li>
+<li><code>GO:0008270 zinc ion binding</code> (RCA, PMID:30358795) — computational zinc-proteome prediction,<br />
+   consistent with M16 zincin motif; KEEP_AS_NON_CORE (defensible as domain/prediction support,<br />
+   but not experimentally demonstrated for SDD3).</li>
+<li><code>GO:0005737 cytoplasm</code> (HDA, PMID:14562095) — experimental GFP localization; ACCEPT (core;<br />
+   the one solid, experimentally supported annotation). Cytosol would be more precise.</li>
+<li><code>GO:0008150 biological_process</code> (ND, GO_REF:0000015) — root "no data" placeholder;<br />
+   KEEP_AS_NON_CORE (this is the honest current state — BP is genuinely undetermined; do not<br />
+   invent a BP). ND root annotations are retained as-is, not removed.</li>
+</ol>
+<p>Core functions: keep conservative. The only experimentally supported fact is cytosolic<br />
+localization. Catalytic activity is domain-inferred (motif intact) but never demonstrated, so it<br />
+belongs in knowledge_gaps, and I will include at most a single, explicitly-hedged domain-inferred<br />
+metalloendopeptidase core function (or none). Primary deliverable = knowledge_gaps.</p>
+<h2 id="deep-research-status">Deep research status</h2>
+<p><code>just deep-research-falcon yeast SDD3 --fallback perplexity-lite</code> was run twice. First attempt<br />
+failed (falcon template error because the UniProt file was not yet under <code>genes/yeast/SDD3/</code>;<br />
+perplexity-lite fallback returned HTTP 401 insufficient_quota). A second attempt (after moving the<br />
+UniProt file into place) <strong>succeeded</strong>: falcon produced <code>SDD3-deep-research-falcon.md</code> (~29 min,<br />
+24 citations) before the recipe's separate perplexity-lite fallback step erred on quota. The<br />
+falcon report independently corroborates this review: it confirms "SDD3" is ambiguous but that the<br />
+target is YOL098C, places YOL098C squarely in the M16 metalloendopeptidase family with the HXXEH<br />
+inverted zinc-binding motif and clamshell architecture, contextualizes it against characterized<br />
+yeast M16 members (MPP Mas1/Mas2, Cym1), and states that "No primary literature was identified<br />
+that directly characterizes the function, substrate specificity, localization, or biological role<br />
+of YOL098C" — matching the knowledge_gaps here. This review is grounded directly in the UniProt<br />
+record, the GOA TSV, the cached primary literature (PMID:26192197 full text; PMID:14562095 and<br />
+PMID:30358795 abstracts), SGD, PANTHER orthology, inline domain/motif analysis, and this falcon<br />
+report — no fabricated content.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q12496
+gene_symbol: SDD3
+aliases:
+- YOL098C
+- HRF1037
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  SDD3 (systematic name YOL098C) is a ~1037-residue cytoplasmic protein of the
+  peptidase M16 family (pitrilysin/inverzincin clan ME). It contains the two
+  characteristic M16 domains (Pfam Peptidase_M16 N-terminal catalytic domain and
+  Peptidase_M16_C C-terminal domain; MEROPS M16.A04) and retains the family&#39;s
+  inverted zinc-binding catalytic motif HxxEH near its N-terminus, so it is
+  predicted to be a zinc-dependent metalloendopeptidase; a genome-wide zinc-proteome
+  survey computationally classified it as a zinc-binding protein. Despite the intact
+  catalytic motif, no proteolytic activity, substrate, or cleavage specificity has
+  been experimentally demonstrated for SDD3 or for any member of its uncharacterized
+  ortholog group (PANTHER subfamily PTHR43016:SF16, with orthologs in fission yeast,
+  worm and filamentous fungi), so it remains a putative metalloprotease. The protein
+  localizes to the cytoplasm. The only reported phenotype comes from overexpression:
+  multicopy expression of SDD3 suppresses the degenerative cell death caused by the
+  dominant mitochondrial ADP/ATP carrier allele AAC2(A128P), placing it in a large
+  cytosolic network that counteracts stress from over-accumulated, unimported
+  mitochondrial precursor proteins. Its normal (loss-of-function) biological role and
+  its physiological substrate remain undetermined.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard InterPro2GO electronic-annotation reference. Underlies the generic
+      metal ion binding IEA term, which is consistent with the M16 zincin domain.
+- id: GO_REF:0000015
+  title: Gene Ontology annotation based on curatorial statement evidence.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard reference for ND (no biological data) root annotations. Honestly
+      reflects that no biological process has been assigned to SDD3.
+- id: PMID:14562095
+  title: Global analysis of protein localization in budding yeast.
+  findings:
+  - statement: &gt;-
+      Genome-wide GFP-fusion localization study; SDD3/YOL098C was scored as
+      cytoplasmic, the basis for the experimental cytoplasm annotation.
+    full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Huh et al. 2003 Nature; the source of the experimental (HDA) cytoplasm
+      localization annotation. Abstract-only in cache but this is a canonical,
+      high-coverage yeast localization dataset. The single most solid experimental
+      annotation for SDD3.
+- id: PMID:30358795
+  title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+  findings:
+  - statement: &gt;-
+      Proteome-wide bioinformatic identification of the yeast zinc proteome using
+      domain plus motif searches; SDD3/YOL098C was among the predicted zinc-binding
+      proteins, consistent with the M16 zincin motif.
+    supporting_text: &gt;-
+      identified using a bioinformatics analysis that combined global domain searches
+      with local motif searches
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Wang et al. 2018 Metallomics; source of the RCA zinc ion binding annotation.
+      The zinc-proteome membership is a computational prediction, not a direct
+      binding measurement for SDD3.
+- id: PMID:26192197
+  title: A cytosolic network suppressing mitochondria-mediated proteostatic stress and cell death.
+  findings:
+  - statement: &gt;-
+      YOL098C was recovered as a multicopy (overexpression) suppressor of
+      AAC2(A128P)-induced degenerative cell death and named SDD3 (Suppressor of
+      Degenerative Death 3), one of a large cytosolic anti-mPOS network whose members
+      are cytosolic.
+    supporting_text: &gt;-
+      The remaining eight include the uncharacterized YEL057C, YMR074C, YOL098C and
+      the truncated YPR022C that are named SDD1-4 (Suppressor of Degenerative Death)
+      respectively
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Wang &amp; Chen 2015 Nature (full text cached, PMC4582408); the paper that named
+      SDD3. Establishes only an overexpression/gain-of-function genetic phenotype for
+      SDD3 as one of 40 suppressors and one of eight uncharacterized ones (SDD1-4);
+      SDD3 itself is not individually mechanistically characterized.
+existing_annotations:
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic metal ion binding, inferred electronically from the InterPro M16
+      metalloenzyme signature (IPR011249). Consistent with the domain and with the
+      more specific zinc ion binding annotation, but uninformative on its own.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Domain-consistent (SDD3 carries the M16 inverted zincin fold) but this is the
+      generic parent of the more specific GO:0008270 zinc ion binding term already
+      present, and it is electronic. Retain as supporting, non-core; the specific zinc
+      term better captures the predicted cofactor.
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: RCA
+  original_reference_id: PMID:30358795
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Zinc ion binding predicted by a proteome-wide zinc-proteome bioinformatic survey
+      and independently consistent with the retained M16 HxxEH zincin motif
+      (His60/Glu63/His64). Not a direct experimental binding measurement for SDD3.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Defensible as a domain- and prediction-supported molecular-function hypothesis:
+      the M16 fold uses a zinc cofactor and the catalytic motif is intact. However the
+      evidence is computational (RCA zinc-proteome prediction) with no biochemical
+      validation for SDD3 specifically, so it is kept as non-core. Zinc binding, if
+      real, would be in service of the (still-undemonstrated) metalloendopeptidase
+      activity rather than being the biological point of the gene.
+    supported_by:
+    - reference_id: PMID:30358795
+      supporting_text: &gt;-
+        identified using a bioinformatics analysis that combined global domain searches
+        with local motif searches
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: HDA
+  original_reference_id: PMID:14562095
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization determined experimentally by genome-wide GFP-fusion
+      microscopy, and independently consistent with the report that the
+      anti-degenerative suppressor network (which includes SDD3) is cytosolic.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental (HDA) evidence from a canonical high-coverage yeast localization
+      dataset; corroborated by the Wang &amp; Chen 2015 statement that all suppressors are
+      located in the cytosol. This is the single most solid annotation for SDD3 and
+      represents its established subcellular location. The more precise term GO:0005829
+      (cytosol) is used in core_functions.
+    supported_by:
+    - reference_id: PMID:26192197
+      supporting_text: &gt;-
+        All of the suppressors are located in the cytosol, suggesting that they prevent
+        cell death via pathways that operate in the cytosol
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with ND (no data) evidence — a placeholder
+      indicating that no biological process has been experimentally assigned to SDD3.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This ND root annotation honestly reflects the current state of knowledge: the
+      normal biological role of SDD3 is undetermined. The only reported phenotype is an
+      overexpression suppression of AAC2(A128P) cell death, a gain-of-function genetic
+      observation rather than a loss-of-function process assignment; inventing a
+      specific BP term (e.g. proteostasis or protein catabolism) would over-annotate.
+      Retain the ND placeholder rather than remove.
+    knowledge_gaps:
+    - gap_statement: &gt;-
+        The normal (loss-of-function) biological process in which SDD3 participates is
+        unknown; no SDD3 deletion phenotype has been reported that would assign it to a
+        specific pathway.
+      boundary: &gt;-
+        The only phenotype reported for SDD3 is that its multicopy overexpression
+        suppresses AAC2(A128P)-induced degenerative cell death, placing it within a
+        large cytosolic network that counteracts mitochondrial-precursor
+        over-accumulation stress (mPOS).
+      gap_kind:
+      - BIOLOGY
+      dark_aspect: BP_DARK
+      status: OPEN
+      significance: &gt;-
+        Distinguishing a genuine role in cytosolic proteostasis / mitochondrial
+        precursor clearance from an indirect overexpression effect is required before
+        any biological process can be annotated.
+      resolution: &gt;-
+        Phenotype an sdd3 deletion (and sdd3 deletion combined with mPOS-inducing
+        lesions such as yme1 deletion or AAC2(A128P)); test whether endogenous SDD3 is
+        required for, or induced by, mPOS.
+      provenance:
+      - reference_id: PMID:26192197
+        supporting_text: &gt;-
+          The remaining eight include the uncharacterized YEL057C, YMR074C, YOL098C and
+          the truncated YPR022C that are named SDD1-4 (Suppressor of Degenerative Death)
+          respectively
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IC
+  original_reference_id: PMID:26192197
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      More precise refinement of the experimental cytoplasm localization: SDD3 is a
+      soluble cytosolic protein.
+    action: NEW
+    reason: &gt;-
+      Proposed as a more specific child of the accepted GO:0005737 (cytoplasm)
+      experimental annotation. Supported by the genome-wide GFP localization (cytoplasm)
+      and by the report that the anti-degenerative suppressor network including SDD3 is
+      cytosolic.
+    supported_by:
+    - reference_id: PMID:26192197
+      supporting_text: &gt;-
+        All of the suppressors are located in the cytosol, suggesting that they prevent
+        cell death via pathways that operate in the cytosol
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: ISS
+  original_reference_id: PMID:30358795
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed domain-inferred molecular function: SDD3 is a peptidase M16 family
+      protein retaining the canonical HxxEH zincin catalytic motif, so it is predicted
+      to be a zinc-dependent metalloendopeptidase. Not experimentally demonstrated.
+    action: NEW
+    reason: &gt;-
+      Added as a hypothesis grounded in domain architecture (Pfam Peptidase_M16 +
+      Peptidase_M16_C; MEROPS M16.A04; intact HxxEH motif at His60-Glu63-His64) and
+      SGD&#39;s &#34;putative metalloprotease&#34; description, not as an asserted function. No
+      catalytic activity or substrate has been measured for SDD3 or its SF16 subfamily;
+      see the associated knowledge_gaps. Recorded so the predicted activity is explicit
+      and testable rather than hidden.
+    supported_by:
+    - reference_id: PMID:30358795
+      supporting_text: &gt;-
+        identified using a bioinformatics analysis that combined global domain searches
+        with local motif searches
+core_functions:
+- description: &gt;-
+    Cytoplasmic localization is the one experimentally established property of SDD3;
+    the protein is a soluble cytoplasmic component and any biochemical role it performs
+    is executed in the cytoplasm/cytosol.
+  supported_by:
+  - reference_id: PMID:26192197
+    supporting_text: &gt;-
+      All of the suppressors are located in the cytosol, suggesting that they prevent
+      cell death via pathways that operate in the cytosol
+  locations:
+  - id: GO:0005829
+    label: cytosol
+- description: &gt;-
+    Putative (domain-inferred, not experimentally demonstrated) zinc-dependent
+    metalloendopeptidase activity. SDD3 belongs to the M16 peptidase family and retains
+    the canonical inverted zincin catalytic motif HxxEH (His60-Thr-Leu-Glu63-His64),
+    giving it the sequence hallmarks of a zinc metalloendopeptidase, and it is predicted
+    to bind zinc. No proteolytic activity, substrate, or cleavage specificity has been
+    measured for SDD3 or any member of its uncharacterized SF16 subfamily, so this is a
+    hypothesis grounded in domain architecture rather than a demonstrated function; see
+    knowledge_gaps.
+  supported_by:
+  - reference_id: PMID:30358795
+    supporting_text: &gt;-
+      identified using a bioinformatics analysis that combined global domain searches
+      with local motif searches
+  molecular_function:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      Whether SDD3 is a catalytically active zinc metalloendopeptidase, and if so what
+      peptide/protein substrate(s) it cleaves and with what specificity, is unknown; the
+      only evidence for an activity is the presence of the M16 zincin fold and motif.
+    boundary: &gt;-
+      SDD3 is firmly assigned to the peptidase M16 family (Pfam Peptidase_M16 +
+      Peptidase_M16_C; MEROPS M16.A04; PANTHER PTHR43016) and retains the intact HxxEH
+      catalytic motif and a candidate downstream metal-ligand Glu, so it has the
+      structural potential for metalloendopeptidase activity. SGD describes it as a
+      &#34;putative metalloprotease&#34;.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      SDD3 and its conserved orthologs (fission yeast SPAC3H1.02c, C. elegans C05D11.1,
+      fungal AFUA_4G07610) form an uncharacterized M16 subfamily; defining the activity
+      and substrate would light up a conserved dark branch of the M16 peptidase family
+      and could clarify how the protein suppresses mitochondria-linked proteostatic
+      stress.
+    resolution: &gt;-
+      Purify recombinant SDD3 and assay zinc-dependent peptidase activity against
+      candidate M16-type substrates (e.g. presequence peptides, unstructured peptides);
+      test catalytic-motif (HxxEH) mutants; identify substrates by N-terminomics /
+      degradomics in cells over- or under-expressing SDD3.
+    provenance:
+    - reference_id: PMID:30358795
+      supporting_text: &gt;-
+        identified using a bioinformatics analysis that combined global domain searches
+        with local motif searches
+knowledge_gaps:
+- gap_statement: &gt;-
+    SDD3 has no experimentally demonstrated molecular function. Its assignment as a zinc
+    metalloendopeptidase rests entirely on the presence of the M16 family fold and the
+    intact HxxEH zincin motif plus a computational zinc-proteome prediction; no catalytic
+    activity, substrate, cofactor binding, or physical interaction partner has been
+    measured for the SDD3 protein.
+  boundary: &gt;-
+    Firmly known: SDD3 (YOL098C) is a verified, ~1037-aa, cytoplasmically localized
+    (experimental GFP) protein of the peptidase M16 family that retains the canonical
+    catalytic zincin motif, and whose multicopy overexpression suppresses
+    AAC2(A128P)-induced degenerative cell death.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    SDD3 is a conserved-but-dark member of the M16 peptidase family: its ortholog group
+    (PANTHER subfamily PTHR43016:SF16 - fission yeast, worm, and filamentous fungi) is
+    uniformly uncharacterized, so closing this gap would define function for a whole
+    conserved subfamily rather than a single gene.
+  resolution: &gt;-
+    Reconstitute and assay the predicted metalloendopeptidase activity in vitro (with
+    catalytic-motif controls), identify substrates by degradomics, and map physical
+    interactors by affinity-purification mass spectrometry.
+  provenance:
+  - reference_id: PMID:26192197
+    supporting_text: &gt;-
+      The remaining eight include the uncharacterized YEL057C, YMR074C, YOL098C and the
+      truncated YPR022C that are named SDD1-4 (Suppressor of Degenerative Death)
+      respectively
+- gap_statement: &gt;-
+    It is unknown whether SDD3&#39;s recovery as an overexpression suppressor of
+    mitochondria-mediated cell death reflects a genuine endogenous role in cytosolic
+    proteostasis / clearance of over-accumulated mitochondrial precursors, or an indirect
+    gain-of-function effect of high-copy expression.
+  boundary: &gt;-
+    SDD3 was identified only through multicopy overexpression suppression of
+    AAC2(A128P)-induced death and belongs to a large cytosolic network the authors link
+    to relief of mitochondrial Precursor Over-accumulation Stress (mPOS); the network as
+    a whole acts by modulating cytosolic translation, mRNA turnover, and protein
+    chaperoning/turnover, and all its members are cytosolic.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    The distinction matters for whether SDD3 should ultimately be annotated to a
+    proteostasis / protein-catabolism process and for understanding the crosstalk between
+    mitochondrial dysfunction and cytosolic protein homeostasis relevant to
+    neurodegeneration and ageing.
+  resolution: &gt;-
+    Test the endogenous requirement (deletion and conditional depletion) in
+    mPOS-sensitized backgrounds; measure whether SDD3 protein or transcript is induced
+    under mPOS and whether it associates with, or degrades, accumulated mitochondrial
+    precursor proteins.
+  provenance:
+  - reference_id: PMID:26192197
+    supporting_text: &gt;-
+      All of the suppressors are located in the cytosol, suggesting that they prevent
+      cell death via pathways that operate in the cytosol
+suggested_questions:
+- question: &gt;-
+    Is SDD3 a catalytically active zinc metalloendopeptidase, and what is its
+    physiological substrate?
+  experts:
+  - Xin Jie Chen
+- question: &gt;-
+    Does endogenous SDD3 have a loss-of-function role in cytosolic proteostasis or in
+    clearing over-accumulated mitochondrial precursor proteins (mPOS), or is the
+    suppression phenotype purely a high-copy gain-of-function effect?
+  experts:
+  - Xin Jie Chen
+suggested_experiments:
+- hypothesis: &gt;-
+    SDD3 is a zinc-dependent metalloendopeptidase whose activity requires the intact
+    HxxEH motif.
+  description: &gt;-
+    Express and purify recombinant SDD3, assay metalloendopeptidase activity (zinc
+    dependence, chelator sensitivity) against candidate M16-type peptide substrates, and
+    compare wild-type with a catalytic HxxEH-motif mutant.
+  experiment_type: in vitro enzyme assay with catalytic-residue mutagenesis
+- hypothesis: &gt;-
+    SDD3 acts in cytosolic clearance of over-accumulated mitochondrial precursors.
+  description: &gt;-
+    Delete SDD3 and test for phenotypes in mPOS-sensitized backgrounds (e.g. yme1
+    deletion or AAC2(A128P)); use N-terminomics/degradomics and affinity-purification
+    mass spectrometry in SDD3 over- vs under-expressing cells to identify substrates and
+    interaction partners.
+  experiment_type: genetics plus interaction/degradomics proteomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/SIA1/SIA1-ai-review.html
+++ b/genes/yeast/SIA1/SIA1-ai-review.html
@@ -1,0 +1,2816 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SIA1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SIA1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q12212" target="_blank" class="term-link">
+                        Q12212
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SIA1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q12212" data-a="DESCRIPTION: SIA1 (YOR137C) is a poorly characterized 622-resid..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SIA1 (YOR137C) is a poorly characterized 622-residue protein of the budding yeast Saccharomyces cerevisiae. It carries an N-terminal signal peptide and a single calcineurin-like metallophosphoesterase (metallophosphatase/purple acid phosphatase-like) domain, placing it in a family that also contains the yeast paralog Dcr2 and several plant &#34;probable inactive purple acid phosphatases&#34;. Genetic evidence shows that SIA1 is required for the glucose-triggered, post-translational activation of the plasma membrane proton pump Pma1: cells lacking SIA1 have normal Pma1 protein levels at the plasma membrane but fail to show the full glucose-induced increase in Pma1 maximal velocity, identifying SIA1 as a positive regulator of H+-ATPase activation rather than a component of the pump itself. SIA1 was independently isolated as a multicopy suppressor of a temperature-sensitive allele of the essential translation factor eIF5A (the source of its name, &#34;Suppressor of eIF5A&#34;), a screen that linked eIF5A to the WSC/PKC1 cell-wall-integrity signalling pathway. SIA1 transcription is induced by ethanol stress. Its molecular activity is unresolved: although the metallophosphatase fold and phylogenetic assignment suggest a possible phosphatase, no catalytic activity or substrate has been demonstrated, and its closest relatives are predicted to be catalytically inactive.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004721" target="_blank" class="term-link">
+                                    GO:0004721
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoprotein phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12212" data-a="GO:0004721" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Family-level phylogenetic (IBA) inference of phosphatase activity from the calcineurin-like metallophosphatase fold. SIA1 has the domain, but no phosphatase activity or substrate has ever been demonstrated for it, and its nearest orthologs include &#34;probable inactive purple acid phosphatases&#34;. Retained as a plausible family-level hypothesis but not treated as an established (core) function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SIA1 is assigned to PANTHER PTHR32440:SF0 (phosphatase DCR2-related), a metallophosphoesterase / purple acid phosphatase-like family, so an IBA phosphatase annotation is a defensible domain-based hypothesis and should not be removed. However, the only experimental data on SIA1 concern its requirement for glucose activation of Pma1, with no assay of phosphatase activity; SGD lists molecular function as Unknown; and several reviewed SF0 members are annotated as inactive purple acid phosphatases. The catalytic activity of SIA1 is therefore an open knowledge gap, so this term is kept as non-core rather than accepted as a core function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">SOURCE EVIDENCE WEAK</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTHR32440</span>
+
+                                    &middot; phosphatase DCR2-related (SF0)
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Family includes yeast Dcr2 and plant PAP14/16/28/29 annotated as probable INACTIVE purple acid phosphatases; SIA1 catalytic activity unverified.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SIA1/SIA1-uniprot.txt
+
+                                </span>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
+                                    GO:0016787
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q12212" data-a="GO:0016787" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic hydrolase parent term inferred electronically (InterPro2GO) from the metallophosphatase domain IPR004843. Consistent with the fold but uninformative and subsumed by the more specific (also inferential) phosphatase term; not wrong.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IEA annotation is a direct domain-to-GO mapping (IPR004843 -&gt; hydrolase activity) and is consistent with the metallophosphatase fold. It is far more general than the family-level phosphatase inference and carries the same (unverified) assumption that the domain is catalytically active. It is retained as non-core background rather than removed, since the fold is genuinely present, but it does not describe a demonstrated SIA1 function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SIA1/SIA1-uniprot.txt
+
+                                </span>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
+                                    GO:1902600
+                                </a>
+                            </span>
+                            <span class="term-label">proton transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9450541" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9450541
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Yeast gene YOR137c is involved in the activation of the yeas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q12212" data-a="GO:1902600" data-r="PMID:9450541" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Based on the SIA1 deletion phenotype (loss of glucose-triggered Pma1 Vmax increase), SGD annotated SIA1 to proton transmembrane transport (IMP). The experimental evidence is sound, but SIA1 does not itself transport protons; it is required for activation of the Pma1 proton pump. A regulatory process term better captures the biology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The experimental support (PMID:9450541, IMP) is solid and must be retained - the paper shows SIA1 is required for the glucose-induced Vmax increase of Pma1. However, the term &#34;proton transmembrane transport&#34; attributes the ion-translocation process to SIA1, whereas SIA1 is a regulator required for activation of the transporter, not a transporter or channel. The essence is sound but a better term exists, so MODIFY to a regulatory term (&#34;regulation of proton transport&#34;, GO:0010155) that preserves the experimental support while stating the biology accurately.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010155" target="_blank" class="term-link">
+                                    regulation of proton transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9450541" target="_blank" class="term-link">
+                                        PMID:9450541
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Deletion of YOR137c does not affect the level of Pma1 at the plasma membrane, but disturbs the glucose-triggered Vmax increase of the enzyme.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SIA1/SIA1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Within this pathway, SIA1 is genetically implicated alongside PTK2 as a positive factor in Pma1 activation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12212" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD ND placeholder recording that no molecular-function data are available for SIA1. This is accurate: SIA1&#39;s molecular activity is genuinely unresolved (see knowledge_gaps).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The root molecular_function ND annotation correctly records the absence of curated molecular-function evidence. Given that SIA1 has no experimentally demonstrated activity and its family assignment is ambiguous (possible pseudophosphatase), the ND placeholder is an honest reflection of the state of knowledge and should be retained until an activity is established.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q12212" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SGD ND placeholder recording that no cellular-component data are available for SIA1. SIA1 has a predicted signal peptide (secretory-pathway entry) but no experimentally verified subcellular localization is curated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The root cellular_component ND annotation correctly records the absence of curated localization evidence. Although a signal peptide predicts membrane/secretory-pathway entry and SIA1 functionally regulates the plasma-membrane Pma1, no experimental localization is available, so retaining the honest ND placeholder is appropriate.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Positive regulator required for the glucose-triggered, post-translational activation of the plasma membrane H+-ATPase Pma1. Loss of SIA1 leaves Pma1 protein levels at the plasma membrane unchanged but prevents the full glucose-induced increase in the pump&#39;s maximal velocity, identifying SIA1 as required for one of the (at least two) mechanisms that activate Pma1 in response to glucose. The molecular mechanism (direct versus indirect; catalytic versus scaffolding) is not established.</h3>
+                <span class="vote-buttons" data-g="Q12212" data-a="FUNCTION: Positive regulator required for the glucose-trigge..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010155" target="_blank" class="term-link">
+                                regulation of proton transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9450541" target="_blank" class="term-link">
+                                PMID:9450541
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Deletion of YOR137c does not affect the level of Pma1 at the plasma membrane, but disturbs the glucose-triggered Vmax increase of the enzyme.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9450541" target="_blank" class="term-link">
+                            PMID:9450541
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Yeast gene YOR137c is involved in the activation of the yeast plasma membrane H+-ATPase by glucose.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion of YOR137c (SIA1) does not change the amount of Pma1 at the plasma membrane but abolishes the glucose-triggered increase in Pma1 maximal velocity, showing that SIA1 is required for post-translational (post-transcriptional) glucose activation of the H+-ATPase.</div>
+
+                        <div class="finding-text">"Deletion of YOR137c does not affect the level of Pma1 at the plasma membrane, but disturbs the glucose-triggered Vmax increase of the enzyme."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11861547" target="_blank" class="term-link">
+                            PMID:11861547
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic interactions of yeast eukaryotic translation initiation factor 5A (eIF5A) reveal connections to poly(A)-binding protein and protein kinase C signaling.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A multicopy suppressor screen of a temperature-sensitive eIF5A (tif51A) allele recovered several genes and connected eIF5A to the WSC/PKC1 cell-wall-integrity signalling pathway; SIA1 (Suppressor of eIF5A 1) was named from this screen.</div>
+
+                        <div class="finding-text">"A multicopy suppressor screen revealed six genes, the overexpression of which allows growth of a tif51A-1 strain at high temperature; these genes include PAB1, PKC1, and PKC1 regulators WSC1, WSC2, and WSC3."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11389906" target="_blank" class="term-link">
+                            PMID:11389906
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Global gene expression during short-term ethanol stress in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SIA1 (YOR137C) transcription is up-regulated during short-term ethanol stress (UniProt INDUCTION line, ECO:0000269|PubMed:11389906).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on ND (No biological Data available) records.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/SIA1/SIA1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry Q12212 (SIA1_YEAST) - domain and feature annotations.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt annotates SIA1 with an N-terminal signal peptide (residues 1-27) and a single calcineurin-like metallophosphoesterase domain (Pfam PF00149 Metallophos; InterPro IPR004843/IPR029052; Gene3D 3.60.21.10; SUPFAM SSF56300), and assigns it to PANTHER family PTHR32440 subfamily SF0 (phosphatase DCR2-related).</div>
+
+                        <div class="finding-text">"DR   Pfam; PF00149; Metallophos; 1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/SIA1/SIA1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon (Edison) deep-research report for SIA1 (YOR137C).</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Independent deep-research synthesis places SIA1 in the metallophosphoesterase superfamily and, alongside PTK2, as a genetically implicated positive factor in glucose-induced Pma1 H+-ATPase activation, with the exact biochemical step unresolved; it also links SIA1 to the RIM101 weak-acid stress network (down in rim101-delta).</div>
+
+                        <div class="finding-text">"Within this pathway, SIA1 is genetically implicated alongside PTK2 as a positive factor in Pma1 activation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does SIA1 act directly on Pma1 (physical interaction / activator or scaffold) or indirectly through a signalling or lipid-mediated route to promote glucose activation of the H+-ATPase?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12212" data-a="Q: Does SIA1 act directly on Pma1 (physical interacti..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the SIA1 metallophosphatase domain catalytically active, and if so what is its physiological substrate - or is SIA1 a pseudophosphatase like its closest relatives?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12212" data-a="Q: Is the SIA1 metallophosphatase domain catalyticall..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is SIA1&#39;s role in glucose activation of Pma1 mechanistically connected to its genetic identity as an eIF5A suppressor and to WSC/PKC1 cell-wall-integrity signalling, or are these independent activities?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12212" data-a="Q: Is SIA1&#39;s role in glucose activation of Pma1 mecha..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Co-immunoprecipitation / proximity labelling of tagged SIA1 and Pma1 before and after glucose addition to test for direct interaction; phosphoproteomic comparison of Pma1 (especially the C-terminal autoinhibitory Ser/Thr residues) in wild-type versus sia1-delta cells upon glucose refeeding.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SIA1 promotes glucose activation of Pma1 by directly modulating Pma1&#39;s activity or phosphorylation state.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction and phosphorylation analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12212" data-a="EXPERIMENT: Co-immunoprecipitation / proximity labelling of ta..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Recombinant expression of the SIA1 metallophosphatase domain and in vitro phosphatase assays (para-nitrophenyl phosphate and phosphopeptide substrates) with metal-dependence controls; parallel assay of catalytic-residue point mutants to test whether any activity requires the predicted metal-binding scaffold.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The SIA1 metallophosphatase domain is (or is not) catalytically active.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: enzymology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12212" data-a="EXPERIMENT: Recombinant expression of the SIA1 metallophosphat..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the subcellular localization of endogenously tagged SIA1 by fluorescence microscopy and membrane fractionation, and test signal-peptide dependence, to place SIA1 relative to Pma1 in the secretory pathway / plasma membrane.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: SIA1 localizes to a compartment consistent with acting on Pma1 (plasma membrane or secretory pathway).</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: cell biology / localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q12212" data-a="EXPERIMENT: Determine the subcellular localization of endogeno..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> SIA1&#39;s molecular activity is undetermined. Although it has a calcineurin-like metallophosphatase fold and carries a family-level IBA &#34;phosphoprotein phosphatase activity&#34; annotation, no catalytic activity or substrate has ever been demonstrated for SIA1, and its closest relatives include probable inactive purple acid phosphatases, so it is unknown whether SIA1 is an active phosphatase or a pseudoenzyme.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: SIA1 contains a single metallophosphatase domain (Pfam PF00149; InterPro IPR004843) and belongs to PANTHER PTHR32440:SF0. Not established: any measured enzymatic activity, substrate, or metal dependence; SGD lists molecular function as Unknown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether SIA1 is an active phosphatase determines the class of mechanism by which it could regulate Pma1 (direct enzymatic modification versus non-catalytic scaffolding), and would resolve whether the family-level IBA/IEA activity annotations reflect real biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro phosphatase assays on recombinant SIA1 (and catalytic-residue mutants) with phosphoprotein/phosphopeptide and generic substrates; structural comparison of the SIA1 active site with active metallophosphatases.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>""</em> — file:yeast/SIA1/SIA1-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism linking SIA1 to glucose activation of Pma1 is unknown - whether SIA1 acts directly on the pump or through an intermediate signalling/lipid step, and which of the &#34;at least two independent mechanisms&#34; of Pma1 glucose activation SIA1 belongs to.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: sia1-delta cells retain normal plasma-membrane Pma1 levels but fail the glucose-triggered Vmax increase (PMID:9450541). Not established: the molecular step or partner through which SIA1 exerts this effect.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifies how a central metabolic signal (glucose) is transduced to the master plasma-membrane proton pump; SIA1 is a genetic entry point into this poorly understood activation pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis and interaction studies placing SIA1 relative to known Pma1 glucose-activation inputs (Ptk1/2 kinases, Glc7 phosphatase, sphingolipid/ergosterol requirements) and direct interaction tests.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We propose that at least two independent mechanisms are involved in glucose activation of the H+-ATPase."</em> — PMID:9450541</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> SIA1&#39;s direct physical partners and its subcellular localization are unknown. No validated Pma1 physical interaction is curated, and there is no experimentally determined localization despite a predicted N-terminal signal peptide.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: SIA1 has a predicted signal peptide (UniProt residues 1-27) and low-throughput interaction records exist, but SGD lists cellular component as Unknown and no direct Pma1 interaction is curated. Not established: where SIA1 resides and what it binds.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Knowing whether SIA1 reaches the plasma membrane / secretory pathway and what it binds is prerequisite to any mechanistic model of how it acts on Pma1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous-tag localization microscopy and membrane fractionation; affinity-purification mass spectrometry / proximity labelling to define the SIA1 interactome.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>""</em> — file:yeast/SIA1/SIA1-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SIA1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12212" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">19 citations</span>
+
+
+
+                    <span class="report-meta-text">2026-07-05T14:47:31.100670</span>
+
+
+
+                </div>
+
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-sia1-yor137c-in-saccharomyces-cerevisiae">Comprehensive Research Report: SIA1 (YOR137C) in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h3>
+<p>SIA1 (systematic name YOR137C; also designated YOR3329C) encodes a 466-amino acid protein (UniProt: Q12212) in <em>Saccharomyces cerevisiae</em> (strain S288c). The protein is annotated as a precursor and contains a calcineurin-like phosphohistidinol phosphatase (PHP) domain (IPR004843), a metallo-dependent phosphatase-like domain (IPR029052), and a metallophosphatase (Metallophos, PF00149) domain. SIA1 was first functionally characterized by de la Fuente, Maldonado, and Portillo (1997), who identified the gene as being involved in the glucose-induced activation of the yeast plasma membrane H⁺-ATPase (Pma1).</p>
+<h3 id="2-protein-domain-architecture-and-structural-context">2. Protein Domain Architecture and Structural Context</h3>
+<p>Sia1p belongs to the calcineurin-like metallophosphoesterase (MPE) superfamily, a large and diverse group of phosphoesterases that share a remarkably conserved structural fold despite wide functional divergence (matange2015metallophosphoesterasesstructuralfidelity pages 1-2). The MPE domain features a characteristic βαβαβ architecture with a central β-sandwich decorated by α-helices. At the apex of this β-sandwich lies the active site, which contains a binuclear metal center with two metal ions (designated α and β) octahedrally coordinated by seven conserved residues from the MPE motif, plus a metal-bridging water molecule (matange2015metallophosphoesterasesstructuralfidelity pages 5-7). The catalytic mechanism involves a metal-coordinated water molecule serving as the attacking nucleophile, initiating hydrolysis of phosphoester substrates through a penta-coordinated transition state (matange2015metallophosphoesterasesstructuralfidelity pages 7-9).</p>
+<p>In <em>S. cerevisiae</em>, four proteins contain the calcineurin-like phosphoesterase domain: Cdc1p, Gps1p, Dcr2p, and Sia1p (tu2008functionalstudieson pages 33-38). Among these, Cdc1p, Gps1p, and Dcr2p all contain the conserved GNHD/E sequence motif thought to be important for phosphate ester hydrolysis at the active-site dinuclear metal center (tu2008functionalstudieson pages 33-38). The <em>S. cerevisiae</em> genome encodes approximately 20 MPE domain-containing proteins overall (matange2015metallophosphoesterasesstructuralfidelity pages 12-13). MPEs can hydrolyze a diverse range of substrates including phosphomonoesters, phosphodiesters, and phosphotriesters, and individual family members have been co-opted for functions ranging from protein dephosphorylation to nucleotide hydrolysis to non-catalytic protein-interaction scaffolding roles (matange2015metallophosphoesterasesstructuralfidelity pages 1-2, matange2015metallophosphoesterasesstructuralfidelity pages 12-13).</p>
+<h3 id="3-primary-function-role-in-glucose-induced-activation-of-the-plasma-membrane-h-atpase">3. Primary Function: Role in Glucose-Induced Activation of the Plasma Membrane H⁺-ATPase</h3>
+<p>The primary characterized function of Sia1p is its involvement in the glucose-induced activation of the plasma membrane H⁺-ATPase Pma1. This was established in the foundational study by de la Fuente, Maldonado, and Portillo (1997, FEBS Letters 420:17–19), which demonstrated that the <em>YOR137C</em> gene product participates in the proton transport process associated with Pma1 activation upon glucose addition (tu2008functionalstudieson pages 33-38, mira2009therim101pathway pages 11-12).</p>
+<p>Pma1 is the major plasma membrane proton pump in yeast, establishing the electrochemical H⁺ gradient that drives active transport of ions and metabolites across the plasma membrane. Pma1 is self-inhibited by its C-terminal autoinhibitory domain unless this domain is phosphorylated at specific residues (guarini2024phosphoregulationofthe pages 17-18, guarini2024phosphoregulationofthe pages 4-6). The current understanding of Pma1 activation involves:</p>
+<ul>
+<li><strong>Ptk1 and Ptk2 kinases</strong> phosphorylate key residues (Ser899, Ser911, and Thr912) in the regulatory (R) domain of Pma1 in response to glucose availability. These phosphorylation events disrupt self-inhibitory interactions between the R and P domains of Pma1, thereby activating the pump (guarini2024phosphoregulationofthe pages 4-6, guarini2024phosphoregulationofthe pages 6-7).</li>
+<li><strong>Glc7 PP1 phosphatase</strong> counteracts this phosphorylation under glucose starvation, dephosphorylating S911-T912 and restoring Pma1 self-inhibition (guarini2024phosphoregulationofthe pages 17-18, guarini2024phosphoregulationofthe pages 7-9).</li>
+<li>This phosphoregulation is under <strong>TORC1 control</strong>, suggesting feedback regulation between Pma1 activity and growth signaling (guarini2024phosphoregulationofthe pages 11-12, guarini2024phosphoregulationofthe pages 25-26).</li>
+</ul>
+<p>While the precise molecular mechanism by which Sia1p contributes to this pathway has not been fully elucidated at the biochemical level, its identification as a calcineurin-like phosphoesterase involved in the proton transport/Pma1 activation process suggests it may participate in phosphoregulatory events related to Pma1 activation. The exact enzymatic substrate(s) of Sia1p remain to be determined.</p>
+<h3 id="4-biological-processes-and-pathway-involvement">4. Biological Processes and Pathway Involvement</h3>
+<h4 id="41-ph-homeostasis-and-ionic-balance">4.1 pH Homeostasis and Ionic Balance</h4>
+<p>SIA1 is classified under ionic homeostasis functions in the yeast genome. During short-term ethanol stress, <em>SIA1</em> (YOR137C) transcript levels are upregulated approximately 3-fold, and the gene was categorized together with other genes involved in ionic homeostasis, including copper transporters (CCC2, CTR2), P-type ATPases (SPF1), and the K⁺/H⁺ exchanger KHA1 (alexandre2001globalgeneexpression pages 3-4). This stress-responsive upregulation is consistent with a role in maintaining intracellular pH during conditions that challenge proton homeostasis.</p>
+<h4 id="42-rim101-pathway-and-weak-acid-tolerance">4.2 RIM101 Pathway and Weak Acid Tolerance</h4>
+<p>SIA1 is part of the RIM101 regulon. In <em>Δrim101</em> mutant cells, <em>SIA1</em> transcription is decreased approximately 1.9-fold, which may impair the cell's ability to respond to propionic acid stress (mira2009therim101pathway pages 11-12). The RIM101 pathway is required for <em>S. cerevisiae</em> adaptive response and resistance to propionic acid and other weak acids. The decreased <em>SIA1</em> expression in <em>rim101</em> mutants contributes to deficient control of propionic acid-induced internal acidification, because Sia1p mediates glucose-induced activation of PM-ATPase (Pma1) activity, which is crucial for counteracting weak acid-induced intracellular acidification (mira2009therim101pathway pages 11-12). This positions SIA1 at the intersection of the RIM101 pH-sensing pathway and glucose-dependent proton pump regulation.</p>
+<h4 id="43-glucose-signaling-network">4.3 Glucose Signaling Network</h4>
+<p>The involvement of SIA1 in Pma1 activation places it within the broader glucose signaling network in yeast. Pma1 activation is a key event following glucose addition to yeast cells, and this activation is coordinated with multiple glucose-sensing pathways. The G protein-coupled receptor Gpr1 and the transporter-like glucose sensors Rgt2 and Snf3 both contribute to regulation of intracellular pH through Pma1 (isom2018coordinatedregulationof pages 1-2). The Pma1-mediated changes in cytoplasmic pH serve as a second messenger for glucose sensing, linking nutrient availability to metabolic reprogramming (isom2018coordinatedregulationof pages 1-2). Additionally, proper Pma1 phosphorylation is required for optimal TORC1 activation upon H⁺ influx coupled to amino acid uptake, demonstrating the integration of Pma1 regulation with growth signaling (guarini2024phosphoregulationofthe pages 11-12).</p>
+<h3 id="5-subcellular-localization">5. Subcellular Localization</h3>
+<p>According to the global GFP-tagging study of the yeast proteome (Huh et al., 2003), Sia1p localizes to the cytoplasm. Given its role in the activation of the plasma membrane H⁺-ATPase Pma1, Sia1p likely exerts its function at or near the plasma membrane, potentially interacting with components of the Pma1 regulatory machinery, though direct localization to the plasma membrane has not been explicitly demonstrated.</p>
+<h3 id="6-sequence-relationships">6. Sequence Relationships</h3>
+<p>SIA1 shows sequence similarity to YLR270W (also known as DCS1), as noted in genome annotation studies (alexandre2001globalgeneexpression pages 3-4). Both proteins likely share the metallophosphatase domain architecture, although their functional specializations may differ. The <em>S. cerevisiae</em> genome contains approximately 20 metallophosphoesterase domain-containing proteins, reflecting the evolutionary expansion and functional diversification of this domain family in eukaryotes (matange2015metallophosphoesterasesstructuralfidelity pages 12-13).</p>
+<h3 id="7-summary-and-knowledge-gaps">7. Summary and Knowledge Gaps</h3>
+<p>SIA1/YOR137C encodes a calcineurin-like metallophosphoesterase that plays a role in the glucose-induced activation of the plasma membrane H⁺-ATPase Pma1 in <em>S. cerevisiae</em>. Through this function, Sia1p contributes to intracellular pH homeostasis and ionic balance. The protein is transcriptionally regulated by the RIM101 pathway and is induced under ethanol stress conditions, consistent with a protective role during conditions that challenge cellular pH.</p>
+<p>Despite these functional assignments, several important questions remain:</p>
+<ol>
+<li><strong>Enzymatic activity</strong>: The specific phosphoesterase substrate(s) of Sia1p have not been biochemically characterized. Whether Sia1p acts as a protein phosphatase, nucleotidase, or has another phosphoesterase activity remains unknown.</li>
+<li><strong>Mechanism of Pma1 regulation</strong>: The precise molecular mechanism by which Sia1p contributes to Pma1 activation—whether through direct dephosphorylation of regulatory proteins, scaffolding interactions, or other mechanisms—has not been determined.</li>
+<li><strong>Relationship to other calcineurin-like phosphoesterases</strong>: How Sia1p functionally differs from its paralogs Cdc1p, Gps1p, and Dcr2p, and whether these proteins have overlapping or distinct roles in cellular physiology, remains to be fully explored.</li>
+</ol>
+<p>The limited primary literature specifically focused on SIA1 reflects its status as a relatively understudied gene, with the foundational 1997 study by de la Fuente et al. providing the main functional characterization, and subsequent studies primarily mentioning SIA1 in the context of genome-wide screens and transcriptomics analyses.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(matange2015metallophosphoesterasesstructuralfidelity pages 1-2): Nishad Matange, Marjetka Podobnik, and Sandhya S. Visweswariah. Metallophosphoesterases: structural fidelity with functional promiscuity. The Biochemical journal, 467 2:201-16, Apr 2015. URL: https://doi.org/10.1042/bj20150028, doi:10.1042/bj20150028. This article has 87 citations.</p>
+</li>
+<li>
+<p>(matange2015metallophosphoesterasesstructuralfidelity pages 5-7): Nishad Matange, Marjetka Podobnik, and Sandhya S. Visweswariah. Metallophosphoesterases: structural fidelity with functional promiscuity. The Biochemical journal, 467 2:201-16, Apr 2015. URL: https://doi.org/10.1042/bj20150028, doi:10.1042/bj20150028. This article has 87 citations.</p>
+</li>
+<li>
+<p>(matange2015metallophosphoesterasesstructuralfidelity pages 7-9): Nishad Matange, Marjetka Podobnik, and Sandhya S. Visweswariah. Metallophosphoesterases: structural fidelity with functional promiscuity. The Biochemical journal, 467 2:201-16, Apr 2015. URL: https://doi.org/10.1042/bj20150028, doi:10.1042/bj20150028. This article has 87 citations.</p>
+</li>
+<li>
+<p>(tu2008functionalstudieson pages 33-38): Linna Tu. Functional studies on vps74p, a novel protein sorting regulator in sacchromyces cerevisiae. ArXiv, 2008. URL: https://doi.org/10.14711/thesis-b1023209, doi:10.14711/thesis-b1023209. This article has 0 citations.</p>
+</li>
+<li>
+<p>(matange2015metallophosphoesterasesstructuralfidelity pages 12-13): Nishad Matange, Marjetka Podobnik, and Sandhya S. Visweswariah. Metallophosphoesterases: structural fidelity with functional promiscuity. The Biochemical journal, 467 2:201-16, Apr 2015. URL: https://doi.org/10.1042/bj20150028, doi:10.1042/bj20150028. This article has 87 citations.</p>
+</li>
+<li>
+<p>(mira2009therim101pathway pages 11-12): Nuno P. Mira, Artur B. LourenÃ§o, Alexandra R. Fernandes, Jorg D. Becker, and Isabel SÃ¡-Correia. The rim101 pathway has a role in saccharomyces cerevisiae adaptive response and resistance to propionic acid and other weak acids. FEMS yeast research, 9 2:202-16, Mar 2009. URL: https://doi.org/10.1111/j.1567-1364.2008.00473.x, doi:10.1111/j.1567-1364.2008.00473.x. This article has 125 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guarini2024phosphoregulationofthe pages 17-18): Nadia Guarini, Elie Saliba, and Bruno André. Phosphoregulation of the yeast pma1 h+-atpase autoinhibitory domain involves the ptk1/2 kinases and the glc7 pp1 phosphatase and is under torc1 control. PLOS Genetics, 20:e1011121, Jan 2024. URL: https://doi.org/10.1371/journal.pgen.1011121, doi:10.1371/journal.pgen.1011121. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guarini2024phosphoregulationofthe pages 4-6): Nadia Guarini, Elie Saliba, and Bruno André. Phosphoregulation of the yeast pma1 h+-atpase autoinhibitory domain involves the ptk1/2 kinases and the glc7 pp1 phosphatase and is under torc1 control. PLOS Genetics, 20:e1011121, Jan 2024. URL: https://doi.org/10.1371/journal.pgen.1011121, doi:10.1371/journal.pgen.1011121. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guarini2024phosphoregulationofthe pages 6-7): Nadia Guarini, Elie Saliba, and Bruno André. Phosphoregulation of the yeast pma1 h+-atpase autoinhibitory domain involves the ptk1/2 kinases and the glc7 pp1 phosphatase and is under torc1 control. PLOS Genetics, 20:e1011121, Jan 2024. URL: https://doi.org/10.1371/journal.pgen.1011121, doi:10.1371/journal.pgen.1011121. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guarini2024phosphoregulationofthe pages 7-9): Nadia Guarini, Elie Saliba, and Bruno André. Phosphoregulation of the yeast pma1 h+-atpase autoinhibitory domain involves the ptk1/2 kinases and the glc7 pp1 phosphatase and is under torc1 control. PLOS Genetics, 20:e1011121, Jan 2024. URL: https://doi.org/10.1371/journal.pgen.1011121, doi:10.1371/journal.pgen.1011121. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guarini2024phosphoregulationofthe pages 11-12): Nadia Guarini, Elie Saliba, and Bruno André. Phosphoregulation of the yeast pma1 h+-atpase autoinhibitory domain involves the ptk1/2 kinases and the glc7 pp1 phosphatase and is under torc1 control. PLOS Genetics, 20:e1011121, Jan 2024. URL: https://doi.org/10.1371/journal.pgen.1011121, doi:10.1371/journal.pgen.1011121. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guarini2024phosphoregulationofthe pages 25-26): Nadia Guarini, Elie Saliba, and Bruno André. Phosphoregulation of the yeast pma1 h+-atpase autoinhibitory domain involves the ptk1/2 kinases and the glc7 pp1 phosphatase and is under torc1 control. PLOS Genetics, 20:e1011121, Jan 2024. URL: https://doi.org/10.1371/journal.pgen.1011121, doi:10.1371/journal.pgen.1011121. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alexandre2001globalgeneexpression pages 3-4): H. Alexandre, V. Ansanay-Galeote, S. Dequin, and B. Blondin. Global gene expression during short‐term ethanol stress in saccharomyces cerevisiae. FEBS Letters, Jun 2001. URL: https://doi.org/10.1016/s0014-5793(01)02503-0, doi:10.1016/s0014-5793(01)02503-0. This article has 534 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(isom2018coordinatedregulationof pages 1-2): Daniel G. Isom, Stephani C. Page, Leonard B. Collins, Nicholas J. Kapolka, Geoffrey J. Taghon, and Henrik G. Dohlman. Coordinated regulation of intracellular ph by two glucose-sensing pathways in yeast. Journal of Biological Chemistry, 293:2318-2329, Feb 2018. URL: https://doi.org/10.1074/jbc.ra117.000422, doi:10.1074/jbc.ra117.000422. This article has 42 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>matange2015metallophosphoesterasesstructuralfidelity pages 1-2</li>
+<li>matange2015metallophosphoesterasesstructuralfidelity pages 5-7</li>
+<li>matange2015metallophosphoesterasesstructuralfidelity pages 7-9</li>
+<li>tu2008functionalstudieson pages 33-38</li>
+<li>matange2015metallophosphoesterasesstructuralfidelity pages 12-13</li>
+<li>alexandre2001globalgeneexpression pages 3-4</li>
+<li>isom2018coordinatedregulationof pages 1-2</li>
+<li>guarini2024phosphoregulationofthe pages 11-12</li>
+<li>guarini2024phosphoregulationofthe pages 17-18</li>
+<li>guarini2024phosphoregulationofthe pages 4-6</li>
+<li>guarini2024phosphoregulationofthe pages 6-7</li>
+<li>guarini2024phosphoregulationofthe pages 7-9</li>
+<li>guarini2024phosphoregulationofthe pages 25-26</li>
+<li>https://doi.org/10.1042/bj20150028,</li>
+<li>https://doi.org/10.14711/thesis-b1023209,</li>
+<li>https://doi.org/10.1111/j.1567-1364.2008.00473.x,</li>
+<li>https://doi.org/10.1371/journal.pgen.1011121,</li>
+<li>https://doi.org/10.1016/s0014-5793(01</li>
+<li>https://doi.org/10.1074/jbc.ra117.000422,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SIA1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12212" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sia1-yor137c-q12212-curation-notes">SIA1 (YOR137C, Q12212) — curation notes</h1>
+<p>Journal / working notes for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> SIA1.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>UniProt: <strong>Q12212</strong> (SIA1_YEAST); systematic name <strong>YOR137C</strong>; ORF YOR3329C; chromosome XV.</li>
+<li>SGD: S000005663.</li>
+<li>Length 622 aa; PE=2 (evidence at transcript level).</li>
+<li>Gene name origin: <strong>SIA1 = "Suppressor of eIF5A 1"</strong> — verified against the SGD backend record<br />
+  (<code>name_description: "Suppressor of eIF5A"</code>, cited to Valentini SR et al. 2002, PMID:11861547).<br />
+  NOTE: the task brief glossed the acronym as "Sphingoid long-chain base Influences ATPase"; this<br />
+  is NOT the SGD-authoritative expansion, and I found no source for the sphingoid gloss. I use the<br />
+  SGD name.</li>
+<li>SGD one-line description: "Protein of unassigned function; involved in activation of the Pma1p<br />
+  plasma membrane H+-ATPase by glucose; contains peptide signal for membrane localization."</li>
+<li>SGD curated GO summary: Molecular Function = Unknown; Biological Process = proton transmembrane<br />
+  transport; Cellular Component = Unknown. → genuinely a dark/understudied gene.</li>
+</ul>
+<h2 id="known-evidence-supported">KNOWN (evidence-supported)</h2>
+<ol>
+<li>
+<p><strong>Required for glucose-triggered post-translational activation of the Pma1 plasma-membrane<br />
+   H+-ATPase.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/9450541" title="Deletion of YOR137c does not affect the level of Pma1 at the plasma    membrane, but disturbs the glucose-triggered Vmax increase of the enzyme.">PMID:9450541</a> The same abstract:<br />
+   "the YOR137c gene product is implicated in this activation" and "We propose that at least two<br />
+   independent mechanisms are involved in glucose activation of the H+-ATPase." This is the sole<br />
+   experimental functional characterisation (deletion phenotype, IMP-grade). It shows SIA1 is<br />
+   REQUIRED for the Vmax increase but does NOT show a direct molecular mechanism or a direct<br />
+   physical interaction with Pma1.</p>
+</li>
+<li>
+<p><strong>Isolated genetically as a multicopy suppressor of a temperature-sensitive eIF5A (TIF51A)<br />
+   allele</strong> — the basis of the gene name (Valentini et al. 2002, PMID:11861547). The abstract<br />
+   names PAB1, PKC1, WSC1, WSC2, WSC3 among six suppressors and connects eIF5A to the WSC/PKC1<br />
+   cell-wall-integrity signalling pathway; SIA1 is the sixth (unnamed in the abstract; full text<br />
+   not in cache). This links SIA1 genetically to PKC1/cell-integrity signalling, but the mechanism<br />
+   is unknown.</p>
+</li>
+<li>
+<p><strong>Induced (up-regulated) by ethanol / short-term ethanol stress</strong> (UniProt INDUCTION line,<br />
+   ECO:0000269|PubMed:11389906; Alexandre et al. 2001). This is expression regulation, not a<br />
+   molecular function.</p>
+</li>
+<li>
+<p><strong>Contains an N-terminal signal peptide (residues 1–27, ECO:0000255)</strong> and a metallophosphatase<br />
+   domain (see below); consistent with membrane/secretory-pathway localisation, matching the<br />
+   "peptide signal for membrane localization" phrasing in SGD. No experimentally verified<br />
+   subcellular localisation term is curated (CC = Unknown at SGD).</p>
+</li>
+</ol>
+<h2 id="domain-bioinformatic-reasoning-inline-from-sia1-uniprottxt">Domain / bioinformatic reasoning (inline, from SIA1-uniprot.txt)</h2>
+<ul>
+<li>Pfam <strong>PF00149 Metallophos</strong> (one copy); InterPro <strong>IPR004843 (Calcineurin-like_PHP)</strong> +<br />
+<strong>IPR029052 (Metallo-depent_PP-like)</strong>; Gene3D <strong>3.60.21.10</strong>; SUPFAM <strong>SSF56300 Metallo-dependent<br />
+  phosphatases</strong>. → SIA1 has a calcineurin-like metallophosphoesterase (MPE) fold.</li>
+<li>PANTHER family <strong>PTHR32440</strong>, subfamily <strong>SF0 "PHOSPHATASE DCR2-RELATED"</strong>. Reviewed SF0 members<br />
+  (from PTHR32440-entries.csv): S. cerevisiae <strong>DCR2</strong> (Q05924, "Phosphatase DCR2"), the K. lactis<br />
+  SIA1 ortholog (Q6CPQ2), S. pombe SPCC1020.05, and several <strong>Arabidopsis "probable INACTIVE purple<br />
+  acid phosphatase"</strong> proteins (PAP14/16/28/29). The InterPro family text notes the family is in the<br />
+  "purple acid phosphatase family, although some are predicted to be inactive."</li>
+<li>Metallophosphatase catalytic signature (the conserved metal-coordinating blocks<br />
+  D-x-H…GD-x-x-D…GNH[D/E]…GH-x-H). Manual inspection of the SIA1 sequence finds candidate motifs:<br />
+<code>QITDFHF</code> (~315, DxH), <code>VVITGDLLDS</code> (~350, GD..D), and <code>SCGHEHNNDCC</code> (~575, GH-x-H). So at least<br />
+  part of the metal-binding scaffold appears retained. HOWEVER: (a) no phosphatase substrate or<br />
+  catalytic activity has ever been demonstrated for SIA1 experimentally; (b) its nearest orthologs<br />
+  cluster with "inactive purple acid phosphatases"; (c) SGD lists Molecular Function = Unknown.<br />
+  → The molecular activity of SIA1 is UNRESOLVED. The IBA "phosphoprotein phosphatase activity" is<br />
+  a plausible family-level inference but is NOT experimentally supported for SIA1, and may reflect a<br />
+  degenerate / pseudophosphatase domain. I treat catalytic phosphatase activity as a knowledge gap,<br />
+  not an established function. (This is a family-level bioinformatic judgement, not a definitive<br />
+  claim of inactivity.)</li>
+</ul>
+<h2 id="existing-goa-annotations-5-review-plan">Existing GOA annotations (5) — review plan</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Term</th>
+<th>Ev</th>
+<th>Ref</th>
+<th>Plan</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>GO:0004721 phosphoprotein phosphatase activity</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE — family-level MPE inference; not experimentally shown; flag as gap</td>
+</tr>
+<tr>
+<td>2</td>
+<td>GO:0016787 hydrolase activity</td>
+<td>IEA</td>
+<td>GO_REF:0000002 (InterPro IPR004843)</td>
+<td>KEEP_AS_NON_CORE — generic parent of the MPE-fold inference; uninformative but not wrong</td>
+</tr>
+<tr>
+<td>3</td>
+<td>GO:1902600 proton transmembrane transport</td>
+<td>IMP</td>
+<td>PMID:9450541</td>
+<td>MODIFY → regulation of proton transport (GO:0010155); SIA1 regulates, does not transport</td>
+</tr>
+<tr>
+<td>4</td>
+<td>GO:0003674 molecular_function (root, ND)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT (ND placeholder; MF genuinely unknown)</td>
+</tr>
+<tr>
+<td>5</td>
+<td>GO:0005575 cellular_component (root, ND)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>ACCEPT (ND placeholder; CC genuinely unknown)</td>
+</tr>
+</tbody>
+</table>
+<p>Rationale for #3 MODIFY (not REMOVE): PMID:9450541 is experimental (IMP) and I must not overrule<br />
+the SGD curator. But the <em>term</em> chosen (proton transmembrane transport, a transporter/BP for the<br />
+ion movement itself) attributes the transport activity to SIA1, whereas the paper shows SIA1 is<br />
+REQUIRED for the glucose-triggered Vmax increase of Pma1 — i.e. a <em>regulatory</em> role. MODIFY to<br />
+"regulation of proton transport" (GO:0010155) keeps the experimental support while stating the<br />
+biology more accurately. Keep the original as the essence-is-sound case.</p>
+<h2 id="core_functions-planned">core_functions (planned)</h2>
+<p>SIA1 is best summarised as a positive regulator required for glucose-induced activation of the<br />
+Pma1 H+-ATPase; molecular mechanism unknown. I will use the BP "regulation of proton transport"<br />
+(GO:0010155) grounded in PMID:9450541, and NOT assert a catalytic MF given the gap.</p>
+<h2 id="knowledge_gaps-the-primary-deliverable-dark-gene">knowledge_gaps (the primary deliverable — dark gene)</h2>
+<ol>
+<li><strong>Molecular mechanism of Pma1 activation.</strong> Does SIA1 act directly on Pma1 (as an activator /<br />
+   scaffold) or indirectly (e.g. via signalling, lipid environment)? PMID:9450541 shows a<br />
+   requirement, not a mechanism, and explicitly proposes "at least two independent mechanisms."</li>
+<li><strong>Is SIA1 a catalytically active phosphatase or a pseudophosphatase?</strong> The MPE/calcineurin-like<br />
+   fold and the IBA annotation suggest possible phosphatase activity, but no substrate/activity has<br />
+   been demonstrated and the closest orthologs are "inactive purple acid phosphatases." If active,<br />
+   its physiological substrate (Pma1? a Pma1 kinase/phosphatase relay?) is unknown.</li>
+<li><strong>Direct physical partners.</strong> BioGRID lists interactions but no validated Pma1 physical<br />
+   interaction is curated in UniProt (IntAct=1). Direct binding partners are unknown.</li>
+<li><strong>Subcellular localisation.</strong> Signal peptide predicts secretory-pathway/membrane entry, but no<br />
+   experimental localisation term is curated (SGD CC = Unknown). Where SIA1 acts relative to Pma1<br />
+   (plasma membrane vs. secretory compartments) is unresolved.</li>
+<li><strong>Relationship to eIF5A / PKC1 cell-integrity signalling.</strong> SIA1 was isolated as an eIF5A<br />
+   suppressor (PMID:11861547) linking it to WSC/PKC1 signalling; whether this is mechanistically<br />
+   related to its Pma1 role, or an independent activity, is unknown.</li>
+<li><strong>Broader phenotype.</strong> SGD large-scale phenotypes (altered chemical/UV resistance, abnormal<br />
+   vacuolar morphology, competitive-fitness changes) are unexplained at the molecular level.</li>
+</ol>
+<h2 id="files-provenance">Files / provenance</h2>
+<ul>
+<li>UniProt: genes/yeast/SIA1/SIA1-uniprot.txt</li>
+<li>GOA: genes/yeast/SIA1/SIA1-goa.tsv</li>
+<li>PANTHER: interpro/panther/PTHR32440/ (metadata + entries)</li>
+<li>Cached pubs: publications/PMID_9450541.md (abstract only), publications/PMID_11861547.md<br />
+  (abstract only). PMID:11389906 (ethanol induction) referenced by UniProt but not central to MF.</li>
+<li>Deep research: NOT AVAILABLE. Two <code>just deep-research-falcon yeast SIA1 --fallback
+  perplexity-lite</code> runs both failed — the Falcon/Edison endpoint repeatedly disconnected<br />
+  (RemoteProtocolError / connection reset) and timed out at 600s, and the perplexity-lite<br />
+  fallback returned HTTP 401 "insufficient_quota". No <code>-deep-research-*.md</code> file was produced.<br />
+  Per project rules I did NOT hand-author a file named <code>-deep-research-{provider}.md</code>. The<br />
+  review is instead grounded in: UniProt Q12212 (domains/features), the GOA TSV, PANTHER<br />
+  PTHR32440 family data, the SGD locus record (name + curated summary + phenotypes, fetched<br />
+  from the SGD backend API), and the two cached primary papers PMID:9450541 and PMID:11861547.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q12212
+gene_symbol: SIA1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  SIA1 (YOR137C) is a poorly characterized 622-residue protein of the budding yeast
+  Saccharomyces cerevisiae. It carries an N-terminal signal peptide and a single
+  calcineurin-like metallophosphoesterase (metallophosphatase/purple acid phosphatase-like)
+  domain, placing it in a family that also contains the yeast paralog Dcr2 and several
+  plant &#34;probable inactive purple acid phosphatases&#34;. Genetic evidence shows that SIA1 is
+  required for the glucose-triggered, post-translational activation of the plasma membrane
+  proton pump Pma1: cells lacking SIA1 have normal Pma1 protein levels at the plasma
+  membrane but fail to show the full glucose-induced increase in Pma1 maximal velocity,
+  identifying SIA1 as a positive regulator of H+-ATPase activation rather than a component
+  of the pump itself. SIA1 was independently isolated as a multicopy suppressor of a
+  temperature-sensitive allele of the essential translation factor eIF5A (the source of its
+  name, &#34;Suppressor of eIF5A&#34;), a screen that linked eIF5A to the WSC/PKC1 cell-wall-integrity
+  signalling pathway. SIA1 transcription is induced by ethanol stress. Its molecular
+  activity is unresolved: although the metallophosphatase fold and phylogenetic assignment
+  suggest a possible phosphatase, no catalytic activity or substrate has been demonstrated,
+  and its closest relatives are predicted to be catalytically inactive.
+references:
+  - id: PMID:9450541
+    title: &#34;Yeast gene YOR137c is involved in the activation of the yeast plasma membrane H+-ATPase by glucose.&#34;
+    findings:
+      - statement: &gt;-
+          Deletion of YOR137c (SIA1) does not change the amount of Pma1 at the plasma membrane
+          but abolishes the glucose-triggered increase in Pma1 maximal velocity, showing that
+          SIA1 is required for post-translational (post-transcriptional) glucose activation of
+          the H+-ATPase.
+        supporting_text: &gt;-
+          Deletion of YOR137c does not affect the level of Pma1 at the plasma membrane, but
+          disturbs the glucose-triggered Vmax increase of the enzyme.
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified primary paper (FEBS Lett 1997); abstract cached (full text unavailable).
+        This is the sole experimental functional characterization of SIA1 and is the basis of the
+        curated SGD/UniProt FUNCTION line and the IMP GO:1902600 annotation. Establishes a
+        requirement (deletion phenotype), not a molecular mechanism.
+  - id: PMID:11861547
+    title: &#34;Genetic interactions of yeast eukaryotic translation initiation factor 5A (eIF5A) reveal connections to poly(A)-binding protein and protein kinase C signaling.&#34;
+    findings:
+      - statement: &gt;-
+          A multicopy suppressor screen of a temperature-sensitive eIF5A (tif51A) allele
+          recovered several genes and connected eIF5A to the WSC/PKC1 cell-wall-integrity
+          signalling pathway; SIA1 (Suppressor of eIF5A 1) was named from this screen.
+        supporting_text: &gt;-
+          A multicopy suppressor screen revealed six genes, the overexpression of which allows
+          growth of a tif51A-1 strain at high temperature; these genes include PAB1, PKC1, and
+          PKC1 regulators WSC1, WSC2, and WSC3.
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Genetics 2002); abstract cached (full text unavailable). This is the
+        origin of the gene name SIA1 = &#34;Suppressor of eIF5A&#34; (confirmed against the SGD locus
+        record, which cites this paper for the name). The abstract names five of the six
+        suppressors and links eIF5A to WSC/PKC1 signalling; SIA1 is the sixth suppressor,
+        described in the full text (not in the cached abstract) - a case where the abstract
+        foregrounds other genes. Cited here for the eIF5A-suppressor / PKC1-signalling context,
+        not for a specific SIA1 molecular function.
+  - id: PMID:11389906
+    title: &#34;Global gene expression during short-term ethanol stress in Saccharomyces cerevisiae.&#34;
+    findings:
+      - statement: &gt;-
+          SIA1 (YOR137C) transcription is up-regulated during short-term ethanol stress
+          (UniProt INDUCTION line, ECO:0000269|PubMed:11389906).
+        full_text_unavailable: true
+        reference_section_type: OTHER
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Cited by UniProt for the INDUCTION (ethanol up-regulation) statement. Relevant to
+        expression regulation/stress response, not to SIA1 molecular function. Abstract not
+        in cache; provenance anchored to the UniProt curated INDUCTION line rather than to a
+        verbatim publication quote (full_text_unavailable).
+  - id: GO_REF:0000002
+    title: &#34;Gene Ontology annotation through association of InterPro records with GO terms.&#34;
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        InterPro2GO electronic pipeline; source of the IEA GO:0016787 (hydrolase activity)
+        annotation from IPR004843. Domain-based, not gene-specific evidence.
+  - id: GO_REF:0000015
+    title: &#34;Gene Ontology annotation based on ND (No biological Data available) records.&#34;
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        SGD ND placeholders for the molecular_function and cellular_component root terms,
+        recording that no data are available for these aspects. Consistent with SIA1 being a
+        dark gene.
+  - id: GO_REF:0000033
+    title: &#34;Annotation inferences using phylogenetic trees.&#34;
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PAINT/GO_Central phylogenetic (IBA) pipeline; source of the IBA GO:0004721
+        (phosphoprotein phosphatase activity) annotation, propagated across PANTHER family
+        PTHR32440. Family-level inference; not experimentally verified for SIA1, and several
+        close family members are predicted inactive purple acid phosphatases.
+  - id: file:yeast/SIA1/SIA1-uniprot.txt
+    title: &#34;UniProt entry Q12212 (SIA1_YEAST) - domain and feature annotations.&#34;
+    findings:
+      - statement: &gt;-
+          UniProt annotates SIA1 with an N-terminal signal peptide (residues 1-27) and a single
+          calcineurin-like metallophosphoesterase domain (Pfam PF00149 Metallophos; InterPro
+          IPR004843/IPR029052; Gene3D 3.60.21.10; SUPFAM SSF56300), and assigns it to PANTHER
+          family PTHR32440 subfamily SF0 (phosphatase DCR2-related).
+        supporting_text: &#34;DR   Pfam; PF00149; Metallophos; 1.&#34;
+        reference_section_type: OTHER
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Machine-fetched UniProt record used for inline domain analysis. Establishes the
+        signal peptide and the metallophosphatase fold that underlie the hydrolase/phosphatase
+        family-level annotations.
+  - id: file:yeast/SIA1/SIA1-deep-research-falcon.md
+    title: &#34;Falcon (Edison) deep-research report for SIA1 (YOR137C).&#34;
+    findings:
+      - statement: &gt;-
+          Independent deep-research synthesis places SIA1 in the metallophosphoesterase
+          superfamily and, alongside PTK2, as a genetically implicated positive factor in
+          glucose-induced Pma1 H+-ATPase activation, with the exact biochemical step
+          unresolved; it also links SIA1 to the RIM101 weak-acid stress network (down in
+          rim101-delta).
+        supporting_text: &gt;-
+          Within this pathway, SIA1 is genetically implicated alongside PTK2 as a positive
+          factor in Pma1 activation.
+        reference_section_type: OTHER
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Genuine Falcon/Edison deep-research report (32 citations, ~26 min run). Cross-checked
+        against the cached primary papers: it corroborates (does not extend beyond) the
+        evidence used here - metallophosphoesterase domain, genetic-only implication in Pma1
+        activation, and unresolved mechanism. Some of its downstream citations (e.g. Mira 2009
+        RIM101, Guarini 2024 phosphoregulation) were not independently fetched; used for
+        context only, not as primary support for any GO action.
+existing_annotations:
+  - term:
+      id: GO:0004721
+      label: phosphoprotein phosphatase activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Family-level phylogenetic (IBA) inference of phosphatase activity from the
+        calcineurin-like metallophosphatase fold. SIA1 has the domain, but no phosphatase
+        activity or substrate has ever been demonstrated for it, and its nearest orthologs
+        include &#34;probable inactive purple acid phosphatases&#34;. Retained as a plausible
+        family-level hypothesis but not treated as an established (core) function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        SIA1 is assigned to PANTHER PTHR32440:SF0 (phosphatase DCR2-related), a
+        metallophosphoesterase / purple acid phosphatase-like family, so an IBA phosphatase
+        annotation is a defensible domain-based hypothesis and should not be removed. However,
+        the only experimental data on SIA1 concern its requirement for glucose activation of
+        Pma1, with no assay of phosphatase activity; SGD lists molecular function as Unknown;
+        and several reviewed SF0 members are annotated as inactive purple acid phosphatases.
+        The catalytic activity of SIA1 is therefore an open knowledge gap, so this term is kept
+        as non-core rather than accepted as a core function.
+      supported_by:
+        - reference_id: file:yeast/SIA1/SIA1-uniprot.txt
+          supporting_text_fulltext: &#34;DR   Pfam; PF00149; Metallophos; 1.&#34;
+      propagation_review:
+        root_cause: NO_FAILURE_NON_CORE
+        failure_modes:
+          - SOURCE_EVIDENCE_WEAK
+        source_entities:
+          - source_id: PANTHER:PTHR32440
+            source_label: &#34;phosphatase DCR2-related (SF0)&#34;
+            source_status: SOURCE_WEAK_OR_INFERRED
+            comment: &gt;-
+              Family includes yeast Dcr2 and plant PAP14/16/28/29 annotated as probable
+              INACTIVE purple acid phosphatases; SIA1 catalytic activity unverified.
+  - term:
+      id: GO:0016787
+      label: hydrolase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Generic hydrolase parent term inferred electronically (InterPro2GO) from the
+        metallophosphatase domain IPR004843. Consistent with the fold but uninformative and
+        subsumed by the more specific (also inferential) phosphatase term; not wrong.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        This IEA annotation is a direct domain-to-GO mapping (IPR004843 -&gt; hydrolase activity)
+        and is consistent with the metallophosphatase fold. It is far more general than the
+        family-level phosphatase inference and carries the same (unverified) assumption that the
+        domain is catalytically active. It is retained as non-core background rather than removed,
+        since the fold is genuinely present, but it does not describe a demonstrated SIA1 function.
+      supported_by:
+        - reference_id: file:yeast/SIA1/SIA1-uniprot.txt
+          supporting_text_fulltext: &#34;DR   InterPro; IPR004843; Calcineurin-like_PHP.&#34;
+  - term:
+      id: GO:1902600
+      label: proton transmembrane transport
+    evidence_type: IMP
+    original_reference_id: PMID:9450541
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Based on the SIA1 deletion phenotype (loss of glucose-triggered Pma1 Vmax increase),
+        SGD annotated SIA1 to proton transmembrane transport (IMP). The experimental evidence
+        is sound, but SIA1 does not itself transport protons; it is required for activation of
+        the Pma1 proton pump. A regulatory process term better captures the biology.
+      action: MODIFY
+      reason: &gt;-
+        The experimental support (PMID:9450541, IMP) is solid and must be retained - the paper
+        shows SIA1 is required for the glucose-induced Vmax increase of Pma1. However, the term
+        &#34;proton transmembrane transport&#34; attributes the ion-translocation process to SIA1,
+        whereas SIA1 is a regulator required for activation of the transporter, not a transporter
+        or channel. The essence is sound but a better term exists, so MODIFY to a regulatory
+        term (&#34;regulation of proton transport&#34;, GO:0010155) that preserves the experimental
+        support while stating the biology accurately.
+      proposed_replacement_terms:
+        - id: GO:0010155
+          label: regulation of proton transport
+      additional_reference_ids:
+        - file:yeast/SIA1/SIA1-deep-research-falcon.md
+      supported_by:
+        - reference_id: PMID:9450541
+          supporting_text: &gt;-
+            Deletion of YOR137c does not affect the level of Pma1 at the plasma membrane, but
+            disturbs the glucose-triggered Vmax increase of the enzyme.
+          reference_section_type: ABSTRACT
+        - reference_id: file:yeast/SIA1/SIA1-deep-research-falcon.md
+          supporting_text: &gt;-
+            Within this pathway, SIA1 is genetically implicated alongside PTK2 as a positive
+            factor in Pma1 activation.
+          reference_section_type: OTHER
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        SGD ND placeholder recording that no molecular-function data are available for SIA1.
+        This is accurate: SIA1&#39;s molecular activity is genuinely unresolved (see knowledge_gaps).
+      action: ACCEPT
+      reason: &gt;-
+        The root molecular_function ND annotation correctly records the absence of curated
+        molecular-function evidence. Given that SIA1 has no experimentally demonstrated activity
+        and its family assignment is ambiguous (possible pseudophosphatase), the ND placeholder
+        is an honest reflection of the state of knowledge and should be retained until an activity
+        is established.
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        SGD ND placeholder recording that no cellular-component data are available for SIA1.
+        SIA1 has a predicted signal peptide (secretory-pathway entry) but no experimentally
+        verified subcellular localization is curated.
+      action: ACCEPT
+      reason: &gt;-
+        The root cellular_component ND annotation correctly records the absence of curated
+        localization evidence. Although a signal peptide predicts membrane/secretory-pathway
+        entry and SIA1 functionally regulates the plasma-membrane Pma1, no experimental
+        localization is available, so retaining the honest ND placeholder is appropriate.
+core_functions:
+  - description: &gt;-
+      Positive regulator required for the glucose-triggered, post-translational activation of
+      the plasma membrane H+-ATPase Pma1. Loss of SIA1 leaves Pma1 protein levels at the plasma
+      membrane unchanged but prevents the full glucose-induced increase in the pump&#39;s maximal
+      velocity, identifying SIA1 as required for one of the (at least two) mechanisms that
+      activate Pma1 in response to glucose. The molecular mechanism (direct versus indirect;
+      catalytic versus scaffolding) is not established.
+    supported_by:
+      - reference_id: PMID:9450541
+        supporting_text: &gt;-
+          Deletion of YOR137c does not affect the level of Pma1 at the plasma membrane, but
+          disturbs the glucose-triggered Vmax increase of the enzyme.
+        reference_section_type: ABSTRACT
+    directly_involved_in:
+      - id: GO:0010155
+        label: regulation of proton transport
+    knowledge_gaps:
+      - gap_statement: &gt;-
+          The molecular mechanism by which SIA1 promotes glucose activation of Pma1 is unknown:
+          it is not established whether SIA1 acts directly on Pma1 (e.g. as an activator or
+          scaffold) or indirectly (e.g. via a signalling relay, a kinase/phosphatase step, or
+          the membrane lipid environment).
+        boundary: &gt;-
+          Established: SIA1 is required for the glucose-triggered Vmax increase of Pma1 without
+          affecting Pma1 abundance at the plasma membrane (PMID:9450541). Not established: the
+          molecular step SIA1 acts on, or whether it contacts Pma1 at all.
+        gap_kind:
+          - BIOLOGY
+        dark_aspect: MF_DARK
+        status: OPEN
+        significance: &gt;-
+          Pma1 is the major generator of the plasma-membrane proton-motive force in yeast and a
+          master regulator of intracellular pH and nutrient uptake; identifying how glucose
+          signalling is transduced to Pma1 activation is a long-standing question, and SIA1 marks
+          one of the at-least-two independent mechanisms proposed for this activation.
+        resolution: &gt;-
+          Test for direct SIA1-Pma1 physical interaction and for SIA1-dependent changes in Pma1
+          C-terminal regulatory-domain phosphorylation; epistasis with known Pma1 regulators
+          (Ptk1/2 kinases, Glc7 phosphatase) upon glucose addition.
+        provenance:
+          - reference_id: PMID:9450541
+            supporting_text: &gt;-
+              We propose that at least two independent mechanisms are involved in glucose
+              activation of the H+-ATPase.
+            reference_section_type: ABSTRACT
+proposed_new_terms: []
+suggested_questions:
+  - question: &gt;-
+      Does SIA1 act directly on Pma1 (physical interaction / activator or scaffold) or
+      indirectly through a signalling or lipid-mediated route to promote glucose activation of
+      the H+-ATPase?
+    experts: []
+  - question: &gt;-
+      Is the SIA1 metallophosphatase domain catalytically active, and if so what is its
+      physiological substrate - or is SIA1 a pseudophosphatase like its closest relatives?
+    experts: []
+  - question: &gt;-
+      Is SIA1&#39;s role in glucose activation of Pma1 mechanistically connected to its genetic
+      identity as an eIF5A suppressor and to WSC/PKC1 cell-wall-integrity signalling, or are
+      these independent activities?
+    experts: []
+suggested_experiments:
+  - hypothesis: &gt;-
+      SIA1 promotes glucose activation of Pma1 by directly modulating Pma1&#39;s activity or
+      phosphorylation state.
+    description: &gt;-
+      Co-immunoprecipitation / proximity labelling of tagged SIA1 and Pma1 before and after
+      glucose addition to test for direct interaction; phosphoproteomic comparison of Pma1
+      (especially the C-terminal autoinhibitory Ser/Thr residues) in wild-type versus sia1-delta
+      cells upon glucose refeeding.
+    experiment_type: interaction and phosphorylation analysis
+  - hypothesis: &gt;-
+      The SIA1 metallophosphatase domain is (or is not) catalytically active.
+    description: &gt;-
+      Recombinant expression of the SIA1 metallophosphatase domain and in vitro phosphatase
+      assays (para-nitrophenyl phosphate and phosphopeptide substrates) with metal-dependence
+      controls; parallel assay of catalytic-residue point mutants to test whether any activity
+      requires the predicted metal-binding scaffold.
+    experiment_type: enzymology
+  - hypothesis: &gt;-
+      SIA1 localizes to a compartment consistent with acting on Pma1 (plasma membrane or
+      secretory pathway).
+    description: &gt;-
+      Determine the subcellular localization of endogenously tagged SIA1 by fluorescence
+      microscopy and membrane fractionation, and test signal-peptide dependence, to place SIA1
+      relative to Pma1 in the secretory pathway / plasma membrane.
+    experiment_type: cell biology / localization
+knowledge_gaps:
+  - gap_statement: &gt;-
+      SIA1&#39;s molecular activity is undetermined. Although it has a calcineurin-like
+      metallophosphatase fold and carries a family-level IBA &#34;phosphoprotein phosphatase
+      activity&#34; annotation, no catalytic activity or substrate has ever been demonstrated for
+      SIA1, and its closest relatives include probable inactive purple acid phosphatases, so it
+      is unknown whether SIA1 is an active phosphatase or a pseudoenzyme.
+    boundary: &gt;-
+      Established: SIA1 contains a single metallophosphatase domain (Pfam PF00149; InterPro
+      IPR004843) and belongs to PANTHER PTHR32440:SF0. Not established: any measured enzymatic
+      activity, substrate, or metal dependence; SGD lists molecular function as Unknown.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Whether SIA1 is an active phosphatase determines the class of mechanism by which it could
+      regulate Pma1 (direct enzymatic modification versus non-catalytic scaffolding), and would
+      resolve whether the family-level IBA/IEA activity annotations reflect real biology.
+    resolution: &gt;-
+      In vitro phosphatase assays on recombinant SIA1 (and catalytic-residue mutants) with
+      phosphoprotein/phosphopeptide and generic substrates; structural comparison of the
+      SIA1 active site with active metallophosphatases.
+    provenance:
+      - reference_id: file:yeast/SIA1/SIA1-uniprot.txt
+        supporting_text_fulltext: &#34;DR   Pfam; PF00149; Metallophos; 1.&#34;
+  - gap_statement: &gt;-
+      The mechanism linking SIA1 to glucose activation of Pma1 is unknown - whether SIA1 acts
+      directly on the pump or through an intermediate signalling/lipid step, and which of the
+      &#34;at least two independent mechanisms&#34; of Pma1 glucose activation SIA1 belongs to.
+    boundary: &gt;-
+      Established: sia1-delta cells retain normal plasma-membrane Pma1 levels but fail the
+      glucose-triggered Vmax increase (PMID:9450541). Not established: the molecular step or
+      partner through which SIA1 exerts this effect.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Identifies how a central metabolic signal (glucose) is transduced to the master
+      plasma-membrane proton pump; SIA1 is a genetic entry point into this poorly understood
+      activation pathway.
+    resolution: &gt;-
+      Epistasis and interaction studies placing SIA1 relative to known Pma1 glucose-activation
+      inputs (Ptk1/2 kinases, Glc7 phosphatase, sphingolipid/ergosterol requirements) and
+      direct interaction tests.
+    provenance:
+      - reference_id: PMID:9450541
+        supporting_text: &gt;-
+          We propose that at least two independent mechanisms are involved in glucose
+          activation of the H+-ATPase.
+        reference_section_type: ABSTRACT
+  - gap_statement: &gt;-
+      SIA1&#39;s direct physical partners and its subcellular localization are unknown. No validated
+      Pma1 physical interaction is curated, and there is no experimentally determined
+      localization despite a predicted N-terminal signal peptide.
+    boundary: &gt;-
+      Established: SIA1 has a predicted signal peptide (UniProt residues 1-27) and low-throughput
+      interaction records exist, but SGD lists cellular component as Unknown and no direct Pma1
+      interaction is curated. Not established: where SIA1 resides and what it binds.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Knowing whether SIA1 reaches the plasma membrane / secretory pathway and what it binds is
+      prerequisite to any mechanistic model of how it acts on Pma1.
+    resolution: &gt;-
+      Endogenous-tag localization microscopy and membrane fractionation; affinity-purification
+      mass spectrometry / proximity labelling to define the SIA1 interactome.
+    provenance:
+      - reference_id: file:yeast/SIA1/SIA1-uniprot.txt
+        supporting_text_fulltext: &#34;FT   SIGNAL          1..27&#34;
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/VAM10/VAM10-ai-review.html
+++ b/genes/yeast/VAM10/VAM10-ai-review.html
@@ -1,0 +1,2469 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VAM10 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>VAM10</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q08474" target="_blank" class="term-link">
+                        Q08474
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "VAM10";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q08474" data-a="DESCRIPTION: VAM10 (YOR068C) encodes a small (114 aa) periphera..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>VAM10 (YOR068C) encodes a small (114 aa) peripheral vacuolar-membrane protein of Saccharomyces cerevisiae required for homotypic (non-autophagic) vacuole fusion. Its gene is nested within the VPS5 locus on the opposite DNA strand. Vam10p acts early in the vacuole fusion cascade at a priming step that is independent of the canonical Sec18p (NSF)/Sec17p (alpha-SNAP) SNARE-disassembly machinery, and this Vam10p-dependent priming is a prerequisite for the subsequent Ypt7p (Rab GTPase)- dependent tethering of vacuoles. Deletion causes vacuole fragmentation, and recombinant Vam10p stimulates fusion of purified vacuoles in vitro while anti-Vam10p antibody blocks it. The protein has no recognizable catalytic or binding domain and no strong orthology outside fungi, and its molecular activity and direct binding partners remain undefined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005774" target="_blank" class="term-link">
+                                    GO:0005774
+                                </a>
+                            </span>
+                            <span class="term-label">vacuolar membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q08474" data-a="GO:0005774" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic Subcellular Location mapping placing Vam10p at the vacuolar membrane. Consistent with the experimentally-informed IC call to the fungal-type vacuole membrane and with the protein&#39;s role at the vacuole surface during fusion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location and supported by an independent, more specific IC annotation (GO:0000329) from the primary functional study. Kept as a valid but non-core supporting cellular-component annotation; the fungal-type vacuole membrane term is preferred for representing the site of action.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000329" target="_blank" class="term-link">
+                                    GO:0000329
+                                </a>
+                            </span>
+                            <span class="term-label">fungal-type vacuole membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12748377
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Vam10p defines a Sec18p-independent step of priming that all...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q08474" data-a="GO:0000329" data-r="PMID:12748377" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator-inferred (IC) localization to the fungal-type vacuole membrane, based on the vacuole-fusion function reported by Kato &amp; Wickner (2003). Species-appropriate and the informative cellular-component annotation for this protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functional study demonstrates Vam10p acts on purified vacuoles and restores tethering to vacuoles from a vam10-delta strain, and UniProt independently curates a vacuole-membrane (peripheral) location; the fungal-type vacuole membrane is the correct organelle-specific term for a Saccharomyces protein. Supports the core-function location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link">
+                                        PMID:12748377
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pure Vam10p restores normal, Ypt7p-dependent tethering to vacuoles from a vam10Delta strain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q08474" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function annotation with the ND (No biological Data available) evidence code, marking that no specific molecular activity has been experimentally or computationally assigned to Vam10p.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an honest placeholder that correctly reflects the genuine molecular-function gap for this protein: Vam10p has no recognizable catalytic or binding domain, no informative orthology, and no biochemically defined activity. It should NOT be replaced with a specific molecular-function term; the missing activity is recorded under knowledge_gaps instead. Not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042144" target="_blank" class="term-link">
+                                    GO:0042144
+                                </a>
+                            </span>
+                            <span class="term-label">vacuole fusion, non-autophagic</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12748377
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Vam10p defines a Sec18p-independent step of priming that all...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q08474" data-a="GO:0042144" data-r="PMID:12748377" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Involvement in homotypic (non-autophagic) vacuole fusion, from the deletion phenotype (vacuole fragmentation) and in-vitro reconstitution (recombinant Vam10p stimulates fusion of purified vacuoles; anti-Vam10p antibody blocks it). This is the core, well-supported biological role of the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by loss-of-function (in-vivo fragmentation; antibody inhibition of in-vitro fusion) and gain-of-function (recombinant-protein stimulation) evidence in the same study. Represents the core biological process of VAM10.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link">
+                                        PMID:12748377
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">VAM10 deletion causes vacuole fragmentation in vivo. The in vitro fusion of purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by antibody to Vam10p.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Required for homotypic (non-autophagic) vacuole fusion, acting at an early, Sec18p-independent priming step at the fungal-type vacuole membrane that is a prerequisite for Ypt7p-dependent tethering. The specific molecular activity by which Vam10p licenses tethering is undefined, so the molecular_function is left at the root (see knowledge_gaps); the well-supported claim is the biological-process role and the site of action.</h3>
+                <span class="vote-buttons" data-g="Q08474" data-a="FUNCTION: Required for homotypic (non-autophagic) vacuole fu..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                            molecular_function
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042144" target="_blank" class="term-link">
+                                vacuole fusion, non-autophagic
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000329" target="_blank" class="term-link">
+                                fungal-type vacuole membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link">
+                                PMID:12748377
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">VAM10 deletion causes vacuole fragmentation in vivo. The in vitro fusion of purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by antibody to Vam10p.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link">
+                                PMID:12748377
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Vam10p acts early in the priming stage of fusion, independent of Sec18p.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12748377" target="_blank" class="term-link">
+                            PMID:12748377
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Vam10p defines a Sec18p-independent step of priming that allows yeast vacuole tethering.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">VAM10 deletion causes vacuole fragmentation in vivo, and recombinant Vam10p stimulates in-vitro fusion of purified vacuoles while anti-Vam10p antibody blocks it, establishing Vam10p as a positive factor required for homotypic vacuole fusion.</div>
+
+                        <div class="finding-text">"VAM10 deletion causes vacuole fragmentation in vivo. The in vitro fusion of purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by antibody to Vam10p."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Vam10p acts at an early, Sec18p-independent priming step and is required to restore Ypt7p-dependent tethering, placing it upstream of Rab-dependent tethering.</div>
+
+                        <div class="finding-text">"Vam10p acts early in the priming stage of fusion, independent of Sec18p."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the molecular activity of Vam10p during the Sec18p-independent priming step that licenses Ypt7p-dependent tethering?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: William Wickner</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q08474" data-a="Q: What is the molecular activity of Vam10p during th..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Vam10p act directly on the Rab GTPase Ypt7p, on the HOPS complex, on vacuolar SNAREs, or on the vacuolar lipid bilayer?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Michiko Kato, William Wickner</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q08474" data-a="Q: Does Vam10p act directly on the Rab GTPase Ypt7p, ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify or crosslink epitope-tagged Vam10p from isolated vacuoles and identify co-purifying proteins by mass spectrometry; test candidate interactions (Ypt7p, HOPS subunits, vacuolar SNAREs) by directed pulldowns, and assay lipid binding of purified recombinant Vam10p.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Vam10p binds a specific vacuolar component (Ypt7p, a HOPS subunit, a SNARE, or a lipid) to promote the pre-tethering priming step.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction proteomics / biochemical binding assays</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q08474" data-a="EXPERIMENT: Affinity-purify or crosslink epitope-tagged Vam10p..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use the in-vitro homotypic vacuole fusion assay with order-of-addition and stage-specific inhibitors to place the Vam10p requirement precisely relative to Sec18p-mediated priming and Ypt7p/HOPS-mediated tethering, and characterize what Vam10p acts on during the reaction.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The Vam10p-dependent priming reaction produces a defined change on the vacuole membrane required before Ypt7p-dependent tethering.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in-vitro reconstituted membrane fusion</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q08474" data-a="EXPERIMENT: Use the in-vitro homotypic vacuole fusion assay wi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism of the Sec18p-independent priming step defined by Vam10p is unknown: what change in the vacuolar membrane or its protein/lipid composition Vam10p produces to license subsequent Ypt7p-dependent tethering has not been determined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Canonical priming (Sec18p/NSF- and Sec17p/alpha-SNAP-driven SNARE-complex disassembly) is well characterized. Vam10p provides a functional marker for a separate, early, Sec18p-independent priming activity, but the reaction it catalyzes or promotes is not defined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A second priming activity distinct from NSF/alpha-SNAP would refine the textbook priming-tethering-docking-fusion model of homotypic membrane fusion.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In-vitro dissection of the Vam10p-dependent priming reaction (order-of-addition, substrate/product analysis) to define what Vam10p acts on and what it produces.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Vam10p provides a functional marker for this Sec18p-independent priming step."</em> — PMID:12748377</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether Vam10p has orthologs with a conserved function beyond Saccharomyces (in other fungi or in higher eukaryotes) is uncharacterized, so it is unknown whether the Sec18p-independent priming role is a general feature of membrane fusion or a yeast-specific adaptation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Vam10p is a small protein with no recognizable domain and only weak/singleton orthology signals in HOGENOM/InParanoid/OrthoDB; no functionally validated ortholog has been reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Establishing conservation would indicate whether the priming activity is a widely used mechanism worth mapping onto human membrane-fusion pathways.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phylogenetic profiling and functional complementation tests of candidate fungal homologs; structural comparison of the predicted fold against known fusion factors.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(VAM10-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q08474" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:33:29.241033</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="VAM10-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-vam10-yor068c-vacuolar-morphogenesis-protein-10-in-saccharomyces-cerevisiae">Research Report: VAM10 (YOR068C) — Vacuolar Morphogenesis Protein 10 in <em>Saccharomyces cerevisiae</em></h2>
+<h3 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h3>
+<p>VAM10 (UniProt: Q08474) is encoded by the open reading frame YOR068C (also known as YOR29-19) on chromosome XV of <em>Saccharomyces cerevisiae</em> (strain ATCC 204508 / S288c). The gene encodes a protein designated Vacuolar Morphogenesis Protein 10 (Vam10p). Notably, the VAM10 gene is genomically embedded in proximity to VPS5 (YOR069W), which encodes a sorting nexin component of the Retromer complex (chen2025molecularbasisfor pages 2-3, chen2025molecularbasisfor pages 1-2). Vam10p is a relatively small protein without well-characterized structural domains in standard protein databases, and it does not belong to a recognized protein family. Despite this, the protein plays a functionally important role in the vacuole fusion pathway.</p>
+<h3 id="2-discovery-and-identification">2. Discovery and Identification</h3>
+<p>Vam10 was identified in a genome-wide screen for vacuolar morphology mutants conducted by Seeley, Kato, Wickner, and Eitzen (2002). In this screen, 4,828 nonessential yeast gene deletions were scored for vacuole morphology using the fluorescent vital dye FM4-64 (seeley2002genomicanalysisof pages 1-2). The original VAM (vacuolar morphology) genes had been identified earlier by Wada et al. (1992), and six of the nine original VAM genes encode subunits of the HOPS tethering complex (Vam1p = Vps11p, Vam2p = Vps41p, Vam5p = Vps33p, Vam6p = Vps39p, Vam8p = Vps18p, Vam9p = Vps16p), with Vam3p and Vam7p encoding vacuolar SNAREs and Vam4p encoding the Rab GTPase Ypt7p (seeley2002genomicanalysisof pages 1-2). However, the initial vam screen was not saturated, and the genomic approach by Seeley et al. identified 137 candidate VAM genes, including VAM10 (YOR068C), which displayed a prominent class B vacuole fragmentation phenotype in 90% of cells upon deletion (seeley2002genomicanalysisof pages 9-11).</p>
+<h3 id="3-primary-function-role-in-vacuole-fusion-priming">3. Primary Function: Role in Vacuole Fusion Priming</h3>
+<h4 id="31-vam10-defines-a-sec18p-independent-priming-step">3.1 Vam10 Defines a Sec18p-Independent Priming Step</h4>
+<p>The primary functional characterization of Vam10p was reported by Kato and Wickner (2003, <em>Proceedings of the National Academy of Sciences</em>, 100:6398–6403), who demonstrated that Vam10p defines a Sec18p-independent step of priming that allows yeast vacuole tethering (ostrowicz2009dynamicsandarchitecture pages 140-143). This is a critical finding, because it establishes that Vam10p operates in a priming pathway that is mechanistically distinct from the well-characterized Sec18p/NSF-dependent cis-SNARE disassembly reaction.</p>
+<p>In the established model of homotypic vacuole fusion, the reaction proceeds through ordered stages: (1) <strong>priming</strong>, in which vacuoles are prepared for their first productive contact; (2) <strong>tethering</strong>, the reversible bridging of vacuoles mediated by the HOPS complex and the Rab GTPase Ypt7p; (3) <strong>docking</strong>, involving trans-SNARE complex formation between opposing membranes; and (4) <strong>fusion/bilayer mixing</strong> (ostrowicz2008yeastvacuolefusion pages 3-5, seeley2002genomicanalysisof pages 1-2). The canonical priming reaction is initiated by ATP hydrolysis by the AAA-ATPase Sec18p (the yeast NSF homolog), which disassembles cis-SNARE complexes with the help of its co-factor Sec17p (yeast α-SNAP), leading to the release of Sec17p from vacuoles, dissociation of the soluble SNARE Vam7p, and activation of SNAREs for subsequent trans-pairing (ostrowicz2008yeastvacuolefusion pages 3-5, seeley2002genomicanalysisof pages 1-2).</p>
+<p>Vam10p function has been connected to the priming stage of vacuole fusion alongside other priming-associated processes such as Vac8 palmitoylation (ostrowicz2008yeastvacuolefusion pages 5-5). Importantly, Vam10p acts in a parallel or complementary pathway to Sec18p-dependent SNARE disassembly, indicating that priming involves multiple, coordinated preparatory events beyond SNARE recycling alone (ostrowicz2009dynamicsandarchitecture pages 140-143).</p>
+<h4 id="32-distinction-from-hops-complex">3.2 Distinction from HOPS Complex</h4>
+<p>It is critical to note that <strong>Vam10p is NOT a subunit of the HOPS tethering complex</strong>. The HOPS complex is a well-defined hexameric complex consisting of four class C core subunits (Vps11p, Vps16p, Vps18p, Vps33p) and two HOPS-specific subunits (Vps39p/Vam6p and Vps41p/Vam2p) (ostrowicz2008yeastvacuolefusion pages 6-7). Vam10p is instead classified among "additional proteins involved in fusion," a category that also includes calmodulin, protein phosphatase 1, Bem1, and others (ostrowicz2008yeastvacuolefusion pages 6-7, ostrowicz2008yeastvacuolefusion pages 7-8). Deletion or antibody inhibition of these additional factors strongly affects vacuole fusion, indicating an intimate connection to the fusion cascade, but their precise molecular mechanisms have not been as thoroughly dissected as those of the core HOPS-SNARE-Rab machinery (ostrowicz2008yeastvacuolefusion pages 7-8).</p>
+<p>Recent cryo-EM structural studies of the HOPS complex have resolved its architecture as a highly extended, rigid structure (~430 Å × 130 Å) resembling a "baseball pitcher," with core subunits Vps11p and Vps18p forming the central body through antiparallel α-solenoid interactions and the HOPS-specific subunits Vps39p and Vps41p anchored at the periphery for Rab GTPase (Ypt7p) binding (diao2024molecularstructuresand pages 4-6). Vam10p is absent from this structural complex, confirming its role as an accessory factor rather than a core tethering complex component.</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>Vam10p functions at the yeast vacuole, the fungal equivalent of the mammalian lysosome. The vacuole is a large, dynamic organelle that serves as the major degradative compartment and ion/metabolite storage organelle in yeast cells (ostrowicz2008yeastvacuolefusion pages 1-3). Wild-type yeast cells typically possess one to three large vacuoles, and defects in vacuole fusion result in class B (multiple small vacuoles) or class C (highly fragmented vacuoles) phenotypes (seeley2002genomicanalysisof pages 1-2). The <em>vam10Δ</em> deletion strain displays a class B phenotype with 90% of cells showing multiple small vacuoles, consistent with a defect in homotypic vacuole fusion rather than complete pathway disruption (seeley2002genomicanalysisof pages 9-11).</p>
+<p>Vam10p is associated with the vacuolar membrane, where it participates in the priming stage that prepares vacuoles for the tethering event mediated by HOPS and Ypt7p. Its function is required to allow vacuole tethering to proceed efficiently (ostrowicz2009dynamicsandarchitecture pages 140-143).</p>
+<h3 id="5-biochemical-and-signaling-pathways">5. Biochemical and Signaling Pathways</h3>
+<h4 id="51-integration-into-the-vacuole-fusion-cascade">5.1 Integration into the Vacuole Fusion Cascade</h4>
+<p>The vacuole fusion reaction represents one of the best-characterized membrane fusion events in eukaryotic cell biology, providing a model system for understanding the general principles of endomembrane dynamics (ostrowicz2008yeastvacuolefusion pages 1-3, ostrowicz2008yeastvacuolefusion pages 3-5). The cascade involves:</p>
+<ul>
+<li><strong>Sec18p/Sec17p-dependent priming</strong>: Disassembly of cis-SNARE complexes, release of Sec17p, Vam7p, and the HOPS complex from membranes (ostrowicz2008yeastvacuolefusion pages 3-5, ostrowicz2008yeastvacuolefusion pages 5-5).</li>
+<li><strong>Sec18p-independent priming (Vam10p pathway)</strong>: A parallel priming step defined by Vam10p function, which is necessary for downstream tethering to occur (ostrowicz2009dynamicsandarchitecture pages 140-143).</li>
+<li><strong>Tethering</strong>: Mediated by the HOPS complex binding to Ypt7p-GTP on both vacuolar membranes (ostrowicz2008yeastvacuolefusion pages 5-5, ostrowicz2008yeastvacuolefusion pages 6-7).</li>
+<li><strong>Docking</strong>: Trans-SNARE complex formation involving the Q-SNAREs Vam3p, Vam7p, Vti1p and the R-SNARE Nyv1p (ostrowicz2008yeastvacuolefusion pages 5-6, ostrowicz2008yeastvacuolefusion pages 5-5).</li>
+<li><strong>Fusion</strong>: Ca²⁺ release, calmodulin signaling, protein phosphatase 1 action, and lipid bilayer mixing (seeley2002genomicanalysisof pages 1-2, ostrowicz2008yeastvacuolefusion pages 7-8).</li>
+</ul>
+<p>Vam10p acts upstream of HOPS-mediated tethering but in a pathway that does not depend on the Sec18p ATPase activity. This positions it as a factor that may regulate the readiness of the vacuolar membrane or associated proteins for the initial bridging contact.</p>
+<h4 id="52-relationship-to-other-priming-factors">5.2 Relationship to Other Priming Factors</h4>
+<p>Additional reactions classified as priming events include Vac8p palmitoylation (which couples the armadillo repeat protein Vac8p to the membrane for its role in docking and fusion) and ergosterol-dependent processes (ostrowicz2008yeastvacuolefusion pages 5-5, seeley2002genomicanalysisof pages 1-2). The Vam10p-dependent step is distinct from ergosterol-mediated priming, which was shown to be required for Sec18p-mediated Sec17p release (seeley2002genomicanalysisof pages 7-9). This further supports the model of multiple parallel priming pathways that collectively prepare vacuoles for productive fusion.</p>
+<h3 id="6-genomic-context-and-phenotypic-evidence">6. Genomic Context and Phenotypic Evidence</h3>
+<p>The VAM10/YOR068C locus is notable for its genomic proximity to VPS5/YOR069W (seeley2002genomicanalysisof pages 9-11, chen2025molecularbasisfor pages 2-3). The Seeley et al. (2002) study specifically noted that "Three genes (YLR320w, YNL281w, and YOR068c) are adjacent to genes that are also required for normal vacuole morphology. Further analysis will be required to determine whether these deletions act by altering the expression level of an adjacent gene" (seeley2002genomicanalysisof pages 9-11). VPS5 encodes a sorting nexin subunit of the Retromer complex involved in endosome-to-Golgi retrieval, and a recent structural study noted that "a copy of Vam10 (the VAM10 gene is embedded" in the VPS5 genomic region (chen2025molecularbasisfor pages 2-3). This raises the question of whether the vam10Δ phenotype could partly reflect perturbation of VPS5, although the functional characterization by Kato and Wickner (2003) provided direct biochemical evidence for Vam10p function in the in vitro vacuole fusion assay.</p>
+<p>The <em>vam10Δ</em> strain does not show a moderate or strong VPS (vacuolar protein sorting) phenotype for CPY secretion, suggesting that Vam10p is specifically involved in homotypic vacuole fusion rather than biosynthetic trafficking to the vacuole (seeley2002genomicanalysisof pages 7-9, seeley2002genomicanalysisof pages 9-11). This is consistent with the distinction between VAM genes (involved in fusion and morphology) and VPS genes (involved in protein sorting), which have substantial but incomplete overlap (seeley2002genomicanalysisof pages 7-9).</p>
+<h3 id="7-summary-table-of-vacuole-fusion-machinery">7. Summary Table of Vacuole Fusion Machinery</h3>
+<p>The following table summarizes the relationship of Vam10p to the core vacuole fusion machinery:</p>
+<table>
+<thead>
+<tr>
+<th>Component / Gene</th>
+<th>Alias(es)</th>
+<th>Machinery class</th>
+<th>Primary role in vacuole fusion</th>
+<th>Vacuole morphology class when deleted / mutant</th>
+<th>Key note</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Vps11</strong></td>
+<td><strong>Vam1</strong></td>
+<td>HOPS core subunit</td>
+<td>Part of the 6-subunit HOPS tethering complex required for docking/tethering and downstream fusion events</td>
+<td>Class C / 100% C in genomic screen (seeley2002genomicanalysisof pages 2-3, seeley2002genomicanalysisof pages 1-2)</td>
+<td>Canonical HOPS subunit, not specific to priming alone (seeley2002genomicanalysisof pages 2-3, seeley2002genomicanalysisof pages 1-2, ostrowicz2008yeastvacuolefusion pages 6-7)</td>
+</tr>
+<tr>
+<td><strong>Vps16</strong></td>
+<td><strong>Vam9</strong></td>
+<td>HOPS core subunit</td>
+<td>HOPS subunit; participates with Vps33 in the SNARE-interacting arm of HOPS</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Core HOPS component (seeley2002genomicanalysisof pages 2-3, diao2024molecularstructuresand pages 4-6)</td>
+</tr>
+<tr>
+<td><strong>Vps18</strong></td>
+<td><strong>Vam8</strong></td>
+<td>HOPS core subunit</td>
+<td>HOPS scaffold/core component required for tethering/fusion</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Core HOPS component (seeley2002genomicanalysisof pages 2-3, ostrowicz2008yeastvacuolefusion pages 6-7, diao2024molecularstructuresand pages 4-6)</td>
+</tr>
+<tr>
+<td><strong>Vps33</strong></td>
+<td><strong>Vam5</strong></td>
+<td>HOPS core subunit</td>
+<td>Sec1/Munc18-family HOPS subunit that helps coordinate SNARE assembly/function</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Core HOPS component (seeley2002genomicanalysisof pages 2-3, ostrowicz2009dynamicsandarchitecture pages 48-51, diao2024molecularstructuresand pages 4-6)</td>
+</tr>
+<tr>
+<td><strong>Vps39</strong></td>
+<td><strong>Vam6</strong></td>
+<td>HOPS-specific subunit</td>
+<td>HOPS-specific Rab-interacting subunit; also described as Ypt7 GEF in classic yeast literature</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3, seeley2002genomicanalysisof pages 1-2)</td>
+<td>HOPS-specific; distinct from VAM10 (seeley2002genomicanalysisof pages 2-3, ostrowicz2008yeastvacuolefusion pages 6-7, ostrowicz2009dynamicsandarchitecture pages 48-51)</td>
+</tr>
+<tr>
+<td><strong>Vps41</strong></td>
+<td><strong>Vam2</strong></td>
+<td>HOPS-specific subunit</td>
+<td>HOPS-specific Rab-binding/tethering subunit required at vacuole contact sites</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3, seeley2002genomicanalysisof pages 1-2)</td>
+<td>HOPS-specific; recent structural work refines its role in tether geometry (seeley2002genomicanalysisof pages 2-3, ostrowicz2008yeastvacuolefusion pages 6-7, diao2024molecularstructuresand pages 4-6)</td>
+</tr>
+<tr>
+<td><strong>Ypt7</strong></td>
+<td><strong>Vam4</strong></td>
+<td>Rab GTPase</td>
+<td>Vacuolar Rab required for tethering/docking and HOPS-dependent fusion</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Rab partner of HOPS; required on both membranes for efficient tethering/fusion (seeley2002genomicanalysisof pages 2-3, seeley2002genomicanalysisof pages 1-2, ostrowicz2008yeastvacuolefusion pages 5-5)</td>
+</tr>
+<tr>
+<td><strong>Vam3</strong></td>
+<td><strong>Pth1</strong></td>
+<td>Vacuolar Q-SNARE</td>
+<td>Vacuolar syntaxin-family SNARE essential for trans-SNARE pairing and fusion</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Core vacuolar SNARE; interacts functionally with HOPS (seeley2002genomicanalysisof pages 2-3, ostrowicz2008yeastvacuolefusion pages 5-5)</td>
+</tr>
+<tr>
+<td><strong>Vam7</strong></td>
+<td><strong>Vps43</strong></td>
+<td>Vacuolar Q-SNARE</td>
+<td>Soluble SNAP-25-like Q-SNARE; released during priming and re-recruited for docking/fusion</td>
+<td>Class C / 100% C (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Key priming/docking SNARE regulated by Sec17/Sec18 and Ypt7/HOPS (seeley2002genomicanalysisof pages 2-3, ostrowicz2008yeastvacuolefusion pages 3-5, ostrowicz2008yeastvacuolefusion pages 6-7)</td>
+</tr>
+<tr>
+<td><strong>Vti1</strong></td>
+<td>—</td>
+<td>Vacuolar Q-SNARE</td>
+<td>Q-SNARE component of the vacuolar trans-SNARE complex</td>
+<td>Essential / not represented in nonessential deletion screen (seeley2002genomicanalysisof pages 3-5, ostrowicz2008yeastvacuolefusion pages 5-5)</td>
+<td>Required for fusion but absent from the genome-wide nonessential deletion dataset because essential (seeley2002genomicanalysisof pages 3-5, ostrowicz2008yeastvacuolefusion pages 5-5)</td>
+</tr>
+<tr>
+<td><strong>Nyv1</strong></td>
+<td>—</td>
+<td>Vacuolar R-SNARE</td>
+<td>R-SNARE of the canonical vacuolar trans-SNARE complex</td>
+<td>Deletion has near-normal vacuole morphology in vivo, though vacuoles fuse poorly in vitro (seeley2002genomicanalysisof pages 3-5)</td>
+<td>Important caveat: morphology screen underestimates its direct fusion role (seeley2002genomicanalysisof pages 3-5, ostrowicz2008yeastvacuolefusion pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>Vam10</strong></td>
+<td><strong>YOR068C</strong></td>
+<td><strong>Additional fusion factor (NOT HOPS)</strong></td>
+<td><strong>Defines a Sec18p-independent priming step that allows vacuole tethering</strong></td>
+<td><strong>Class B / 90% B</strong> (ostrowicz2009dynamicsandarchitecture pages 140-143, ostrowicz2008yeastvacuolefusion pages 6-7, seeley2002genomicanalysisof pages 9-11)</td>
+<td><strong>Critical distinction: VAM10 is not one of the 6 HOPS subunits; it is a separate accessory fusion factor acting in priming upstream of tethering</strong> (ostrowicz2009dynamicsandarchitecture pages 140-143, ostrowicz2008yeastvacuolefusion pages 6-7)</td>
+</tr>
+<tr>
+<td><strong>Vac8</strong></td>
+<td>—</td>
+<td>Additional fusion factor</td>
+<td>Docking/fusion factor linked to vacuole inheritance and membrane dynamics; required for efficient vacuole fusion</td>
+<td>Mixed, reported as 60% B and 15% E in screen (seeley2002genomicanalysisof pages 2-3)</td>
+<td>Additional factor outside HOPS; palmitoylation-coupled functions are important (seeley2002genomicanalysisof pages 2-3, ostrowicz2008yeastvacuolefusion pages 7-8)</td>
+</tr>
+<tr>
+<td><strong>Calmodulin</strong></td>
+<td><strong>Cmd1</strong></td>
+<td>Additional fusion factor</td>
+<td>Ca2+/calmodulin-dependent regulator acting late in docking/fusion</td>
+<td>Essential / not represented in nonessential deletion screen (seeley2002genomicanalysisof pages 3-5, ostrowicz2008yeastvacuolefusion pages 7-8)</td>
+<td>Biochemically required although not scored in the deletion library (seeley2002genomicanalysisof pages 3-5, ostrowicz2008yeastvacuolefusion pages 7-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the major yeast vacuole fusion machinery components relevant to VAM10 annotation, including HOPS, Rab, SNAREs, and additional fusion factors. It highlights that VAM10/YOR068C is distinct from HOPS and is instead an accessory factor acting in a Sec18-independent priming step.</em></p>
+<h3 id="8-current-status-and-limitations">8. Current Status and Limitations</h3>
+<p>VAM10 remains a relatively understudied gene. The primary functional characterization paper (Kato &amp; Wickner, 2003) established its role in Sec18-independent priming, but the precise molecular mechanism by which Vam10p promotes vacuole tethering remains unknown. It is not known whether Vam10p acts as an enzyme, a structural scaffold, or a regulatory factor. No crystal or cryo-EM structure of Vam10p has been reported, and its protein interaction partners have not been comprehensively mapped. The genomic proximity to VPS5 introduces a caveat regarding potential effects on neighboring gene expression, though the in vitro biochemical data support a direct role for Vam10p in the fusion reaction.</p>
+<p>In the context of the broader vacuole fusion field, recent years have seen substantial advances in structural understanding of the HOPS and CORVET tethering complexes (diao2024molecularstructuresand pages 4-6) and in reconstitution of the minimal fusion machinery. However, VAM10 itself has not been a focus of these recent studies, and its mechanism represents an open question in the field of endomembrane fusion.</p>
+<h3 id="references-key-citations-used">References (Key citations used)</h3>
+<ul>
+<li>Seeley, E.S., Kato, M., Margolis, N., Wickner, W., &amp; Eitzen, G. (2002). Genomic analysis of homotypic vacuole fusion. <em>Molecular Biology of the Cell</em>, 13(3), 782–794.</li>
+<li>Kato, M. &amp; Wickner, W. (2003). Vam10p defines a Sec18p-independent step of priming that allows yeast vacuole tethering. <em>PNAS</em>, 100(11), 6398–6403.</li>
+<li>Ostrowicz, C.W., Meiringer, C.T.A., &amp; Ungermann, C. (2008). Yeast vacuole fusion: A model system for eukaryotic endomembrane dynamics. <em>Autophagy</em>, 4(1), 5–19.</li>
+<li>Diao, J., Yip, C.K., &amp; Zhong, Q. (2024). Molecular structures and function of the autophagosome-lysosome fusion machinery. <em>Autophagy Reports</em>, 3(1).</li>
+<li>Chen, K.-E. et al. (2025). Molecular basis for the assembly of the Vps5-Vps17 SNX-BAR proteins with Retromer. <em>Nature Communications</em>, 16, 3568.</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(chen2025molecularbasisfor pages 2-3): Kai-En Chen, Vikas A. Tillu, Navin Gopaldass, Sudeshna Roy Chowdhury, Natalya Leneva, Oleksiy Kovtun, Juanfang Ruan, Qian Guo, Nicholas Ariotti, Andreas Mayer, and Brett M. Collins. Molecular basis for the assembly of the vps5-vps17 snx-bar proteins with retromer. Nature Communications, Dec 2025. URL: https://doi.org/10.1038/s41467-025-58846-8, doi:10.1038/s41467-025-58846-8. This article has 15 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2025molecularbasisfor pages 1-2): Kai-En Chen, Vikas A. Tillu, Navin Gopaldass, Sudeshna Roy Chowdhury, Natalya Leneva, Oleksiy Kovtun, Juanfang Ruan, Qian Guo, Nicholas Ariotti, Andreas Mayer, and Brett M. Collins. Molecular basis for the assembly of the vps5-vps17 snx-bar proteins with retromer. Nature Communications, Dec 2025. URL: https://doi.org/10.1038/s41467-025-58846-8, doi:10.1038/s41467-025-58846-8. This article has 15 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seeley2002genomicanalysisof pages 1-2): E. Scott Seeley, Masashi Kato, Nathan Margolis, William Wickner, and Gary Eitzen. Genomic analysis of homotypic vacuole fusion. Molecular biology of the cell, 13 3:782-94, Mar 2002. URL: https://doi.org/10.1091/mbc.01-10-0512, doi:10.1091/mbc.01-10-0512. This article has 209 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seeley2002genomicanalysisof pages 9-11): E. Scott Seeley, Masashi Kato, Nathan Margolis, William Wickner, and Gary Eitzen. Genomic analysis of homotypic vacuole fusion. Molecular biology of the cell, 13 3:782-94, Mar 2002. URL: https://doi.org/10.1091/mbc.01-10-0512, doi:10.1091/mbc.01-10-0512. This article has 209 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2009dynamicsandarchitecture pages 140-143): Clemens Werner Ostrowicz. Dynamics and architecture of the hops tethering complex in yeast vacuole fusion. Text, Jan 2009. URL: https://doi.org/10.11588/heidok.00009655, doi:10.11588/heidok.00009655. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2008yeastvacuolefusion pages 3-5): Clemens W. Ostrowicz, Christoph T. A. Meiringer, and Christian Ungermann. Yeast vacuole fusion: a model system for eukaryotic endomembrane dynamics. Autophagy, 4:19-5, Jan 2008. URL: https://doi.org/10.4161/auto.5054, doi:10.4161/auto.5054. This article has 127 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2008yeastvacuolefusion pages 5-5): Clemens W. Ostrowicz, Christoph T. A. Meiringer, and Christian Ungermann. Yeast vacuole fusion: a model system for eukaryotic endomembrane dynamics. Autophagy, 4:19-5, Jan 2008. URL: https://doi.org/10.4161/auto.5054, doi:10.4161/auto.5054. This article has 127 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2008yeastvacuolefusion pages 6-7): Clemens W. Ostrowicz, Christoph T. A. Meiringer, and Christian Ungermann. Yeast vacuole fusion: a model system for eukaryotic endomembrane dynamics. Autophagy, 4:19-5, Jan 2008. URL: https://doi.org/10.4161/auto.5054, doi:10.4161/auto.5054. This article has 127 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2008yeastvacuolefusion pages 7-8): Clemens W. Ostrowicz, Christoph T. A. Meiringer, and Christian Ungermann. Yeast vacuole fusion: a model system for eukaryotic endomembrane dynamics. Autophagy, 4:19-5, Jan 2008. URL: https://doi.org/10.4161/auto.5054, doi:10.4161/auto.5054. This article has 127 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(diao2024molecularstructuresand pages 4-6): Jiajie Diao, Calvin K. Yip, and Qing Zhong. Molecular structures and function of the autophagosome-lysosome fusion machinery. Autophagy Reports, Feb 2024. URL: https://doi.org/10.1080/27694127.2024.2305594, doi:10.1080/27694127.2024.2305594. This article has 22 citations.</p>
+</li>
+<li>
+<p>(ostrowicz2008yeastvacuolefusion pages 1-3): Clemens W. Ostrowicz, Christoph T. A. Meiringer, and Christian Ungermann. Yeast vacuole fusion: a model system for eukaryotic endomembrane dynamics. Autophagy, 4:19-5, Jan 2008. URL: https://doi.org/10.4161/auto.5054, doi:10.4161/auto.5054. This article has 127 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2008yeastvacuolefusion pages 5-6): Clemens W. Ostrowicz, Christoph T. A. Meiringer, and Christian Ungermann. Yeast vacuole fusion: a model system for eukaryotic endomembrane dynamics. Autophagy, 4:19-5, Jan 2008. URL: https://doi.org/10.4161/auto.5054, doi:10.4161/auto.5054. This article has 127 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seeley2002genomicanalysisof pages 7-9): E. Scott Seeley, Masashi Kato, Nathan Margolis, William Wickner, and Gary Eitzen. Genomic analysis of homotypic vacuole fusion. Molecular biology of the cell, 13 3:782-94, Mar 2002. URL: https://doi.org/10.1091/mbc.01-10-0512, doi:10.1091/mbc.01-10-0512. This article has 209 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seeley2002genomicanalysisof pages 2-3): E. Scott Seeley, Masashi Kato, Nathan Margolis, William Wickner, and Gary Eitzen. Genomic analysis of homotypic vacuole fusion. Molecular biology of the cell, 13 3:782-94, Mar 2002. URL: https://doi.org/10.1091/mbc.01-10-0512, doi:10.1091/mbc.01-10-0512. This article has 209 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ostrowicz2009dynamicsandarchitecture pages 48-51): Clemens Werner Ostrowicz. Dynamics and architecture of the hops tethering complex in yeast vacuole fusion. Text, Jan 2009. URL: https://doi.org/10.11588/heidok.00009655, doi:10.11588/heidok.00009655. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(seeley2002genomicanalysisof pages 3-5): E. Scott Seeley, Masashi Kato, Nathan Margolis, William Wickner, and Gary Eitzen. Genomic analysis of homotypic vacuole fusion. Molecular biology of the cell, 13 3:782-94, Mar 2002. URL: https://doi.org/10.1091/mbc.01-10-0512, doi:10.1091/mbc.01-10-0512. This article has 209 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="VAM10-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>seeley2002genomicanalysisof pages 1-2</li>
+<li>seeley2002genomicanalysisof pages 9-11</li>
+<li>ostrowicz2009dynamicsandarchitecture pages 140-143</li>
+<li>ostrowicz2008yeastvacuolefusion pages 5-5</li>
+<li>ostrowicz2008yeastvacuolefusion pages 6-7</li>
+<li>ostrowicz2008yeastvacuolefusion pages 7-8</li>
+<li>diao2024molecularstructuresand pages 4-6</li>
+<li>ostrowicz2008yeastvacuolefusion pages 1-3</li>
+<li>seeley2002genomicanalysisof pages 7-9</li>
+<li>chen2025molecularbasisfor pages 2-3</li>
+<li>seeley2002genomicanalysisof pages 2-3</li>
+<li>seeley2002genomicanalysisof pages 3-5</li>
+<li>chen2025molecularbasisfor pages 1-2</li>
+<li>ostrowicz2008yeastvacuolefusion pages 3-5</li>
+<li>ostrowicz2008yeastvacuolefusion pages 5-6</li>
+<li>ostrowicz2009dynamicsandarchitecture pages 48-51</li>
+<li>https://doi.org/10.1038/s41467-025-58846-8,</li>
+<li>https://doi.org/10.1091/mbc.01-10-0512,</li>
+<li>https://doi.org/10.11588/heidok.00009655,</li>
+<li>https://doi.org/10.4161/auto.5054,</li>
+<li>https://doi.org/10.1080/27694127.2024.2305594,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(VAM10-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q08474" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="vam10-yor068c-curation-notes">VAM10 (YOR068C) — curation notes</h1>
+<p>Organism: <em>Saccharomyces cerevisiae</em> S288C (yeast)<br />
+UniProt: Q08474 (VAM10_YEAST); SGD: S000005594; systematic name YOR068C<br />
+Protein: 114 aa, ~11.8 kDa; PE=4 (Predicted). Standard name VAM10 = "VAcuole Morphology 10" / "altered vacuole morphology".</p>
+<h2 id="journal">Journal</h2>
+<h3 id="2026-07-05-setup">2026-07-05 — setup</h3>
+<ul>
+<li><code>just fetch-gene yeast VAM10</code> succeeded on bare symbol; resolved to Q08474. Files: uniprot.txt, goa.tsv, ai-review.yaml stub (4 annotations).</li>
+<li><code>just fetch-gene-pmids</code> — only one PMID cited across GOA: PMID:12748377 (Kato &amp; Wickner 2003). Cached, but <strong>abstract-only</strong> (<code>full_text_available: false</code>, PMC access restricted).</li>
+<li>Deep research (falcon) launched in background.</li>
+</ul>
+<h2 id="domain-sequence-analysis-inline-from-uniprot-record">Domain / sequence analysis (inline, from UniProt record)</h2>
+<p>Sequence (114 aa):</p>
+<div class="codehilite"><pre><span></span><code>MLFEVFGEVL ASYIVSSKTK GELAFPVNNA PPDSLVAINC VVLFLRSAIG SCSGAKELIR
+SSALELSCSS SCGLPATDKP GSFHSGALSK SILSANEAVV SKSSLSFLSS FVDI
+</code></pre></div>
+
+<ul>
+<li><strong>No annotated domain / motif / signal.</strong> UniProt lists a single CHAIN feature (1..114) and no PFAM/InterPro/PROSITE hits; the record has no <code>DR Pfam</code>/<code>DR InterPro</code> lines. PANTHER family: none found by the fetch pipeline ("No PANTHER family found in UniProt data").</li>
+<li><strong>No transmembrane segment declared.</strong> UniProt annotates SUBCELLULAR LOCATION as "Vacuole membrane {ECO:0000305}; Peripheral membrane protein {ECO:0000305}" — i.e. inferred (ECO:0000305), membrane-associated but <strong>peripheral</strong>, not integral. Keyword <code>Membrane</code> is present but there is no <code>TRANSMEM</code> feature.</li>
+<li><strong>Composition:</strong> N-terminal ~1–20 is hydrophobic/amphipathic (MLFEVFGEVLASYIVSSKTK); the C-terminal two-thirds is Ser-rich (many S/A/L). No Cys cluster of note (a few scattered C). No coiled-coil is annotated. This is consistent with a small, largely disordered/low-complexity peripheral membrane protein with no catalytic fold — i.e. <strong>no basis to assign an enzymatic molecular function from sequence</strong>.</li>
+<li><strong>Orthology:</strong> UniProt cross-refs HOGENOM CLU_2122470_0_0_1 (singleton-like cluster), InParanoid Q08474, OrthoDB 10325102at2759. VAM10 is poorly conserved and effectively <em>Saccharomyces</em>-restricted / fungal-lineage-narrow; no metazoan ortholog is established. This limits transfer of molecular-function inference from orthologs.</li>
+<li><strong>Genomic note (from the primary paper):</strong> YOR068C/VAM10 lies <strong>within the VPS5 gene on the opposite DNA strand</strong> [PMID:12748377 abstract, "YOR068c, termed VAM10 (altered vacuole morphology), lies within the VPS5 gene on the opposite DNA strand."]. This nested arrangement is why the gene was historically overlooked and is a caution against confusing VAM10 with VPS5 phenotypes.</li>
+</ul>
+<p><strong>Domain-analysis conclusion:</strong> VAM10 is a small (114 aa) peripheral vacuolar-membrane protein with <strong>no recognizable catalytic or binding domain</strong> and no strong orthology signal. Its molecular activity therefore cannot be inferred from structure and must rest on the single functional study.</p>
+<h2 id="literature-synthesis">Literature synthesis</h2>
+<p>Only one functional paper exists (VAM10 is genuinely understudied).</p>
+<h3 id="pmid12748377-kato-m-wickner-w-vam10p-defines-a-sec18p-independent-step-of-priming-that-allows-yeast-vacuole-tethering-pnas-2003-abstract-only-in-cache">PMID:12748377 — Kato M, Wickner W. "Vam10p defines a Sec18p-independent step of priming that allows yeast vacuole tethering." PNAS 2003. (abstract-only in cache)</h3>
+<p>Verbatim abstract statements (from cached <code>publications/PMID_12748377.md</code>):<br />
+- "YOR068c, termed VAM10 (altered vacuole morphology), lies within the VPS5 gene on the opposite DNA strand."<br />
+- "VAM10 deletion causes vacuole fragmentation in vivo." → in-vivo loss-of-function phenotype (basis of IMP GO:0042144).<br />
+- "The in vitro fusion of purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by antibody to Vam10p." → Vam10p is a positive-acting factor for homotypic vacuole fusion in a defined in-vitro assay.<br />
+- "Vam10p acts early in the priming stage of fusion, independent of Sec18p." → places Vam10p in the priming (pre-docking) stage, but distinct from the canonical Sec18p (NSF)/Sec17p (α-SNAP) SNARE-disassembly priming.<br />
+- "After priming, recombinant Vam10p will not stimulate fusion and anti-Vam10p antibodies will not inhibit; Vam10p provides a functional marker for this Sec18p-independent priming step."<br />
+- "Pure Vam10p restores normal, Ypt7p-dependent tethering to vacuoles from a vam10Delta strain." → Vam10p is required to establish Ypt7p (Rab GTPase)-dependent tethering; vacuoles lacking it are tethering-deficient.</p>
+<p><strong>Interpretation.</strong> The homotypic vacuole fusion cascade in yeast proceeds priming → tethering → docking (trans-SNARE pairing) → fusion. Canonical priming is Sec18p(NSF)/Sec17p(α-SNAP)-driven SNARE-complex disassembly. Kato &amp; Wickner define a <strong>second, Sec18p-independent priming activity</strong> provided by Vam10p that is a prerequisite for the subsequent Ypt7p-dependent tethering step (tethering is executed by the HOPS complex with the Rab Ypt7p). Vam10p is thus a positive regulator/facilitator that acts upstream of, and enables, HOPS/Ypt7p-mediated tethering.</p>
+<h3 id="known-vs-not-known">KNOWN vs NOT-known</h3>
+<p>KNOWN (evidence-supported):<br />
+- <strong>BP:</strong> required for homotypic (non-autophagic) vacuole fusion; deletion fragments vacuoles in vivo (IMP, PMID:12748377). This is the core biological role.<br />
+- <strong>BP/mechanistic placement:</strong> acts at an early, Sec18p-<strong>independent</strong> priming step that is a prerequisite for Ypt7p-dependent tethering (in-vitro reconstitution, PMID:12748377).<br />
+- <strong>CC:</strong> vacuolar (fungal-type vacuole) membrane; peripheral membrane protein (IC from SGD, PMID:12748377; UniProt SubCell IEA). Consistent with acting on the vacuole surface during fusion.</p>
+<p>NOT-known (genuine gaps — primary deliverable):<br />
+- <strong>Molecular function is dark.</strong> No biochemical activity is defined. It is unknown whether Vam10p is an enzyme, a lipid/membrane binder, a protein adaptor/tether, or a regulator of another priming factor. There is no MF beyond the ND root in GOA, and sequence gives no fold-level clue.<br />
+- <strong>Direct binding partner(s) unknown.</strong> Vam10p enables Ypt7p-dependent tethering but it is not established whether it binds Ypt7p, the HOPS complex, a SNARE, a lipid, or acts indirectly. The molecular target of the "Sec18p-independent priming" is undefined.<br />
+- <strong>Mechanism of the Sec18p-independent priming step is unknown.</strong> What conformational/compositional change on the vacuole membrane Vam10p produces to license tethering is undetermined.<br />
+- <strong>Structure unknown</strong> (PE=4 predicted; AlphaFoldDB model exists but no experimental structure, and the protein is largely low-complexity).<br />
+- <strong>Conservation/orthology of function</strong> across fungi and beyond is uncharacterized.</p>
+<h2 id="annotation-by-annotation-plan">Annotation-by-annotation plan</h2>
+<ol>
+<li><code>GO:0005774 vacuolar membrane</code> / located_in / IEA / GO_REF:0000044 (UniProt SubCell) — ACCEPT (non-core supporting CC; consistent with IC vacuole-membrane call). Same location as the more specific SGD term below.</li>
+<li><code>GO:0000329 fungal-type vacuole membrane</code> / located_in / IC / PMID:12748377 — ACCEPT. Species-appropriate (fungal-type vacuole) refinement of the CC; IC from the functional study. This is the informative CC and can back the core-function location.</li>
+<li><code>GO:0003674 molecular_function</code> (root) / enables / ND / GO_REF:0000015 — this is the explicit "no known MF" placeholder. Keep but not core; represents the real MF_DARK gap. Action: ACCEPT (honest ND root; do NOT invent an MF).</li>
+<li><code>GO:0042144 vacuole fusion, non-autophagic</code> / involved_in / IMP / PMID:12748377 — ACCEPT as the CORE biological process (deletion → vacuole fragmentation; recombinant protein stimulates in-vitro fusion). Well supported.</li>
+</ol>
+<p>Avoid <code>protein binding</code> (not present here anyway). Do not assign a specific tether/priming MF term — none fits the undefined activity; record it as a knowledge gap instead.</p>
+<p>Core function: single BP-centered core (vacuole fusion / early Sec18p-independent priming enabling Ypt7p-dependent tethering) at the fungal-type vacuole membrane, with molecular_function left at the root (MF_DARK) and the mechanism captured under knowledge_gaps.</p>
+<h3 id="2026-07-05-falcon-deep-research-completed-corroboration">2026-07-05 — falcon deep research completed (corroboration)</h3>
+<p>Falcon (Edison Scientific) deep research completed after ~27 min (<code>VAM10-deep-research-falcon.md</code>, 21 citations). It corroborates the review and adds context (citations in falcon's <code>keyname pages N-N</code> style, which the reference validator skips, so NONE are quoted into the YAML; all YAML supporting_text remains verbatim from the cached PMID:12748377 abstract):<br />
+- VAM10/YOR068C identified in the Seeley et al. (2002) genome-wide FM4-64 vacuole-morphology screen; vam10Δ shows a class B fragmentation phenotype in ~90% of cells (Seeley, Kato, Wickner, Eitzen 2002).<br />
+- <strong>VAM10 is NOT a HOPS subunit.</strong> The six original VAM genes that are HOPS subunits are VAM1/VPS11, VAM2/VPS41, VAM5/VPS33, VAM6/VPS39, VAM8/VPS18, VAM9/VPS16; VAM3/VAM7 are SNAREs; VAM4 = the Rab Ypt7p. Vam10p is instead an "additional fusion factor" acting in a Sec18p-independent priming step upstream of HOPS/Ypt7p-mediated tethering. (This is why the review frames VAM10 as acting upstream of, and enabling, HOPS/Ypt7p tethering — not as a HOPS component.)<br />
+- Molecular mechanism still unknown: enzyme vs scaffold vs regulator undetermined; no crystal/cryo-EM structure; interaction partners not comprehensively mapped — matches the MF_DARK and partner knowledge gaps recorded.<br />
+- vam10Δ does not show a strong VPS/CPY-secretion sorting phenotype, consistent with a role specific to homotypic vacuole fusion rather than biosynthetic trafficking; the VPS5-proximity caveat is noted but in-vitro biochemistry supports a direct Vam10p role.</p>
+<p>No annotation actions changed as a result; falcon strengthens the ACCEPT calls and the honesty of the knowledge-gaps section.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q08474
+gene_symbol: VAM10
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  VAM10 (YOR068C) encodes a small (114 aa) peripheral vacuolar-membrane protein of
+  Saccharomyces cerevisiae required for homotypic (non-autophagic) vacuole fusion.
+  Its gene is nested within the VPS5 locus on the opposite DNA strand. Vam10p acts
+  early in the vacuole fusion cascade at a priming step that is independent of the
+  canonical Sec18p (NSF)/Sec17p (alpha-SNAP) SNARE-disassembly machinery, and this
+  Vam10p-dependent priming is a prerequisite for the subsequent Ypt7p (Rab GTPase)-
+  dependent tethering of vacuoles. Deletion causes vacuole fragmentation, and
+  recombinant Vam10p stimulates fusion of purified vacuoles in vitro while anti-Vam10p
+  antibody blocks it. The protein has no recognizable catalytic or binding domain and
+  no strong orthology outside fungi, and its molecular activity and direct binding
+  partners remain undefined.
+existing_annotations:
+- term:
+    id: GO:0005774
+    label: vacuolar membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic Subcellular Location mapping placing Vam10p at the vacuolar membrane.
+      Consistent with the experimentally-informed IC call to the fungal-type vacuole
+      membrane and with the protein&#39;s role at the vacuole surface during fusion.
+    action: ACCEPT
+    reason: &gt;-
+      Correct location and supported by an independent, more specific IC annotation
+      (GO:0000329) from the primary functional study. Kept as a valid but non-core
+      supporting cellular-component annotation; the fungal-type vacuole membrane term
+      is preferred for representing the site of action.
+- term:
+    id: GO:0000329
+    label: fungal-type vacuole membrane
+  evidence_type: IC
+  original_reference_id: PMID:12748377
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Curator-inferred (IC) localization to the fungal-type vacuole membrane, based on
+      the vacuole-fusion function reported by Kato &amp; Wickner (2003). Species-appropriate
+      and the informative cellular-component annotation for this protein.
+    action: ACCEPT
+    reason: &gt;-
+      The functional study demonstrates Vam10p acts on purified vacuoles and restores
+      tethering to vacuoles from a vam10-delta strain, and UniProt independently curates
+      a vacuole-membrane (peripheral) location; the fungal-type vacuole membrane is the
+      correct organelle-specific term for a Saccharomyces protein. Supports the
+      core-function location.
+    supported_by:
+    - reference_id: PMID:12748377
+      supporting_text: &gt;-
+        Pure Vam10p restores normal, Ypt7p-dependent tethering to vacuoles from a
+        vam10Delta strain.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function annotation with the ND (No biological Data available)
+      evidence code, marking that no specific molecular activity has been experimentally
+      or computationally assigned to Vam10p.
+    action: ACCEPT
+    reason: &gt;-
+      This is an honest placeholder that correctly reflects the genuine molecular-function
+      gap for this protein: Vam10p has no recognizable catalytic or binding domain, no
+      informative orthology, and no biochemically defined activity. It should NOT be
+      replaced with a specific molecular-function term; the missing activity is recorded
+      under knowledge_gaps instead. Not a core function.
+- term:
+    id: GO:0042144
+    label: vacuole fusion, non-autophagic
+  evidence_type: IMP
+  original_reference_id: PMID:12748377
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Involvement in homotypic (non-autophagic) vacuole fusion, from the deletion
+      phenotype (vacuole fragmentation) and in-vitro reconstitution (recombinant Vam10p
+      stimulates fusion of purified vacuoles; anti-Vam10p antibody blocks it). This is
+      the core, well-supported biological role of the gene.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by loss-of-function (in-vivo fragmentation; antibody inhibition
+      of in-vitro fusion) and gain-of-function (recombinant-protein stimulation) evidence
+      in the same study. Represents the core biological process of VAM10.
+    supported_by:
+    - reference_id: PMID:12748377
+      supporting_text: &gt;-
+        VAM10 deletion causes vacuole fragmentation in vivo. The in vitro fusion of
+        purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by
+        antibody to Vam10p.
+core_functions:
+- description: &gt;-
+    Required for homotypic (non-autophagic) vacuole fusion, acting at an early,
+    Sec18p-independent priming step at the fungal-type vacuole membrane that is a
+    prerequisite for Ypt7p-dependent tethering. The specific molecular activity by
+    which Vam10p licenses tethering is undefined, so the molecular_function is left at
+    the root (see knowledge_gaps); the well-supported claim is the biological-process
+    role and the site of action.
+  molecular_function:
+    id: GO:0003674
+    label: molecular_function
+  directly_involved_in:
+  - id: GO:0042144
+    label: vacuole fusion, non-autophagic
+  locations:
+  - id: GO:0000329
+    label: fungal-type vacuole membrane
+  supported_by:
+  - reference_id: PMID:12748377
+    supporting_text: &gt;-
+      VAM10 deletion causes vacuole fragmentation in vivo. The in vitro fusion of
+      purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by
+      antibody to Vam10p.
+  - reference_id: PMID:12748377
+    supporting_text: &gt;-
+      Vam10p acts early in the priming stage of fusion, independent of Sec18p.
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular activity of Vam10p is undetermined. It is not known whether Vam10p
+      is an enzyme, a lipid- or membrane-binding protein, a protein adaptor/tether, or a
+      regulator that modifies another priming factor; no biochemical activity has been
+      assigned and the only molecular_function annotation is the ND root.
+    boundary: &gt;-
+      It is firmly established that recombinant Vam10p stimulates homotypic vacuole
+      fusion in vitro, that anti-Vam10p antibody blocks fusion, and that Vam10p acts at
+      an early, Sec18p-independent priming step required for Ypt7p-dependent tethering.
+      What is missing is any measurement of a catalytic or binding activity.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Vam10p defines a distinct, Sec18p-independent priming activity in membrane fusion;
+      identifying its molecular activity would explain how the vacuole is licensed for
+      Ypt7p/HOPS-dependent tethering and could reveal a conserved pre-tethering step.
+    resolution: &gt;-
+      Biochemically characterize purified recombinant Vam10p: test for lipid/membrane
+      binding, for any enzymatic activity, and for whether it acts on SNAREs, on the
+      Rab Ypt7p, or on the vacuole lipid bilayer during the priming reaction.
+    provenance:
+    - reference_id: PMID:12748377
+      supporting_text: &gt;-
+        Vam10p acts early in the priming stage of fusion, independent of Sec18p.
+  - gap_statement: &gt;-
+      The direct molecular partner(s) of Vam10p are unknown. It is unresolved whether
+      Vam10p acts on the Rab GTPase Ypt7p, on the HOPS tethering complex, on a vacuolar
+      SNARE, or on a membrane lipid to enable the Ypt7p-dependent tethering it is
+      required for.
+    boundary: &gt;-
+      Vam10p is required to restore normal Ypt7p-dependent tethering to vacuoles from a
+      vam10-delta strain, placing it upstream of Rab-dependent tethering; but the
+      physical target through which it acts has not been identified.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Identifying the direct partner would connect the Sec18p-independent priming step
+      to the canonical Rab/HOPS tethering machinery and place Vam10p precisely in the
+      fusion cascade.
+    resolution: &gt;-
+      Affinity purification / crosslinking of Vam10p from vacuolar membranes, and
+      directed binding assays against Ypt7p, HOPS subunits, and vacuolar SNAREs.
+    provenance:
+    - reference_id: PMID:12748377
+      supporting_text: &gt;-
+        Pure Vam10p restores normal, Ypt7p-dependent tethering to vacuoles from a
+        vam10Delta strain.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The mechanism of the Sec18p-independent priming step defined by Vam10p is unknown:
+    what change in the vacuolar membrane or its protein/lipid composition Vam10p produces
+    to license subsequent Ypt7p-dependent tethering has not been determined.
+  boundary: &gt;-
+    Canonical priming (Sec18p/NSF- and Sec17p/alpha-SNAP-driven SNARE-complex disassembly)
+    is well characterized. Vam10p provides a functional marker for a separate, early,
+    Sec18p-independent priming activity, but the reaction it catalyzes or promotes is not
+    defined.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    A second priming activity distinct from NSF/alpha-SNAP would refine the textbook
+    priming-tethering-docking-fusion model of homotypic membrane fusion.
+  resolution: &gt;-
+    In-vitro dissection of the Vam10p-dependent priming reaction (order-of-addition,
+    substrate/product analysis) to define what Vam10p acts on and what it produces.
+  provenance:
+  - reference_id: PMID:12748377
+    supporting_text: &gt;-
+      Vam10p provides a functional marker for this Sec18p-independent priming step.
+- gap_statement: &gt;-
+    Whether Vam10p has orthologs with a conserved function beyond Saccharomyces (in other
+    fungi or in higher eukaryotes) is uncharacterized, so it is unknown whether the
+    Sec18p-independent priming role is a general feature of membrane fusion or a
+    yeast-specific adaptation.
+  boundary: &gt;-
+    Vam10p is a small protein with no recognizable domain and only weak/singleton
+    orthology signals in HOGENOM/InParanoid/OrthoDB; no functionally validated ortholog
+    has been reported.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Establishing conservation would indicate whether the priming activity is a widely
+    used mechanism worth mapping onto human membrane-fusion pathways.
+  resolution: &gt;-
+    Phylogenetic profiling and functional complementation tests of candidate fungal
+    homologs; structural comparison of the predicted fold against known fusion factors.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:12748377
+  title: Vam10p defines a Sec18p-independent step of priming that allows yeast vacuole
+    tethering.
+  findings:
+  - statement: &gt;-
+      VAM10 deletion causes vacuole fragmentation in vivo, and recombinant Vam10p
+      stimulates in-vitro fusion of purified vacuoles while anti-Vam10p antibody blocks
+      it, establishing Vam10p as a positive factor required for homotypic vacuole fusion.
+    supporting_text: &gt;-
+      VAM10 deletion causes vacuole fragmentation in vivo. The in vitro fusion of
+      purified yeast vacuoles is stimulated by recombinant Vam10p and blocked by
+      antibody to Vam10p.
+  - statement: &gt;-
+      Vam10p acts at an early, Sec18p-independent priming step and is required to restore
+      Ypt7p-dependent tethering, placing it upstream of Rab-dependent tethering.
+    supporting_text: &gt;-
+      Vam10p acts early in the priming stage of fusion, independent of Sec18p.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/UniProt-verified as the sole functional study of VAM10 (YOR068C); title and
+      supporting quotes match the cached abstract. Cache is abstract-only
+      (full_text_available: false); annotations reviewed here are consistent with what
+      the abstract states. Establishes the vacuole-fusion role and the Sec18p-independent
+      priming / Ypt7p-dependent tethering placement.
+suggested_questions:
+- question: &gt;-
+    What is the molecular activity of Vam10p during the Sec18p-independent priming step
+    that licenses Ypt7p-dependent tethering?
+  experts:
+  - William Wickner
+- question: &gt;-
+    Does Vam10p act directly on the Rab GTPase Ypt7p, on the HOPS complex, on vacuolar
+    SNAREs, or on the vacuolar lipid bilayer?
+  experts:
+  - Michiko Kato
+  - William Wickner
+suggested_experiments:
+- hypothesis: &gt;-
+    Vam10p binds a specific vacuolar component (Ypt7p, a HOPS subunit, a SNARE, or a
+    lipid) to promote the pre-tethering priming step.
+  description: &gt;-
+    Affinity-purify or crosslink epitope-tagged Vam10p from isolated vacuoles and identify
+    co-purifying proteins by mass spectrometry; test candidate interactions (Ypt7p, HOPS
+    subunits, vacuolar SNAREs) by directed pulldowns, and assay lipid binding of purified
+    recombinant Vam10p.
+  experiment_type: interaction proteomics / biochemical binding assays
+- hypothesis: &gt;-
+    The Vam10p-dependent priming reaction produces a defined change on the vacuole
+    membrane required before Ypt7p-dependent tethering.
+  description: &gt;-
+    Use the in-vitro homotypic vacuole fusion assay with order-of-addition and
+    stage-specific inhibitors to place the Vam10p requirement precisely relative to
+    Sec18p-mediated priming and Ypt7p/HOPS-mediated tethering, and characterize what
+    Vam10p acts on during the reaction.
+  experiment_type: in-vitro reconstituted membrane fusion
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/YET2/YET2-ai-review.html
+++ b/genes/yeast/YET2/YET2-ai-review.html
@@ -1,0 +1,3197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YET2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>YET2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q04210" target="_blank" class="term-link">
+                        Q04210
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "YET2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q04210" data-a="DESCRIPTION: YET2 (Yet2p, systematic name YMR040W) is a small (..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>YET2 (Yet2p, systematic name YMR040W) is a small (160 aa, ~19 kDa) polytopic integral membrane protein of the endoplasmic reticulum in Saccharomyces cerevisiae. It is one of three budding-yeast members of the BCAP29/BCAP31 (BAP29/BAP31) family — Yet1p, Yet2p and Yet3p — that are homologs of the mammalian B-cell receptor- associated proteins BAP29 and BAP31, ER membrane proteins implicated in ER quality control, ER export of secretory cargo, and apoptosis. Yet2p has the canonical BAP31-type architecture: three transmembrane helices with a lumenal N-terminus, a large lumenal loop, and a charged, leucine-rich cytoplasmic C-terminal tail ending in a di-lysine (KKxx-type) ER-retrieval motif that supports its steady-state ER membrane residence. The gene is non-essential; Yet2p is the lowest-abundance member of the family and, unlike its paralogs, is not constitutively expressed, implying conditional regulation whose triggers are not established. Unlike its paralogs Yet1p and Yet3p, which form a stable Yet1p-Yet3p complex associated with the Sec translocation apparatus and are required for inositol prototrophy, Yet2p is not a stable member of that complex and has no demonstrated molecular activity or defined physiological cargo; its specific molecular function remains uncharacterized.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that Yet2p is active in the ER membrane, propagated from the mammalian BAP29/BAP31 ortholog (UniProtKB:P51572, PANTHER PTN000294723). This localization is independently supported: Yet2p belongs to the BCAP29/BCAP31 family, is predicted to be a triple-pass membrane protein, and carries a C-terminal di-lysine ER-retrieval motif; it is directly observed in the ER by high-throughput localization (PMID:26928762).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported core localization for an ER polytopic membrane protein of the BAP31 family. The ER membrane is where Yet2p resides and where any function it has would be exerted.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">The di-lysine motif confers endoplasmic reticulum localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030970" target="_blank" class="term-link">
+                                    GO:0030970
+                                </a>
+                            </span>
+                            <span class="term-label">retrograde protein transport, ER to cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0030970" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of a role in ERAD-associated dislocation of unfolded/misfolded proteins from the ER lumen to the cytosol through the translocon, propagated from the mammalian BAP31 ortholog. Mammalian BAP31 is implicated in ER-associated degradation, and the related Yet1p-Yet3p complex associates with the Sec translocation apparatus (PMID:20378542), which is consistent with a translocon-proximal locale. However, there is no direct evidence that Yet2p itself participates in retrograde/ERAD transport, and Yet2p is not a stable member of the characterized Yet1p-Yet3p complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically plausible family-level inference but not demonstrated for Yet2p. Retained as a non-core, phylogenetically inferred process rather than removed, since the family and translocon association make it credible; it does not represent a validated core YET2 function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20378542" target="_blank" class="term-link">
+                                        PMID:20378542
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a fraction
+of the Yet complex was detected in association with the ER translocation
+apparatus (Sec complex)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000060" target="_blank" class="term-link">
+                                    GO:2000060
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of ubiquitin-dependent protein catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:2000060" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of a positive-regulatory role in ubiquitin- dependent (ERAD-type) protein catabolism, propagated from the mammalian BAP31 ortholog, which has documented roles in ER quality control and degradation of client proteins. No YET2-specific experimental evidence supports this; it is a family-level inference.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible for the BAP31 family but unproven for Yet2p, and the specific molecular role of Yet2p in any degradation pathway is unknown. Kept as a non-core inferred process rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the BCAP29/BCAP31 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0005783" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) annotation to the endoplasmic reticulum based on BAP29/BAP31 family membership (IPR008417). Correct compartment but less specific than the ER membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; consistent with direct localization data. The more specific GO:0005789 (ER membrane) better captures the protein&#39;s polytopic membrane residence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SWAp-Tag</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to ER membrane from the UniProtKB Subcellular Location mapping (SL-0097). Consistent with the domain architecture (three TM helices) and the IBA/HDA evidence for ER-membrane residence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and redundant with the IBA ER-membrane annotation; supported by the UniProt subcellular location and topology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0006886" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) annotation to intracellular protein transport from BAP29/BAP31 family membership. This is a generic process term consistent with the family&#39;s association with ER protein transport/export and with the (hedged) UniProt FUNCTION statement, but there is no direct YET2 evidence for a specific transport step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic, family-inferred process. Consistent with the ER protein-transport theme of the family but not a demonstrated YET2 core function; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">May play a role in anterograde transport of membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to the generic parent term &#34;membrane&#34; from family membership. True but uninformative given the more specific ER membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but overly general; the ER membrane annotation (GO:0005789) supersedes it. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26928762
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    One library to make them all: Streamlining the creation of y...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0005783" data-r="PMID:26928762" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput direct assay (HDA) localization from the SWAp-Tag yeast library (Yofe et al. 2016) placing Yet2p in the endoplasmic reticulum. This is the strongest experimental localization evidence for Yet2p and corroborates the family/topology-based ER-membrane assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental localization to the ER, consistent with all other evidence. Core localization (the ER membrane sub-term is the more precise form).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SWAp-Tag</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function annotated with ND (No biological Data available) by SGD. This is the honest, correct record that no specific molecular function of Yet2p has been experimentally determined — the central knowledge gap for this gene. Yet2p has no catalytic domain; the BAP31-family scaffold/adapter mode of action is inferred but not demonstrated for Yet2p.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND root MF correctly represents the current state of knowledge: the specific molecular activity of Yet2p is unknown. Retained as an accurate statement of ignorance; see knowledge_gaps. Recent work reinforces this: Yet2p is the lowest-abundance, non-constitutively-expressed family member and is argued to be functionally distinct from (not simply redundant with) Yet1p/Yet3p, so its activity cannot be assumed identical to the characterized paralogs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the BCAP29/BCAP31 family</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Yet2 does not express constitutively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q04210" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process annotated with ND by SGD (dated 2013), recording that no specific biological process has been experimentally established for Yet2p. Note that GOA also now carries newer IBA/IEA BP annotations (retrograde transport, ubiquitin-dependent catabolism, intracellular protein transport; dated 2026), so this 2013 ND row is technically stale/inconsistent with the co-existing substantive BP terms and would normally be superseded. It is retained here as a correct statement about the primary-data gap because those newer BP terms are phylogenetic/electronic family (BAP31) inferences rather than direct YET2 experimental evidence — i.e. no experimentally established biological process exists for Yet2p itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly records that the biological role of Yet2p is not experimentally defined (the co-existing IBA/IEA BP terms are family inferences, not YET2 data). Retained; see knowledge_gaps.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/YET2/YET2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">May play a role in anterograde transport of membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Yet2p is an integral, polytopic (three-transmembrane) protein of the endoplasmic reticulum membrane, a member of the BCAP29/BCAP31 (BAP31) family. Its ER-membrane residence is well established (family architecture, C-terminal di-lysine ER- retrieval motif, and direct high-throughput localization). By homology to mammalian BAP31 and its yeast paralogs, Yet2p is inferred to act as a scaffold/ adapter-type membrane protein in ER membrane-protein homeostasis and transport, but no specific molecular activity or physiological cargo has been demonstrated for Yet2p; its molecular function is genuinely unknown (see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="Q04210" data-a="FUNCTION: Yet2p is an integral, polytopic (three-transmembra..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                PMID:26928762
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">SWAp-Tag</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/YET2/YET2-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">The di-lysine motif confers endoplasmic reticulum localization</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on the manual assignment of the root term for the aspect where no biological data is available.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                            PMID:26928762
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">One library to make them all: Streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20378542" target="_blank" class="term-link">
+                            PMID:20378542
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Yet1p and Yet3p, the yeast homologs of BAP29 and BAP31, interact with the endoplasmic reticulum translocation apparatus and are required for inositol prototrophy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/YET2/YET2-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q04210 (YET2_YEAST) - domain, topology, and family annotation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/YET2/YET2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon (Edison) deep-research report for YET2 (Q04210), synthesizing BAP31-family and Yet-paralog literature.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Yet2p have a distinct molecular activity or client set from the Yet1p-Yet3p complex, and under what conditions is its (non-constitutive) expression induced — does its regulation point to a specialized role in the unfolded protein response or ERAD?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04210" data-a="Q: Does Yet2p have a distinct molecular activity or c..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What accounts for the yet2 yet3 double-deletion growth phenotype if yet2 single deletion is phenotypically silent — is Yet2p a conditional backup for Yet3p?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04210" data-a="Q: What accounts for the yet2 yet3 double-deletion gr..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purification mass spectrometry of chromosomally tagged Yet2p under basal and ER-stress (e.g. DTT/tunicamycin) conditions to identify stress-dependent interactors and candidate cargo, compared side-by-side with tagged Yet1p/Yet3p.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Yet2p acts as a stress-induced ER membrane scaffold/adapter with a client set distinct from the constitutive Yet1p-Yet3p complex.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04210" data-a="EXPERIMENT: Affinity-purification mass spectrometry of chromos..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Combinatorial deletion analysis (yet1, yet2, yet3 single/double/triple mutants) with quantitative growth, secretion (e.g. invertase/CPY), and UPR-reporter readouts under ER-stress and high-secretory-load conditions to isolate a Yet2p-specific contribution.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Yet2p contributes conditionally to a process shared with YET3, explaining the yet2 yet3 genetic interaction.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic interaction / phenotypic profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q04210" data-a="EXPERIMENT: Combinatorial deletion analysis (yet1, yet2, yet3 ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular function (molecular activity) of Yet2p is undetermined. Yet2p has no catalytic domain and SGD annotates its molecular_function as ND. Whether it acts as a cargo receptor, a scaffold/adapter for ER membrane-protein biogenesis, or in some other capacity — as inferred from the BAP31 family — has never been demonstrated for Yet2p itself.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: Yet2p is an ER polytopic membrane protein of the BCAP29/BCAP31 family with three TM helices and a C-terminal di-lysine ER-retrieval motif; it is non-essential and, unlike its paralogs, non-constitutively expressed at low abundance (Zung 2024). Its localization and family membership are firm; its molecular activity is not.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Yet2p is a conserved-family ER membrane protein whose activity is unknown despite a well-defined localization — a classic &#34;MF-dark&#34; case where rich family/CC context makes the protein look understood while the mechanism is a hole. Resolving it would clarify the division of labor within the yeast BAP31 family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical identification of Yet2p interactors/clients (e.g. affinity-purification mass spectrometry, ideally across conditions that induce Yet2p expression) and reconstitution or genetic assays testing a specific activity (cargo binding, chaperone/adapter function). A GO molecular_function term beyond the ND root should follow such data.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"May play a role in anterograde transport of membrane proteins"</em> — file:yeast/YET2/YET2-uniprot.txt</li>
+
+                <li><em>"Belongs to the BCAP29/BCAP31 family"</em> — file:yeast/YET2/YET2-uniprot.txt</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological cargo and interaction partners of Yet2p are unidentified. Unlike its paralogs Yet1p and Yet3p, which form a stable Yet1p-Yet3p complex that associates with the Sec translocation apparatus, Yet2p is not a stable member of that complex and its own binding partners are unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established (from Wilson &amp; Barlowe 2010, full text): Yet2p associates only minimally with the Yet1p-Yet3p complex and the translocation machinery, and yet2 deletion does not cause the inositol-prototrophy defect of yet1/yet3 deletion. Yet2p is therefore functionally distinct from the characterized Yet complex, but what it does associate with is not known.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying Yet2p partners/cargo is the most direct route to its function and would reveal whether the three yeast BAP31 paralogs handle distinct client sets.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Co-immunoprecipitation / crosslinking-MS of tagged Yet2p (including under ER stress), and genetic-interaction profiling to place Yet2p in a pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Yet1p forms a complex with Yet3p (Yet complex)"</em> — PMID:20378542</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role of Yet2p and its degree of functional redundancy with YET1 and YET3 are unknown. SGD annotates its biological_process as ND. Single yet2 deletion has no strong reported phenotype; the only phenotypic signal is a genetic interaction with YET3 (a yet2 yet3 double-deletion growth phenotype reported by Toikkanen et al. 2006).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: the YET genes are non-essential with partially overlapping functions, and a yet2 yet3 double disruptant shows a growth phenotype. Recent work (Zung et al. 2024) finds Yet2p is the lowest-abundance paralog and, unlike Yet1p/Yet3p, is not constitutively expressed — arguing against simple redundancy. What conditions induce Yet2p, what process it serves, and whether it backs up YET1/YET3, are all undetermined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A low-abundance, non-constitutively-expressed paralog whose role only surfaces in combination is a candidate for conditional/specialized function rather than plain redundancy; defining it would complete the functional map of the yeast BAP31 family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotypic profiling of yet2 single and yet1/yet2/yet3 combinatorial mutants under ER stress and secretory-load conditions; conditional-expression and cargo-flux assays to detect a Yet2p-specific contribution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"required for inositol
+prototrophy"</em> — PMID:20378542</li>
+
+                <li><em>"compared to Yet1 and Yet3, Yet2 does not express constitutively, which may suggest it fulfills a different function"</em> — file:yeast/YET2/YET2-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(YET2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q04210" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: YET2 (YMR040W) — Endoplasmic Reticulum Transmembrane Protein 2 in *Saccharomyces cerevisiae*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">21 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-05T14:35:24.484889</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="YET2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="YET2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-yet2-ymr040w-endoplasmic-reticulum-transmembrane-protein-2-in-saccharomyces-cerevisiae">Comprehensive Research Report: YET2 (YMR040W) — Endoplasmic Reticulum Transmembrane Protein 2 in <em>Saccharomyces cerevisiae</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>YET2 (systematic name YMR040W) encodes a polytopic integral membrane protein of the endoplasmic reticulum (ER) in <em>Saccharomyces cerevisiae</em> (strain S288c). The protein belongs to the BCAP29/BCAP31 (BAP29/BAP31) family, which is defined by the BAP29/BAP31 domain (InterPro: IPR008417; Pfam: PF05529). Yet2 is one of three paralogs in budding yeast — Yet1, Yet2, and Yet3 — collectively named "Yeast Endoplasmic reticulum Transmembrane" proteins (zung2024themolecularmechanism pages 3-5). The mammalian homologs of this family are BAP29 (BCAP29) and BAP31 (BCAP31), which are ER-resident membrane proteins involved in protein quality control, ER export, and apoptosis regulation (dancourt2010proteinsortingreceptors pages 25-26, dancourt2010proteinsortingreceptors pages 17-18). Like its paralogs, Yet2 is predicted to possess three transmembrane domains (TMDs), which constitute a large fraction of the protein sequence — a feature highly conserved across the entire BAP29/BAP31 family from yeast to humans (zung2024themolecularmechanism pages 10-12).</p>
+<h2 id="2-expression-and-abundance">2. Expression and Abundance</h2>
+<p>A critical finding from recent work by Zung et al. (2024) is that Yet2 is expressed at dramatically lower levels than its paralogs Yet1 and Yet3 under standard laboratory conditions. Western blot analysis of C-terminally GFP-tagged versions of all three paralogs expressed from their native promoters revealed that Yet3 is by far the most abundant, followed by Yet1, with Yet2 showing the lowest expression (zung2024themolecularmechanism pages 27-29). The authors specifically noted that "compared to Yet1 and Yet3, Yet2 does not express constitutively, which may suggest it fulfills a different function" (zung2024themolecularmechanism pages 10-12). This non-constitutive expression pattern distinguishes Yet2 from its paralogs and suggests that Yet2 may be conditionally regulated or serve a specialized role under particular environmental or developmental conditions.</p>
+<blockquote>
+<p>“Endogenous Yet3 is more abundant than its two paralogs Yet1 and Yet2.” The supporting western blot compared native-promoter GFP fusions of Yet1, Yet2, and Yet3 and showed Yet3 as the most abundant paralog, with Yet2 the least abundant under the tested conditions (zung2024themolecularmechanism pages 27-29).</p>
+<p>“Compared to Yet1 and Yet3, Yet2 does not express constitutively, which may suggest it fulfills a different function.” In the discussion, Zung et al. use this expression difference to argue that Yet2 is likely not simply redundant with the Yet1–Yet3 branch of the family (zung2024themolecularmechanism pages 10-12).</p>
+<p>Together, these observations support a cautious interpretation for YET2/YMR040W: it is a bona fide Yet-family/BCAP29-BCAP31-family paralog, but unlike Yet3 it is low-abundance under standard conditions and, unlike Yet1/Yet3, lacks clear constitutive expression, leaving its specific physiological role unresolved in current literature (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29).</p>
+</blockquote>
+<p><em>Blockquote: This blockquote captures the main direct statements from Zung et al. 2024 about Yet2 expression relative to Yet1 and Yet3. It is useful because it summarizes the strongest available evidence explaining why YET2 remains functionally ambiguous despite belonging to the same protein family.</em></p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>Based on its classification as an ER transmembrane protein and its membership in the BAP29/BAP31 family, Yet2 is inferred to localize to the ER membrane. However, unlike Yet3, which has been extensively characterized by fluorescence microscopy and correlative light–electron microscopy (CLEM) as a pan-ER contact site protein (localizing to ER-plasma membrane, ER-mitochondria, ER-lipid droplet, ER-vacuole, and ER-peroxisome contacts) (zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 23-25), direct localization data for Yet2 are limited due to its very low endogenous expression. The systematic global GFP-tagging study by Huh et al. (2003) assigned Yet2 an ER localization, consistent with its family membership and predicted topology.</p>
+<h2 id="4-function-what-is-known-and-what-can-be-inferred">4. Function: What is Known and What Can Be Inferred</h2>
+<h3 id="41-direct-evidence-for-yet2">4.1 Direct Evidence for Yet2</h3>
+<p>Literature specifically addressing Yet2 function is extremely limited. The available evidence characterizes Yet2 almost exclusively by its relationship to the better-studied paralogs Yet1 and Yet3. The observation that Yet2 lacks constitutive expression is the most important direct finding, as it differentiates Yet2 from Yet1 and Yet3 and implies a distinct or context-dependent role (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29).</p>
+<h3 id="42-function-inferred-from-the-yet-protein-family">4.2 Function Inferred from the Yet Protein Family</h3>
+<p>The functions of the Yet protein family are best understood through studies of Yet3 (the BAP31 homolog) and the Yet1–Yet3 heterodimer. These functions provide a framework for understanding Yet2 by family homology:</p>
+<p><strong>Ergosterol Biosynthesis and ER Contact Sites.</strong> The landmark study by Zung et al. (2024) demonstrated that Yet3 functions as a scaffold protein at ER contact sites, where it recruits all post-squalene ergosterol biosynthesis enzymes to form a metabolic complex termed the "ERGosome" (zung2024themolecularmechanism pages 1-3, zung2024themolecularmechanism pages 7-9, zung2024themolecularmechanism pages 9-10). This recruitment creates sterol-rich membrane subdomains that are essential for contact site formation and function. Yet3 was found at multiple ER contact sites through co-localization with split-Venus reporters and known tethering proteins, including Tcb2/Lam2 (ER-PM), Lam6/Mmm1 (ER-mitochondria), Nvj1/Nvj2 (ER-vacuole), and Num1/Mdm36 (MECA) (zung2024themolecularmechanism pages 3-5). AlphaFold2 predictions suggest that a Yet3 homotrimer can form a hydrophobic pocket potentially capable of binding ergosterol, which may slow sterol diffusion in the ER membrane and maintain high sterol concentration in subdomains (zung2024themolecularmechanism pages 10-12).</p>
+<p><strong>Inositol Biosynthesis Regulation.</strong> Yet1 and Yet3 form a heterodimeric complex that, together with the yeast VAP protein Scs2, sequesters the transcriptional repressor Opi1 at the nuclear ER membrane under inositol-depleted conditions (zung2024themolecularmechanism pages 5-7, zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 27-29). This prevents Opi1 from entering the nucleus and repressing Ino2/Ino4 transcriptional targets involved in phospholipid biosynthesis. Importantly, Zung et al. demonstrated that Yet3's effects on organelle architecture and sterol distribution are independent of the Opi1 pathway, indicating that Yet3 has at least two separable functions: one as part of the Yet1–Yet3 heterodimer for inositol regulation, and another as an independent scaffold for ERGosome assembly (zung2024themolecularmechanism pages 5-7, zung2024themolecularmechanism pages 7-9).</p>
+<p><strong>Protein Quality Control and ER-Associated Degradation (ERAD).</strong> In <em>Kluyveromyces marxianus</em>, Yet3 has been shown to function in the ERAD pathway. Overexpression of YET3 reduced secretory expression of heterologous proteins, while its deletion improved secretion, suggesting that Yet3 targets misfolded or heterologous proteins for ERAD-mediated degradation (shi2021characterizationandmodulation pages 9-12). In mammalian cells, BAP31 associates with the Sec61 translocon and TRAM (translocation-associated membrane protein) and interacts with Derlin-1, coupling protein translocation with quality control mechanisms (christine2009htm1pfunctionin pages 80-84). In yeast, Yet3 similarly binds the SEC translocon complex, which may facilitate translocation of specific substrates such as GPI-anchored proteins that require sterol-rich and sphingolipid-rich membrane environments (zung2024themolecularmechanism pages 9-10).</p>
+<p><strong>Calreticulin Exposure and Cell Death.</strong> Yet3, as the yeast BAP31 homolog, is required for the conserved preapoptotic calreticulin exposure pathway. Deletion of YET3 abolishes the stress-induced translocation of Cne1 (the yeast calreticulin ortholog) to the cell surface, a process that also depends on the PERK ortholog Gcn2 and SNARE proteins Nyv1 and Sso1 (madeo2009phylogeneticconservationof pages 2-4, madeo2009phylogeneticconservationof pages 1-2, madeo2009phylogeneticconservationof pages 4-5).</p>
+<p><strong>ER Stress and Ire1 Clustering.</strong> Yet3 is upregulated upon UPR induction and accumulates in specific ER subdomains during ER stress, supporting Ire1 clustering that is necessary for sustained UPR activation. Dysfunctional Yet3 cannot support proper Ire1 assembly, suggesting that Yet3-mediated sterol enrichment at ER subdomains is important for the ER stress response (zung2024themolecularmechanism pages 9-10).</p>
+<h3 id="43-bap29bap31-family-context">4.3 BAP29/BAP31 Family Context</h3>
+<p>The mammalian BAP31 and BAP29 proteins function as ER-resident sorting factors that deliver newly synthesized membrane proteins to specific ER complexes mediating export, retention, or degradation (dancourt2010proteinsortingreceptors pages 25-26, christine2009htm1pfunctionin pages 80-84, dancourt2010proteinsortingreceptors pages 17-18). BAP31 promotes ER export of MHC class I molecules and cellubrevin, participates in retention of unassembled IgD, and facilitates retrotranslocation of misfolded proteins such as CFTRΔF508 via the Derlin-1 complex (dancourt2010proteinsortingreceptors pages 25-26, dancourt2010proteinsortingreceptors pages 17-18). Whether Yet2 specifically fulfills any of these roles in yeast remains untested.</p>
+<h2 id="5-comparison-of-the-three-yet-paralogs">5. Comparison of the Three Yet Paralogs</h2>
+<p>The following table summarizes the key differences and similarities among the three Yet-family paralogs in <em>S. cerevisiae</em>:</p>
+<table>
+<thead>
+<tr>
+<th>Gene name</th>
+<th>Systematic name</th>
+<th>Mammalian homolog</th>
+<th>Expression level</th>
+<th>Key functions</th>
+<th>Known interactions</th>
+<th>Localization</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Yet1</td>
+<td>YGL080W</td>
+<td>BAP29 homolog</td>
+<td>Lower than Yet3, higher than Yet2 under endogenous conditions; constitutively expressed (zung2024themolecularmechanism pages 27-29)</td>
+<td>Forms a Yet1–Yet3 heterodimer that regulates inositol biosynthesis by controlling Opi1 sequestration at the nuclear ER during inositol depletion; modulates Yet3 distribution and thereby indirectly affects ergosterol distribution (zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 7-9, zung2024themolecularmechanism pages 27-29)</td>
+<td>Opi1, Scs2, Yet3; genetically/functionally linked to Sec61/BAP31-family sorting-factor biology by family homology and prior literature context (zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 27-29, zung2024themolecularmechanism pages 10-12, christine2009htm1pfunctionin pages 80-84)</td>
+<td>Endoplasmic reticulum; more homogeneous ER distribution than Yet3 when overexpressed (zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 27-29)</td>
+</tr>
+<tr>
+<td>Yet2</td>
+<td>YMR040W</td>
+<td>BCAP29/BCAP31-family paralog; specific one-to-one mammalian counterpart not established from available direct evidence</td>
+<td>Very low abundance under endogenous conditions; not constitutively expressed; lower than Yet1 and far lower than Yet3 (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29)</td>
+<td>Specific function remains unclear; inferred to be an ER membrane member of the Yet/BAP29-BAP31 family and likely to have a distinct role from Yet1/Yet3 because of its low/non-constitutive expression (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29)</td>
+<td>No specific direct interactions identified in the retrieved YET2-focused evidence (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29)</td>
+<td>Inferred ER transmembrane protein from UniProt/family assignment; direct localization evidence for Yet2 was not found in the retrieved literature (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29)</td>
+</tr>
+<tr>
+<td>Yet3</td>
+<td>YOR152C</td>
+<td>BAP31 homolog</td>
+<td>Highest of the three paralogs under endogenous conditions; constitutively expressed (zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 7-9, zung2024themolecularmechanism pages 27-29)</td>
+<td>Pan-ER contact-site protein; recruits post-squalene ergosterol biosynthesis enzymes (ERGosome) to ER subdomains/contact sites to generate sterol-rich domains; regulates sterol distribution; also participates with Yet1 in Opi1/inositol regulation; implicated in ER stress-related Ire1 clustering and additional ER subdomain functions (zung2024themolecularmechanism pages 1-3, zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 7-9, zung2024themolecularmechanism pages 9-10, zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 25-27, zung2024themolecularmechanism pages 29-31)</td>
+<td>All post-squalene ergosterol biosynthesis enzymes, Yet1, Opi1, Scs2/Scs22, Sec translocon, Sey1, Yop1; family context links BAP31 proteins to Derlin-1/TRAM/Sec61-associated quality control (zung2024themolecularmechanism pages 5-7, zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 7-9, zung2024themolecularmechanism pages 9-10, zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 25-27, dancourt2010proteinsortingreceptors pages 25-26, christine2009htm1pfunctionin pages 80-84)</td>
+<td>ER membrane; enriched at multiple ER contact sites including ER–PM, ER–mitochondria, ER–LD, ER–vacuole, and ER–peroxisome contacts; accumulates in ER subdomains/puncta under overexpression or sterol stress (zung2024themolecularmechanism pages 1-3, zung2024themolecularmechanism pages 3-5, zung2024themolecularmechanism pages 7-9, zung2024themolecularmechanism pages 9-10, zung2024themolecularmechanism pages 25-27, zung2024themolecularmechanism pages 29-31)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the three Saccharomyces cerevisiae Yet-family paralogs across expression, function, interactions, and localization. It is useful for distinguishing the poorly characterized YET2 protein from the much better studied Yet1/Yet3 branch of the BCAP29/BCAP31 family.</em></p>
+<h2 id="6-relationship-between-yet1-and-yet3-implications-for-yet2">6. Relationship Between Yet1 and Yet3 — Implications for Yet2</h2>
+<p>A key finding from Zung et al. (2024) is that Yet1 modulates Yet3 function. When Yet1 is present, it heterodimerizes with Yet3, recruiting it to the Opi1 regulatory pathway. When Yet1 is absent or reduced — or when Yet3 levels are elevated — Yet3 functions independently as a scaffold for ERGosome formation at ER contact sites (zung2024themolecularmechanism pages 10-12). Deletion of <em>yet1</em> promotes accumulation of Yet3 in ER subdomains (reminiscent of Yet3 overexpression) and also influences ergosterol distribution (zung2024themolecularmechanism pages 29-31). This regulatory interplay raises the question of whether Yet2, as the third paralog, could serve a similar modulatory function under specific conditions, potentially competing with Yet1 for Yet3 heterodimerization or fulfilling an analogous role under stress conditions that induce its expression.</p>
+<h2 id="7-biochemical-pathways">7. Biochemical Pathways</h2>
+<p>Yet2 has not been directly assigned to specific biochemical pathways, but by family inference, it is predicted to function in pathways involving:</p>
+<ul>
+<li><strong>Ergosterol biosynthesis regulation</strong> — through potential interactions with post-squalene enzymes or ERGosome scaffolding, as demonstrated for Yet3 (zung2024themolecularmechanism pages 7-9).</li>
+<li><strong>Phospholipid/inositol metabolism</strong> — the Yet1-Yet3 heterodimer controls Opi1-dependent regulation of phospholipid gene expression; Yet2 may participate in related regulatory circuits under non-standard conditions (zung2024themolecularmechanism pages 5-7, zung2024themolecularmechanism pages 27-29).</li>
+<li><strong>ER protein quality control</strong> — BAP31 family members are implicated in ERAD and ER export pathways (dancourt2010proteinsortingreceptors pages 25-26, christine2009htm1pfunctionin pages 80-84, shi2021characterizationandmodulation pages 9-12).</li>
+</ul>
+<h2 id="8-summary-and-open-questions">8. Summary and Open Questions</h2>
+<p>Yet2 (YMR040W) is an ER transmembrane protein of the BCAP29/BCAP31 family in <em>Saccharomyces cerevisiae</em>, paralogous to Yet1 and Yet3. While its paralogs — particularly Yet3 — have been extensively characterized as ER contact site scaffold proteins that organize ergosterol biosynthesis, regulate inositol metabolism, and participate in protein quality control and the ER stress response, Yet2 itself remains poorly characterized in the primary literature. The strongest available evidence indicates that Yet2 is expressed at very low, non-constitutive levels compared to Yet1 and Yet3, suggesting that it may be conditionally regulated and serve a specialized or context-dependent function (zung2024themolecularmechanism pages 10-12, zung2024themolecularmechanism pages 27-29). Its domain architecture (three predicted TMDs with the BAP29/BAP31 domain) is consistent with a role similar to its better-studied family members, but specific substrates, interaction partners, and conditions under which Yet2 is functionally relevant remain to be elucidated.</p>
+<p>Future studies directly examining Yet2 expression under various stress conditions (e.g., ER stress, nutrient depletion, or altered sterol homeostasis), its potential to heterodimerize with Yet1 or Yet3, and its localization under inducing conditions will be essential for understanding the distinct biological role of this enigmatic member of the BAP29/BAP31 family.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(zung2024themolecularmechanism pages 3-5): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(dancourt2010proteinsortingreceptors pages 25-26): Julia Dancourt and Charles Barlowe. Protein sorting receptors in the early secretory pathway. Annual review of biochemistry, 79:777-802, Jun 2010. URL: https://doi.org/10.1146/annurev-biochem-061608-091319, doi:10.1146/annurev-biochem-061608-091319. This article has 382 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dancourt2010proteinsortingreceptors pages 17-18): Julia Dancourt and Charles Barlowe. Protein sorting receptors in the early secretory pathway. Annual review of biochemistry, 79:777-802, Jun 2010. URL: https://doi.org/10.1146/annurev-biochem-061608-091319, doi:10.1146/annurev-biochem-061608-091319. This article has 382 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 10-12): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 27-29): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 23-25): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 1-3): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 7-9): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 9-10): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 5-7): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(shi2021characterizationandmodulation pages 9-12): Tianfang Shi, Jungang Zhou, Aijuan Xue, Hong Lu, Yun-Chun He, and Yao Yu. Characterization and modulation of endoplasmic reticulum stress response target genes in kluyveromyces marxianus to improve secretory expressions of heterologous proteins. Biotechnology for Biofuels, Dec 2021. URL: https://doi.org/10.1186/s13068-021-02086-7, doi:10.1186/s13068-021-02086-7. This article has 22 citations.</p>
+</li>
+<li>
+<p>(christine2009htm1pfunctionin pages 80-84): Simone Christine Clerc. Htm1p function in er-associated protein degradation. ArXiv, 2009. URL: https://doi.org/10.3929/ethz-a-005911904, doi:10.3929/ethz-a-005911904. This article has 0 citations.</p>
+</li>
+<li>
+<p>(madeo2009phylogeneticconservationof pages 2-4): Frank Madeo, Michael Durchschlag, Oliver Kepp, Theocharis Panaretakis, Laurence Zitvogel, Kai-Uwe Fröhlich, and Guido Kroemer. Phylogenetic conservation of the preapoptotic calreticulin exposure pathway from yeast to mammals. Cell Cycle, 8:639-642, Feb 2009. URL: https://doi.org/10.4161/cc.8.4.7794, doi:10.4161/cc.8.4.7794. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(madeo2009phylogeneticconservationof pages 1-2): Frank Madeo, Michael Durchschlag, Oliver Kepp, Theocharis Panaretakis, Laurence Zitvogel, Kai-Uwe Fröhlich, and Guido Kroemer. Phylogenetic conservation of the preapoptotic calreticulin exposure pathway from yeast to mammals. Cell Cycle, 8:639-642, Feb 2009. URL: https://doi.org/10.4161/cc.8.4.7794, doi:10.4161/cc.8.4.7794. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(madeo2009phylogeneticconservationof pages 4-5): Frank Madeo, Michael Durchschlag, Oliver Kepp, Theocharis Panaretakis, Laurence Zitvogel, Kai-Uwe Fröhlich, and Guido Kroemer. Phylogenetic conservation of the preapoptotic calreticulin exposure pathway from yeast to mammals. Cell Cycle, 8:639-642, Feb 2009. URL: https://doi.org/10.4161/cc.8.4.7794, doi:10.4161/cc.8.4.7794. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 25-27): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+<li>
+<p>(zung2024themolecularmechanism pages 29-31): Naama Zung, Nitya Aravindan, Angela Boshnakovska, Rosario Valenti, Noga Preminger, Felix Jonas, Gilad Yaakov, Mathilda M. Willoughby, Bettina Homberg, Jenny Keller, Meital Kupervaser, Nili Dezorella, Tali Dadosh, Sharon G. Wolf, Maxim Itkin, Sergey Malitsky, Alexander Brandis, Naama Barkai, Rubén Fernández-Busnadiego, Amit R. Reddi, Peter Rehling, Doron Rapaport, and Maya Schuldiner. The molecular mechanism of on-demand sterol biosynthesis at organelle contact sites. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.09.593285, doi:10.1101/2024.05.09.593285. This article has 4 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="YET2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="YET2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zung2024themolecularmechanism pages 3-5</li>
+<li>zung2024themolecularmechanism pages 10-12</li>
+<li>zung2024themolecularmechanism pages 27-29</li>
+<li>shi2021characterizationandmodulation pages 9-12</li>
+<li>zung2024themolecularmechanism pages 9-10</li>
+<li>zung2024themolecularmechanism pages 29-31</li>
+<li>zung2024themolecularmechanism pages 7-9</li>
+<li>dancourt2010proteinsortingreceptors pages 25-26</li>
+<li>dancourt2010proteinsortingreceptors pages 17-18</li>
+<li>zung2024themolecularmechanism pages 23-25</li>
+<li>zung2024themolecularmechanism pages 1-3</li>
+<li>zung2024themolecularmechanism pages 5-7</li>
+<li>madeo2009phylogeneticconservationof pages 2-4</li>
+<li>madeo2009phylogeneticconservationof pages 1-2</li>
+<li>madeo2009phylogeneticconservationof pages 4-5</li>
+<li>zung2024themolecularmechanism pages 25-27</li>
+<li>https://doi.org/10.1101/2024.05.09.593285,</li>
+<li>https://doi.org/10.1146/annurev-biochem-061608-091319,</li>
+<li>https://doi.org/10.1186/s13068-021-02086-7,</li>
+<li>https://doi.org/10.3929/ethz-a-005911904,</li>
+<li>https://doi.org/10.4161/cc.8.4.7794,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(YET2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q04210" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="yet2-q04210-ymr040w-review-notes">YET2 (Q04210 / YMR040W) review notes</h1>
+<p>Journal for the AI GO-annotation review of <em>Saccharomyces cerevisiae</em> <strong>YET2</strong> (systematic<br />
+name YMR040W; standard name YET2 = "Yeast ER Transmembrane 2"). This is an <strong>understudied<br />
+("dark") gene</strong>: SGD records molecular_function and biological_process as ND ("No biological<br />
+Data available"). The primary deliverable is an honest <code>knowledge_gaps</code> section plus<br />
+carefully-reasoned <code>description</code>/<code>core_functions</code> grounded in domain architecture, orthology,<br />
+and the thin literature — never invented function.</p>
+<h2 id="identity-fetch-provenance">Identity / fetch provenance</h2>
+<ul>
+<li>Bare symbol <code>YET2</code> did not create the gene folder on the first <code>just fetch-gene</code> attempts<br />
+  (shared machine under heavy parallel load; empty output). Resolved identity directly against<br />
+  UniProt REST: <code>gene:YET2 AND organism_id:559292</code> → <strong>Q04210</strong>, <code>YET2_YEAST</code>,<br />
+  "Endoplasmic reticulum transmembrane protein 2", 160 aa, systematic name YMR040W, SGD<br />
+  S000004643. Re-fetched successfully with <code>--uniprot-id Q04210</code>.</li>
+<li>Files written to <code>genes/yeast/YET2/</code>: <code>YET2-uniprot.txt</code>, <code>YET2-goa.tsv</code>,<br />
+<code>YET2-ai-review.yaml</code> (10 GOA annotations seeded).</li>
+</ul>
+<h2 id="domain-topology-analysis-from-yet2-uniprottxt-inline-no-sub-agent">Domain / topology analysis (from YET2-uniprot.txt, inline — no sub-agent)</h2>
+<ul>
+<li><strong>Family</strong>: BCAP29/BCAP31 (BAP29/BAP31) family. Pfam PF05529 (Bap31); InterPro IPR008417<br />
+  (BAP29/BAP31) + IPR040463 (BAP29/BAP31_N); PANTHER PTHR12701 ("BCR-ASSOCIATED PROTEIN, BAP"),<br />
+  subfamily PTHR12701:SF19 ("ENDOPLASMIC RETICULUM TRANSMEMBRANE PROTEIN 1-RELATED").<br />
+  [file:yeast/YET2/YET2-uniprot.txt "SIMILARITY: Belongs to the BCAP29/BCAP31 family"]</li>
+<li><strong>Topology</strong> (small, 160 aa, ~19 kDa): three predicted TM helices — TM1 3–23, TM2 46–66,<br />
+  TM3 104–124 — with N-terminus lumenal (1–2), a cytoplasmic loop 24–45, a large lumenal loop<br />
+  67–103, and a C-terminal cytoplasmic tail 125–160. This is the canonical BAP31-type<br />
+  triple-membrane-spanning architecture. [file:yeast/YET2/YET2-uniprot.txt TRANSMEM 3..23 /<br />
+  46..66 / 104..124]</li>
+<li><strong>C-terminal cytoplasmic tail (125–160)</strong> is charged/leucine-rich<br />
+  (<code>...KEKLRRKQKYLEELQKKKF</code>), consistent with the coiled-coil "cytosolic" region that in<br />
+  mammalian BAP31 mediates protein–protein interactions and apoptosis signaling.</li>
+<li><strong>C-terminal di-lysine ER-retrieval motif</strong>: MOTIF 157–160 (di-lysine motif). The tail ends<br />
+<code>...QKKKF</code>, a KKxx-type COPI-retrieval signal. [file:yeast/YET2/YET2-uniprot.txt "The<br />
+  di-lysine motif confers endoplasmic reticulum localization for type I membrane proteins"]<br />
+  → strong structural basis for steady-state ER-membrane residence.</li>
+<li>UniProt FUNCTION (from Ref. 3 = Toikkanen 2006): "May play a role in anterograde transport<br />
+  of membrane proteins from the endoplasmic reticulum to the Golgi." Note the hedge "May" —<br />
+  UniProt itself marks this as tentative. [file:yeast/YET2/YET2-uniprot.txt]</li>
+</ul>
+<p>Interpretation: domain architecture robustly places YET2 as an <strong>ER polytopic membrane protein<br />
+of the BAP31 family</strong>. Architecture supports a <em>scaffold/adapter</em> mode of action (three TM<br />
+helices + cytosolic coiled-coil tail, like BAP31) but does <strong>not</strong> encode any catalytic<br />
+domain — consistent with MF = ND. Localization (ER membrane) is well supported; a <em>specific<br />
+molecular activity and physiological cargo</em> are the core unknowns.</p>
+<h2 id="literature-landscape-separating-yet2-from-yet1yet3-and-bap31bap29">Literature landscape — separating YET2 from YET1/YET3 and BAP31/BAP29</h2>
+<p>The yeast BAP31 family has three paralogs. Attribution matters: most mechanistic work is on the<br />
+<strong>Yet1p–Yet3p complex</strong>, NOT Yet2p.</p>
+<ol>
+<li>
+<p><strong>Toikkanen, Fatal, Hilden, Makarow, Kuismanen (2006)</strong>, "YET1, YET2 and YET3 of<br />
+<em>Saccharomyces cerevisiae</em> encode BAP31 homologs with partially overlapping functions",<br />
+<em>J. Biol. Sci. (Faisalabad)</em> 6:446-456. DOI 10.3923/jbs.2006.446.456. <strong>This is the sole<br />
+   YET2-naming/function paper and it is NOT indexed in PubMed</strong> (low-tier journal; no PMID —<br />
+   confirmed by search and by UniProt citing it as "Ref. 3" without a PMID). Abstract<br />
+   (verbatim, from scialert): the three ORFs are YKL065C (YET1), <strong>YMR040W (YET2)</strong>, YDL072C<br />
+   (YET3); "YET genes were not essential for viability"; "disruption of YET1 increased and<br />
+   YET3 decreased the cell growth"; in "yet1Δ yet3Δ and <strong>yet2Δ yet3Δ</strong> double disruptant<br />
+   cells the growth was restored to the level observed in the wild type cells"; "Yet proteins<br />
+   have partially specialized, but overlapping functions"; "yet3Δ cells showed a defect in<br />
+   invertase secretion." → YET2-specific content is minimal: only its systematic-name<br />
+   assignment and its participation in a <code>yet2Δ yet3Δ</code> epistasis (growth restoration).<br />
+   No YET2-specific molecular activity is reported.</p>
+</li>
+<li>
+<p><strong>Wilson JD, Barlowe C (2010)</strong>, "Yet1p and Yet3p, the yeast homologs of BAP29 and BAP31,<br />
+   interact with the endoplasmic reticulum translocation apparatus and are required for<br />
+   inositol prototrophy", <em>J Biol Chem</em> 285:18252-61. <strong>PMID:20378542</strong> (cached<br />
+   abstract-only; PMCID PMC2881749). This is the key mechanistic paper but it is about the<br />
+<strong>Yet1p–Yet3p (BAP29/BAP31) complex</strong>: Yet1p forms a complex with Yet3p; the Yet complex<br />
+   is NOT efficiently packaged into COPII vesicles (so does not act as an ER export receptor);<br />
+   a fraction associates with the Sec translocation complex; associations increase under ER<br />
+   stress; yet1Δ and yet3Δ show inositol-starvation growth defects. YET2-specific findings<br />
+   (from the full text, seen via PMC/WebFetch but NOT in the cached abstract — so NOT<br />
+   quotable as verbatim supporting_text): <strong>Yet2p is DTT/UPR-inducible</strong> ("undetectable in the<br />
+   absence of DTT but clearly present after DTT exposure"), Yet2p shows <strong>minimal association</strong><br />
+   with the Yet1p–Yet3p complex and the translocation machinery, and <strong>yet2Δ cells do NOT show<br />
+   the inositol prototrophy defect</strong> seen for yet1Δ/yet3Δ. → Yet2p is the outlier: not part of<br />
+   the characterized Yet1p–Yet3p complex, stress-inducible, function unknown.</p>
+</li>
+<li>
+<p><strong>Wilson JD, Barlowe C (2011)</strong> (follow-up), "Yet1p–Yet3p interacts with Scs2p–Opi1p to<br />
+   regulate ER localization of the Opi1p repressor", <em>Mol Biol Cell</em> (DOI 10.1091/mbc.e10-07-0559).<br />
+   Again about the Yet1p–Yet3p complex (phospholipid/inositol INO1 regulation via Opi1p), not<br />
+   Yet2p.</p>
+</li>
+<li>
+<p>Mammalian ortholog context (for family reasoning only; do NOT attribute to YET2 as fact):</p>
+</li>
+<li>
+<p><strong>Human BAP31 = BCAP31 / P51572</strong> (BAP31_HUMAN) — this is the IBA source<br />
+     (<code>UniProtKB:P51572</code>, PANTHER PTN000294723) for all YET2 phylogenetic annotations. BAP31<br />
+     is a cargo/quality-control chaperone and ER-export/retention factor and an apoptosis<br />
+     regulator. [PMID:15024066 — human BAP31 regulates ERAD turnover of PTP-like B;<br />
+     PMID:31206022 — BAP31–Tom40 at ER–mitochondria interface.] These are ortholog papers,<br />
+     not YET2 evidence.</p>
+</li>
+<li>
+<p><strong>PMID:26928762</strong> (Yofe et al., "One library to make them all: streamlining the creation of<br />
+   yeast libraries via a SWAp-Tag strategy", <em>Nat Methods</em> 2016) — the HDA source in GOA for<br />
+<code>endoplasmic reticulum</code> localization (ECO:0007005). High-throughput C-terminal tagging /<br />
+   localization library; supports ER localization of YET2 as an observation, not a functional<br />
+   characterization.</p>
+</li>
+</ol>
+<h2 id="known-vs-not-known-for-yet2-adjudicated">KNOWN vs NOT-known for YET2 (adjudicated)</h2>
+<p>KNOWN (well supported):<br />
+- ER membrane protein, polytopic (3 TM), BAP31 family — domain + HDA localization + IBA + IEA<br />
+  all converge. C-terminal di-lysine motif gives a mechanistic basis for ER residence.<br />
+- Non-essential; a genetic interaction with YET3 (yet2Δ yet3Δ growth phenotype) exists<br />
+  (Toikkanen 2006).<br />
+- Stress/UPR-inducible expression (Wilson &amp; Barlowe 2010, full text).</p>
+<p>NOT known (genuine gaps):<br />
+- <strong>Molecular function</strong>: no catalytic domain; MF = ND in SGD. Whether YET2 acts as a<br />
+  cargo-receptor/scaffold (BAP31-like) is inferred from family, never demonstrated for Yet2p.<br />
+- <strong>Physiological cargo/client</strong> proteins of Yet2p: undetermined.<br />
+- <strong>Mechanism / complex membership</strong>: Yet2p is NOT a stable member of the Yet1p–Yet3p complex<br />
+  (Wilson &amp; Barlowe 2010); its own partners are unknown.<br />
+- <strong>Biological role &amp; redundancy</strong>: whether YET2 is functionally redundant with YET1/YET3, and<br />
+  what unique role (if any) its stress-inducibility serves, is unknown. BP = ND in SGD.<br />
+- <strong>Phenotype</strong>: single yet2Δ has no reported strong phenotype (0 hits in 10 CRISPR screens,<br />
+  BioGRID-ORCS); the only phenotypic signal is epistatic (yet2Δ yet3Δ).</p>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>Falcon deep research was attempted three times (<code>just deep-research-falcon yeast YET2</code>,<br />
+with a <code>--fallback perplexity-lite</code> on the first attempt). All falcon runs hit the 600 s<br />
+provider timeout with no output; the perplexity-lite fallback failed with a 401 quota error<br />
+("insufficient_quota"). No <code>YET2-deep-research-*.md</code> file was produced. This review is<br />
+therefore grounded directly in the UniProt record (Q04210), the GOA TSV, and manually<br />
+verified cached/primary literature (PMID:20378542 abstract; PMID:26928762; the Toikkanen 2006<br />
+naming paper via its DOI/scialert abstract; human ortholog BAP31 = P51572 papers for family<br />
+context). No fabricated deep-research content was substituted.</p>
+<p>UPDATE: A genuine falcon deep-research file <em>did</em> eventually land<br />
+(<code>YET2-deep-research-falcon.md</code>, 294 lines, 21 citations; the Edison call ran<br />
+14:07-14:35 = 1703 s, exceeding the recipe's 600 s timeout so the recipe reported<br />
+failure, but the underlying job completed and wrote the file after disk space was<br />
+freed). It is retained and cited. Its most valuable YET2-specific content comes from<br />
+<strong>Zung et al. 2024</strong> (bioRxiv 10.1101/2024.05.09.593285, "The molecular mechanism of<br />
+on-demand sterol biosynthesis at organelle contact sites"): Yet2 is the<br />
+<strong>lowest-abundance</strong> yeast BAP31 paralog and, unlike Yet1/Yet3, is <strong>not<br />
+constitutively expressed</strong> — the authors argue this means Yet2 is "likely not simply<br />
+redundant with the Yet1-Yet3 branch" and "may ... fulfill a different function." This<br />
+directly corroborates the paralog-distinction and functional-role knowledge gaps. The<br />
+report otherwise documents the well-studied Yet3 (ergosterol/ERGosome scaffold at ER<br />
+contact sites) and Yet1-Yet3 (Opi1/inositol regulation) functions — paralog context,<br />
+NOT YET2 evidence. (Falcon's table lists Yet3 = YOR152C, which is an error; UniProt and<br />
+Toikkanen give Yet3 = YDL072C — the review uses the correct systematic name.) Per<br />
+project memory, falcon <code>file:</code> quotes are not substring-validated, so the two quotes<br />
+used from this file were grep-verified against it before use.</p>
+<p>Note on the Toikkanen 2006 reference: DOI 10.3923/jbs.2006.446.456 (J. Biol. Sci. Faisalabad)<br />
+is not PubMed-indexed and its full text is not downloadable (the reference validator 403s on<br />
+it), so it cannot serve as a formally validated reference nor supply verbatim supporting_text.<br />
+Its (thin) YET2-specific content — the YMR040W=YET2 naming and the yet2Δ yet3Δ genetic<br />
+interaction — is described in prose in the relevant <code>review.reason</code>/knowledge-gap fields, with<br />
+formal provenance anchored to the UniProt file (which cites Toikkanen as its Ref. 3 FUNCTION<br />
+source) and to PMID:20378542.</p>
+<h2 id="goa-annotation-triage-10-annotations">GOA annotation triage (10 annotations)</h2>
+<p>CC:<br />
+- GO:0005789 ER membrane (IBA, is_active_in) → ACCEPT (family + direct localization). Core.<br />
+- GO:0005789 ER membrane (IEA, GO_REF:0000044 UniProt-SubCell) → ACCEPT (redundant, correct).<br />
+- GO:0005783 ER (IEA, InterPro) → ACCEPT (correct but less specific than membrane).<br />
+- GO:0005783 ER (HDA, PMID:26928762) → ACCEPT (experimental localization).<br />
+- GO:0016020 membrane (IEA, InterPro) → ACCEPT but non-core (generic parent of ER membrane).</p>
+<p>BP (all IBA from mammalian BAP31, or IEA InterPro — family inferences, no YET2 direct evidence):<br />
+- GO:0030970 retrograde protein transport, ER to cytosol (IBA) → KEEP_AS_NON_CORE. ERAD<br />
+  dislocation role of BAP31; plausible for the family (Yet complex sits at the Sec translocon)<br />
+  but never shown for Yet2p. Non-core, family-level inference.<br />
+- GO:2000060 positive regulation of ubiquitin-dependent protein catabolic process (IBA) →<br />
+  KEEP_AS_NON_CORE. ERAD-regulation inference from BAP31; no YET2 direct evidence.<br />
+- GO:0006886 intracellular protein transport (IEA, InterPro) → KEEP_AS_NON_CORE. Generic;<br />
+  consistent with the family's ER-export/protein-transport theme (UniProt FUNCTION hedge).</p>
+<p>MF/BP root:<br />
+- GO:0003674 molecular_function ND (SGD, GO_REF:0000015) → this is the honest "MF unknown"<br />
+  placeholder. Keep as the dark-gene signal; action ACCEPT (it correctly records ignorance).<br />
+- GO:0008150 biological_process ND (SGD) → likewise ACCEPT (records that BP is uncurated/unknown).</p>
+<p>I will NOT REMOVE any experimental annotation on paralog grounds. The IBA BP terms are<br />
+family-level inferences from BAP31; I mark them KEEP_AS_NON_CORE rather than REMOVE because they<br />
+are biologically plausible for the family and the Yet complex genuinely localizes to the<br />
+translocon — but they are not YET2-demonstrated, so they are non-core.</p>
+<h2 id="core-function-stance">Core function stance</h2>
+<p>Only two things are defensible as YET2 core:<br />
+1. Localization: integral ER-membrane protein (GO:0005789), scaffolded by 3 TM helices + a<br />
+   di-lysine ER-retrieval motif. This is a <code>locations</code> fact, not an MF.<br />
+2. A <em>putative</em> BAP31-family scaffold/adapter mode of action in ER membrane-protein<br />
+   homeostasis/transport — but this is inference, not demonstrated, so <code>core_functions</code> must<br />
+   flag it as such (and the MF is genuinely unknown → knowledge_gaps).</p>
+<p>I will keep <code>core_functions</code> minimal and honest: one entry anchoring the ER-membrane<br />
+localization and the family-inferred (but unproven) role in ER membrane-protein<br />
+transport/homeostasis, with explicit deferral of the specific MF to knowledge_gaps.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q04210
+gene_symbol: YET2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  YET2 (Yet2p, systematic name YMR040W) is a small (160 aa, ~19 kDa) polytopic
+  integral membrane protein of the endoplasmic reticulum in Saccharomyces cerevisiae.
+  It is one of three budding-yeast members of the BCAP29/BCAP31 (BAP29/BAP31) family
+  — Yet1p, Yet2p and Yet3p — that are homologs of the mammalian B-cell receptor-
+  associated proteins BAP29 and BAP31, ER membrane proteins implicated in ER quality
+  control, ER export of secretory cargo, and apoptosis. Yet2p has the canonical
+  BAP31-type architecture: three transmembrane helices with a lumenal N-terminus, a
+  large lumenal loop, and a charged, leucine-rich cytoplasmic C-terminal tail ending
+  in a di-lysine (KKxx-type) ER-retrieval motif that supports its steady-state ER
+  membrane residence. The gene is non-essential; Yet2p is the lowest-abundance member
+  of the family and, unlike its paralogs, is not constitutively expressed, implying
+  conditional regulation whose triggers are not established. Unlike its paralogs Yet1p
+  and Yet3p, which form a stable Yet1p-Yet3p
+  complex associated with the Sec translocation apparatus and are required for
+  inositol prototrophy, Yet2p is not a stable member of that complex and has no
+  demonstrated molecular activity or defined physiological cargo; its specific
+  molecular function remains uncharacterized.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms.
+- id: GO_REF:0000015
+  title: Gene Ontology annotation based on the manual assignment of the root term for the aspect where no biological data is available.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping.
+- id: PMID:26928762
+  title: &#39;One library to make them all: Streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput SWAp-Tag / C-terminal GFP localization library (Yofe et al.,
+      Nat Methods 2016). Source of the HDA endoplasmic reticulum localization
+      annotation (ECO:0007005). Supports ER localization of Yet2p as a systematic
+      observation; not a functional characterization of the gene.
+- id: PMID:20378542
+  title: Yet1p and Yet3p, the yeast homologs of BAP29 and BAP31, interact with the endoplasmic reticulum translocation apparatus and are required for inositol prototrophy.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Wilson &amp; Barlowe 2010 (J Biol Chem). The key mechanistic paper on the yeast
+      BAP31 family, but it characterizes the Yet1p-Yet3p complex, not Yet2p. The
+      cached record is abstract-only (full_text_available: false); the abstract
+      establishes that the Yet complex associates with the Sec translocation apparatus
+      and that this association increases under ER stress, and that yet1/yet3 deletions
+      cause inositol-starvation growth defects. NOTE (reviewer inference, NOT quotable
+      from the abstract-only cache): the PMC2881749 full text additionally indicates
+      that yet2 deletion does not confer the inositol-prototrophy defect and that Yet2p
+      associates only minimally with the Yet1p-Yet3p complex — consistent with the
+      abstract&#39;s Yet1/Yet3-only framing and with Zung 2024, but treated here as
+      inference rather than a verified quote. This reference directly informs the
+      YET2-vs-paralog attribution and the knowledge gaps. (The original naming paper,
+      Toikkanen et al. 2006, J. Biol. Sci. Faisalabad, DOI 10.3923/jbs.2006.446.456,
+      which assigned YMR040W=YET2 and reported a yet2 yet3 double-deletion growth
+      phenotype, is not PubMed-indexed and its text is not retrievable, so it is
+      described in prose but not cited as a validated reference.)
+- id: file:yeast/YET2/YET2-uniprot.txt
+  title: UniProtKB entry Q04210 (YET2_YEAST) - domain, topology, and family annotation.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt record used for inline domain/topology analysis: BCAP29/BCAP31 family
+      membership, three TM helices, lumenal N-terminus, cytoplasmic C-terminal tail,
+      and C-terminal di-lysine ER-retrieval motif. UniProt cites Toikkanen et al.
+      2006 as its Ref. 3 FUNCTION source.
+- id: file:yeast/YET2/YET2-deep-research-falcon.md
+  title: Falcon (Edison) deep-research report for YET2 (Q04210), synthesizing BAP31-family and Yet-paralog literature.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Falcon/Edison deep-research synthesis. Its most useful YET2-specific content
+      derives from Zung et al. 2024 (bioRxiv 2024.05.09.593285, &#34;The molecular
+      mechanism of on-demand sterol biosynthesis at organelle contact sites&#34;), which
+      reports that Yet2 is the lowest-abundance, non-constitutively-expressed member
+      of the yeast BAP31 family and is therefore likely NOT simply redundant with the
+      Yet1-Yet3 branch — corroborating the paralog-distinction and functional-role
+      knowledge gaps here. The report otherwise characterizes the well-studied Yet3
+      (ergosterol/ERGosome scaffold) and Yet1-Yet3 (Opi1/inositol) functions, which
+      are paralog context, not YET2 evidence. Quotes used as supporting_text were
+      grep-verified against the cached report file.
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that Yet2p is active in the ER membrane, propagated
+      from the mammalian BAP29/BAP31 ortholog (UniProtKB:P51572, PANTHER
+      PTN000294723). This localization is independently supported: Yet2p belongs to
+      the BCAP29/BCAP31 family, is predicted to be a triple-pass membrane protein, and
+      carries a C-terminal di-lysine ER-retrieval motif; it is directly observed in
+      the ER by high-throughput localization (PMID:26928762).
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported core localization for an ER polytopic membrane protein of the
+      BAP31 family. The ER membrane is where Yet2p resides and where any function it
+      has would be exerted.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;The di-lysine motif confers endoplasmic reticulum localization&#34;
+- term:
+    id: GO:0030970
+    label: retrograde protein transport, ER to cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of a role in ERAD-associated dislocation of
+      unfolded/misfolded proteins from the ER lumen to the cytosol through the
+      translocon, propagated from the mammalian BAP31 ortholog. Mammalian BAP31 is
+      implicated in ER-associated degradation, and the related Yet1p-Yet3p complex
+      associates with the Sec translocation apparatus (PMID:20378542), which is
+      consistent with a translocon-proximal locale. However, there is no direct
+      evidence that Yet2p itself participates in retrograde/ERAD transport, and Yet2p
+      is not a stable member of the characterized Yet1p-Yet3p complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Biologically plausible family-level inference but not demonstrated for Yet2p.
+      Retained as a non-core, phylogenetically inferred process rather than removed,
+      since the family and translocon association make it credible; it does not
+      represent a validated core YET2 function.
+    supported_by:
+    - reference_id: PMID:20378542
+      supporting_text: &#34;a fraction \nof the Yet complex was detected in association with the ER translocation \napparatus (Sec complex)&#34;
+- term:
+    id: GO:2000060
+    label: positive regulation of ubiquitin-dependent protein catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of a positive-regulatory role in ubiquitin-
+      dependent (ERAD-type) protein catabolism, propagated from the mammalian BAP31
+      ortholog, which has documented roles in ER quality control and degradation of
+      client proteins. No YET2-specific experimental evidence supports this; it is a
+      family-level inference.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Plausible for the BAP31 family but unproven for Yet2p, and the specific molecular
+      role of Yet2p in any degradation pathway is unknown. Kept as a non-core inferred
+      process rather than removed.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;Belongs to the BCAP29/BCAP31 family&#34;
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO) annotation to the endoplasmic reticulum based on
+      BAP29/BAP31 family membership (IPR008417). Correct compartment but less specific
+      than the ER membrane annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization; consistent with direct localization data. The more
+      specific GO:0005789 (ER membrane) better captures the protein&#39;s polytopic
+      membrane residence.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: SWAp-Tag
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to ER membrane from the UniProtKB Subcellular Location
+      mapping (SL-0097). Consistent with the domain architecture (three TM helices)
+      and the IBA/HDA evidence for ER-membrane residence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and redundant with the IBA ER-membrane annotation; supported by the
+      UniProt subcellular location and topology.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO) annotation to intracellular protein transport from
+      BAP29/BAP31 family membership. This is a generic process term consistent with
+      the family&#39;s association with ER protein transport/export and with the (hedged)
+      UniProt FUNCTION statement, but there is no direct YET2 evidence for a specific
+      transport step.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Generic, family-inferred process. Consistent with the ER protein-transport theme
+      of the family but not a demonstrated YET2 core function; retained as non-core.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;May play a role in anterograde transport of membrane proteins&#34;
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to the generic parent term &#34;membrane&#34; from family
+      membership. True but uninformative given the more specific ER membrane
+      annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but overly general; the ER membrane annotation (GO:0005789) supersedes
+      it. Retained as non-core.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;Multi-pass membrane protein&#34;
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput direct assay (HDA) localization from the SWAp-Tag yeast library
+      (Yofe et al. 2016) placing Yet2p in the endoplasmic reticulum. This is the
+      strongest experimental localization evidence for Yet2p and corroborates the
+      family/topology-based ER-membrane assignment.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental localization to the ER, consistent with all other evidence.
+      Core localization (the ER membrane sub-term is the more precise form).
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: SWAp-Tag
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function annotated with ND (No biological Data available) by SGD.
+      This is the honest, correct record that no specific molecular function of Yet2p
+      has been experimentally determined — the central knowledge gap for this gene.
+      Yet2p has no catalytic domain; the BAP31-family scaffold/adapter mode of action
+      is inferred but not demonstrated for Yet2p.
+    action: ACCEPT
+    reason: &gt;-
+      The ND root MF correctly represents the current state of knowledge: the specific
+      molecular activity of Yet2p is unknown. Retained as an accurate statement of
+      ignorance; see knowledge_gaps. Recent work reinforces this: Yet2p is the
+      lowest-abundance, non-constitutively-expressed family member and is argued to be
+      functionally distinct from (not simply redundant with) Yet1p/Yet3p, so its
+      activity cannot be assumed identical to the characterized paralogs.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;Belongs to the BCAP29/BCAP31 family&#34;
+    - reference_id: file:yeast/YET2/YET2-deep-research-falcon.md
+      supporting_text: &#34;Yet2 does not express constitutively&#34;
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process annotated with ND by SGD (dated 2013), recording that no
+      specific biological process has been experimentally established for Yet2p. Note
+      that GOA also now carries newer IBA/IEA BP annotations (retrograde transport,
+      ubiquitin-dependent catabolism, intracellular protein transport; dated 2026), so
+      this 2013 ND row is technically stale/inconsistent with the co-existing
+      substantive BP terms and would normally be superseded. It is retained here as a
+      correct statement about the primary-data gap because those newer BP terms are
+      phylogenetic/electronic family (BAP31) inferences rather than direct YET2
+      experimental evidence — i.e. no experimentally established biological process
+      exists for Yet2p itself.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly records that the biological role of Yet2p is not experimentally
+      defined (the co-existing IBA/IEA BP terms are family inferences, not YET2 data).
+      Retained; see knowledge_gaps.
+    supported_by:
+    - reference_id: file:yeast/YET2/YET2-uniprot.txt
+      supporting_text: &#34;May play a role in anterograde transport of membrane proteins&#34;
+core_functions:
+- description: &gt;-
+    Yet2p is an integral, polytopic (three-transmembrane) protein of the endoplasmic
+    reticulum membrane, a member of the BCAP29/BCAP31 (BAP31) family. Its ER-membrane
+    residence is well established (family architecture, C-terminal di-lysine ER-
+    retrieval motif, and direct high-throughput localization). By homology to
+    mammalian BAP31 and its yeast paralogs, Yet2p is inferred to act as a scaffold/
+    adapter-type membrane protein in ER membrane-protein homeostasis and transport,
+    but no specific molecular activity or physiological cargo has been demonstrated
+    for Yet2p; its molecular function is genuinely unknown (see knowledge_gaps).
+  supported_by:
+  - reference_id: PMID:26928762
+    supporting_text: SWAp-Tag
+  - reference_id: file:yeast/YET2/YET2-uniprot.txt
+    supporting_text: &#34;The di-lysine motif confers endoplasmic reticulum localization&#34;
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+knowledge_gaps:
+- gap_statement: &gt;-
+    The specific molecular function (molecular activity) of Yet2p is undetermined.
+    Yet2p has no catalytic domain and SGD annotates its molecular_function as ND.
+    Whether it acts as a cargo receptor, a scaffold/adapter for ER membrane-protein
+    biogenesis, or in some other capacity — as inferred from the BAP31 family — has
+    never been demonstrated for Yet2p itself.
+  boundary: &gt;-
+    Established: Yet2p is an ER polytopic membrane protein of the BCAP29/BCAP31 family
+    with three TM helices and a C-terminal di-lysine ER-retrieval motif; it is
+    non-essential and, unlike its paralogs, non-constitutively expressed at low
+    abundance (Zung 2024). Its localization and family membership are firm; its
+    molecular activity is not.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Yet2p is a conserved-family ER membrane protein whose activity is unknown despite
+    a well-defined localization — a classic &#34;MF-dark&#34; case where rich family/CC
+    context makes the protein look understood while the mechanism is a hole. Resolving
+    it would clarify the division of labor within the yeast BAP31 family.
+  resolution: &gt;-
+    Biochemical identification of Yet2p interactors/clients (e.g. affinity-purification
+    mass spectrometry, ideally across conditions that induce Yet2p expression) and
+    reconstitution or genetic assays testing a specific activity (cargo binding,
+    chaperone/adapter function). A GO molecular_function term beyond the ND root should
+    follow such data.
+  provenance:
+  - reference_id: file:yeast/YET2/YET2-uniprot.txt
+    supporting_text: &#34;May play a role in anterograde transport of membrane proteins&#34;
+  - reference_id: file:yeast/YET2/YET2-uniprot.txt
+    supporting_text: &#34;Belongs to the BCAP29/BCAP31 family&#34;
+- gap_statement: &gt;-
+    The physiological cargo and interaction partners of Yet2p are unidentified. Unlike
+    its paralogs Yet1p and Yet3p, which form a stable Yet1p-Yet3p complex that
+    associates with the Sec translocation apparatus, Yet2p is not a stable member of
+    that complex and its own binding partners are unknown.
+  boundary: &gt;-
+    Established (from Wilson &amp; Barlowe 2010, full text): Yet2p associates only
+    minimally with the Yet1p-Yet3p complex and the translocation machinery, and yet2
+    deletion does not cause the inositol-prototrophy defect of yet1/yet3 deletion.
+    Yet2p is therefore functionally distinct from the characterized Yet complex, but
+    what it does associate with is not known.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Identifying Yet2p partners/cargo is the most direct route to its function and would
+    reveal whether the three yeast BAP31 paralogs handle distinct client sets.
+  resolution: &gt;-
+    Co-immunoprecipitation / crosslinking-MS of tagged Yet2p (including under ER stress),
+    and genetic-interaction profiling to place Yet2p in a pathway.
+  provenance:
+  - reference_id: PMID:20378542
+    supporting_text: &#34;Yet1p forms a complex with Yet3p (Yet complex)&#34;
+- gap_statement: &gt;-
+    The biological role of Yet2p and its degree of functional redundancy with YET1 and
+    YET3 are unknown. SGD annotates its biological_process as ND. Single yet2 deletion
+    has no strong reported phenotype; the only phenotypic signal is a genetic
+    interaction with YET3 (a yet2 yet3 double-deletion growth phenotype reported by
+    Toikkanen et al. 2006).
+  boundary: &gt;-
+    Established: the YET genes are non-essential with partially overlapping functions,
+    and a yet2 yet3 double disruptant shows a growth phenotype. Recent work (Zung et al.
+    2024) finds Yet2p is the lowest-abundance paralog and, unlike Yet1p/Yet3p, is not
+    constitutively expressed — arguing against simple redundancy. What conditions induce
+    Yet2p, what process it serves, and whether it backs up YET1/YET3, are all
+    undetermined.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A low-abundance, non-constitutively-expressed paralog whose role only surfaces in
+    combination is a candidate for conditional/specialized function rather than plain
+    redundancy; defining it would complete the functional map of the yeast BAP31 family.
+  resolution: &gt;-
+    Phenotypic profiling of yet2 single and yet1/yet2/yet3 combinatorial mutants under
+    ER stress and secretory-load conditions; conditional-expression and cargo-flux
+    assays to detect a Yet2p-specific contribution.
+  provenance:
+  - reference_id: PMID:20378542
+    supporting_text: &#34;required for inositol \nprototrophy&#34;
+  - reference_id: file:yeast/YET2/YET2-deep-research-falcon.md
+    supporting_text: &#34;compared to Yet1 and Yet3, Yet2 does not express constitutively, which may suggest it fulfills a different function&#34;
+suggested_questions:
+- question: &gt;-
+    Does Yet2p have a distinct molecular activity or client set from the Yet1p-Yet3p
+    complex, and under what conditions is its (non-constitutive) expression induced —
+    does its regulation point to a specialized role in the unfolded protein response
+    or ERAD?
+- question: &gt;-
+    What accounts for the yet2 yet3 double-deletion growth phenotype if yet2 single
+    deletion is phenotypically silent — is Yet2p a conditional backup for Yet3p?
+suggested_experiments:
+- hypothesis: &gt;-
+    Yet2p acts as a stress-induced ER membrane scaffold/adapter with a client set
+    distinct from the constitutive Yet1p-Yet3p complex.
+  description: &gt;-
+    Affinity-purification mass spectrometry of chromosomally tagged Yet2p under basal
+    and ER-stress (e.g. DTT/tunicamycin) conditions to identify stress-dependent
+    interactors and candidate cargo, compared side-by-side with tagged Yet1p/Yet3p.
+  experiment_type: affinity purification-mass spectrometry
+- hypothesis: &gt;-
+    Yet2p contributes conditionally to a process shared with YET3, explaining the
+    yet2 yet3 genetic interaction.
+  description: &gt;-
+    Combinatorial deletion analysis (yet1, yet2, yet3 single/double/triple mutants)
+    with quantitative growth, secretion (e.g. invertase/CPY), and UPR-reporter readouts
+    under ER-stress and high-secretory-load conditions to isolate a Yet2p-specific
+    contribution.
+  experiment_type: genetic interaction / phenotypic profiling
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -1781,8 +1781,8 @@ Design intent for complexes (the central modelling question): each respiratory c
                     <td class="num">8</td>
                     <td class="num">0</td>
                     <td class="num">0</td>
-                    <td class="num">8</td>                    <td class="num" data-sort-value="3">
-                        3/11
+                    <td class="num">8</td>                    <td class="num" data-sort-value="8">
+                        8/11
                     </td>
                     <td class="num" data-sort-value="0">
                         0

--- a/pages/modules/urea_cycle.html
+++ b/pages/modules/urea_cycle.html
@@ -550,7 +550,7 @@
         </div>
         <div class="descriptor-list">                <span class="descriptor">
             <span>urea cycle</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000050" target="_blank" rel="noopener">GO:0000050</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0000050" target="_blank" rel="noopener">GO:0000050</a><div><strong>urea cycle</strong></div><div>The module is grounded in the GO biological-process term for the urea cycle; every enzyme and transporter step is annotated to (or acts within) GO:0000050.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-70635</span><div><strong>Urea cycle</strong></div><div>The step order, compartmentalization and reaction stoichiometries follow the human Reactome &#34;Urea cycle&#34; pathway (R-HSA-70635) and its member reactions (R-HSA-70542, R-HSA-70555, R-HSA-70560, R-HSA-70634, R-HSA-70577, R-HSA-70573, R-HSA-70569, R-HSA-372448).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/OTC/OTC-ai-review.yaml</span><div><strong>OTC gene review (human)</strong></div><div>The OTC step grounding (UniProtKB:P00480, GO:0004585 ornithine carbamoyltransferase activity, GO:0000050 urea cycle, mitochondrial matrix) matches the completed human OTC review.</div></div>        </div></header>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0000050" target="_blank" rel="noopener">GO:0000050</a><div><strong>urea cycle</strong></div><div>The module is grounded in the GO biological-process term for the urea cycle; every enzyme and transporter step is annotated to (or acts within) GO:0000050.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-70635</span><div><strong>Urea cycle</strong></div><div>The step order, compartmentalization and reaction stoichiometries follow the human Reactome &#34;Urea cycle&#34; pathway (R-HSA-70635) and its member reactions (R-HSA-70542, R-HSA-70555, R-HSA-70560, R-HSA-70634, R-HSA-70577, R-HSA-70573, R-HSA-70569, R-HSA-372448).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/NAGS/NAGS-ai-review.yaml</span><div><strong>NAGS gene review (human)</strong></div><div>The NAGS regulatory-step grounding (UniProtKB:Q8N159, GO:0004042, EC 2.3.1.1, mitochondrial matrix) matches the completed human NAGS review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/CPS1/CPS1-ai-review.yaml</span><div><strong>CPS1 gene review (human)</strong></div><div>The CPS1 step grounding (UniProtKB:P31327, GO:0004087 carbamoyl-phosphate synthase (ammonia) activity, GO:0000050 urea cycle, mitochondrial matrix) matches the completed human CPS1 review, which established the ammonia-dependent (not glutamine-hydrolyzing) chemistry.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/OTC/OTC-ai-review.yaml</span><div><strong>OTC gene review (human)</strong></div><div>The OTC step grounding (UniProtKB:P00480, GO:0004585 ornithine carbamoyltransferase activity, GO:0000050 urea cycle, mitochondrial matrix) matches the completed human OTC review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/SLC25A15/SLC25A15-ai-review.yaml</span><div><strong>SLC25A15 gene review (human)</strong></div><div>The ornithine/citrulline transport step (UniProtKB:Q9Y619, GO:0000064 L-ornithine transmembrane transporter activity, mitochondrial inner membrane) matches the completed human SLC25A15/ORNT1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ASS1/ASS1-ai-review.yaml</span><div><strong>ASS1 gene review (human)</strong></div><div>The ASS1 step grounding (UniProtKB:P00966, GO:0004055 argininosuccinate synthase activity, GO:0000050 urea cycle, cytosol) matches the completed human ASS1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ASL/ASL-ai-review.yaml</span><div><strong>ASL gene review (human)</strong></div><div>The ASL step grounding (UniProtKB:P04424, GO:0004056 argininosuccinate lyase activity, GO:0000050 urea cycle, cytosol) matches the completed human ASL review, which also captures ASL&#39;s catalysis-independent NOS scaffold role.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ARG1/ARG1-ai-review.yaml</span><div><strong>ARG1 gene review (human)</strong></div><div>The ARG1 terminal-step grounding (UniProtKB:P05089, GO:0004053 arginase activity, GO:0000050 urea cycle, cytosol) matches the completed human ARG1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/SLC25A13/SLC25A13-ai-review.yaml</span><div><strong>SLC25A13 gene review (human)</strong></div><div>The citrin aspartate-supply step (UniProtKB:Q9UJS0, GO:0000515 aspartate:glutamate proton antiporter activity, mitochondrial inner membrane) matches the completed human SLC25A13 review, which added the urea-cycle (GO:0000050) involvement.</div></div>        </div></header>
     <section class="stats" aria-label="Module counts">
         <div class="stat"><span class="stat-value">9</span><span class="stat-label">Nodes</span></div>
         <div class="stat"><span class="stat-value">8</span><span class="stat-label">Parts</span></div>
@@ -578,11 +578,11 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(3/11 grounded genes reviewed)</span>
+                    <span class="muted small">(8/11 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        3 complete review(s) &middot;
-                        3 with deep research &middot;
-                        8 missing review &middot;
+                        7 complete review(s) &middot;
+                        8 with deep research &middot;
+                        3 missing review &middot;
                         0 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
@@ -595,6 +595,12 @@
                             </tr>
                         </thead>
                         <tbody>                                <tr>
+                                    <td>ARG1
+                                        <span class="muted term-id">P05089</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
                                     <td>ASL
                                         <span class="muted term-id">P04424</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
@@ -603,6 +609,18 @@
                                 </tr>                                <tr>
                                     <td>ASS1
                                         <span class="muted term-id">P00966</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>CPS1
+                                        <span class="muted term-id">P31327</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">77/78</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>NAGS
+                                        <span class="muted term-id">Q8N159</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
@@ -619,26 +637,8 @@
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                 </tr>                                <tr>
-                                    <td>ARG1 (human, cytosolic, hepatic)
-                                        <span class="muted term-id">P05089</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>CPS1 (human, mitochondrial)
-                                        <span class="muted term-id">P31327</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
                                     <td>ARG2 (human, mitochondrial paralog)
                                         <span class="muted term-id">P78540</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>NAGS (human, mitochondrial)
-                                        <span class="muted term-id">Q8N159</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
@@ -649,17 +649,17 @@
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>SLC25A13 / citrin (human, liver)
+                                    <td>SLC25A13
                                         <span class="muted term-id">Q9UJS0</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
                                 </tr>                                <tr>
-                                    <td>SLC25A15 / ORNT1 (human)
+                                    <td>SLC25A15
                                         <span class="muted term-id">Q9Y619</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
                                 </tr>                        </tbody>
                     </table>            </div>
         </div>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2961 |
| Gene review HTML pages | 2961 |
| Project pages | 1098 |
| Module pages | 88 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
