### PR TITLE
[codex] Add KCTD18 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/KCTD18/KCTD18-hypotheses/kgap-kctd18-cul3-substrate-adaptor/openscientist.md
+++ b/genes/human/KCTD18/KCTD18-hypotheses/kgap-kctd18-cul3-substrate-adaptor/openscientist.md
@@ -1,0 +1,141 @@
+# KCTD18 as a CUL3-RING Ubiquitin Ligase Substrate Adaptor: Evidence Assessment
+
+## Summary
+
+**Annotating KCTD18 with GO:1990756 (ubiquitin ligase substrate adaptor activity involved in CUL3-dependent protein catabolic process) is premature and not defensible at the current state of evidence.** While high-throughput proteomics data suggest KCTD18 may associate with CUL3 and CRL complex components, no targeted binding validation, substrate identification, or ubiquitination assay has been published. The evidence is sufficient to motivate experimental investigation but insufficient for GO curation.
+
+---
+
+## Key Findings
+
+### 1. High-Throughput Evidence for KCTD18-CUL3 Association
+
+Two independent high-throughput proteomics studies detected KCTD18 in association with CUL3-RING ligase complex components:
+
+| Study | PMID | Method | Partners Detected | Evidence Code |
+|-------|------|--------|-------------------|---------------|
+| Bennett et al. 2010 | 21145461 | TAP-MS (MI:0676) | CUL3, COPS5, COPS6 | HTP |
+| Huttlin et al. 2021 (BioPlex 3.0) | 33961781 | AP-MS (MI:0007) | RBX1, COPS5, COPS6, LRP1 | HTP |
+| Huttlin et al. 2017 (BioPlex 2.0) | 28514442 | AP-MS (MI:0007) | LRP1 | HTP |
+
+- **Bennett et al. 2010** performed systematic quantitative proteomics of the CRL network using AQUA technology and TAP purification. KCTD18 co-purified with CUL3 (IntAct MI-score: 0.53).
+- **BioPlex 3.0** detected KCTD18 with RBX1 (the RING-box protein in CRL complexes) and COP9 signalosome subunits (COPS5/6, which deneddylate cullins), circumstantially consistent with CRL participation.
+
+**Critically**, both are high-throughput discovery screens. Neither study individually validated the KCTD18-CUL3 interaction. HTP AP-MS evidence is subject to false positives from indirect bridging interactions, overexpression artifacts, and non-specific associations.
+
+### 2. No Targeted Validation Exists
+
+The following types of evidence, which support GO:1990756 annotation for other KCTD family members (KCTD10, KCTD13, KCTD17), are **entirely absent** for KCTD18:
+
+- **No targeted co-immunoprecipitation** of endogenous or recombinant KCTD18 with CUL3
+- **No purified-protein binding assay** (ITC, SPR, pull-down)
+- **No mutational analysis** of the KCTD18 BTB domain to map CUL3 binding determinants
+- **No substrate identification** for KCTD18
+- **No ubiquitination or degradation experiments** involving KCTD18
+- **No GO:1990756 annotation** (checked QuickGO, July 2026)
+
+### 3. BTB Domain Structure is Compatible but Not Determinative
+
+KCTD18 contains a BTB/POZ domain (residues 12-80) with:
+- The conserved **LNVGG motif** shared by CUL3-binding KCTDs
+- **46.2% sequence identity** to the closest confirmed CUL3-binding KCTD (KCTD6)
+- **High AlphaFold confidence** in the BTB domain (mean pLDDT = 87.9)
+- The conserved **VIDRD** motif important for BTB fold integrity
+
+However, BTB domain presence with LNVGG motif is **necessary but not sufficient** for CUL3 binding:
+- **KCTD16** has the LNVGG motif but **does not bind CUL3** (Ji et al. 2016, PMID 26334369)
+- **KCTD1** has a BTB domain but **does not bind CUL3** (Ji et al. 2016)
+- The Balasco et al. 2024 comprehensive AlphaFold-based analysis (PMID 38339159) obtained reliable KCTD-CUL3 complex models for exactly **15 members** that were "known to interact with Cul3" -- this implies KCTD18 was **not** among the established binders
+
+### 4. Comparison with Established KCTD CUL3 Adaptors
+
+| Feature | KCTD13 (confirmed) | KCTD17 (confirmed) | KCTD18 (in question) |
+|---------|:-------------------:|:-------------------:|:--------------------:|
+| GO:1990756 annotation | IDA (PMID:19782033) | IDA (PMID:25270598) | None |
+| Targeted CUL3 co-IP | Yes | Yes | No |
+| Purified binding data | Partial | Yes | No |
+| Substrate identified | RhoA (KCTD13) | Multiple | None |
+| Ubiquitination assay | Yes | Yes | No |
+| BTB domain present | Yes | Yes | Yes |
+| HT CUL3 co-purification | Yes | Yes | Yes |
+| AlphaFold BTB pLDDT | High | High | High (87.9) |
+
+### 5. KCTD18 Functional Context
+
+KCTD18 remains largely uncharacterized functionally:
+- **Fat cell number regulation**: GWAS + siRNA knockdown showed KCTD18 influences adipocyte stem cell proliferation (Kulyté et al. 2022, PMID 35320353)
+- **Restless legs syndrome**: RLS4 locus fine-mapped to a 46.9 Kb region containing KCTD18 (Pichler et al. 2013, PMID 23054586)
+- **Neurological phenotypes**: Chromosomal duplication including KCTD18 associated with epilepsy and developmental delay (Usui et al. 2013, PMID 23463730)
+- **None of these functional associations** have been mechanistically linked to CUL3 or ubiquitin-mediated degradation
+
+---
+
+## Evidence Classification
+
+### Direct Evidence (Experimental)
+| Evidence Type | Status | Source |
+|---|---|---|
+| HT TAP-MS co-purification with CUL3 | **Present** | PMID 21145461 |
+| HT AP-MS co-purification with RBX1 | **Present** | PMID 33961781 |
+| Targeted co-IP with CUL3 | **Absent** | -- |
+| Purified protein binding assay | **Absent** | -- |
+| Substrate identification | **Absent** | -- |
+| Ubiquitination/degradation assay | **Absent** | -- |
+| Mutational validation | **Absent** | -- |
+
+### Predicted/Computational Evidence
+| Evidence Type | Status | Source |
+|---|---|---|
+| BTB domain (IPR003131) | **Present** | UniProt, InterPro |
+| LNVGG CUL3-binding motif | **Present** | Sequence analysis |
+| AlphaFold BTB domain confidence | **High** (pLDDT 87.9) | AlphaFold DB AF-Q6PI47-F1 |
+| AlphaFold complex model with CUL3 | **Not validated** | Balasco et al. 2024 did not classify KCTD18 as known binder |
+| Sequence similarity to CUL3-binders | **Moderate** (46.2% to KCTD6 BTB) | This analysis |
+
+---
+
+## Conclusion
+
+**GO:1990756 (ubiquitin ligase substrate adaptor activity) is NOT defensible for KCTD18 at this time.**
+
+The evidence landscape for KCTD18 as a CUL3-RING ubiquitin ligase substrate adaptor can be summarized as:
+
+1. **What we know**: KCTD18 has a BTB domain, co-purifies with CUL3 and RBX1 in high-throughput proteomics, and has structural features compatible with CUL3 binding.
+
+2. **What we don't know**: Whether KCTD18 directly binds CUL3 with meaningful affinity, whether it recruits any substrate for ubiquitination, and whether any of its known biological functions (cell proliferation, neurological associations) are mediated through CUL3.
+
+3. **The gap**: The evidence for KCTD18 is at the "hypothesis-generating" stage, comparable to where KCTD5 was before Bayon et al. 2008 (PMID 18573101) performed targeted validation. For comparison, KCTD13 and KCTD17 earned GO:1990756 IDA annotation only after targeted co-IP, substrate identification, and ubiquitination assays were published.
+
+4. **AlphaFold is not enough**: While AlphaFold predictions can guide experiments, the Balasco et al. 2024 study (PMID 38339159) explicitly demonstrated that structural prediction discriminates known binders from non-binders -- it did not reclassify any uncharacterized KCTDs as binders based on prediction alone, establishing the appropriate precedent.
+
+**Recommended next steps to resolve this question**:
+- Targeted co-IP of endogenous or recombinant KCTD18 with CUL3 in relevant cell types
+- In vitro binding assay (ITC or SPR) with purified KCTD18 BTB domain and CUL3 N-terminal domain
+- KCTD18 BTB domain mutagenesis to test CUL3-binding determinants
+- Proximity labeling (BioID/TurboID) with KCTD18 bait to identify candidate substrates
+- Ubiquitination assays with reconstituted KCTD18-CUL3-RBX1 complexes
+
+---
+
+## References
+
+1. Bennett EJ, Rush J, Gygi SP, Harper JW. Dynamics of cullin-RING ubiquitin ligase network revealed by systematic quantitative proteomics. *Cell*. 2010;143(6):951-965. PMID: 21145461
+2. Huttlin EL et al. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome. *Cell*. 2021;184(11):3022-3040.e28. PMID: 33961781
+3. Huttlin EL et al. Architecture of the human interactome defines protein communities and disease networks. *Nature*. 2017;545(7655):505-509. PMID: 28514442
+4. Ji AX et al. Structural insights into KCTD protein assembly and Cullin3 recognition. *J Mol Biol*. 2016;428(1):92-107. PMID: 26334369
+5. Balasco N et al. A comprehensive analysis of the structural recognition between KCTD proteins and Cullin 3. *Int J Mol Sci*. 2024;25(3):1881. PMID: 38339159
+6. Balasco N et al. Molecular recognition of Cullin3 by KCTDs: insights from experimental and computational investigations. *Biochim Biophys Acta*. 2014;1844(7):1289-1298. PMID: 24747150
+7. Bayon Y et al. KCTD5, a putative substrate adaptor for cullin3 ubiquitin ligases. *FEBS J*. 2008;275(15):3900-3910. PMID: 18573101
+8. Kulyté A et al. Genome-wide association study identifies genetic loci associated with fat cell number and overlap with genetic risk loci for type 2 diabetes. *Diabetes*. 2022;71(6):1350-1362. PMID: 35320353
+9. Pichler I et al. Fine-mapping of restless legs locus 4 (RLS4) identifies a haplotype over the SPATS2L and KCTD18 genes. *J Mol Med*. 2013;91(1):101-112. PMID: 23054586
+10. Usui D et al. Interstitial duplication of 2q32.1-q33.3 in a patient with epilepsy, developmental delay, and autistic behavior. *Am J Med Genet A*. 2013;161A(5):1078-1084. PMID: 23463730
+11. Tomkins JE et al. Comparative protein interaction network analysis identifies shared and distinct functions for the human ROCO proteins. *Proteomics*. 2018;18(10):e1700444. PMID: 29513927
+
+---
+
+## Data Sources Queried
+- UniProt (Q6PI47), QuickGO, InterPro (IPR003131, IPR045704)
+- IntAct/PSICQUIC (15 interaction records)
+- STRING v12.0 (KCTD18 network)
+- AlphaFold DB (AF-Q6PI47-F1, v6)
+- PubMed (KCTD18: 6 papers; KCTD family/CUL3: ~20 papers reviewed)

