### PR TITLE
[codex] Add AP4B1 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/AP4B1/AP4B1-hypotheses/kgap-ap4b1-tepsin-coat-assembly/openscientist.md
+++ b/genes/human/AP4B1/AP4B1-hypotheses/kgap-ap4b1-tepsin-coat-assembly/openscientist.md
@@ -1,0 +1,229 @@
+# AP4B1, Tepsin, and Clathrin-Independent AP-4 Coat Assembly: Molecular Role Analysis
+
+## Summary
+
+**AP4B1 (beta4) functions as an obligate structural subunit of the heterotetrameric AP-4 complex, and the most specific molecular contribution attributable to the beta4 subunit — as opposed to the complex as a whole — is its C-terminal ear (appendage) domain, which directly recruits the accessory protein tepsin.** The beta4-ear binds a conserved [GS]LFXG[ML]X[LV] motif in tepsin's disordered C-terminal region via a hydrophobic platform surface (NMR structure PDB 2MJ7). This interaction, combined with a second motif–ear interaction between tepsin and the epsilon subunit ear, produces bivalent binding that may cross-link AP-4 heterotetramers and contribute to coat lattice assembly. However, no reconstitution experiment has directly tested whether tepsin is required for vesicle budding or membrane deformation, leaving the mechanistic contribution of the beta4-ear to coat formation formally unresolved.
+
+Cargo recognition within the AP-4 complex is mediated by the mu4 subunit (AP4M1), which binds tyrosine-based YXXΦE sorting signals in the cytoplasmic tails of transmembrane cargos such as ATG9A and SERINC1/3. The beta4-ear domain binds accessory proteins, not cargo directly. The well-documented cellular phenotypes of AP4B1 deficiency — ATG9A mislocalization, autophagy dysregulation, and the neurological manifestations of hereditary spastic paraplegia type 47 (SPG47) — are best explained as indirect consequences of whole-complex destabilization rather than loss of a beta4-specific molecular function. Loss of any single AP-4 subunit destabilizes the entire heterotetramer, producing an indistinguishable "AP-4 deficiency syndrome" across SPG47 (AP4B1), SPG50 (AP4M1), SPG51 (AP4E1), and SPG52 (AP4S1).
+
+Three decisive experiments remain unperformed: (1) in vitro reconstitution of AP-4 coat assembly with and without tepsin to test whether bivalent tepsin–ear interactions are required for coat lattice formation; (2) liposome tubulation/budding assays with tepsin's ENTH domain to assess its membrane-deforming capacity; and (3) beta4-ear-deleted rescue experiments in AP4B1-null cells to separate ear-specific functions from whole-complex stability. Until these experiments are completed, the literature supports AP4B1 at the level of broad molecular-adaptor representation, with the beta4-ear–tepsin interaction as the strongest candidate for a subunit-specific function.
+
+---
+
+## Key Findings
+
+### Finding 1: The AP4B1 Beta4-Ear Domain Directly Binds Tepsin via a Conserved Hydrophobic Surface
+
+The most structurally characterized molecular interaction specific to AP4B1 is the binding of its C-terminal ear domain (residues 601–739) to the accessory protein tepsin. Fregno et al. (2015) solved the NMR structure of the beta4-ear (PDB 2MJ7) and demonstrated that tepsin contains two phylogenetically conserved peptide motifs — [GS]LFXG[ML]X[LV] and S[AV]F[SA]FLN — in its C-terminal unstructured region, which bind the ear domains of the beta4 and epsilon subunits of AP-4, respectively ([PMID: 26542808](https://pubmed.ncbi.nlm.nih.gov/26542808/)). Structure-based mutational analyses mapped the [GS]LFXG[ML]X[LV] motif binding site to "a conserved, hydrophobic surface on the β4-ear platform fold." The bivalent nature of tepsin's interactions with two different AP-4 ears increases avidity and, critically, "may enable cross-linking of multiple AP-4 heterotetramers, thus contributing to the assembly of the AP-4 coat" ([PMID: 26542808](https://pubmed.ncbi.nlm.nih.gov/26542808/)).
+
+This cross-linking model is conceptually analogous to how accessory proteins bridge coat components in the clathrin pathway, but it remains a hypothesis. No experiment has tested whether disrupting the beta4-ear–tepsin interaction specifically (without destabilizing the AP-4 core) impairs coat assembly or vesicle formation. The NMR structure reveals a platform fold in the beta4-ear that is topologically related to appendage domains of other AP complex beta subunits, consistent with a conserved role in accessory protein recruitment across the AP family.
+
+{{figure:plot_1.png|caption=AP4B1 domain architecture showing the core trunk domain (required for complex stability and membrane association) and the C-terminal beta4-ear domain (tepsin recruitment platform). Evidence for each functional role is classified by experimental approach: biochemical/structural (NMR, binding assays), cellular (immunofluorescence, trafficking), and genetic/phenotypic (patient and animal model studies).}}
+
+### Finding 2: AP4B1 Is a Structural Subunit of the Non-Clathrin AP-4 Coat at the TGN
+
+AP-4 was originally identified as a heterotetramer (epsilon4/beta4/mu4/sigma4) by coimmunoprecipitation and yeast two-hybrid analysis ([PMID: 10436028](https://pubmed.ncbi.nlm.nih.gov/10436028/)). Immuno-gold electron microscopy demonstrated that "AP-4 is associated with nonclathrin-coated vesicles in the region of the trans-Golgi network" ([PMID: 10436028](https://pubmed.ncbi.nlm.nih.gov/10436028/)). AP-4 TGN association is ARF-GTPase dependent and BFA-sensitive, consistent with other AP complexes.
+
+AP4B1 loss destabilizes the entire AP-4 complex. In AP4S1-mutant patient fibroblasts, all AP-4 subunits were reduced and tepsin membrane recruitment was abolished ([PMID: 25552650](https://pubmed.ncbi.nlm.nih.gov/25552650/)). The chaperone AAGAB was shown to stabilize AP-4 subunits during assembly, further emphasizing the obligate interdependence of subunits for complex integrity ([PMID: 35976721](https://pubmed.ncbi.nlm.nih.gov/35976721/)). AP4B1-knockout mice recapitulate the human SPG47 phenotype, with motor dysfunction, cerebellar pathology marked by calbindin-positive spheroids, and ATG9A mislocalization in neurons ([PMID: 36632189](https://pubmed.ncbi.nlm.nih.gov/36632189/)). AAV9-mediated AP4B1 gene replacement in the SPG47 mouse model restores AP-4 cargo distribution, normalizes brain morphology, and ameliorates motor dysfunction ([PMID: 39358605](https://pubmed.ncbi.nlm.nih.gov/39358605/)), confirming that beta4 loss is the proximate cause of disease through complex destabilization.
+
+A recent advance identified SCAMP5 as a novel regulator of AP-4 recruitment: SCAMP5 recruits PI4KB to the TGN for PtdIns4P production, which is essential for AP-4 membrane association ([PMID: 40958389](https://pubmed.ncbi.nlm.nih.gov/40958389/)). This places AP-4 coat initiation downstream of phosphoinositide metabolism, adding regulatory context to the coat-assembly pathway.
+
+Crucially, **no structural data exists for the full AP-4 coat lattice** — unlike the AP-2/clathrin coat, there is no cryo-EM or X-ray structure showing how AP-4 tetramers organize on a membrane surface.
+
+### Finding 3: Cargo Recognition Is Mediated by Mu4, Not the Beta4-Ear of AP4B1
+
+The mu4 subunit (AP4M1) is the cargo-recognition component of AP-4, binding tyrosine-based YXXΦE sorting signals in cargo cytoplasmic tails. ATG9A was identified as a specific AP-4 cargo sorted via its cytoplasmic domain ([PMID: 29180427](https://pubmed.ncbi.nlm.nih.gov/29180427/); [PMID: 30262884](https://pubmed.ncbi.nlm.nih.gov/30262884/)). SERINC1 and SERINC3 were identified as AP-4 cargos through dynamic organellar maps proteomics, alongside APP (amyloid precursor protein). As reviewed by Mattera et al. (2020), AP-4 "associates with the trans-Golgi network (TGN) through interaction with small GTPases of the ARF family and recognizes transmembrane proteins (i.e. cargos) having specific sorting signals in their cytosolic domains," with "accessory proteins (tepsin, RUSC2 and the FHF complex) that co-operate with AP-4" constituting a functionally distinct category from cargos ([PMID: 33084855](https://pubmed.ncbi.nlm.nih.gov/33084855/)).
+
+Computational drug screening for SPG50 modeled the mu4-beta4 interface for therapeutic stabilization — not a beta4-cargo interface ([PMID: 39723768](https://pubmed.ncbi.nlm.nih.gov/39723768/)). This is consistent with the beta4-ear functioning in accessory protein recruitment rather than cargo binding. **No study has identified a direct beta4–cargo interaction.** The beta4-ear binds tepsin; cargo binding maps exclusively to mu4.
+
+### Finding 4: Tepsin Links AP-4 Vesicles to Autophagy Machinery via Multivalent LC3B Binding
+
+A critical recent advance is the discovery that tepsin — the protein recruited by the beta4-ear — contains four LC3-interacting region (LIR) motifs that independently engage the LC3B LIR docking site. This was established by AlphaFold Multimer modeling, bio-layer interferometry (BLI), and biochemistry ([PMID: 41198464](https://pubmed.ncbi.nlm.nih.gov/41198464/)). Cohen et al. reported that "all four motifs in tepsin must be mutated to abrogate binding to LC3B in vitro, while stoichiometry data estimate one tepsin likely binds two LC3B at one time on a surface or membrane." The data "suggest tepsin could respond dynamically to LC3B concentrations on membranes by leveraging multivalency to modulate binding strength" ([PMID: 41198464](https://pubmed.ncbi.nlm.nih.gov/41198464/)).
+
+Earlier work by Wallace et al. (2024) established that tepsin binds LC3B and that this interaction promotes proper ATG9A trafficking and delivery. Loss of tepsin's canonical LIR motif alters ATG9A distribution in cells ([PMID: 38381558](https://pubmed.ncbi.nlm.nih.gov/38381558/)).
+
+This provides a molecular logic chain: **AP4B1 beta4-ear → tepsin → LC3B → autophagosome membranes**. By recruiting tepsin, the beta4-ear indirectly connects AP-4-derived vesicles carrying ATG9A to the autophagy machinery. The multivalent nature of the tepsin–LC3B interaction suggests a cooperative, concentration-dependent sensing mechanism rather than a simple binary switch.
+
+### Finding 5: AP-4 Deficiency Causes ATG9A Mislocalization and Autophagy Defects — An Indirect AP4B1 Contribution
+
+AP-4 knockout (any subunit) causes ATG9A retention at the TGN and reduced delivery to pre-autophagosomal structures. Davies et al. (2018) demonstrated that "AP-4 deficiency causes missorting of ATG9A in diverse cell types, including patient-derived cells, as well as dysregulation of autophagy," and that "RUSC2 facilitates the transport of AP-4-derived, ATG9A-positive vesicles from the trans-Golgi network to the cell periphery" ([PMID: 30262884](https://pubmed.ncbi.nlm.nih.gov/30262884/)). Mattera et al. (2017) originally identified ATG9A as an AP-4 cargo that is exported from the TGN in a signal-dependent manner ([PMID: 29180427](https://pubmed.ncbi.nlm.nih.gov/29180427/)).
+
+The clinical presentation of AP-4 deficiency is remarkably consistent across all four genetic subtypes. Ebrahimi-Fakhari et al. (2020) analyzed 156 patients from 101 families and established that "disease severity and major phenotypes were equally distributed among the four subtypes, establishing that SPG47, SPG50, SPG51 and SPG52 share a common phenotype, an 'AP-4 deficiency syndrome'" ([PMID: 32979048](https://pubmed.ncbi.nlm.nih.gov/32979048/)). Plasma neurofilament light chain (NfL) is elevated in AP-4-HSP patients (Mann-Whitney U test: P = 3.0 × 10⁻¹⁰; AUC = 0.87, 95% CI 0.80–0.94), confirming ongoing neuroaxonal damage ([PMID: 37482941](https://pubmed.ncbi.nlm.nih.gov/37482941/)). The ATG9A ratio in patient fibroblasts has been validated as a functional diagnostic assay ([PMID: 34729478](https://pubmed.ncbi.nlm.nih.gov/34729478/); [PMID: 41491634](https://pubmed.ncbi.nlm.nih.gov/41491634/)).
+
+**The clinical and cellular indistinguishability of SPG47 from the other AP-4-HSP subtypes confirms that AP4B1 mutations exert their pathological effects through whole-complex destabilization rather than a beta4-specific function.**
+
+### Finding 6: Tepsin's ENTH Domain Membrane-Deformation Capacity Is Untested — A Key Gap for AP-4 Vesicle Budding
+
+Tepsin (525 amino acids) contains an N-terminal ENTH domain (residues 8–141) homologous to epsins, which in the clathrin pathway deform membranes via an amphipathic helix that inserts into lipid bilayers upon PtdIns(4,5)P₂ binding. Tepsin was originally identified as "the first AP-4 accessory protein" and characterized as an ENTH/VHS-domain protein ([PMID: 22472443](https://pubmed.ncbi.nlm.nih.gov/22472443/)). Since AP-4 operates without clathrin, if the coat requires a membrane-deforming component for vesicle budding, tepsin's ENTH domain is the only identified candidate.
+
+However, **no study has tested whether tepsin's ENTH domain binds specific phosphoinositides, inserts into membranes, or induces curvature.** No in vitro budding reconstitution with AP-4 ± tepsin exists. Tepsin-knockout zebrafish show developmental defects similar to AP-4 subunit knockouts, "display[ing] abnormal head morphology and neural necrosis" ([PMID: 36642642](https://pubmed.ncbi.nlm.nih.gov/36642642/)), suggesting functional importance but not revealing the mechanism.
+
+This gap is significant because it leaves unanswered the fundamental question of how AP-4 vesicles bud from the TGN membrane. In the clathrin pathway, clathrin itself provides the cage-like scaffold while epsins and other ENTH domain proteins generate initial membrane curvature. AP-4 lacks a clathrin equivalent, making the mechanism of membrane deformation entirely unknown.
+
+{{figure:plot_2.png|caption=Evidence landscape for AP4B1 molecular functions, classifying available evidence by type (biochemical/structural, cellular, genetic/phenotypic) and highlighting the critical missing experiments — in vitro reconstitution, ENTH domain characterization, and ear-deletion rescue — needed to resolve the beta4-ear's specific contribution to coat assembly and vesicle budding.}}
+
+---
+
+## Mechanistic Model and Interpretation
+
+### The AP-4 Vesicle Formation Pathway
+
+Based on the current evidence, the AP-4-mediated vesicle formation pathway at the TGN can be modeled as follows:
+
+```
+TGN MEMBRANE (PtdIns4P-enriched)
+     │
+     ▼
+ SCAMP5 recruits PI4KB → PtdIns4P production
+     │
+     ▼
+ ARF-GTP recruits AP-4 heterotetramer (ε4/β4/μ4/σ4)
+     │
+     ├─── μ4 subunit recognizes YXXΦE signals in ATG9A, SERINC1/3, APP
+     │
+     ├─── β4-ear recruits tepsin (via [GS]LFXG[ML]X[LV] motif)
+     │    ε-ear also binds tepsin (via S[AV]F[SA]FLN motif)
+     │         │
+     │         ├─── Bivalent tepsin may cross-link AP-4 tetramers → coat lattice?
+     │         │
+     │         ├─── ENTH domain → membrane deformation? (UNTESTED)
+     │         │
+     │         └─── 4× LIR motifs bind LC3B → autophagy connection
+     │
+     ▼
+ AP-4 coated vesicle buds (mechanism unknown — no clathrin equivalent)
+     │
+     ▼
+ Uncoating (mechanism unknown)
+     │
+     ▼
+ RUSC2 mediates peripheral transport of ATG9A-positive vesicles
+     │
+     ▼
+ Tepsin-LC3B interaction delivers ATG9A to pre-autophagosomal structures
+```
+
+### Classification of AP4B1 Proposed Functions
+
+| Proposed Function | Evidence Level | Key Evidence | Verdict |
+|---|---|---|---|
+| Structural coat-assembly subunit | **Strong** (biochemical, genetic) | Loss of AP4B1 destabilizes entire complex; immuno-gold EM shows non-clathrin coat; AAGAB chaperone required for assembly | **Supported** |
+| Cargo/adaptor-recognition module | **Absent** (no direct evidence) | Cargo binding maps to mu4, not beta4; beta4-ear binds accessory protein tepsin only | **Not supported** |
+| Tepsin-dependent vesicle budding/membrane deformation factor | **Hypothetical** | Tepsin has ENTH domain; bivalent ear binding could cross-link coat; but no reconstitution data | **Plausible but untested** |
+| Indirect contributor to ATG9A/autophagy phenotypes | **Strong** (cellular, animal, clinical) | ATG9A mislocalized in all AP-4 KOs; phenotype indistinguishable across subtypes | **Supported, but not beta4-specific** |
+
+### Can AP4B1 Be Distinguished from Other AP-4 Subunits?
+
+The central question is whether AP4B1 has a molecular function beyond its contribution to complex stability. The evidence hierarchy is:
+
+1. **Complex stability (dominant effect)**: Any AP-4 subunit loss → whole complex degradation → identical phenotype. This explains the vast majority of the biology and is the reason all four AP-4-HSP subtypes are clinically equivalent.
+
+2. **Beta4-ear–tepsin interaction (subunit-specific, biochemically characterized)**: The only molecularly characterized function unique to AP4B1. The beta4-ear binds tepsin via a specific motif-ear interaction mapped at atomic resolution. However, whether this interaction is functionally redundant with the epsilon-ear–tepsin interaction remains unknown.
+
+3. **Tepsin-mediated coat cross-linking (proposed model)**: Bivalent tepsin binding to both beta4-ear and epsilon-ear could cross-link AP-4 heterotetramers. This is architecturally plausible and consistent with known coat-assembly principles, but has not been tested by reconstitution.
+
+4. **Tepsin-mediated membrane deformation (untested)**: Tepsin's ENTH domain is the only candidate for generating membrane curvature in the clathrin-free AP-4 coat system. Its lipid-binding specificity and curvature-generating capacity are completely uncharacterized.
+
+**Assessment**: The current literature supports AP4B1 at the level of broad molecular-adaptor representation with one notable specificity — the beta4-ear–tepsin axis. Whether this constitutes a truly separable molecular function or is functionally redundant with the epsilon-ear cannot be determined without ear-deletion rescue experiments.
+
+---
+
+## Evidence Base
+
+### Structural and Biochemical Studies
+
+| Reference | Key Contribution | PMID |
+|---|---|---|
+| Hirst et al. (1999), *Mol Biol Cell* | Original identification of AP-4 heterotetramer; immuno-gold EM showing non-clathrin coat at TGN; mu4 binds YXXΦE signals | [10436028](https://pubmed.ncbi.nlm.nih.gov/10436028/) |
+| Borner et al. (2012), *J Cell Biol* | Discovery and characterization of tepsin as the first AP-4 accessory protein with ENTH domain | [22472443](https://pubmed.ncbi.nlm.nih.gov/22472443/) |
+| Fregno et al. (2015), *Structure* | NMR structure of beta4-ear (PDB 2MJ7); mapping of bivalent tepsin motif–ear interactions; coat cross-linking model | [26542808](https://pubmed.ncbi.nlm.nih.gov/26542808/) |
+| Mattera et al. (2022), *J Biol Chem* | AAGAB chaperone stabilizes AP-4 subunits during assembly, confirming obligate nature of subunit interdependence | [35976721](https://pubmed.ncbi.nlm.nih.gov/35976721/) |
+| Cohen et al. (2026), *J Biol Chem* | Four LIR motifs in tepsin bind LC3B multivalently; stoichiometry ~1 tepsin : 2 LC3B; dynamic concentration sensing | [41198464](https://pubmed.ncbi.nlm.nih.gov/41198464/) |
+| Francisco et al. (2025), *Sci Rep* | Computational drug screening models mu4-beta4 interface, not beta4-cargo; identifies rutin as candidate stabilizer | [39723768](https://pubmed.ncbi.nlm.nih.gov/39723768/) |
+
+### Cargo Identification and Trafficking Studies
+
+| Reference | Key Contribution | PMID |
+|---|---|---|
+| Mattera et al. (2017), *PNAS* | ATG9A identified as specific AP-4 cargo via cytoplasmic domain sorting signal | [29180427](https://pubmed.ncbi.nlm.nih.gov/29180427/) |
+| Davies et al. (2018), *Nat Commun* | ATG9A missorting across cell types; SERINC1/3 identification; RUSC2-mediated peripheral transport | [30262884](https://pubmed.ncbi.nlm.nih.gov/30262884/) |
+| Ivankovic et al. (2020), *Autophagy* | AP-4 epsilon KO mouse; axonal autophagosome maturation defect through ATG9A missorting | [31142229](https://pubmed.ncbi.nlm.nih.gov/31142229/) |
+| Wallace et al. (2024), *J Cell Sci* | Tepsin binds LC3B; tepsin's LIR motif required for proper ATG9A distribution | [38381558](https://pubmed.ncbi.nlm.nih.gov/38381558/) |
+| Mattera et al. (2020), *Biochem Soc Trans* | Comprehensive review of AP-4 cargos and accessory proteins | [33084855](https://pubmed.ncbi.nlm.nih.gov/33084855/) |
+| Park et al. (2025), *Autophagy* | SCAMP5 recruits PI4KB for PtdIns4P production at TGN; required for AP-4 recruitment | [40958389](https://pubmed.ncbi.nlm.nih.gov/40958389/) |
+
+### Clinical and Animal Model Studies
+
+| Reference | Key Contribution | PMID |
+|---|---|---|
+| Ebrahimi-Fakhari et al. (2020), *Brain* | 156 AP-4-HSP patients; unified phenotype across all four subtypes; "AP-4 deficiency syndrome" | [32979048](https://pubmed.ncbi.nlm.nih.gov/32979048/) |
+| Scarrott et al. (2023), *Brain Commun* | AP4B1⁻/⁻ mouse: motor dysfunction, cerebellar calbindin-positive spheroids, ATG9A mislocalization | [36632189](https://pubmed.ncbi.nlm.nih.gov/36632189/) |
+| Ebrahimi-Fakhari et al. (2023), *Mov Disord* | Elevated plasma NfL in AP-4-HSP (P = 3.0 × 10⁻¹⁰ vs controls; AUC = 0.87) | [37482941](https://pubmed.ncbi.nlm.nih.gov/37482941/) |
+| Scarrott et al. (2024), *Mol Ther* | AAV9/hAP4B1 gene therapy restores ATG9A distribution, motor function, and NfL in SPG47 mice | [39358605](https://pubmed.ncbi.nlm.nih.gov/39358605/) |
+| Ebrahimi-Fakhari et al. (2026), *Neurol Genet* | ATG9A ratio validated as clinical diagnostic assay for AP-4-HSP | [41491634](https://pubmed.ncbi.nlm.nih.gov/41491634/) |
+| Pembridge et al. (2023), *Traffic* | AP-4 and tepsin KO zebrafish show similar developmental defects | [36642642](https://pubmed.ncbi.nlm.nih.gov/36642642/) |
+| Rosengarten et al. (2025), *Hum Mol Genet* | AP4B1⁻/⁻ zebrafish: reduced motor neuron axonal length, developmental malformations | [40267240](https://pubmed.ncbi.nlm.nih.gov/40267240/) |
+| Abou Jamra et al. (2014), *Hum Mutat* | AP4S1 mutations cause AP-4 complex loss and abolish tepsin membrane recruitment | [25552650](https://pubmed.ncbi.nlm.nih.gov/25552650/) |
+| Ebrahimi-Fakhari et al. (2021), *Mov Disord* | High-throughput ATG9A imaging as diagnostic assay | [34729478](https://pubmed.ncbi.nlm.nih.gov/34729478/) |
+
+---
+
+## Limitations and Knowledge Gaps
+
+### Critical Missing Experiments
+
+1. **No in vitro reconstitution of AP-4 coat assembly.** Unlike AP-1, AP-2, and COPI/COPII coats, AP-4 coat formation has never been reconstituted with purified components on synthetic membranes. This is the single largest gap in the field and prevents definitive assignment of roles to individual components.
+
+2. **Tepsin ENTH domain function is unknown.** Despite its homology to epsin family ENTH domains (which insert amphipathic helices into membranes to induce curvature), no study has tested: (a) which phosphoinositides bind tepsin's ENTH domain; (b) whether the ENTH domain generates membrane curvature; (c) whether ENTH function is required for AP-4 vesicle budding.
+
+3. **No ear-deletion rescue experiments.** A beta4-ear-deleted AP4B1 construct that still supports complex assembly could separate ear-dependent functions (tepsin recruitment, coat cross-linking) from structural stability. Similarly, an epsilon-ear-deleted AP4E1 construct would reveal whether the two ear–tepsin interactions are redundant or synergistic.
+
+4. **No structure of the assembled AP-4 coat lattice.** The stoichiometry and geometry of AP-4 on membranes are completely unknown. Cryo-electron tomography of AP-4-coated vesicles has not been attempted.
+
+5. **No quantification of AP-4 coat dynamics.** How AP-4 coat assembly and disassembly are temporally regulated, whether tepsin participates in the assembly or disassembly step, and the relationship between coat maturation and cargo loading are all unstudied.
+
+### Interpretive Limitations
+
+- **Phenotypic indistinguishability across subtypes**: Because loss of any one AP-4 subunit destabilizes the whole complex, genetic studies cannot attribute any phenotype specifically to AP4B1 versus another subunit. All disease phenotypes are complex-level, not subunit-level.
+
+- **Tepsin's bivalent cross-linking model is inferential**: The proposal that bivalent tepsin–ear binding drives coat lattice formation is structurally plausible but based on domain architecture arguments and analogy to clathrin pathway mechanisms, not experimental demonstration.
+
+- **LC3B binding functionality assessed only in cells**: While tepsin binds LC3B with clear multivalency in vitro, the functional consequence for autophagosome biogenesis has been assessed in cellular knockdown/knockout experiments, not in fully reconstituted systems.
+
+- **Literature-only analysis**: This assessment is based on published findings; no original experimental data was generated. Conclusions are limited by what has been published and indexed.
+
+---
+
+## Proposed Follow-up Experiments
+
+### High Priority (Would Resolve Core Questions)
+
+1. **In vitro AP-4 coat reconstitution on GUVs/liposomes.** Purify recombinant AP-4 complex, ARF1, and tepsin. Assay coat assembly on giant unilamellar vesicles (GUVs) or liposomes bearing ATG9A cytoplasmic domain. Use cryo-EM to visualize coat organization. Test with and without tepsin to determine its necessity for coat lattice formation. **Would resolve:** Whether AP-4 alone suffices for coat formation or tepsin is required, and whether coat assembly requires the bivalent cross-linking mechanism.
+
+2. **Tepsin ENTH domain membrane deformation assay.** Express and purify tepsin ENTH domain (residues 1–141). Test binding to phosphoinositide panels (PIP strips, liposome cosedimentation). Perform liposome tubulation assays and compare to epsin-1 ENTH domain as positive control. Introduce amphipathic helix mutations to test the insertion mechanism. **Would resolve:** Whether tepsin can deform membranes for vesicle budding, filling the gap in understanding how AP-4 vesicles bud without clathrin.
+
+3. **Beta4-ear-deleted AP4B1 rescue.** Generate AP4B1 Δear (residues 1–600) and AP4B1 full-length constructs. Express in AP4B1-KO cells. Assess: (a) complex stability by co-immunoprecipitation; (b) tepsin membrane recruitment by immunofluorescence; (c) ATG9A trafficking by ATG9A ratio assay; (d) coat formation by immuno-EM. **Would resolve:** Whether the beta4-ear has functions beyond complex stability, separating ear-specific roles from the structural requirement for the tetramer.
+
+### Medium Priority (Complementary Mechanistic Insights)
+
+4. **Epsilon-ear-deleted AP4E1 rescue.** Same experimental design as #3 but for the epsilon subunit, to test whether the two ear–tepsin interactions are redundant or both required. This would reveal the minimum binding valency needed for functional tepsin recruitment.
+
+5. **AP-4 coat cryo-ET.** Enrich AP-4-coated vesicles from cell extracts (e.g., by immunoisolation or density gradient) and determine the coat structure by cryo-electron tomography and subtomogram averaging. **Would reveal:** Coat geometry, subunit arrangement, and where ear domains project relative to the membrane.
+
+6. **Tepsin–LC3B functional reconstitution.** Test whether tepsin can tether AP-4-coated vesicles to LC3B-decorated membranes in vitro, and whether multivalent LIR binding is required for efficient tethering. Use liposomes coated with AP-4 + tepsin and acceptor membranes with LC3B.
+
+### Lower Priority / Longer Term
+
+7. **Live imaging of AP-4 coat dynamics.** Use CRISPR knock-in of fluorescent tags on AP-4 subunits and tepsin to measure coat assembly/disassembly kinetics and tepsin recruitment timing relative to coat formation by live-cell TIRF or lattice light-sheet microscopy.
+
+8. **Comparative ear-domain analysis across AP complexes.** The beta subunit ears of AP-1 and AP-2 also recruit accessory proteins. Systematic comparison of ear–accessory protein interaction mechanisms may reveal whether AP-4's tepsin cross-linking model represents a conserved coat-assembly principle or a divergent adaptation.
+
+9. **SCAMP5–PI4KB–AP-4 pathway reconstitution.** Reconstitute the complete upstream pathway to understand the full hierarchy of coat initiation and regulation at the TGN.
+
+---
+
+## Conclusions
+
+AP4B1 functions primarily as an obligate structural subunit of the heterotetrameric AP-4 coat complex. Its most specific molecular contribution is the C-terminal beta4-ear domain, which serves as one of two anchor points for the accessory protein tepsin. Tepsin has emerged as a multifunctional molecule: it potentially cross-links AP-4 heterotetramers (coat assembly), it bridges AP-4 vesicles to LC3B on autophagosomal membranes (via four LIR motifs with ~1:2 tepsin:LC3B stoichiometry), and it contains an ENTH domain whose membrane-deformation capacity is entirely untested. Cargo recognition is mediated by mu4, not beta4, and there is no evidence that AP4B1 directly participates in cargo sorting. The ATG9A/SERINC trafficking and autophagy phenotypes of AP4B1 mutations — including the complete SPG47 clinical syndrome — are indirect consequences of whole-complex loss, clinically identical to loss of any other AP-4 subunit.
+
+**Whether AP4B1 has a specific molecular function beyond complex stability and tepsin recruitment is the central unresolved question.** The three experiments most likely to resolve it are: in vitro coat reconstitution ± tepsin, tepsin ENTH domain membrane deformation assays, and beta4-ear-deleted rescue in AP4B1-KO cells. The field has the reagents and model systems to perform these experiments; they represent the decisive next steps for understanding AP-4 coat biology and, potentially, for informing therapeutic strategies for AP-4 deficiency syndromes.

--- a/genes/human/AP4B1/AP4B1-hypotheses/kgap-ap4b1-tepsin-coat-assembly/openscientist.md.citations.md
+++ b/genes/human/AP4B1/AP4B1-hypotheses/kgap-ap4b1-tepsin-coat-assembly/openscientist.md.citations.md
@@ -1,0 +1,32 @@
+# OpenScientist citation sidecar: AP4B1
+
+- OpenScientist job: `337f2474-6000-4aa5-b380-ff7bea1b052d`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:10436028
+- PMID:22472443
+- PMID:25552650
+- PMID:26542808
+- PMID:29180427
+- PMID:30262884
+- PMID:31142229
+- PMID:32979048
+- PMID:33084855
+- PMID:34729478
+- PMID:35976721
+- PMID:36632189
+- PMID:36642642
+- PMID:37482941
+- PMID:38381558
+- PMID:39358605
+- PMID:39723768
+- PMID:40267240
+- PMID:40958389
+- PMID:41198464
+- PMID:41491634
+
+## Detected DOIs
+
+- None detected

--- a/genes/human/AP4B1/AP4B1-hypotheses/kgap-ap4b1-tepsin-coat-assembly/prompt.md
+++ b/genes/human/AP4B1/AP4B1-hypotheses/kgap-ap4b1-tepsin-coat-assembly/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: AP4B1, tepsin, and clathrin-independent AP-4 coat assembly
+
+Investigate the molecular role of human AP4B1 in clathrin-independent AP-4 coat formation, with special attention to AP4B1 beta4-ear binding to tepsin.
+
+Focus on whether the literature supports AP4B1 as:
+
+- a structural coat-assembly subunit;
+- a cargo/adaptor-recognition module;
+- a tepsin-dependent vesicle budding or membrane-deformation factor;
+- an indirect contributor to ATG9A/SERINC trafficking and autophagy-related phenotypes.
+
+Please distinguish direct biochemical, structural, and reconstitution evidence from cellular cargo-missorting phenotypes. Assess whether AP4B1 needs only broad molecular-adaptor representation or whether a more specific molecular function could be supported. Include PMIDs and highlight the decisive missing experiments.


### PR DESCRIPTION
Adds a focused OpenScientist hypothesis report for the AP4B1 MF-dark knowledge gap on beta4-ear/tepsin roles in clathrin-independent AP-4 coat assembly.\n\nIncludes the prompt, markdown report, and citation sidecar.\n\nValidation: git diff --cached --check.