### PR TITLE
[codex] Add DNAJC4 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/DNAJC4/DNAJC4-hypotheses/kgap-dnajc4-hsp70-cochaperone-activity/openscientist.md
+++ b/genes/human/DNAJC4/DNAJC4-hypotheses/kgap-dnajc4-hsp70-cochaperone-activity/openscientist.md
@@ -1,0 +1,322 @@
+# DNAJC4 HSP70 Co-chaperone Activity: Evidence Assessment
+
+## Summary
+
+**Human DNAJC4 has no direct experimental evidence for HSP70 co-chaperone activity.** Despite possessing a conserved J-domain with an intact HPD motif (H62-P63-D64) — the canonical signature required for stimulating HSP70 ATPase activity — no published study has ever tested DNAJC4 in an ATPase stimulation assay, a direct HSP70 binding assay, or a client recruitment experiment. The molecular function annotations currently assigned to DNAJC4 in UniProt ("unfolded protein binding," GO:0051082; "protein folding," GO:0006457) are based on Non-traceable Author Statement (NAS) evidence codes, meaning they are inferred from DNAJC4's membership in the DNAJ family rather than from any experiment performed on DNAJC4 itself.
+
+High-throughput protein-protein interaction screens have detected DNAJC4 associations with huntingtin (HTT) and wolframin (WFS1) — two disease-relevant proteins linked to protein quality control — but these interactions were identified exclusively by yeast two-hybrid (Y2H) and affinity pull-down/mass spectrometry methods, and none has been validated by targeted low-throughput approaches such as co-immunoprecipitation or proximity ligation. No specific HSP70 paralog partner (HSPA8/Hsc70, HSPA1A/Hsp70, or otherwise) has been established for DNAJC4. Furthermore, DNAJC4 is an unusual DNAJ family member: it is a single-pass transmembrane protein (TM helix at residues 156-175) with a topology that distinguishes it from the cytoplasmic DNAJ co-chaperones most commonly studied in protein-folding contexts.
+
+The critical experiments needed to resolve this gap are straightforward: (1) an in vitro ATPase stimulation assay using purified DNAJC4 J-domain against candidate HSP70 paralogs with an HPD-mutant control, (2) direct binding assays (SPR, ITC, or co-IP) between DNAJC4 and HSP70 family members, and (3) client recruitment assays to determine whether DNAJC4 delivers substrates to HSP70 in a J-domain-dependent manner.
+
+---
+
+## Key Findings
+
+### Finding 1: Conserved J-domain with Intact HPD Motif, but No Functional Validation
+
+DNAJC4 (UniProt Q9NNZ3, 241 amino acids) contains a canonical J-domain spanning residues 34-99 (66 amino acids) with a conserved HPD motif at positions 62-64. The HPD tripeptide is positioned at approximately residue 29 within the J-domain, matching the canonical position found in experimentally proven HSP70 co-chaperones such as DNAJA1, DNAJB1, DNAJC1, DNAJC12, and *E. coli* DnaJ. This structural conservation strongly predicts the capability to stimulate HSP70 ATPase activity — the HPD motif is the single most critical determinant of J-domain/HSP70 functional interaction across all domains of life.
+
+However, **prediction is not evidence.** No published study has ever:
+
+- Tested purified DNAJC4 (or its isolated J-domain) for stimulation of any HSP70's ATPase activity
+- Measured direct binding between DNAJC4 and any HSP70 paralog using biophysical methods
+- Demonstrated that DNAJC4 recruits client proteins to HSP70
+
+The original characterization of DNAJC4 (then called MCG18 or HSPF2) by Silins et al. (1998) noted that "MCG18 is predicted to encode a 241 amino acid product that has partial homology to *Escherichia coli* dnaJ in that it contains the J domain" ([PMID: 9473517](https://pubmed.ncbi.nlm.nih.gov/9473517/)). Since that initial sequence-based annotation nearly three decades ago, no biochemical follow-up has been published.
+
+An important structural nuance comes from large-scale evolutionary analysis of J-domain proteins. Liu et al. (2023) demonstrated that "key residues within the J-domains have coevolved with their obligatory Hsp70 partners" ([PMID: 37523524](https://pubmed.ncbi.nlm.nih.gov/37523524/)). DNAJC4's helix II region — which flanks the HPD motif and makes direct contact with HSP70 — shows significant divergence from canonical DNAJ proteins, including charge reversals at key HSP70-contact positions. This divergence raises the possibility that DNAJC4 may have altered or diminished HSP70-stimulatory activity, or specificity for an atypical HSP70 partner, compared to well-characterized co-chaperones.
+
+The helix II divergence is summarized below:
+
+| Protein | Helix II + HPD Sequence | Notes |
+|---------|------------------------|-------|
+| **DNAJC4** | **RAFFSKSKELHPD** | Charge reversal at position -2 (E vs. K/R) |
+| DNAJA1 | KAYRKLALKYHPD | Canonical basic residues |
+| DNAJB1 | RAYRRQALRYHPD | Canonical basic residues |
+| DNAJC1/MTJ1 | KAYRKLSLTLHPD | Proven BiP co-chaperone |
+| DNAJC12 | AAYRRLCMLYHPD | Proven Hsc70 co-chaperone |
+| *E. coli* DnaJ | KAYKRLAMKYHPD | Prototype J-domain |
+
+The UniProt GO annotations for DNAJC4 carry NAS (Non-traceable Author Statement) evidence codes for both "unfolded protein binding" (GO:0051082) and "protein folding" (GO:0006457). These annotations were assigned based on DNAJ family membership, not on any direct experiment. This is a textbook example of **family-level inference** being mistaken for molecule-specific evidence.
+
+### Finding 2: High-Throughput Interaction Data Link DNAJC4 to HTT and WFS1, Without Mechanistic Validation
+
+DNAJC4 has been detected as an interactor of huntingtin (HTT) in two independent high-throughput studies:
+
+| Study | Method | Interactors Detected | PMID |
+|-------|--------|---------------------|------|
+| Kaltenbach et al. 2007 | Y2H + affinity pull-down/MS | HTT-DNAJC4 | [17500595](https://pubmed.ncbi.nlm.nih.gov/17500595/) |
+| Haenig et al. 2020 | Systematic Y2H (ND interactome) | HTT-DNAJC4, WFS1-DNAJC4 | [32814053](https://pubmed.ncbi.nlm.nih.gov/32814053/) |
+| Rolland et al. 2014 | Proteome-scale binary Y2H | DNAJC4-FAM9B | [25416956](https://pubmed.ncbi.nlm.nih.gov/25416956/) |
+| Huttlin et al. 2021 | AP-MS (BioPlex) | DNAJC4-PGAM2 | [33961781](https://pubmed.ncbi.nlm.nih.gov/33961781/) |
+| Deribe et al. 2009 | Membrane Y2H | DNAJC4-EGFR | [20029029](https://pubmed.ncbi.nlm.nih.gov/20029029/) |
+
+The HTT interaction is the most robust, having been detected by two orthogonal methods (Y2H and pull-down/MS) across two independent laboratories. Kaltenbach et al. (2007) identified "a comprehensive set of Htt interactors using two complementary approaches: high-throughput yeast two-hybrid screening and affinity pull down followed by mass spectrometry" ([PMID: 17500595](https://pubmed.ncbi.nlm.nih.gov/17500595/)). The WFS1 (wolframin) interaction, detected by Haenig et al. (2020) in a neurodegenerative disease-focused interactome mapping "~5,000 human proteins via ~30,000 candidate interactions" ([PMID: 32814053](https://pubmed.ncbi.nlm.nih.gov/32814053/)), is notable because WFS1 is an ER transmembrane protein involved in the unfolded protein response — potentially consistent with DNAJC4's own transmembrane topology.
+
+**Critically, none of these interactions has been validated by low-throughput, targeted methods** such as co-immunoprecipitation from endogenous proteins, proximity ligation assay, or FRET/BRET. Furthermore, detecting a physical interaction with HTT or WFS1 does not establish an HSP70-dependent mechanism. DNAJC4 could interact with these proteins through its non-J-domain regions (e.g., its C-terminal domain or transmembrane segment) independently of any chaperone cycle.
+
+### Finding 3: No HSP70 Paralog Specificity Established
+
+A systematic examination of protein interaction databases reveals no convincing evidence for DNAJC4 binding to any specific HSP70 paralog:
+
+| HSP70 Paralog | STRING Evidence Score | Physical Binding Assay | Notes |
+|---------------|----------------------|----------------------|-------|
+| HSPA8 (Hsc70) | Not in top 27 partners | None | Major cytoplasmic constitutive HSP70 |
+| HSPA1A (Hsp70) | Not in top 27 partners | None | Major stress-inducible HSP70 |
+| HSPA9 (mortalin) | Experimental: 0.488 | None validated | Mitochondrial HSP70; likely co-fractionation artifact |
+| HSPA1L | Experimental: 0.045 | None | Marginal signal |
+| HSPA5 (BiP/GRP78) | Not detected | None | ER-resident HSP70 |
+
+The absence of HSPA8 and HSPA1A — the two major cytoplasmic HSP70 paralogs most commonly partnered with DNAJ co-chaperones — from DNAJC4's interaction network is notable. The only HSP70 family member with any experimental signal is HSPA9 (mortalin), the mitochondrial HSP70, with a moderate STRING experimental score of 0.488. However, this likely reflects co-occurrence or co-fractionation data rather than direct physical binding.
+
+This stands in stark contrast to well-characterized DNAJ co-chaperones. For example, DNAJC12 has been shown to "synergistically stimulate Hsc70 ATPase activity when complexed with TH [tyrosine hydroxylase]" ([PMID: 40113792](https://pubmed.ncbi.nlm.nih.gov/40113792/)), and the *Plasmodium* J-domain protein A8iJp was demonstrated to "stimulate the ATPase and aggregation suppression activity of the human HSP70 chaperone HsHSPA8" ([PMID: 38418371](https://pubmed.ncbi.nlm.nih.gov/38418371/)). No equivalent demonstration exists for DNAJC4.
+
+### Finding 4: DNAJC4 Is a Transmembrane J-domain Protein with Distinctive Biology
+
+DNAJC4 is not a typical cytoplasmic DNAJ co-chaperone. Several features distinguish it:
+
+**Transmembrane topology:** DNAJC4 contains a single transmembrane helix at residues 156-175, making it a type III (class C) membrane-anchored J-domain protein. This was noted in the original characterization: "MCG18 has greatest similarity to a functionally undefined protein from *Caenorhabditis elegans*, both of which are predicted to have a membrane-spanning region adjacent to their J domains" ([PMID: 9473517](https://pubmed.ncbi.nlm.nih.gov/9473517/)). This membrane anchoring constrains which HSP70 paralogs DNAJC4 could partner with and limits its ability to act as a freely diffusing cytoplasmic co-chaperone.
+
+**Temperature-regulated expression:** Sonna et al. (2010) showed that DNAJC4 mRNA expression correlates with core body temperature in ICU patients with sepsis/SIRS, with differential temperature-dependent responses between sepsis and noninfectious SIRS ([PMID: 19496026](https://pubmed.ncbi.nlm.nih.gov/19496026/)). Notably, DNAJC4 was among a select group of 12 genes (out of 278 tested) that showed temperature-dependent responses that "differed significantly between patients with sepsis and noninfectious SIRS," alongside other heat shock proteins HSPA1A, HSPA1B, and HSPA1L. This co-regulation with HSP70 family members is suggestive of a shared functional pathway.
+
+**Fertility-related expression:** Ing et al. (2015) demonstrated that dexamethasone treatment decreased DNAJC4 mRNA in stallion testes by more than 60%, with DNAJC4 expressed specifically in germ cells during spermiogenesis ([PMID: 25487569](https://pubmed.ncbi.nlm.nih.gov/25487569/)). A related study noted that DNAJC4 mRNA concentrations in stallion spermatozoa were not different between dense and less dense sperm fractions (P > 0.1), unlike spermatozoa-specific calcium channels ([PMID: 24857629](https://pubmed.ncbi.nlm.nih.gov/24857629/)).
+
+**HIV-1 replication:** Chand et al. (2023) found that "DNAJC4 seem[s] to positively regulate virus replication" based on knockdown and overexpression experiments ([PMID: 36723955](https://pubmed.ncbi.nlm.nih.gov/36723955/)).
+
+While these phenotypic observations are consistent with a protein quality control function, **none establishes an HSP70-dependent mechanism.** They remain phenotypic correlations that could be mediated through HSP70-independent pathways.
+
+{{figure:dnajc4_evidence_summary.png|caption=DNAJC4 evidence assessment heatmap and domain architecture. Left: assessment of evidence levels across key functional categories, showing that all current evidence is based on sequence prediction or high-throughput screens, with no direct biochemical validation. Right: domain architecture of DNAJC4 showing J-domain (with HPD motif), linker region, and transmembrane helix.}}
+
+---
+
+## Mechanistic Model and Interpretation
+
+### The Evidence Hierarchy for DNAJC4
+
+The current state of knowledge about DNAJC4 can be organized into a clear evidence hierarchy:
+
+```
+LEVEL 1 - Sequence prediction (ESTABLISHED)
+  |-- J-domain with HPD motif --> predicts HSP70 ATPase stimulation
+  |-- Type III DNAJ classification --> predicts co-chaperone role
+  +-- Transmembrane helix --> constrains subcellular localization
+
+LEVEL 2 - High-throughput interactions (DETECTED, NOT VALIDATED)
+  |-- HTT binding (Y2H + pull-down/MS, 2 independent studies)
+  |-- WFS1 binding (Y2H, 1 study)
+  |-- EGFR, FAM9B, PGAM2 (various HT methods)
+  +-- No HSP70 paralog detected as direct partner
+
+LEVEL 3 - Cellular phenotypes (OBSERVED, MECHANISM UNKNOWN)
+  |-- Temperature-regulated expression in sepsis/SIRS
+  |-- Glucocorticoid-responsive in testes
+  +-- HIV-1 replication modulation
+
+LEVEL 4 - Direct biochemical activity (COMPLETELY ABSENT)
+  |-- HSP70 ATPase stimulation --> NOT TESTED
+  |-- HSP70 direct binding --> NOT TESTED
+  |-- Client delivery to HSP70 --> NOT TESTED
+  +-- Unfolded protein binding --> NOT TESTED
+```
+
+### Competing Mechanistic Models
+
+Given the available evidence, several models are plausible:
+
+**Model A - Canonical HSP70 co-chaperone:** DNAJC4 functions as a membrane-anchored HSP70 co-chaperone, using its J-domain to stimulate a specific HSP70 paralog and recruit transmembrane or membrane-proximal client proteins. This is the default assumption based on its J-domain, but it is entirely untested. The closest validated analog is DNAJC1/MTJ1, which is also a transmembrane J-domain protein and has been shown to stimulate BiP/GRP78 ATPase activity through its luminal J-domain ([PMID: 10777498](https://pubmed.ncbi.nlm.nih.gov/10777498/)).
+
+**Model B - Attenuated or specialized co-chaperone:** The divergent helix II residues in DNAJC4's J-domain may result in weak or context-dependent HSP70 stimulation, potentially specific to an unusual HSP70 partner (e.g., HSPA9/mortalin or HSPA5/BiP). This model would explain why no HSP70 partner has been detected in standard interaction screens.
+
+**Model C - HSP70-independent function:** DNAJC4 may have evolved away from canonical HSP70 co-chaperone activity while retaining the J-domain fold for structural reasons. Some J-domain proteins have been shown to have HSP70-independent activities — for example, DNAJB6 suppresses polyglutamine aggregation "independent of HSPA1 and ATP" at substoichiometric ratios ([PMID: 23904097](https://pubmed.ncbi.nlm.nih.gov/23904097/)), and DNAJC12 binding stabilizes tyrosine hydroxylase "in an Hsp70-independent manner" ([PMID: 40113792](https://pubmed.ncbi.nlm.nih.gov/40113792/)).
+
+Without the key biochemical experiments (ATPase stimulation, binding assays), it is impossible to distinguish among these models.
+
+### Comparison to Experimentally Validated DNAJ Co-chaperones
+
+To contextualize the evidence gap, consider how other DNAJ family members have been validated:
+
+| DNAJ Protein | HSP70 Partner | ATPase Stimulation | Direct Binding | Client Delivery | Key PMID |
+|-------------|---------------|-------------------|---------------|----------------|----------|
+| DNAJC12 | Hsc70 (HSPA8) | Yes (synergistic with TH) | Yes (cryo-EM) | Yes (TH) | [40113792](https://pubmed.ncbi.nlm.nih.gov/40113792/) |
+| DNAJB1 | HSPA1A | Yes | Yes | Yes (luciferase) | [21231916](https://pubmed.ncbi.nlm.nih.gov/21231916/) |
+| DNAJB6 | HSPA/HSP70 | Yes (J-domain dependent) | Yes | Yes (polyQ, TDP-43) | [41135683](https://pubmed.ncbi.nlm.nih.gov/41135683/) |
+| DNAJA1 | HSPA1A | Yes | Yes | Yes (polyQ htt) | [32424160](https://pubmed.ncbi.nlm.nih.gov/32424160/) |
+| DNAJC1/MTJ1 | BiP (HSPA5) | Yes (stoichiometric) | Yes (HPD-dependent) | ER clients | [10777498](https://pubmed.ncbi.nlm.nih.gov/10777498/) |
+| DNAJC5/CSP | Hsc70 (HSPA8) | Yes | Yes | Synaptic vesicle proteins | [12956868](https://pubmed.ncbi.nlm.nih.gov/12956868/) |
+| **DNAJC4** | **Unknown** | **NOT TESTED** | **NOT TESTED** | **NOT TESTED** | -- |
+
+The contrast is stark. Every DNAJ protein with a confirmed HSP70 co-chaperone role has been tested in at least an ATPase stimulation assay. DNAJC4 has not.
+
+---
+
+## Evidence Base
+
+### Primary Literature on DNAJC4
+
+- **Silins et al. (1998)** - *Characterisation of a new human and murine member of the DnaJ family of proteins.* [PMID: 9473517](https://pubmed.ncbi.nlm.nih.gov/9473517/). The original cloning and sequence characterization of DNAJC4 (MCG18/HSPF2). Identified the J-domain and transmembrane region. No functional assays performed. Key quote: "MCG18 is predicted to encode a 241 amino acid product that has partial homology to *Escherichia coli* dnaJ in that it contains the J domain."
+
+- **Kaltenbach et al. (2007)** - *Huntingtin interacting proteins are genetic modifiers of neurodegeneration.* [PMID: 17500595](https://pubmed.ncbi.nlm.nih.gov/17500595/). Identified DNAJC4 as an HTT interactor by Y2H and pull-down/MS in a large-scale screen of 234 high-confidence HTT-associated proteins.
+
+- **Haenig et al. (2020)** - *Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins.* [PMID: 32814053](https://pubmed.ncbi.nlm.nih.gov/32814053/). Independently detected HTT-DNAJC4 and WFS1-DNAJC4 interactions in a systematic Y2H screen of ~500 neurodegenerative disease-related proteins covering ~30,000 candidate interactions.
+
+- **Sonna et al. (2010)** - *Core temperature correlates with expression of selected stress and immunomodulatory genes in febrile patients.* [PMID: 19496026](https://pubmed.ncbi.nlm.nih.gov/19496026/). Showed temperature-dependent DNAJC4 expression in sepsis/SIRS patients. DNAJC4 was among 12 genes showing differential temperature-sensitivity between sepsis and noninfectious SIRS.
+
+- **Ing et al. (2015)** - *Dexamethasone acutely regulates endocrine parameters in stallions.* [PMID: 25487569](https://pubmed.ncbi.nlm.nih.gov/25487569/). Demonstrated >60% reduction in testicular DNAJC4 mRNA after dexamethasone treatment. DNAJC4 expressed in germ cells during spermiogenesis.
+
+- **Chand et al. (2023)** - *DNAJB8 facilitates autophagic-lysosomal degradation of viral Vif protein.* [PMID: 36723955](https://pubmed.ncbi.nlm.nih.gov/36723955/). Found DNAJC4 positively regulates HIV-1 replication in knockdown/overexpression experiments.
+
+- **Rolland et al. (2014)** - *A proteome-scale map of the human interactome network.* [PMID: 25416956](https://pubmed.ncbi.nlm.nih.gov/25416956/). Identified DNAJC4-FAM9B interaction in a systematic binary interactome mapping ~14,000 high-quality human protein-protein interactions.
+
+- **Deribe et al. (2009)** - *Regulation of epidermal growth factor receptor trafficking by lysine deacetylase HDAC6.* [PMID: 20029029](https://pubmed.ncbi.nlm.nih.gov/20029029/). Identified DNAJC4-EGFR interaction using a modified membrane yeast two-hybrid system.
+
+### Key Contextual Literature on DNAJ/HSP70 Biology
+
+- **Liu et al. (2023)** - *Data-driven large-scale genomic analysis reveals an intricate phylogenetic and functional landscape in J-domain proteins.* [PMID: 37523524](https://pubmed.ncbi.nlm.nih.gov/37523524/). Demonstrated coevolution between J-domain residues and HSP70 partners, showing that "key residues within the J-domains have coevolved with their obligatory Hsp70 partners." Directly relevant to DNAJC4's divergent helix II.
+
+- **Chevalier et al. (2000)** - *Interaction of murine BiP/GRP78 with the DnaJ homologue MTJ1.* [PMID: 10777498](https://pubmed.ncbi.nlm.nih.gov/10777498/). Demonstrated that the transmembrane J-domain protein MTJ1 (DNAJC1) stimulates BiP ATPase activity through its J-domain, and that H89Q mutation in the HPD motif abolishes both binding and ATPase stimulation. This is the closest validated analog to DNAJC4.
+
+- **Kampinga et al. (2009)** - *Guidelines for the nomenclature of the human heat shock proteins.* [PMID: 18663603](https://pubmed.ncbi.nlm.nih.gov/18663603/). Established the DNAJ nomenclature system. DNAJC4 classified as a type III (class C) J-domain protein.
+
+- **Cyr & Ramos (2023)** - *Specification of Hsp70 Function by Hsp40 Co-chaperones.* [PMID: 36520305](https://pubmed.ncbi.nlm.nih.gov/36520305/). Comprehensive review of how "Hsp40s select substrates for Hsp70 via use of an intrinsic chaperone activity to bind non-native regions of proteins" and how they "employ a conserved J-domain to stimulate Hsp70 ATPase activity."
+
+- **Aurora et al. (2025)** - *De novo designed Hsp70 activator dissolves intracellular condensates.* [PMID: 39922190](https://pubmed.ncbi.nlm.nih.gov/39922190/). Demonstrates that de novo designed J-domain mimetics can stimulate HSP70 ATPase activity, establishing that the assay is technically straightforward and could be applied to DNAJC4.
+
+- **Fernandez-Fernandez et al. (2025)** - *Structural recognition and stabilization of tyrosine hydroxylase by DNAJC12.* [PMID: 40113792](https://pubmed.ncbi.nlm.nih.gov/40113792/). Gold-standard example of DNAJC-class co-chaperone characterization: cryo-EM structure, ATPase stimulation, client binding, HPD-dependent mechanism. Directly illustrates the type of evidence completely lacking for DNAJC4.
+
+---
+
+## Evidence Classification Summary
+
+| Claim | Evidence Level | Basis |
+|-------|---------------|-------|
+| DNAJC4 is a J-domain protein | **Strong** (direct) | Sequence analysis, Pfam PF00226 annotation |
+| DNAJC4 has conserved HPD motif | **Strong** (direct) | Sequence analysis (H62-P63-D64) |
+| DNAJC4 is a transmembrane protein | **Strong** (direct) | Sequence analysis (TM helix 156-175) |
+| DNAJC4 binds HSP70 | **Predicted** (no direct evidence) | Family inference from J-domain + HPD |
+| DNAJC4 stimulates HSP70 ATPase | **Not tested** | No published assay |
+| DNAJC4 binds unfolded proteins | **Family inference** (NAS) | GO annotation from family membership |
+| DNAJC4 interacts with HTT | **Moderate** (HTP, 2 studies) | Y2H + pull-down/MS |
+| DNAJC4 interacts with WFS1 | **Low-moderate** (single HTP) | One Y2H study |
+| DNAJC4 has specific HSP70 paralog partner | **Not tested** | No data for any paralog |
+
+---
+
+## Limitations and Knowledge Gaps
+
+### What We Know
+- DNAJC4 has a canonical J-domain with an intact HPD motif at positions 62-64
+- DNAJC4 interacts with HTT and WFS1 in high-throughput screens (2 and 1 independent studies, respectively)
+- DNAJC4 expression responds to thermal stress and glucocorticoids
+- DNAJC4 has a transmembrane helix distinguishing it from cytoplasmic DNAJ proteins
+
+### What We Do Not Know
+- **Whether DNAJC4 stimulates any HSP70's ATPase activity** — this is the single most important unanswered question
+- **Which HSP70 paralog(s) DNAJC4 partners with**, if any
+- **Whether DNAJC4 binds unfolded proteins** — the GO annotation is family-level inference only
+- **Whether the HTT and WFS1 interactions are HSP70-dependent** — they could be mediated through non-J-domain regions
+- **The subcellular localization of endogenous DNAJC4** — transmembrane topology suggests ER or plasma membrane, but this has not been experimentally confirmed in human cells
+- **Whether the helix II divergence functionally impacts HSP70 interaction** — the charge reversals at key contact positions could reduce or alter binding
+- **The orientation of the J-domain relative to the membrane** — whether it faces the cytoplasm or an organellar lumen determines which HSP70 paralogs are accessible
+
+### Limitations of This Analysis
+- The literature search may not have captured unpublished or preprint data
+- Negative results (e.g., DNAJC4 tested but inactive in a chaperone screen) are typically not published, so absence of evidence may partially reflect publication bias
+- STRING and IntAct interaction scores are aggregated metrics that may not distinguish direct from indirect associations
+- DNAJC4 is severely understudied: no dedicated functional study exists. It appears only in high-throughput screens, transcriptomic surveys, and bioinformatic analyses
+
+---
+
+## Proposed Follow-up Experiments
+
+The following experiments are ordered by priority, with the most critical and feasible listed first:
+
+### Priority 1: In Vitro ATPase Stimulation Assay (Essential)
+
+**Rationale:** This is the gold-standard test for J-domain protein co-chaperone activity and the single experiment most needed to resolve the evidence gap.
+
+**Design:**
+- Express and purify human DNAJC4 J-domain (residues 34-99) and, if feasible, solubilized full-length DNAJC4
+- Test stimulation of ATPase activity for HSPA8 (Hsc70), HSPA1A (Hsp70), HSPA5 (BiP/GRP78), and HSPA9 (mortalin) using a malachite green phosphate release assay
+- Include HPD->QPD mutant (H62Q) as a negative control
+- Include DNAJB1 J-domain as a positive control
+- Measure dose-response and calculate fold-stimulation
+
+**Expected outcome:** If DNAJC4 stimulates any HSP70 with >2-fold activation that is abolished by the H62Q mutation, this would constitute direct evidence for co-chaperone activity. If no stimulation is observed, this would support Model C (HSP70-independent function).
+
+### Priority 2: Direct HSP70 Binding Assay
+
+**Design:**
+- Surface plasmon resonance (SPR) or isothermal titration calorimetry (ITC) with purified DNAJC4 J-domain and candidate HSP70 paralogs
+- Compare binding affinity (Kd) to that of known co-chaperone pairs (typically 1-50 uM)
+- Test in the presence of ATP, ADP, and nucleotide-free states
+
+### Priority 3: Subcellular Localization and Topology Determination
+
+**Design:**
+- Immunofluorescence with validated anti-DNAJC4 antibody in human cell lines (HEK293, HeLa)
+- Co-staining with ER (calnexin), Golgi (GM130), and plasma membrane markers
+- Protease protection assay or fluorescence-based topology mapping to determine whether J-domain faces cytoplasm or organellar lumen
+- Proximity ligation assay (PLA) with candidate HSP70 paralogs to detect endogenous complexes
+
+### Priority 4: Validation of HTT and WFS1 Interactions
+
+**Design:**
+- Co-immunoprecipitation of DNAJC4 with HTT and WFS1 from HEK293 cells expressing endogenous or tagged proteins
+- Test whether interactions are disrupted by the HPD->QPD J-domain mutation (would indicate HSP70-dependent mechanism)
+- Test whether interactions require HSP70 (using VER-155008 or other HSP70 inhibitors)
+
+### Priority 5: Functional Phenotyping with Mechanistic Controls
+
+**Design:**
+- DNAJC4 knockout/knockdown in human cell lines, measuring effects on:
+  - Protein aggregation (filter trap assay)
+  - ER stress markers (BiP upregulation, CHOP induction, XBP1 splicing)
+  - Polyglutamine aggregation (using HTT-exon1-Q74 reporter)
+- Rescue with wild-type DNAJC4 vs. HPD-mutant DNAJC4 to determine whether phenotypes are J-domain-dependent
+- This would connect molecular function to cellular phenotype and distinguish HSP70-dependent from HSP70-independent activities
+
+---
+
+## Supported and Refuted Hypotheses
+
+### Supported (with caveats)
+- **DNAJC4 has a functional J-domain capable of HSP70 interaction** - Supported by sequence conservation of HPD motif, but helix II divergence adds uncertainty. NOT experimentally confirmed.
+- **DNAJC4 participates in protein quality control networks** - Supported by HTT and WFS1 interactions (HTP evidence) and stress-responsive expression. Mechanism unknown.
+
+### Neither Supported nor Refuted (untested)
+- **DNAJC4 stimulates HSP70 ATPase activity** - Never tested biochemically.
+- **DNAJC4 shows specificity for HSPA8 or HSPA1A** - No evidence for any specific paralog.
+- **DNAJC4 recruits clients to HSP70 for folding** - No client recruitment data.
+
+### Weakly Refuted
+- **DNAJC4 is a typical cytoplasmic HSP70 co-chaperone** - Its transmembrane topology and helix II divergence argue against this. More likely a membrane-anchored, compartment-specific J-domain protein with potentially restricted HSP70 paralog preference.
+
+---
+
+## Conclusions
+
+DNAJC4 represents one of the most significant gaps in our understanding of the human DNAJ co-chaperone family. While its J-domain with intact HPD motif strongly predicts HSP70 co-chaperone capability, this prediction remains entirely unvalidated after nearly 30 years since the gene's initial characterization in 1998. The current molecular function annotations in databases are family-level inferences, not experimental findings. High-throughput interaction data link DNAJC4 to disease-relevant proteins (HTT, WFS1), but these associations do not establish an HSP70-dependent mechanism. The transmembrane topology and divergent helix II sequence of DNAJC4 suggest it may have specialized or atypical co-chaperone properties that cannot be assumed from family membership alone.
+
+Until the key biochemical experiments — particularly the ATPase stimulation assay — are performed, **it is not scientifically justified to annotate DNAJC4 as having "HSP70 protein binding" or "unfolded protein binding" as experimentally supported molecular functions.** These remain plausible hypotheses, not established facts. The single most impactful experiment to resolve this gap is an in vitro ATPase stimulation assay testing purified DNAJC4 J-domain against a panel of HSP70 paralogs (HSPA8, HSPA1A, HSPA5/BiP, HSPA9), with an HPD-mutant control.
+
+---
+
+## Key References
+
+| PMID | Citation | Relevance to DNAJC4 |
+|------|----------|---------------------|
+| [9473517](https://pubmed.ncbi.nlm.nih.gov/9473517/) | Silins et al. 1998 | Original characterization of DNAJC4 |
+| [37523524](https://pubmed.ncbi.nlm.nih.gov/37523524/) | Liu et al. 2023 | J-domain coevolution with HSP70 partners |
+| [17500595](https://pubmed.ncbi.nlm.nih.gov/17500595/) | Kaltenbach et al. 2007 | HTT-DNAJC4 interaction (Y2H + MS) |
+| [32814053](https://pubmed.ncbi.nlm.nih.gov/32814053/) | Haenig et al. 2020 | HTT and WFS1 interactions (Y2H) |
+| [10777498](https://pubmed.ncbi.nlm.nih.gov/10777498/) | Chevalier et al. 2000 | MTJ1/DNAJC1 as closest validated analog |
+| [40113792](https://pubmed.ncbi.nlm.nih.gov/40113792/) | Fernandez-Fernandez et al. 2025 | DNAJC12 gold-standard characterization |
+| [19496026](https://pubmed.ncbi.nlm.nih.gov/19496026/) | Sonna et al. 2010 | Temperature-regulated DNAJC4 expression |
+| [25487569](https://pubmed.ncbi.nlm.nih.gov/25487569/) | Ing et al. 2015 | DNAJC4 in stallion spermiogenesis |
+| [36723955](https://pubmed.ncbi.nlm.nih.gov/36723955/) | Chand et al. 2023 | DNAJC4 modulates HIV-1 replication |
+| [18663603](https://pubmed.ncbi.nlm.nih.gov/18663603/) | Kampinga et al. 2009 | DNAJ nomenclature guidelines |
+| [36520305](https://pubmed.ncbi.nlm.nih.gov/36520305/) | Cyr & Ramos 2023 | Review: DNAJ specification of HSP70 function |
+| [39922190](https://pubmed.ncbi.nlm.nih.gov/39922190/) | Aurora et al. 2025 | De novo HSP70 activator design |
+| [25416956](https://pubmed.ncbi.nlm.nih.gov/25416956/) | Rolland et al. 2014 | DNAJC4-FAM9B interaction |
+| [20029029](https://pubmed.ncbi.nlm.nih.gov/20029029/) | Deribe et al. 2009 | DNAJC4-EGFR interaction |
+| [33961781](https://pubmed.ncbi.nlm.nih.gov/33961781/) | Huttlin et al. 2021 | DNAJC4-PGAM2 interaction (BioPlex) |

--- a/genes/human/DNAJC4/DNAJC4-hypotheses/kgap-dnajc4-hsp70-cochaperone-activity/openscientist.md.citations.md
+++ b/genes/human/DNAJC4/DNAJC4-hypotheses/kgap-dnajc4-hsp70-cochaperone-activity/openscientist.md.citations.md
@@ -1,0 +1,33 @@
+# OpenScientist citation sidecar: DNAJC4
+
+- OpenScientist job: `0cc17233-1a27-48e7-8ad6-49189e10d264`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:9473517
+- PMID:10777498
+- PMID:12956868
+- PMID:17500595
+- PMID:18663603
+- PMID:19496026
+- PMID:20029029
+- PMID:21231916
+- PMID:23904097
+- PMID:24857629
+- PMID:25416956
+- PMID:25487569
+- PMID:32424160
+- PMID:32814053
+- PMID:33961781
+- PMID:36520305
+- PMID:36723955
+- PMID:37523524
+- PMID:38418371
+- PMID:39922190
+- PMID:40113792
+- PMID:41135683
+
+## Detected DOIs
+
+- None detected

--- a/genes/human/DNAJC4/DNAJC4-hypotheses/kgap-dnajc4-hsp70-cochaperone-activity/prompt.md
+++ b/genes/human/DNAJC4/DNAJC4-hypotheses/kgap-dnajc4-hsp70-cochaperone-activity/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: DNAJC4 HSP70 co-chaperone activity
+
+Investigate whether human DNAJC4 has direct evidence for HSP70 co-chaperone activity, including stimulation of HSP70 ATPase activity, HSP70 binding, and client recruitment.
+
+Focus on:
+
+- J-domain/HPD motif conservation and whether it has been tested experimentally;
+- HSP70 paralog specificity, especially HSPA8, HSPA1A, or other partners;
+- evidence involving HTT, WFS1, unfolded protein response, or protein-folding phenotypes;
+- whether observed protein-binding or cellular-stress phenotypes establish a molecular function or remain family-level inference.
+
+Please assess whether Hsp70 protein binding, unfolded protein binding, or another molecular function is supported by direct evidence. Include PMIDs and identify the key experiments needed to resolve this gap.


### PR DESCRIPTION
Adds a focused OpenScientist hypothesis report for the DNAJC4 MF-dark knowledge gap on HSP70 co-chaperone activity and client recruitment.\n\nIncludes the prompt, markdown report, and citation sidecar.\n\nValidation: git diff --cached --check.