--- a/genes/human/KCTD18/KCTD18-hypotheses/kgap-kctd18-cul3-substrate-adaptor/openscientist.md.citations.md
+++ b/genes/human/KCTD18/KCTD18-hypotheses/kgap-kctd18-cul3-substrate-adaptor/openscientist.md.citations.md
@@ -1,0 +1,24 @@
+# OpenScientist citation sidecar: KCTD18
+
+- OpenScientist job: `dae787f0-e0d8-4557-844d-b7f8c40ac112`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:18573101
+- PMID:19782033
+- PMID:21145461
+- PMID:23054586
+- PMID:23463730
+- PMID:24747150
+- PMID:25270598
+- PMID:26334369
+- PMID:28514442
+- PMID:29513927
+- PMID:33961781
+- PMID:35320353
+- PMID:38339159
+
+## Detected DOIs
+
+- None detected

--- a/genes/human/KCTD18/KCTD18-hypotheses/kgap-kctd18-cul3-substrate-adaptor/prompt.md
+++ b/genes/human/KCTD18/KCTD18-hypotheses/kgap-kctd18-cul3-substrate-adaptor/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: KCTD18 CUL3 substrate-adaptor hypothesis
+
+Investigate whether human KCTD18 directly binds CUL3 and functions as a CUL3-RING ubiquitin ligase substrate adaptor.
+
+Focus on:
+
+- direct KCTD18-CUL3 binding evidence from co-immunoprecipitation, purified-protein binding, structural modeling, or mutational analysis;
+- comparison with established KCTD/BTB-family CUL3 substrate adaptors without overextending family inference;
+- any candidate KCTD18 substrates, proximity/affinity-proteomics hits, or ubiquitination/degradation experiments;
+- whether AlphaFold-predicted BTB-CUL3 compatibility is enough to guide experiments but insufficient for curation.
+
+Please conclude whether GO:1990756-like CUL3-RING ubiquitin ligase substrate adaptor activity is defensible now for KCTD18, or whether it remains premature. Include PMIDs or stable identifiers and note which evidence is direct versus predicted.


### PR DESCRIPTION
Adds an OpenScientist report for the KCTD18 knowledge gap on possible CUL3 substrate-adaptor function.

Included files:
- prompt.md
- openscientist.md
- openscientist.md.citations.md