### PR TITLE
[codex] Add AGR3 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/AGR3/AGR3-hypotheses/kgap-agr3-noncanonical-pdi-redox-clients/openscientist.md
+++ b/genes/human/AGR3/AGR3-hypotheses/kgap-agr3-noncanonical-pdi-redox-clients/openscientist.md
@@ -1,0 +1,115 @@
+# AGR3 Noncanonical PDI: Redox Activity and Physiological Clients
+
+**Research question:** Does human AGR3 have bona fide thiol-disulfide oxidoreductase/foldase
+activity despite its noncanonical DCYQS thioredoxin-like motif, and are there supported
+physiological substrates or receptors?
+
+**Approach:** Literature-based synthesis (PubMed). Iteration 1. Direct AGR3-specific
+experiments are distinguished throughout from inference drawn from the AGR2/PDI family.
+
+---
+
+## 1. Summary answer
+
+There is **no direct biochemical evidence** that human AGR3 is a catalytically active
+thiol-disulfide oxidoreductase, isomerase, reductase, or foldase. No AGR3-specific in vitro
+enzymatic turnover assay has ever been reported, and the solved AGR3 crystal structure shows
+it **lacks elements of the canonical PDI active site** (it carries a single, noncanonical
+CXXS-type cysteine — DCYQS — not a redox-active CXXC). Its one well-supported physiological
+role — regulation of airway **ciliary beat frequency and mucociliary clearance** — is
+**calcium-dependent** and has never been tested for a requirement for catalytic-cysteine
+chemistry. Any "oxidoreductase/chaperone" attribution to AGR3 is therefore **inference by
+homology to AGR2**, for which covalent catalytic-cysteine chemistry *is* directly demonstrated.
+Reported partners (alpha-dystroglycan, C4.4a) are unvalidated yeast-two-hybrid, cancer-context
+leads. GO curation should **not** assert a specific catalytic molecular function for AGR3.
+
+---
+
+## 2. Key findings and evidence
+
+### 2.1 No direct AGR3 catalytic evidence; structurally non-canonical
+- The crystal structure of human AGR3 (Nguyen et al., 2018, **PMID 29969106**;
+  *Acta Cryst F*, DOI ~10.1107/S2053230X18008129 — *DOI uncached/unverified*) states plainly
+  that "AGR2 and AGR3 **lack elements of the active-site motif** found in other family members."
+- A 2025 review (Law et al., **PMID 40867591**; *DOI uncached*) classifies AGR3 among
+  non-canonical CXXS PDIs that act as "**sensors or effectors of protein folding quality
+  control**" rather than classical disulfide-shuffling enzymes, and highlights "a unique role
+  for AGR3 in cilia."
+- No PubMed record contains an AGR3 reductase/oxidase/isomerase turnover assay, a
+  catalytic-dead (Cys→Ser) rescue, or an identified covalent AGR3 client.
+
+### 2.2 The airway/ciliary phenotype is calcium-linked, mechanistically open
+- Bonser et al., 2015 (**PMID 25751668**; *Am J Respir Cell Mol Biol*, DOI ~10.1165/rcmb.2014-0464OC
+  — *DOI uncached*): *Agr3⁻/⁻* mice are viable with normal-appearing cilia but reduced ciliary
+  beat frequency (**~20% lower baseline, ~35% lower after ATP**) and impaired mucociliary
+  clearance. The defect **disappears in calcium-free solution**, indicating AGR3 is required
+  for **calcium-mediated** regulation of ciliary function.
+- AGR3 is ER-resident, **restricted to ciliated cells**, and — unlike AGR2 — **not induced by
+  ER stress**. This diverges from AGR2's goblet-cell/mucin/UPR biology.
+- The study performed no active-site mutagenesis, so whether the phenotype needs cysteine
+  chemistry, client binding, extracellular signaling, or a non-enzymatic ER Ca²⁺-handling
+  scaffold role is **undetermined**.
+
+### 2.3 Catalytic-cysteine chemistry is proven only for AGR2 (the inference basis)
+- Park et al., 2009 (**PMID 19359471**; *J Clin Invest*): a cysteine in AGR2's thioredoxin-like
+  domain "**forms mixed disulfide bonds with MUC2**," a direct covalent role in mucin processing;
+  AGR2 is essential for intestinal MUC2 production.
+- Cloots et al., 2024 (**PMID 38177501**; *Nat Commun*): AGR2 acts as a mucin chaperone and
+  **rheostat of IRE1β**; mutants "**lacking their catalytic cysteine**, or displaying...H117Y,
+  were no longer able to dampen IRE1β activity."
+- Human RIFTD disease variants in the AGR2 CXXS region (e.g., Ser84Arg, Takada et al., 2024,
+  **PMID 39673647**; and Al-Shaibi et al., 2021, **PMID 34237462**) disrupt monomer–dimer
+  equilibrium and mucin binding.
+- Even for AGR2 this is best described as **substrate-selective covalent chaperoning/sensing
+  ("pseudo-PDI")** rather than robust classical isomerase turnover. Extending it to AGR3 is an
+  inference: AGR3 shares the fold and single cysteine but its clients and covalent chemistry
+  are unproven.
+
+### 2.4 Reported partners are leads, not validated substrates/receptors
+- alpha-dystroglycan (DAG1) and C4.4a (LYPD3): sole source is Fletcher et al., 2003
+  (**PMID 12592373**; *Br J Cancer*), a **yeast-two-hybrid** screen in ER⁺ breast tumour context,
+  explicitly conditional ("**which if replicated in clinical oncology** would demonstrate a
+  potential role..."). No orthogonal biochemical validation as ER-lumen folding substrates or
+  signaling receptors; both are extracellular/GPI-anchored, topologically inconsistent with
+  AGR3's ER-luminal residence except when secreted.
+- Other AGR3 partners (FZD4/Wnt-β-catenin in CRC, Chi et al., 2020, **PMID 31526829**;
+  ESR1/estrogen axis and tamoxifen resistance, Jiang et al., 2021, **PMID 34519905**) are
+  cancer-context and indirect; AGR3 also circulates as a **secreted serum biomarker** in breast
+  cancer (Garczyk et al., 2015, **PMID 25875093**).
+
+---
+
+## 3. Supported vs. refuted hypotheses
+
+| Hypothesis | Verdict | Basis |
+|---|---|---|
+| AGR3 is a bona fide catalytic thiol-disulfide oxidoreductase/isomerase | **Not supported** (no direct evidence; structure lacks canonical active site) | PMID 29969106, 40867591 |
+| AGR3's airway function requires classical PDI catalysis | **Unresolved** (never tested; phenotype is Ca²⁺-dependent) | PMID 25751668 |
+| AGR3 acts via ER calcium homeostasis to regulate ciliary motility | **Supported (genetic/IMP)**, mechanism open | PMID 25751668 |
+| alpha-dystroglycan / C4.4a are physiological AGR3 substrates/receptors | **Not supported as physiological**; remain Y2H/cancer leads | PMID 12592373 |
+| AGR2 (paralog) uses catalytic-cysteine covalent chemistry with mucin clients | **Supported (direct)** | PMID 19359471, 38177501 |
+
+## 4. GO-curation recommendation
+
+- **Do not** assign a specific catalytic molecular function (e.g., GO:0003756
+  protein-disulfide isomerase activity, or generic oxidoreductase) to AGR3 by IDA/IMP — such a
+  term would be supportable only by **ISS/homology from AGR2**, and should be flagged as such if used.
+- **Retain partner interactions (alpha-dystroglycan, C4.4a, FZD4) only as low-confidence
+  "protein binding" (IPI)** non-core leads.
+- **Annotate the well-supported layers:** cellular component *endoplasmic reticulum lumen*;
+  biological process *regulation of cilium beat frequency / mucociliary clearance* and
+  *calcium-dependent regulation* (IMP from the knockout).
+- **Label the core airway molecular mechanism "unresolved"** pending (i) catalytic-cysteine
+  (Cys→Ser) rescue experiments, (ii) direct in vitro redox/isomerase assays on recombinant
+  AGR3, and (iii) identification of a genuine ER-luminal AGR3 client.
+
+## 5. Limitations and future directions
+- This is a literature synthesis; no primary data were analyzed. AGR3-specific biochemistry is
+  genuinely sparse, so absence of evidence is partly absence of study.
+- DOIs above are provided from memory and are **flagged as uncached/unverified**; PMIDs are the
+  authoritative identifiers.
+- Priority experiments: recombinant AGR3 insulin-reduction/di-eosin-GSSG or scrambled-RNase
+  isomerase assays; catalytic-cysteine mutant knock-in mouse airway rescue; ER Ca²⁺ imaging in
+  AGR3-null ciliated cells; unbiased proximity-labeling (BioID/APEX) in ciliated airway cells to
+  find bona fide ER-luminal clients; validation of C4.4a/alpha-dystroglycan binding by
+  co-IP/SPR with topology controls.

--- a/genes/human/AGR3/AGR3-hypotheses/kgap-agr3-noncanonical-pdi-redox-clients/openscientist.md.citations.md
+++ b/genes/human/AGR3/AGR3-hypotheses/kgap-agr3-noncanonical-pdi-redox-clients/openscientist.md.citations.md
@@ -1,0 +1,23 @@
+# OpenScientist citation sidecar: AGR3
+
+- OpenScientist job: `3d52e5ed-f812-4033-9084-bd182e56485a`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:12592373
+- PMID:19359471
+- PMID:25751668
+- PMID:25875093
+- PMID:29969106
+- PMID:31526829
+- PMID:34237462
+- PMID:34519905
+- PMID:38177501
+- PMID:39673647
+- PMID:40867591
+
+## Detected DOIs
+
+- DOI:10.1107/S2053230X18008129
+- DOI:10.1165/rcmb.2014-0464OC

--- a/genes/human/AGR3/AGR3-hypotheses/kgap-agr3-noncanonical-pdi-redox-clients/prompt.md
+++ b/genes/human/AGR3/AGR3-hypotheses/kgap-agr3-noncanonical-pdi-redox-clients/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: AGR3 noncanonical PDI redox activity and clients
+
+Investigate whether human AGR3 has a bona fide thiol-disulfide oxidoreductase/foldase activity despite its noncanonical DCYQS thioredoxin-like motif, and identify any supported physiological substrates or receptors.
+
+Focus on:
+
+- direct biochemical evidence for or against AGR3 redox, isomerase, reductase, chaperone, or folding-client activity;
+- whether AGR3's airway/ciliary calcium and mucociliary phenotypes require catalytic cysteine chemistry, client binding, extracellular signaling, or a non-enzymatic scaffold role;
+- evidence for alpha-dystroglycan, C4.4a, or other reported partners as physiological substrates/receptors versus high-throughput or cancer-context binding leads;
+- whether GO-style curation should support a specific molecular function, retain only non-core binding leads, or treat the core airway function as mechanistically unresolved.
+
+Please include PMIDs and DOIs, flag uncached or uncertain citations, and distinguish direct AGR3-specific experiments from PDI-family inference.


### PR DESCRIPTION
Adds an OpenScientist report for the AGR3 knowledge gap on noncanonical PDI redox activity and physiological clients/receptors.

Included files:
- prompt.md
- openscientist.md
- openscientist.md.citations.md