### PR TITLE
[codex] Add TRAPPC12 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/TRAPPC12/TRAPPC12-hypotheses/kgap-trappc12-kinetochore-moonlighting/openscientist.md
+++ b/genes/human/TRAPPC12/TRAPPC12-hypotheses/kgap-trappc12-kinetochore-moonlighting/openscientist.md
@@ -1,0 +1,76 @@
+# TRAPPC12/TRAMM: Is the mitotic kinetochore function mechanistically separable from the TRAPP trafficking role?
+
+*OpenScientist literature investigation — Iteration 1. Literature-only (no primary datasets provided).*
+
+## 1. Summary (answer to the research question)
+
+Human **TRAPPC12 (a.k.a. TTC-15; "TRAMM" in the mitotic literature)** has two reported activities:
+(i) a **well-established, independently corroborated role as an integral subunit of the TRAPP tethering complex acting early in ER-to-Golgi vesicular transport**, and (ii) a **reported "moonlighting" mitotic role** promoting chromosome congression, kinetochore stability, and **CENP-E recruitment**. The trafficking role is high-confidence (multiple labs, multiple methods, structural placement, and human disease genetics). The kinetochore role is supported by a **single primary study** whose internal evidence is multi-pronged and mechanistically coherent — most notably a **cell-cycle phosphorylation switch** that gates CENP-E association — but it has **not been independently replicated**, lacks direct-binding (reconstitution/structural) data, and has not mapped the kinase, phospho-sites, or separating domains. Thus the mitotic function is **plausibly mechanistically separable** (best-supported model = a phospho-regulated, chromosome-associated pool acting as a CENP-E adaptor), but *separation of function has not been formally demonstrated*, and an indirect/trafficking-derived contribution cannot be fully excluded.
+
+## 2. Evidence base and key papers
+
+| Role | Key evidence | Source (PMID / DOI) | Confidence |
+|------|--------------|---------------------|-----------|
+| TRAPP subunit; early ER→Golgi transport | Co-purification with TRAPP; binary interaction map; ER→Golgi trafficking assay | Scrivens et al. 2011, **PMID 21525244**, DOI 10.1091/mbc.E10-11-0873 *(DOI likely; verify)* | High |
+| Structural placement in TRAPPIII (recruited via TRAPPC2L) | Size-fractionation + MS + negative-stain EM in *Aspergillus*; homology to metazoan subunits | Pinar et al. 2019, **PMID 31869332**, DOI *uncertain — flag* | High (for architecture) |
+| Human disease: loss causes progressive childhood encephalopathy + Golgi dysfunction | Biallelic LoF variants; Golgi defects in patient cells | Milev et al. 2017, **PMID 28777934**, DOI 10.1016/j.ajhg.2017.07.008 *(DOI likely; verify)* | High |
+| TRAPPopathy framing (disease-mechanism review) | Review of TRAPP subunit disorders | Hall et al. 2024, **PMID 39769094**, DOI *uncertain — flag* | High (as review) |
+| **Mitotic kinetochore / CENP-E role** | RNAi → noncongressed chromosomes + mitotic arrest; small chromosome-associated pool; CENP-E mislocalization; TRAMM–CENP-E co-IP; mitotic phospho-cycle correlating with CENP-E binding; phosphomimetic recruits CENP-E better than nonphosphorylatable mutant | **Milev et al. 2015, PMID 25918224**, DOI 10.1091/mbc.E14-11-1607 *(DOI uncertain — flag)* | **Moderate; single lab, unreplicated** |
+| CENP-E kinetochore-recruitment context (independent) | CENP-E recruitment depends on Bub1/BubR1; outer-corona region mediates BubR1-independent recruitment | Johnson 2004 (PMID 15020684); Weber 2024 (PMID 38354735) | High (context only, not TRAPPC12-specific) |
+| Precedent: a trafficking protein moonlighting in mitosis | ZW10 cited as "a moonlighting protein with a dual function in membrane trafficking and mitosis" | Escudero-Paniagua 2020, PMID 31095674 | Established precedent |
+
+**Asymmetry of evidence is the central finding:** the trafficking role is supported by ≥4 independent studies across biochemistry, structure, and human genetics; the kinetochore role is essentially **one primary paper from one group**.
+
+## 3. Which mechanistic model does the evidence favor?
+
+The four candidate models from the task, assessed against the data:
+
+1. **A distinct non-TRAPP pool.** *Partially supported.* "Small amounts of TRAMM associated with chromosomes" (PMID 25918224) implies a minor, spatially distinct pool separate from the bulk Golgi/TRAPP pool. However, it was **not shown to be TRAPP-free** (no demonstration that chromosome-bound TRAMM lacks other TRAPP subunits). *Direct evidence: partial. Model: plausible.*
+
+2. **Phosphorylation-dependent relocalization / activity switch.** *Best-supported.* TRAMM is phosphorylated in early mitosis and dephosphorylated at anaphase onset; the phospho-cycle **correlates temporally with CENP-E association/dissociation**; and a **phosphomimetic mutant out-performs a nonphosphorylatable mutant** in CENP-E recruitment. This is the strongest, most mechanistic, and closest-to-causal evidence for a regulated, mitosis-specific activity. *Direct experimental evidence (mutant phenotypes), though kinase and sites are unmapped.*
+
+3. **Direct CENP-E recruitment (adaptor).** *Supported but not proven direct.* Co-IP + depletion-dependent loss of CENP-E kinetochore signal are consistent with an adaptor role, but **co-IP does not establish direct binding** — the interaction could be bridged by other kinetochore/corona components (e.g., Bub1/BubR1-dependent pathways; PMID 15020684, 38354735). No reconstituted binary binding or structure exists. *Plausible mechanistic model, not direct proof of directness.*
+
+4. **Indirect consequence of trafficking defects.** *Not excluded, but disfavored as the sole explanation.* The specificity (strongest effect on CENP-E), the chromosome-associated pool, and especially the phospho-switch argue against a purely secondary trafficking artifact. Still, TRAPPC12 depletion perturbs secretion/Golgi (PMID 28777934), which can indirectly affect mitosis, so an additive indirect contribution remains possible. *Cannot be formally ruled out without a trafficking-competent/mitosis-dead separation-of-function allele.*
+
+**Verdict:** the data most favor **model 2 (phospho-gated) combined with model 3 (adaptor)** — a phosphorylation-regulated, chromosome-associated pool of TRAMM that promotes CENP-E recruitment — while models 1 and 4 remain open at the margins.
+
+## 4. Domains, motifs, phospho-sites, and separation-of-function evidence
+
+- **Architecture:** TRAPPC12 = **TTC-15**, a tetratricopeptide-repeat–type (TPR/WD-like) scaffold protein. This modular, protein–protein-interaction architecture is *consistent with* an adaptor/scaffold role but is **not itself evidence** for the mitotic function.
+- **Separating domains/residues:** **Not mapped.** No study has localized the CENP-E-binding region versus the TRAPP-assembly region, so a structural basis for separability is absent.
+- **Phospho-sites / kinase:** The **specific phospho-sites and responsible mitotic kinase are not identified** in the primary paper's abstract. Phosphomimetic and nonphosphorylatable mutants exist and behave differently (a genuine separation-of-*state* reagent), but they do not constitute a **trafficking-competent / mitosis-dead** (or vice versa) **separation-of-function allele**.
+- **Bottom line:** true separation of function is **incomplete**. The single most valuable missing experiment is an allele that abolishes CENP-E recruitment while preserving TRAPP incorporation/ER-to-Golgi transport (or the reciprocal).
+
+## 5. Recommendation on GO-style curation
+
+The evidence supports an **intermediate** position — go **beyond** "stop at TRAPP/vesicle trafficking" but stop **short** of a definitive mitotic-adaptor molecular-function statement:
+
+- **Core (keep):** *TRAPP complex* (CC), *ER-to-Golgi vesicle-mediated transport* / secretory pathway (BP), Rab-GEF-associated function — strongly supported (PMIDs 21525244, 31869332, 28777934).
+- **Non-core (retain, with caveat):** *CENP-E `protein binding`* (IPI, PMID 25918224) — **keep as non-core**, annotated that **directness is unestablished** (co-IP only).
+- **Optional, evidence-tagged addition:** a **mitotic-process** annotation (e.g., *chromosome congression* / *mitotic sister chromatid segregation* / positive regulation of CENP-E kinetochore localization), **IMP** from RNAi, explicitly flagged **single-source / awaiting independent replication**.
+- **Do NOT yet assert** a specific "mitotic adaptor/scaffold" molecular function. Upgrade only after: (a) independent replication; (b) direct-binding evidence; (c) kinase/phospho-site mapping; (d) a separation-of-function allele.
+
+## 6. Direct experimental evidence vs. plausible model (explicit)
+
+**Directly demonstrated (PMID 25918224):** TRAMM depletion → congression failure + mitotic arrest; a chromosome-associated TRAMM pool; CENP-E kinetochore mislocalization on depletion; TRAMM–CENP-E co-IP; mitotic phospho→anaphase-dephospho cycle; phosphomimetic > nonphosphorylatable for CENP-E recruitment.
+
+**Model / inference (not directly proven):** direct (unbridged) TRAMM–CENP-E binding; a fully TRAPP-independent kinetochore pool; identity of the kinase and phospho-sites; that the mitotic phenotype is independent of any trafficking perturbation.
+
+## 7. Limitations
+
+- The mitotic conclusions derive from **one lab / one primary paper**; RNAi off-target and indirect trafficking effects are incompletely controlled.
+- **No structural or reconstitution data** for the TRAMM–CENP-E interaction.
+- **DOIs are provided from memory and flagged where uncertain**; PMIDs (returned by the literature tool) are reliable. Please verify: Milev 2015 DOI (10.1091/mbc.E14-11-1607, *uncertain*), Pinar 2019 DOI, Hall 2024 DOI.
+- The 2017 patient study (PMID 28777934) documents Golgi dysfunction but the abstract does not report a mitotic/aneuploidy phenotype in patient cells — a notable gap for establishing physiological relevance of the mitotic role.
+
+## 8. Highest-value future experiments
+
+1. Independent replication (different cells/labs) with rescue by RNAi-resistant TRAMM.
+2. Reconstituted binary TRAMM–CENP-E binding ± phospho-mimicry (test directness).
+3. Map phospho-sites and identify the mitotic kinase (Cdk1/Plk1/Aurora candidates).
+4. Engineer a **trafficking-competent, mitosis-dead** (or reciprocal) allele for true separation of function.
+5. Assess mitotic fidelity/aneuploidy in TRAPPC12-patient fibroblasts (PMID 28777934 cohort).
+
+---
+*Citations: PMIDs are tool-verified. DOIs are best-recollection and flagged where uncertain. Findings recorded to the knowledge state (#1 trafficking role, #2 mitotic/phospho-switch role, #3 curation recommendation).*

--- a/genes/human/TRAPPC12/TRAPPC12-hypotheses/kgap-trappc12-kinetochore-moonlighting/openscientist.md.citations.md
+++ b/genes/human/TRAPPC12/TRAPPC12-hypotheses/kgap-trappc12-kinetochore-moonlighting/openscientist.md.citations.md
@@ -1,0 +1,21 @@
+# OpenScientist citation sidecar: TRAPPC12
+
+- OpenScientist job: `979d6d89-1387-41a1-9556-9e9025e4bafe`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:15020684
+- PMID:21525244
+- PMID:25918224
+- PMID:28777934
+- PMID:31095674
+- PMID:31869332
+- PMID:38354735
+- PMID:39769094
+
+## Detected DOIs
+
+- DOI:10.1016/j.ajhg.2017.07.008
+- DOI:10.1091/mbc.E10-11-0873
+- DOI:10.1091/mbc.E14-11-1607

--- a/genes/human/TRAPPC12/TRAPPC12-hypotheses/kgap-trappc12-kinetochore-moonlighting/prompt.md
+++ b/genes/human/TRAPPC12/TRAPPC12-hypotheses/kgap-trappc12-kinetochore-moonlighting/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: TRAPPC12/TRAMM kinetochore moonlighting mechanism
+
+Investigate the evidence that human TRAPPC12/TRAMM has a mitotic kinetochore function that is mechanistically separable from its canonical role as a TRAPP trafficking subunit.
+
+Focus on:
+
+- the strength of evidence for TRAPPC12 in ER-to-Golgi/TRAPP complexes versus its mitotic CENP-E/kinetochore role;
+- whether the kinetochore function reflects a distinct non-TRAPP pool, phosphorylation-dependent relocalization, direct CENP-E recruitment, or an indirect consequence of trafficking defects;
+- domains, motifs, phosphorylation sites, or separation-of-function evidence that could distinguish trafficking from mitotic roles;
+- whether current GO-style curation should stop at TRAPP complex/vesicle-trafficking roles, keep CENP-E `protein binding` as non-core, or support a more specific mitotic adaptor/scaffold statement.
+
+Please include PMIDs and DOIs, flag uncached or uncertain citations, and explicitly distinguish direct experimental evidence from plausible mechanistic models.


### PR DESCRIPTION
Adds an OpenScientist report for the TRAPPC12 knowledge gap on the mitotic kinetochore moonlighting mechanism.

Included files:
- prompt.md
- openscientist.md
- openscientist.md.citations.md