### PR TITLE
[codex] Add HSPB9 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/HSPB9/HSPB9-hypotheses/kgap-hspb9-small-hsp-holdase/openscientist.md
+++ b/genes/human/HSPB9/HSPB9-hypotheses/kgap-hspb9-small-hsp-holdase/openscientist.md
@@ -1,0 +1,248 @@
+# HSPB9: Assessment of Small Heat Shock Protein Holdase Chaperone Activity
+
+## Summary
+
+**Human HSPB9 is not a demonstrated ATP-independent holdase chaperone.** Despite its classification in the small heat shock protein (sHSP/HSP20) family based on alpha-crystallin domain (ACD) homology, there is no published experimental evidence that HSPB9 possesses holdase, anti-aggregation, or chaperone activity. No purified-protein assay, no client/substrate identification, no oligomeric state characterization, and no aggregation-protection experiment has been reported for this protein. The only specific interactor identified through targeted study—DYNLT1/TCTEL1, a dynein light chain—was not tested as a chaperone substrate and may instead reflect a distinct dynein-related role in spermatogenesis. Current database annotations of chaperone function for HSPB9 derive entirely from family-level inference and are not experimentally justified.
+
+---
+
+## 1. Alpha-Crystallin Domain Conservation: Family Membership vs. Functional Inference
+
+### 1.1 Domain Architecture
+
+HSPB9 (UniProt Q9BQS6) is a 159-amino acid protein containing:
+- **N-terminal domain** (residues 1–35): 35 aa, shorter than most sHSPs
+- **Alpha-crystallin domain (ACD)** (residues 36–147): 112 aa, annotated by Pfam (PF00011), InterPro (IPR002068), SUPFAM (SSF49764), and CDD (cd06481, "ACD_HspB9_like")
+- **C-terminal extension** (residues 148–159): Only 12 aa
+
+### 1.2 Sequence Divergence
+
+Pairwise alignment of ACD sequences across all nine human sHSPs (HSPB1–HSPB9, excluding HSPB10/ODF1) reveals that **HSPB9 has the lowest average identity to other family members**:
+
+| Member | Avg. ACD Identity to Others |
+|--------|---------------------------|
+| HSPB1  | 42.9%                     |
+| HSPB5  | 42.7%                     |
+| HSPB6  | 41.2%                     |
+| HSPB4  | 40.5%                     |
+| HSPB2  | 37.3%                     |
+| HSPB3  | 35.2%                     |
+| HSPB8  | 34.8%                     |
+| HSPB7  | 32.6%                     |
+| **HSPB9** | **30.9%**              |
+
+HSPB9 is notably divergent even from the closest-related canonical chaperones: 34.3% identity to HSPB1 (Hsp27), 30.8% to HSPB5 (αB-crystallin), and only 27.6% to HSPB8.
+
+### 1.3 Missing Key Motifs
+
+- **IXI/V motif**: HSPB9 lacks the C-terminal IXI/V motif found in canonical sHSPs (e.g., HSPB1-ITI, HSPB4-IPV, HSPB5-IPI). This motif mediates inter-subunit contacts, oligomer dynamics, and substrate binding regulation. Its absence suggests HSPB9 may not form the dynamic oligomeric assemblies characteristic of holdase-competent sHSPs.
+- **Conserved core**: While HSPB9 does contain a recognizable xHF...PE-like motif within its ACD, many of the highly conserved positions in canonical chaperone sHSPs show substitutions in HSPB9.
+
+### 1.4 Rapid Evolutionary Divergence
+
+Human-mouse HSPB9 identity is only **62.8%**, compared to ~87% for HSPB1 (Hsp27). Kappé et al. (2001, PMID 11470154) noted this 38% sequence difference and suggested it may reflect a sex-related role under relaxed selective constraint. This rapid divergence is atypical for a conserved chaperone and more consistent with a testis-specific protein undergoing positive selection or neofunctionalization.
+
+### 1.5 Conclusion on Domain Conservation
+
+The ACD is sufficient to classify HSPB9 as a member of the sHSP superfamily at the sequence/structural level. However, **domain membership alone does not establish holdase function**. The superfamily includes members with diverse non-chaperone roles (e.g., HSPB10/ODF1 is a structural sperm tail protein). HSPB9's extreme divergence, missing IXI/V motif, and rapid evolution indicate that family-level functional inference is especially weak for this member.
+
+---
+
+## 2. Direct Biochemical Evidence: Holdase/Anti-Aggregation Assays
+
+### 2.1 What Has Been Done
+
+**Nothing.** A comprehensive PubMed search reveals no publications reporting:
+- Purified recombinant HSPB9 holdase activity (e.g., citrate synthase aggregation, insulin reduction, luciferase refolding)
+- Anti-aggregation assays with model or physiological substrates
+- Oligomeric state characterization (SEC, AUC, DLS, native PAGE)
+- Quaternary structure analysis (cryo-EM, cross-linking MS)
+- Substrate trapping or cross-linking experiments
+- Cell-based polyglutamine or amyloid aggregation suppression tests
+
+### 2.2 What Has Been Done for Other Family Members
+
+For context, holdase/chaperone activity has been experimentally demonstrated for:
+- **HSPB1** (Hsp27): Extensive in vitro holdase assays, client identification, oligomer dynamics (IDA evidence)
+- **HSPB4** (αA-crystallin): In vitro anti-aggregation, client binding with T4 lysozyme and crystallins (IMP evidence)
+- **HSPB5** (αB-crystallin): Holdase activity, oligomer characterization, solid-state NMR structure (IDA, IPI evidence)
+- **HSPB6** (Hsp20): Chaperone activity demonstrated (IDA evidence)
+- **HSPB7**: Anti-aggregation activity against polyQ proteins via autophagy (cell-based, Vos et al. 2010, PMID 21045566)
+- **HSPB8**: Holdase activity, TDP43 LC domain binding characterized (PMID 41690263)
+
+HSPB9 is conspicuously absent from all such studies.
+
+### 2.3 UniProt and GO Evidence Codes
+
+UniProt GO molecular function annotations for HSPB9 are **entirely absent**—no "unfolded protein binding," no "protein folding chaperone," no "chaperone binding." The only molecular function annotation in QuickGO is GO:0005515 ("protein binding," IPI from IntAct), reflecting the DYNLT1 interaction.
+
+This contrasts sharply with experimentally characterized members:
+- HSPB1: "protein folding chaperone" (IDA), "unfolded protein binding" (IBA)
+- HSPB4: "unfolded protein binding" (IMP)
+- HSPB5: "unfolded protein binding" (IPI)
+- HSPB6: "unfolded protein binding" (IDA), "protein folding chaperone" (IDA)
+
+---
+
+## 3. The HSPB9–DYNLT1/TCTEL1 Interaction
+
+### 3.1 Published Evidence
+
+De Wit et al. (2004, PMID 15503857) performed the only targeted functional study of HSPB9:
+- **Yeast two-hybrid screen** using HSPB9 as bait identified TCTEL1 (now DYNLT1) as an interactor
+- **Co-immunoprecipitation** confirmed the interaction
+- **Immunohistochemistry** showed co-expression in similar stages of spermatogenesis and in tumor cells
+- DYNLT1 is a light chain component of cytoplasmic and flagellar dynein
+
+### 3.2 What This Does and Does Not Show
+
+**Does show:**
+- HSPB9 and DYNLT1 physically interact (two independent methods: Y2H + co-IP)
+- They co-localize in spermatogenic cells and tumors
+- HSPB9 participates in protein-protein interactions
+
+**Does NOT show:**
+- That the interaction is a chaperone-client relationship
+- That HSPB9 protects DYNLT1 from aggregation or unfolding
+- That the interaction involves the HSPB9 ACD substrate-binding surface
+- Any holdase, foldase, or anti-aggregation activity
+
+### 3.3 Alternative Interpretation
+
+DYNLT1 is a component of the dynein motor complex, essential for flagellar motility and intracellular transport. Given HSPB9's testis-specific expression during spermatogenesis—a process requiring extensive flagellar assembly—the HSPB9-DYNLT1 interaction may reflect a **specialized role in dynein complex assembly, flagellar organization, or intracellular transport during spermiogenesis** rather than a generic chaperone function. This interpretation is at least as plausible as a chaperone-client model, especially given the absence of any holdase evidence.
+
+---
+
+## 4. Testis/Germ Cell Expression Context
+
+### 4.1 Expression Profile
+
+| Finding | Reference |
+|---------|-----------|
+| Testis-exclusive by Northern blot | Kappé et al. 2001 (PMID 11470154) |
+| Testis-specific by RT-PCR across normal tissues | de Wit et al. 2004 (PMID 15503857) |
+| Expression from late pachytene spermatocytes to elongate spermatids | Kappé et al. 2001 |
+| Expressed in spermatogonia, spermatocytes, round spermatids (goat) | Xun et al. 2015 (PMID 25685801) |
+| Upregulated by heat stress in goat testis (P<0.05) | Xun et al. 2015 |
+| Higher expression in hot season (P<0.01) and breeding season (P<0.05) | Xun et al. 2015 |
+| Cancer/testis antigen—ectopic expression in tumors | de Wit et al. 2004 |
+| Cytoplasmic and nuclear localization (HPA) | UniProt, GO IDA |
+
+### 4.2 Interpretive Limitations
+
+Testis-specific expression during spermatogenesis is consistent with roles in:
+- Protein quality control during meiotic stress (chaperone hypothesis)
+- Flagellar assembly and sperm morphogenesis (structural hypothesis)
+- Dynein complex organization (DYNLT1 interaction)
+- Male germ cell-specific signaling
+
+Heat-stress inducibility is suggestive but not diagnostic—many non-chaperone proteins are heat-responsive. The cancer/testis antigen status reflects epigenetic derepression, not functional characterization.
+
+---
+
+## 5. Are Current Database Annotations Justified?
+
+### 5.1 Assessment of Common Annotations
+
+| Annotation | Justified? | Basis |
+|-----------|-----------|-------|
+| "Small heat shock protein family member" | **Yes** | Pfam PF00011, ACD detected by multiple algorithms |
+| "Molecular chaperone" | **No** | No experimental evidence; purely family-level inference |
+| "Holdase activity" | **No** | No holdase assay performed |
+| "Unfolded protein binding" | **No** | Not annotated in UniProt GO; no experimental evidence |
+| "ATP-independent chaperone" | **No** | No chaperone activity demonstrated |
+| "Stress response" | **Cautious yes** | Heat-inducible in goat testis (PMID 25685801); UniProt keyword present |
+
+### 5.2 Recommendation
+
+The only defensible annotation for HSPB9 at present is:
+- **"Member of the small heat shock protein (HSP20/alpha-crystallin) family, based on alpha-crystallin domain homology"**
+- **"Testis-specific expression"** (IDA evidence)
+- **"Interacts with DYNLT1"** (Y2H + co-IP evidence)
+
+Generic chaperone, holdase, unfolded-protein binding, or foldase annotations are **NOT justified** and should be qualified as "inferred from family membership, not experimentally demonstrated."
+
+---
+
+## 6. Key Missing Experiments
+
+The following experiments would be required to establish or refute holdase activity for HSPB9:
+
+### 6.1 Critical Priority
+
+1. **In vitro holdase assay**: Express and purify recombinant HSPB9; test anti-aggregation activity using model substrates (citrate synthase thermal aggregation, insulin DTT-induced aggregation, luciferase thermal denaturation)
+2. **Oligomeric state characterization**: SEC-MALS, AUC, or native MS to determine whether HSPB9 forms the dynamic oligomers characteristic of holdase-competent sHSPs
+3. **DYNLT1 aggregation protection**: Test whether HSPB9 protects DYNLT1 from thermal or chemical denaturation—this would distinguish chaperone-client from functional partnership
+
+### 6.2 High Priority
+
+4. **Substrate trapping/cross-linking MS**: Identify any endogenous substrates bound by HSPB9 under stress in testis-derived cells
+5. **Polyglutamine/aggregation suppression in cells**: Repeat the Vos et al. (2010) approach—test whether HSPB9 overexpression suppresses polyQ aggregation in cell models
+6. **Oligomer dynamics**: Test temperature-dependent oligomer dissociation (a hallmark of sHSP activation)
+
+### 6.3 Complementary
+
+7. **HSPB9 knockout/knockdown in spermatogenesis**: Mouse or cell-based models to determine phenotype—is it a chaperone deficiency (protein aggregation) or a structural/transport defect?
+8. **Domain swap experiments**: Replace HSPB9 ACD with canonical ACD (e.g., from HSPB5) to test whether the domain confers holdase activity in this protein context
+9. **AlphaFold structure analysis**: Compare predicted HSPB9 ACD fold to structurally characterized sHSP ACDs to assess structural compatibility with substrate binding
+
+---
+
+## 7. High-Throughput Interaction Data
+
+IntAct records 20 interactions for HSPB9:
+- **5 entries** from de Wit et al. 2004 (PMID 15503857): DYNLT1, via Y2H and co-IP
+- **15 entries** from BioPlex high-throughput AP-MS (PMIDs 28514442, 33961781): CYFIP2, FBXW5, NCKAP1, OXLD1, PARS2, ISCA1, KPTN, ZNF507, ITFG2, USP12
+
+The BioPlex interactions are from large-scale, untargeted co-immunoprecipitation studies. None have been validated, and none were characterized as chaperone-substrate relationships. STRING DB confirms that all sHSP family connections to HSPB9 are text-mining only (experimental score = 0.000 for HSPB7, HSPB2, CRYAA, CRYAB, etc.).
+
+---
+
+## 8. Supported and Refuted Hypotheses
+
+### Supported
+- **H1**: HSPB9 is a bona fide member of the sHSP superfamily based on ACD homology ✓
+- **H2**: HSPB9 is testis-specific and expressed during spermatogenesis ✓
+- **H3**: HSPB9 physically interacts with DYNLT1/TCTEL1 ✓
+- **H4**: HSPB9 is a cancer/testis antigen ✓
+
+### Not supported (insufficient evidence)
+- **H5**: HSPB9 is an ATP-independent holdase chaperone — **No evidence**
+- **H6**: HSPB9 has anti-aggregation activity — **No evidence**
+- **H7**: HSPB9 binds unfolded proteins — **No evidence**
+- **H8**: The HSPB9-DYNLT1 interaction represents a chaperone-client relationship — **Not tested**
+- **H9**: HSPB9 has identified chaperone substrates/clients — **None known**
+
+### Cautiously supported (family-level inference only)
+- **H10**: HSPB9 may have chaperone-like activity given ACD presence — plausible but unproven
+
+---
+
+## 9. Limitations of This Analysis
+
+1. **Literature coverage**: PubMed searches may miss non-English publications or conference proceedings
+2. **Preprint servers**: We did not systematically search bioRxiv/medRxiv for unpublished work
+3. **Negative publication bias**: Failed holdase assays for HSPB9 may exist but never be published
+4. **Structural biology**: AlphaFold structure analysis was not performed in this iteration but could inform substrate-binding site predictions
+5. **Patent literature**: Industrial characterization of HSPB9 (e.g., for cancer immunotherapy) may exist outside academic literature
+
+---
+
+## 10. Key References
+
+| PMID | Key Finding |
+|------|-------------|
+| 11470154 | Kappé et al. 2001: HSPB9 identification, testis-specific expression, 38% human-mouse divergence |
+| 15503857 | de Wit et al. 2004: HSPB9 cancer/testis antigen, TCTEL1/DYNLT1 interaction (Y2H + co-IP) |
+| 12820654 | Kappé et al. 2003: Complete inventory of 10 human sHSPs, intronless HSPB9 gene |
+| 12820655 | Fontaine et al. 2003: HSPB10/ODF1 identification, phylogenetic placement of sHSP family |
+| 25685801 | Xun et al. 2015: HSPB9 heat-stress upregulation in goat testis |
+| 21045566 | Vos et al. 2011: Systematic comparison of 10 human sHSPs—some function independently of Hsp70; HSPB9 not individually characterized |
+| 31091419 | Mogk et al. 2019: sHSP holdase mechanism review—oligomer dissociation, substrate sequestration |
+| 34271010 | Reinle et al. 2022: sHSP diversity in proteostasis network |
+
+---
+
+## Conclusion
+
+HSPB9 is an experimentally orphan member of the human sHSP family. Its classification rests entirely on alpha-crystallin domain homology—the weakest possible basis for functional annotation. No holdase assay, no substrate identification, no oligomer characterization, and no aggregation-protection experiment has ever been published. The sole targeted interactor (DYNLT1) was identified in 2004 but never tested as a chaperone substrate. Generic chaperone, holdase, or unfolded-protein binding annotations for HSPB9 are currently unjustified and should be flagged as family-level hypotheses requiring experimental validation. The most urgent experiment is a standard in vitro holdase assay with purified recombinant protein and model substrates.

