### PR TITLE
[codex] Add SCGB1C1 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/SCGB1C1/SCGB1C1-hypotheses/kgap-scgb1c1-ligand-specificity/openscientist.md
+++ b/genes/human/SCGB1C1/SCGB1C1-hypotheses/kgap-scgb1c1-ligand-specificity/openscientist.md
@@ -1,0 +1,240 @@
+# SCGB1C1 Ligand Specificity: A Systematic Assessment of Direct Biochemical Evidence
+
+## Summary
+
+**Human SCGB1C1 has no direct biochemical evidence for binding any odorant, lipid, steroid, or other hydrophobic small molecule.** A systematic survey of published literature, protein databases (UniProt Q8TD33), and structural repositories reveals zero studies reporting purified SCGB1C1 protein in any ligand-binding assay. No binding constants (Kd, IC50, or Ki), no co-crystal structures, and no competitive displacement data exist for SCGB1C1 with any ligand class. The protein's annotation as an "odorant-binding protein" in several databases and publications is traceable to a single 1991 paper that identified the rat ortholog (RYD5) as a novel gene expressed in olfactory mucosa with sequence homology to proteins that bind lipopolysaccharides or polychlorinated biphenyls ([PMID: 1915264](https://pubmed.ncbi.nlm.nih.gov/1915264/)). This homology-based inference was never experimentally validated for RYD5/SCGB1C1 itself, yet it propagated through the literature and into gene annotation databases as if it were established fact.
+
+Critically, the "odorant-binding protein" label conflates two structurally and evolutionarily distinct protein families. True mammalian odorant-binding proteins (OBPs) belong to the **lipocalin superfamily**, characterized by an eight-stranded β-barrel fold, whereas SCGB1C1 is a **secretoglobin** with an α-helical homodimeric fold. Furthermore, even within the secretoglobin family, ligand specificity is not transferable by homology: human CC10/SCGB1A1 retains only 4.6% of the progesterone-binding activity of rabbit uteroglobin despite 55–61% sequence identity ([PMID: 2378892](https://pubmed.ncbi.nlm.nih.gov/2378892/)). The only experimentally demonstrated function of SCGB1C1 is **immunomodulatory**—specifically, suppression of allergic airway inflammation via regulatory T cell expansion in a murine model ([PMID: 38892470](https://pubmed.ncbi.nlm.nih.gov/38892470/)). Neither "odorant binding" (GO:0005549) nor a broader "small-molecule/lipid binding" annotation is defensible for SCGB1C1 without direct binding experiments using purified recombinant protein.
+
+---
+
+## Key Findings
+
+### Finding 1: No Direct Biochemical Evidence Exists for SCGB1C1 Binding Any Ligand
+
+A comprehensive search of the published literature, UniProt (accession Q8TD33), NCBI Gene (ID 147199), Gene Ontology, the Protein Data Bank, and PubMed returned **zero studies** in which purified SCGB1C1 protein was used in any ligand-binding assay—whether fluorescence displacement, isothermal titration calorimetry, surface plasmon resonance, co-crystallization, or any other technique. UniProt carries no molecular function annotation for SCGB1C1. The only Gene Ontology annotation is GO:0005576 (extracellular region), assigned by electronic annotation (IEA), which describes localization, not molecular function. No crystal structure, NMR structure, or cryo-EM structure of SCGB1C1 has been deposited in the PDB. No co-purification of endogenous ligands has been reported—in contrast to SCGB1A1 (CC10), which was found to co-purify with phosphatidylcholine and phosphatidylinositol from human lung lavage ([PMID: 7664082](https://pubmed.ncbi.nlm.nih.gov/7664082/)).
+
+The foundational paper by Dear et al. (1991) used subtractive hybridization to identify novel genes in rat olfactory mucosa ([PMID: 1915264](https://pubmed.ncbi.nlm.nih.gov/1915264/)). The authors reported that "the predicted proteins for three of these clones are homologous to proteins which bind to either lipopolysaccharides (RYA3 and RY2G5) or to polychlorinated biphenyls (RYD5)." This statement is an inference from sequence homology—it does not describe any binding experiment performed on RYD5 itself. The word "might" was used in the original paper when discussing potential odorant interactions, indicating this was a hypothesis, not a conclusion. No follow-up study has ever tested this inference experimentally for SCGB1C1/RYD5.
+
+### Finding 2: The "Odorant Binding Protein" Designation Is Unsupported and Conflates Two Protein Families
+
+The claim that SCGB1C1 is an odorant-binding protein appears in at least one peer-reviewed publication. Pehlivan et al. (2018) stated that "the Secretoglobin 1C1 gene synthesizes odor molecule binding proteins (OBPs) in the nasal mucosa and regulates some cytokines" ([PMID: 29412801](https://pubmed.ncbi.nlm.nih.gov/29412801/)). However, this claim cites no experimental evidence for odorant binding and conflates two unrelated protein families:
+
+| Feature | True Human OBPs (Lipocalins) | SCGB1C1 (Secretoglobin) |
+|---|---|---|
+| **Protein family** | Lipocalin superfamily | Secretoglobin superfamily |
+| **Fold** | Eight-stranded antiparallel β-barrel | Four α-helix homodimer |
+| **Representative** | hOBPIIa (LCN15) | SCGB1C1 (RYD5) |
+| **Direct binding evidence** | Yes—binding assays, crystal structures | None |
+| **InterPro** | IPR000566 (Lipocalin) | IPR016126, IPR043215 (Secretoglobin) |
+| **Genetic evidence for olfaction** | rs2590498 polymorphism associated with olfactory threshold ([PMID: 31195037](https://pubmed.ncbi.nlm.nih.gov/31195037/)) | None |
+
+Briand et al. (2002) characterized the true human odorant-binding protein (hOBPIIa) as belonging to the lipocalin superfamily, noting that "odorant-binding proteins (OBPs) are small abundant extracellular proteins belonging to the lipocalin superfamily" ([PMID: 12044155](https://pubmed.ncbi.nlm.nih.gov/12044155/)). This family is structurally and phylogenetically unrelated to secretoglobins. The bovine OBP, for example, has been shown to naturally bind 1-octen-3-ol with high specificity ([PMID: 11114310](https://pubmed.ncbi.nlm.nih.gov/11114310/))—an experimental rigor that has never been applied to SCGB1C1. The mislabeling of SCGB1C1 as an OBP likely arose because the gene was originally identified in olfactory tissue, and the name "ligand binding protein RYD5" was informally escalated to "odorant binding protein" given its tissue of origin—a logical leap unsupported by any biochemical data.
+
+### Finding 3: SCGB1C1 Has Demonstrated Immunomodulatory Function Independent of Ligand Binding
+
+The only experimentally demonstrated function of SCGB1C1 protein is immunomodulatory. Kim et al. (2024) showed that intranasal administration of SCGB1C1 (5 μg) to ovalbumin-challenged mice produced significant anti-inflammatory effects ([PMID: 38892470](https://pubmed.ncbi.nlm.nih.gov/38892470/)). Specifically, "the intranasal administration of SCGB1C1 significantly inhibited AHR, the presence of eosinophils in BALF, eosinophilic inflammation, goblet cell hyperplasia in the lung, and serum total and allergen-specific IgE." SCGB1C1 treatment also decreased IL-5 in BALF and IL-4 in lung-draining lymph nodes, while significantly increasing regulatory T cell (Treg) populations.
+
+This immunomodulatory activity is consistent with the broader secretoglobin family's established anti-inflammatory roles. SCGB1A1/CC10, for example, modulates lung inflammatory and immune responses to respiratory syncytial virus infection ([PMID: 12847279](https://pubmed.ncbi.nlm.nih.gov/12847279/)), and attenuates allergic airway inflammation by modulating lung dendritic cell functions ([PMID: 39078462](https://pubmed.ncbi.nlm.nih.gov/39078462/)). However, it is important to note that this immunomodulatory function does not require or imply ligand-binding activity. Many secretoglobins exert their effects through protein–protein interactions, receptor engagement, or phospholipase A2 inhibition rather than by sequestering small hydrophobic molecules. The mechanism by which SCGB1C1 promotes Treg expansion is unknown and could involve direct receptor engagement on immune cells rather than small-molecule sequestration.
+
+Additional studies have implicated SCGB1C1 in immune contexts without testing its molecular function. Kim et al. (2020) found that Scgb1c1 was significantly upregulated in mouse lungs after treatment with adipose stem cell-derived extracellular vesicles that suppressed allergic airway inflammation ([PMID: 32676117](https://pubmed.ncbi.nlm.nih.gov/32676117/)). Sobiech et al. (2016) reported that low blood SCGB1C1 expression correlated with high IL-5 levels in athletes (corrected P = 0.00065; fold change = 3.17), suggesting it may serve as a susceptibility marker for upper respiratory tract infections ([PMID: 27274102](https://pubmed.ncbi.nlm.nih.gov/27274102/)).
+
+### Finding 4: Secretoglobin Family Members Have Diverse, Non-Transferable Ligand Specificities
+
+A key argument against imputing binding function to SCGB1C1 by family analogy is that ligand specificity within the secretoglobin family is remarkably diverse and cannot be predicted from sequence similarity alone:
+
+| Family Member | Demonstrated Ligands/Activities | Key Evidence |
+|---|---|---|
+| **Rabbit uteroglobin** | Progesterone, retinols, PCBs, phospholipids, PLA2 inhibition | [PMID: 17916741](https://pubmed.ncbi.nlm.nih.gov/17916741/) |
+| **Human SCGB1A1 (CC10)** | Phosphatidylcholine, phosphatidylinositol, PCBs; **only 4.6%** of rabbit uteroglobin's progesterone binding | [PMID: 7664082](https://pubmed.ncbi.nlm.nih.gov/7664082/), [PMID: 2378892](https://pubmed.ncbi.nlm.nih.gov/2378892/) |
+| **Rat CC17** | PCB methyl sulfones (Kd = 2.5–15 nM), weak progesterone | [PMID: 3918256](https://pubmed.ncbi.nlm.nih.gov/3918256/), [PMID: 2115524](https://pubmed.ncbi.nlm.nih.gov/2115524/) |
+| **SCGB3A2 (UGRP1)** | MARCO receptor binding, PLA2 inhibition, cytokine-like activity | No small-molecule binding demonstrated |
+| **SCGB1D2** | Guanylate cyclase activator | Entirely different function |
+| **SCGB2A1/2A2 (Mammaglobins)** | No binding activity demonstrated | Used as breast cancer biomarkers |
+| **SCGB1C1 (RYD5)** | **None demonstrated** | — |
+
+The most instructive comparison is between human CC10 and rabbit uteroglobin. Despite 55–61% sequence identity and conservation of the hydrophobic cavity architecture, Peri et al. (1993) found that "human CC10 does not inhibit papain and has markedly lower progesterone binding (4.6% of rabbit uteroglobin)" ([PMID: 2378892](https://pubmed.ncbi.nlm.nih.gov/2378892/)). This dramatic functional divergence between closely related orthologs underscores that **ligand specificity in secretoglobins cannot be assumed from homology**. SCGB1C1, which is more distantly related to uteroglobin than CC10 is, may have entirely different—or no—small-molecule binding activity.
+
+The broader secretoglobin family shows a pattern where immunomodulatory functions (PLA2 inhibition, anti-chemotaxis, anti-inflammatory signaling) are at least as prominent as hydrophobic ligand binding, and in several family members (SCGB3A2, SCGB1D2, SCGB2A1, SCGB2A2) no small-molecule binding has been demonstrated at all. Mukherjee et al. (2007) noted that uteroglobin "inhibits soluble phospholipase A(2) activity and binds and perhaps sequesters hydrophobic ligands such as progesterone, retinols, polychlorinated biphenyls, phospholipids, and prostaglandins" ([PMID: 17916741](https://pubmed.ncbi.nlm.nih.gov/17916741/)), but this diversity of binding in one family member cannot be extrapolated to SCGB1C1 without direct evidence.
+
+### Finding 5: SCGB1C1 Has Very Low Expression Across All GTEx Tissues; Olfactory Tissue Is Unsampled
+
+Expression data provides context for physiological relevance but does not itself prove molecular function:
+
+- **GTEx v8 data** shows maximum median expression of only **0.335 TPM** (pancreas), 0.264 TPM (whole blood), and 0.220 TPM (kidney medulla). Most tissues register 0.0 TPM, including lung (0.0 TPM)—a notable absence given that secretoglobins are classically considered lung-expressed proteins.
+- **Human nasal mucosa**: SCGB1C1 mRNA was detected by RT-qPCR in human nasal mucosa explants, where "the expression of SCGBs except SCGB1D2 (lipophilin B) could be found in upper airway and be differentially regulated by different cytokines" ([PMID: 21385388](https://pubmed.ncbi.nlm.nih.gov/21385388/)). Expression was significantly elevated in nasal polyps ("the level of Secretoglobin 1C1's expression increased in NP (P = 0.003)"; [PMID: 29412801](https://pubmed.ncbi.nlm.nih.gov/29412801/)).
+- **Olfactory tissue**: The original rat RYD5 identification was in olfactory mucosa ([PMID: 1915264](https://pubmed.ncbi.nlm.nih.gov/1915264/)), but GTEx does not sample human olfactory epithelium, so human olfactory expression remains unconfirmed by modern transcriptomics.
+- **Blood**: Low-level expression was detected in blood of elite athletes, and SCGB1C1 expression correlated inversely with IL-5 levels ([PMID: 27274102](https://pubmed.ncbi.nlm.nih.gov/27274102/)).
+
+The nasal expression pattern is consistent with but does not prove an odorant-binding role. Many proteins are expressed in the nasal mucosa with functions unrelated to olfaction (e.g., immune defense, mucosal barrier maintenance, antimicrobial peptides). The upregulation of SCGB1C1 in nasal polyps—an inflammatory condition—and its cytokine-regulated expression pattern are more consistent with an immunomodulatory role than a chemosensory one.
+
+{{figure:scgb1c1_evidence_summary.png|caption=Summary of evidence landscape for SCGB1C1 molecular function. No direct ligand-binding evidence exists; the odorant-binding annotation derives from untested homology inference and protein family conflation. The only demonstrated activity is immunomodulatory (Treg expansion).}}
+
+---
+
+## Mechanistic Model and Interpretation
+
+### The Propagation of an Untested Hypothesis
+
+The current annotation landscape for SCGB1C1 can be understood as a case study in how an untested 1991 hypothesis became entrenched as assumed fact through citation propagation and terminological drift:
+
+```
+1991: Dear et al. identify RYD5 in rat olfactory mucosa
+      → Infer PCB-binding from sequence homology to SCGB1A1
+      → Authors use cautious language ("might interact with odorants")
+      → No binding experiment performed on RYD5
+            │
+            ▼
+2000: Secretoglobin nomenclature committee names it "SCGB1C1"
+      → Informal alias "ligand binding protein RYD5" persists
+      → The word "ligand" implies demonstrated binding
+            │
+            ▼
+2011: Yoon et al. refer to SCGB1C1 as "ligand binding protein RYD5"
+      → Study examines expression only, not binding
+      → Perpetuates implication of binding activity
+            │
+            ▼
+2018: Pehlivan et al. escalate to "odor molecule binding proteins (OBPs)"
+      → Conflates secretoglobins with lipocalin OBP family
+      → No new binding data; no experimental citation for claim
+            │
+            ▼
+2024: Kim et al. demonstrate immunomodulatory function
+      → First functional data for SCGB1C1
+      → Function is immunological, not ligand-binding
+            │
+            ▼
+Present: Databases and literature carry unsupported OBP label
+      → GO, UniProt have NO molecular function annotation
+      → Informal literature carries propagated, unsupported labels
+```
+
+### What SCGB1C1 Likely Does vs. What It Might Do
+
+**Demonstrated:** SCGB1C1 functions as an anti-inflammatory and immunomodulatory protein, consistent with the broader secretoglobin family pattern. The mechanism appears to involve Treg expansion, which could operate through protein–protein interactions (e.g., receptor engagement on immune cells) rather than small-molecule sequestration. This is functionally analogous to SCGB3A2, which exerts immunomodulatory effects through binding the MARCO receptor, and to SCGB1A1, which modulates dendritic cell function.
+
+**Possible but unproven:** SCGB1C1 could retain hydrophobic ligand-binding capability in its presumptive central cavity (by homology to the structurally characterized SCGB1A1 cavity), but: (a) the cavity dimensions and residue composition have not been characterized; (b) no ligand has been shown to occupy this cavity; and (c) even if binding occurs, it may be incidental or physiologically irrelevant, as demonstrated by the dramatic difference in progesterone binding between human CC10 and rabbit uteroglobin.
+
+**Unlikely:** That SCGB1C1 functions as an odorant-binding protein in the classical sense. True OBPs are lipocalins with β-barrel architecture optimized for volatile molecule transport; secretoglobins have a fundamentally different fold. The two families appear to have converged on expression in nasal tissue but likely serve different functions.
+
+### What Annotation Is Defensible?
+
+| Annotation | Defensible? | Basis |
+|---|---|---|
+| "Odorant binding protein" | **No** | No experimental evidence; confuses two protein families |
+| "Odorant binding" (GO:0005549) | **No** | No experimental evidence |
+| "Lipid binding" | **No** | No experimental evidence, only family inference |
+| "Steroid binding" | **No** | No experimental evidence |
+| "Hydrophobic small-molecule binding" | **No** | Plausible from fold but entirely untested |
+| "Anti-inflammatory protein" | **Yes (cautious)** | Mouse in vivo evidence ([PMID: 38892470](https://pubmed.ncbi.nlm.nih.gov/38892470/)) |
+| "Secreted protein" | **Yes** | Signal peptide, family membership |
+| "Secretoglobin family member" | **Yes** | Sequence/structure classification |
+
+---
+
+## Evidence Base
+
+### Primary Sources Directly Relevant to SCGB1C1
+
+| Reference | Year | Key Contribution | Direct SCGB1C1 Data? |
+|---|---|---|---|
+| Dear et al. [PMID: 1915264](https://pubmed.ncbi.nlm.nih.gov/1915264/) | 1991 | Identified RYD5/SCGB1C1 in rat olfactory mucosa; inferred binding from homology | Gene identification only |
+| Klug et al. [PMID: 11193777](https://pubmed.ncbi.nlm.nih.gov/11193777/) | 2000 | Secretoglobin nomenclature (RYD5 → SCGB1C1) | Nomenclature only |
+| Yoon et al. [PMID: 21385388](https://pubmed.ncbi.nlm.nih.gov/21385388/) | 2011 | SCGB1C1 mRNA in human upper airway; cytokine regulation | Expression only |
+| Sobiech et al. [PMID: 27274102](https://pubmed.ncbi.nlm.nih.gov/27274102/) | 2016 | Blood SCGB1C1 expression as URTI susceptibility marker | Expression only |
+| Pehlivan et al. [PMID: 29412801](https://pubmed.ncbi.nlm.nih.gov/29412801/) | 2018 | Elevated SCGB1C1 in nasal polyps; incorrectly calls it "OBP" | Expression only |
+| Kim et al. [PMID: 32676117](https://pubmed.ncbi.nlm.nih.gov/32676117/) | 2020 | SCGB1C1 upregulated by anti-inflammatory EVs | Expression only |
+| Kim et al. [PMID: 38892470](https://pubmed.ncbi.nlm.nih.gov/38892470/) | 2024 | **SCGB1C1 suppresses allergic inflammation via Treg expansion** | **Functional data** |
+
+### Key Comparative Secretoglobin Studies
+
+| Reference | Key Contribution |
+|---|---|
+| Peri et al. [PMID: 2378892](https://pubmed.ncbi.nlm.nih.gov/2378892/) | Human CC10 has only 4.6% of rabbit uteroglobin's progesterone binding despite high identity—**demonstrates non-transferability of ligand specificity** |
+| Umland et al. [PMID: 7664082](https://pubmed.ncbi.nlm.nih.gov/7664082/) | Crystal structure of human CC10 with phospholipid at 1.9 Å—**gold standard for secretoglobin ligand characterization** |
+| Mukherjee et al. [PMID: 17916741](https://pubmed.ncbi.nlm.nih.gov/17916741/) | Comprehensive review of uteroglobin: diverse ligand binding and immunomodulatory properties |
+| Bratt et al. [PMID: 2115524](https://pubmed.ncbi.nlm.nih.gov/2115524/) | Rat PCB-binding protein cloning; 53% identity with uteroglobin |
+| Lund et al. [PMID: 3918256](https://pubmed.ncbi.nlm.nih.gov/3918256/) | High-affinity PCB methyl sulfone binding by rat lung cytosol protein (Kd = 2.5–15 nM) |
+
+### OBP Family References (Contrasting Protein Family)
+
+| Reference | Key Contribution |
+|---|---|
+| Briand et al. [PMID: 12044155](https://pubmed.ncbi.nlm.nih.gov/12044155/) | Characterized human OBPIIa as a lipocalin, structurally distinct from secretoglobins |
+| Ramoni et al. [PMID: 11114310](https://pubmed.ncbi.nlm.nih.gov/11114310/) | Bovine OBP naturally binds 1-octen-3-ol—example of rigorous OBP ligand identification |
+| Sollai et al. [PMID: 31195037](https://pubmed.ncbi.nlm.nih.gov/31195037/) | OBPIIa rs2590498 polymorphism associated with olfactory threshold—genetic evidence linking true OBPs to olfaction |
+
+---
+
+## Limitations and Knowledge Gaps
+
+### Limitations of This Assessment
+
+1. **Negative evidence is not proof of absence.** The lack of published binding studies could reflect lack of investigator interest rather than genuine inability to bind ligands. SCGB1C1 is an understudied protein with only a handful of dedicated publications.
+
+2. **Olfactory tissue data gap.** GTEx does not sample human olfactory epithelium. If SCGB1C1 is highly expressed specifically in olfactory neuroepithelium (as the rat ortholog was), this would strengthen the case for olfactory relevance—though not for odorant binding per se.
+
+3. **No structural data.** Without a crystal structure or high-confidence homology model, we cannot assess whether SCGB1C1's hydrophobic cavity (if present) has the dimensions and chemistry to accommodate odorants, lipids, or other small molecules.
+
+4. **Species extrapolation.** The original RYD5 identification was in rat. Whether rat and human SCGB1C1 have equivalent expression patterns and functions is unknown.
+
+5. **Limited functional studies.** Only one study (Kim et al., 2024) has examined SCGB1C1 protein function, and it focused on immunomodulation, not ligand binding.
+
+6. **Publication bias.** Negative binding results (SCGB1C1 tested but showed no binding) may exist unpublished.
+
+### Critical Knowledge Gaps
+
+- No recombinant SCGB1C1 protein has been reported as purified for biophysical studies
+- No structural model (experimental or high-confidence computational) has been analyzed for cavity properties
+- No interactome data (IP-MS, BioID, or yeast two-hybrid) exists
+- No knockout/knockdown phenotype has been reported in any model organism
+- No human genetic variants in SCGB1C1 have been linked to olfactory or metabolic phenotypes
+
+---
+
+## Proposed Follow-up Experiments
+
+The following experiments are ranked by priority for resolving the molecular-function gap:
+
+### Tier 1: Essential — Directly Test Binding
+
+1. **Express and purify recombinant human SCGB1C1** in *E. coli* or mammalian cells. The homodimeric secretoglobin fold should be amenable to bacterial expression with refolding, as demonstrated for SCGB1A1. Verify homodimer formation by size-exclusion chromatography.
+
+2. **Fluorescent ligand displacement assay (ANS/1-NPN):** Screen SCGB1C1 against panels of:
+   - Common odorants (1-octen-3-ol, vanillin, eugenol, hexanal, linalool, musks)
+   - Phospholipids (PtdCho, PtdIns, PtdSer, PtdEtn)
+   - Steroids (progesterone, cortisol, estradiol, testosterone)
+   - PCB methyl sulfones (the ligand class originally inferred by homology)
+   - Fatty acids (C12–C20 saturated and unsaturated)
+   - Prostaglandins and leukotrienes (given the immunomodulatory context)
+
+3. **Isothermal titration calorimetry (ITC)** or **microscale thermophoresis (MST)** for quantitative binding constants of any hits from the displacement screen.
+
+### Tier 2: Important — Characterize Binding Site
+
+4. **X-ray crystallography or cryo-EM** of apo and ligand-bound SCGB1C1 to determine whether the canonical secretoglobin hydrophobic cavity is present and occupied.
+
+5. **AlphaFold2/3 structure prediction with cavity analysis** as an interim measure. Evaluate predicted central cavity dimensions and compare residue composition to the known phospholipid-binding site in SCGB1A1.
+
+6. **Lipid strip/lipid overlay assay** — quick screen for phospholipid binding.
+
+### Tier 3: Contextual — Physiological Relevance
+
+7. **Single-cell RNA-seq of human olfactory epithelium** to determine which specific cell types express SCGB1C1 (sustentacular cells, olfactory sensory neurons, immune cells, or gland cells).
+
+8. **Co-immunoprecipitation from nasal mucus** to identify protein–protein interaction partners (e.g., does SCGB1C1 bind a receptor, as SCGB3A2 binds MARCO?).
+
+9. **SCGB1C1 knockout mouse** with phenotyping of olfactory behavior (odorant detection thresholds), airway inflammation, and immune responses.
+
+### Tier 4: Annotation Correction
+
+10. **Formal Gene Ontology annotation review** to remove or flag the informal "odorant binding protein" label from databases. The current evidence supports, at most, annotation as "secreted protein" (GO:0005576) with potential "immune regulation" based on Kim et al. (2024).
+
+---
+
+## Conclusions
+
+SCGB1C1 represents a significant molecular-function gap in the secretoglobin family. The "odorant-binding protein" annotation that appears in some databases and publications is not supported by any direct biochemical evidence and appears to be a propagated inference from a 1991 homology-based hypothesis that was cautiously worded even in the original paper. The only demonstrated function is immunomodulatory (anti-inflammatory via Treg expansion). Whether SCGB1C1 binds any small molecule—odorant, lipid, steroid, or otherwise—remains completely unknown and requires direct experimental testing with purified protein.
+
+**The single most informative experiment would be a fluorescence displacement ligand screen using recombinant SCGB1C1, testing panels of odorants, fatty acids, phospholipids, steroids, and PCB metabolites.** Until such data are available, the most defensible annotation for SCGB1C1 molecular function is "uncharacterized with respect to ligand binding; demonstrated immunomodulatory activity."

--- a/genes/human/SCGB1C1/SCGB1C1-hypotheses/kgap-scgb1c1-ligand-specificity/openscientist.md.citations.md
+++ b/genes/human/SCGB1C1/SCGB1C1-hypotheses/kgap-scgb1c1-ligand-specificity/openscientist.md.citations.md
@@ -1,0 +1,28 @@
+# OpenScientist citation sidecar: SCGB1C1
+
+- OpenScientist job: `3fd24689-0187-4101-ba21-1617f3880f98`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:1915264
+- PMID:2115524
+- PMID:2378892
+- PMID:3918256
+- PMID:7664082
+- PMID:11114310
+- PMID:11193777
+- PMID:12044155
+- PMID:12847279
+- PMID:17916741
+- PMID:21385388
+- PMID:27274102
+- PMID:29412801
+- PMID:31195037
+- PMID:32676117
+- PMID:38892470
+- PMID:39078462
+
+## Detected DOIs
+
+- None detected

--- a/genes/human/SCGB1C1/SCGB1C1-hypotheses/kgap-scgb1c1-ligand-specificity/prompt.md
+++ b/genes/human/SCGB1C1/SCGB1C1-hypotheses/kgap-scgb1c1-ligand-specificity/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: SCGB1C1 ligand specificity
+
+Investigate whether human SCGB1C1 has direct biochemical evidence for odorant binding, lipid binding, steroid binding, or another hydrophobic small-molecule binding activity.
+
+Focus on:
+
+- purified SCGB1C1 ligand-binding assays, ligand screens, or structural studies;
+- comparison with other secretoglobin family members without assuming identical ligand specificity;
+- expression/localization evidence that helps interpret physiological relevance but does not itself prove molecular function;
+- whether odorant binding is specifically supported or whether a broader small-molecule/lipid-binding annotation would be more defensible.
+
+Please separate direct ligand evidence from family inference. Include PMIDs and list the highest-priority experiments or ligand classes needed to resolve the molecular-function gap.


### PR DESCRIPTION
Adds a focused OpenScientist hypothesis report for the SCGB1C1 MF-dark knowledge gap on odorant/lipid/steroid ligand specificity.\n\nIncludes the prompt, markdown report, and citation sidecar.\n\nValidation: git diff --cached --check.