--- a/genes/human/HSPB9/HSPB9-hypotheses/kgap-hspb9-small-hsp-holdase/openscientist.md.citations.md
+++ b/genes/human/HSPB9/HSPB9-hypotheses/kgap-hspb9-small-hsp-holdase/openscientist.md.citations.md
@@ -1,0 +1,18 @@
+# OpenScientist citation sidecar: HSPB9
+
+- OpenScientist job: `521484ad-6ecd-442e-9d72-0361b8aecc09`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:11470154
+- PMID:15503857
+- PMID:21045566
+- PMID:25685801
+- PMID:28514442
+- PMID:33961781
+- PMID:41690263
+
+## Detected DOIs
+
+- None detected

--- a/genes/human/HSPB9/HSPB9-hypotheses/kgap-hspb9-small-hsp-holdase/prompt.md
+++ b/genes/human/HSPB9/HSPB9-hypotheses/kgap-hspb9-small-hsp-holdase/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: HSPB9 small-HSP holdase activity
+
+Investigate whether human HSPB9 is a bona fide ATP-independent small heat shock protein holdase chaperone, and whether any clients or protected substrates are experimentally established.
+
+Focus on:
+
+- alpha-crystallin/HSP20 domain conservation and whether it supports only family-level inference;
+- direct purified-protein holdase or anti-aggregation assays, oligomer-state analysis, and substrate/client discovery;
+- the reported interaction with TCTEL1/DYNLT1 and whether it establishes a chaperone function or a distinct dynein-related role;
+- testis or germ-cell expression contexts that may help prioritize experiments but do not themselves prove molecular function.
+
+Please assess whether generic chaperone, unfolded-protein binding, or foldase annotations are justified for HSPB9 now, or whether the evidence supports only a cautious family-level hypothesis. Include PMIDs and key missing experiments.


### PR DESCRIPTION
Adds an OpenScientist report for the HSPB9 knowledge gap on small-HSP holdase/chaperone activity.

Included files:
- prompt.md
- openscientist.md
- openscientist.md.citations.md