### PR TITLE
[codex] Add KCTD14 OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/openscientist.md
+++ b/genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/openscientist.md
@@ -1,0 +1,96 @@
+# KCTD14: CUL3 Substrate-Adaptor or Alternative Function?
+
+**Research question:** What is the evidence for human KCTD14 molecular function—specifically, does it act as a CUL3‑RING ubiquitin ligase (CRL3) substrate adaptor like several KCTD paralogs, or does it have another activity? What GO‑style curation posture is justified?
+
+**Date:** 2026‑07‑07 · Iteration 1 (literature synthesis; no primary data files provided)
+
+---
+
+## 1. Summary (answer)
+
+There is **no direct experimental evidence** that human KCTD14 binds CUL3, oligomerizes (beyond prediction), recognizes a substrate, or participates in a CRL3 complex. The entire KCTD14 primary literature is transcriptomic/biomarker work with no biochemical characterization. Its BTB/T1 fold and its close relationship to the validated Cul3 adaptor **KCTD7** make a CRL3 substrate‑adaptor role a **plausible, high‑priority hypothesis**, but family membership is *not* sufficient to assert it, because Cul3 binding is demonstrably **not universal** among KCTDs (KCTD1 and KCTD16 do not bind Cul3). The only functionally defensible molecular‑function annotation today is **protein homo‑oligomerization** via the BTB/T1 domain, and even that rests on AlphaFold prediction plus family‑level inference rather than KCTD14‑specific experiment. **KCTD14 should remain largely MF‑dark**: keep non‑core "protein binding," optionally add homo‑oligomerization at an inferred (IBA/computational) evidence level, and do **not** annotate a specific adaptor/substrate‑recognition function.
+
+---
+
+## 2. Key findings and evidence
+
+### 2.1 The KCTD14 primary literature is functionally empty
+A systematic PubMed search returns only ~9 records mentioning KCTD14. All are transcriptomic signature / prognostic‑biomarker studies:
+- Pancreatic‑cancer DC signature, "KCTD14–TNF axis" (correlative, not mechanistic) — PMID **41080575** (2025).
+- Ovarian‑cancer methylation prognostic panel — PMID **36978087** (2023).
+- Prostate‑cancer CAF signature — PMID **36195908** (2022).
+- Dengue transcriptome biomarkers — PMIDs **39397194** (2025), **35220956** (2022).
+- Diabetic rat ileal/colon transcriptome — PMID **34806320** (2021).
+- Mouse oocyte/follicle expression — PMID **40044995** (2025).
+- Incidental co‑regulation in a Znf230‑KO transcriptome — PMID **25505846** (2014).
+
+None report protein interactions, enzymatic activity, oligomerization, or a CUL3 relationship. → **KCTD14 is MF‑dark.**
+
+### 2.2 No KCTD14–CUL3 binding has ever been tested
+The definitive family binding survey — Ji, Chu, Nielsen, Benlekbir, Rubinstein & Privé, *"Structural Insights into KCTD Protein Assembly and Cullin3 Recognition"* (PMID **26334369**, 2016) — measured Cul3 binding for KCTD1, 5, 6, 9, 16, 17 but **did not include KCTD14**. No pulldown, ITC, cryo‑EM, or proteomic study places KCTD14 in a CRL3 complex.
+
+### 2.3 Cul3 binding is member‑specific → family transfer is unreliable
+From the same study (PMID **26334369**): *"the KCTD proteins 5, 6, 9 and 17 bind to Cul3 with high affinity, while the KCTD proteins 1 and 16 do not have detectable binding,"* and KCTDs *"do not share many of the previously identified determinants for Cul3 binding."* Because two tested KCTDs (KCTD1, KCTD16) fail to bind Cul3 despite the shared BTB fold, **homology‑based inference of adaptor function to the untested KCTD14 is not safe.**
+
+### 2.4 KCTD14 oligomerization is predicted, not observed
+Esposito, Balasco & Vitagliano, *"AlphaFold Predictions Provide Insights into the Structural Features of the Functional Oligomers of All Members of the KCTD Family"* (PMID **36362127**, 2022) predict a reliable **pentameric** KCTD14 assembly, but with an **atypical CTD**: *"the structure of the related proteins KCTD7 and KCTD14, although pentameric, appears to be characterized by a different organization of the CTD region, with the five chains forming a circle‑like structure with a large cavity."* Family‑wide negative‑stain EM (Smaldone et al., PMID **27152988**, 2016) shows KCTD BTB domains across five clades "prevalently assume pentameric states." Together these support homo‑oligomerization as an **inherited fold property**, but there is **no KCTD14‑specific experimental oligomerization data**, and the atypical CTD hints KCTD14/KCTD7 may engage partners non‑canonically.
+
+### 2.5 The closest paralog KCTD7 *is* a validated Cul3 partner (hypothesis, not proof)
+- Staropoli et al. (PMID **22748208**, 2012): an NCL/PME disease mutation *"abrogated interaction with cullin‑3, a ubiquitin‑ligase component and known KCTD7 interactor."*
+- Jiang, Wang, Kong & Zheng (PMID **37450587**, 2023): cryo‑EM structures of the *"KCTD5–Gβγ fusion complex and the KCTD7–Cul3 complex."*
+
+Because AlphaFold groups KCTD14 with KCTD7 by CTD architecture, KCTD7's proven Cul3 partnership makes a CRL3 role for KCTD14 a **strong, testable prediction** — but strictly a prediction, especially given §2.3.
+
+### 2.6 Reliability of high‑throughput "protein binding" interactors
+Reported KCTD14 GO "protein binding" annotations trace to high‑throughput/curated PPI compilations (e.g., Skoblov et al., PMID **23592240**, 2013, which explicitly notes *"The value of manual curation of PPIs and analysis of existing high‑throughput data should not be underestimated"* but offers only hypotheses). Such Y2H/AP‑MS hits for a low‑expression, uncharacterized protein are prone to false positives, are non‑reciprocated, and none has been validated as a physiological KCTD14 substrate or partner. They justify only a **non‑core, low‑confidence "protein binding"** annotation, not a substrate‑recognition function.
+
+---
+
+## 3. Hypotheses: supported vs. refuted
+
+| Hypothesis | Verdict | Basis |
+|---|---|---|
+| KCTD14 is a proven CUL3/CRL3 substrate adaptor | **Not supported (no evidence)** | No KCTD14–CUL3 data exist (§2.2) |
+| KCTD14 homo‑oligomerizes (BTB/T1 pentamer) | **Provisionally supported (computational + family IBA)** | AlphaFold pentamer + family EM (§2.4) |
+| Family membership alone proves adaptor function | **Refuted** | KCTD1/KCTD16 don't bind Cul3 (§2.3) |
+| CRL3 adaptor role is a worthwhile hypothesis to test | **Supported as hypothesis** | KCTD7 paralogy (§2.5) |
+| Reported HT "protein binding" partners are physiological substrates | **Not supported** | Unvalidated HT hits (§2.6) |
+
+---
+
+## 4. Recommended GO‑style curation posture
+
+1. **Keep KCTD14 essentially MF‑dark.** Retain only non‑core, low‑confidence **`protein binding` (GO:0005515)** from HT data, clearly flagged as unvalidated.
+2. **Best‑justified positive annotation:** **`protein homo‑oligomerization` (GO:0051260)** / identical protein binding, at an **inferred/computational** evidence level (AlphaFold prediction + family IBA), *not* IDA.
+3. **Do NOT annotate** `Cul3‑RING ubiquitin ligase binding`, `ubiquitin‑protein transferase/ligase adaptor activity`, or any specific substrate‑recognition MF. These are unsupported and would over‑annotate.
+4. Record the CRL3 substrate‑adaptor role as an **open hypothesis** (paralogy to KCTD7), pending direct experiment.
+
+---
+
+## 5. Limitations and future directions
+
+**Limitations.** This is a literature‑only synthesis (no primary data). PMIDs below were confirmed to resolve via the PubMed search tool; **DOIs are supplied from model knowledge and should be independently verified** before publication‑grade use (flagged). Absence of evidence for KCTD14 reflects the field's neglect of this gene, not a demonstrated negative.
+
+**Experiments that would resolve the question.**
+- Co‑IP / ITC / AP‑MS of tagged KCTD14 vs. CUL3 (± the BTB determinants mutated) — the exact assay Ji 2016 applied to other KCTDs.
+- Reconstituted in‑vitro ubiquitination with CUL3–RBX1–E2 to test ligase‑adaptor activity.
+- SEC‑MALS/native‑MS/cryo‑EM to confirm the predicted pentamer and the atypical CTD cavity.
+- Unbiased BioID/TurboID interactome in a physiologically relevant tissue to identify candidate substrates and test whether any HT "protein binding" hits reciprocate.
+
+---
+
+## 6. Citations (PMIDs confirmed via PubMed; DOIs to be verified)
+
+- **PMID 26334369** — Ji et al. 2016, *J Biol Chem* — KCTD assembly & Cul3 recognition; member‑specific binding. DOI (verify): 10.1074/jbc.M115.669580.
+- **PMID 36362127** — Esposito, Balasco, Vitagliano 2022, *Int J Mol Sci* — AlphaFold oligomers of all KCTDs incl. KCTD14. DOI (verify): 10.3390/ijms232113346.
+- **PMID 27152988** — Smaldone et al. 2016, *Biochim Biophys Acta Mol Cell Res* — KCTD BTB domains are pentameric; KCTD6–Cul3 pinwheel. DOI (verify): 10.1016/j.bbamcr.2016.04.023.
+- **PMID 22748208** — Staropoli et al. 2012, *Am J Hum Genet* — KCTD7–cullin‑3 interaction; NCL/PME. DOI (verify): 10.1016/j.ajhg.2012.05.023.
+- **PMID 37450587** — Jiang, Wang, Kong, Zheng 2023, *Sci Adv* — cryo‑EM KCTD5–Gβγ and KCTD7–Cul3. DOI (verify): 10.1126/sciadv.adg8369.
+- **PMID 24747150** — Balasco et al. 2014, *PLoS One* — KCTD5–Cul3 5:5 heterodecamer, Kd ≈ 59 nM. DOI (verify): 10.1371/journal.pone.0091093.
+- **PMID 23592240** — Skoblov et al. 2013, *BioEssays* — KCTD PPI curation (hypothesis‑generating). DOI (verify): 10.1002/bies.201200169.
+- **PMID 24268103** — Liu, Xiang, Sun 2013 — KCTD family review (structure/function/disease). DOI (verify): 10.1007/s12035‑013‑8555‑y.
+- **PMID 34001146** — Angrisani et al. 2021, *Semin Cancer Biol* — KCTDs in cancer review. DOI (verify): 10.1016/j.semcancer.2021.05.019.
+- **PMID 40925965** — Jiang & Zheng 2026 — KCTDs as regulators of GPCR biased signaling (Gβγ degradation). DOI: not confirmed (flag as uncached).
+- KCTD14 transcriptomic references: PMIDs 41080575, 40044995, 39397194, 36978087, 36195908, 35220956, 34806320, 25505846.
+
+**Suspect/uncached flags:** All DOIs above are reconstructed from model knowledge and must be verified against CrossRef/PubMed. PMID 40925965 (2026) and PMID 41080575 (2025) are recent; treat their DOIs as unconfirmed. No previously reported KCTD14 citation was accepted without re‑confirmation in this PubMed session; any claim of a direct KCTD14–CUL3 experiment in secondary sources should be treated as **suspect** because none was found here.

--- a/genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/openscientist.md.citations.md
+++ b/genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/openscientist.md.citations.md
@@ -1,0 +1,37 @@
+# OpenScientist citation sidecar: KCTD14
+
+- OpenScientist job: `d5534552-fa09-4c3c-b461-2f8cb313935a`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:22748208
+- PMID:23592240
+- PMID:24268103
+- PMID:24747150
+- PMID:25505846
+- PMID:26334369
+- PMID:27152988
+- PMID:34001146
+- PMID:34806320
+- PMID:35220956
+- PMID:36195908
+- PMID:36362127
+- PMID:36978087
+- PMID:37450587
+- PMID:39397194
+- PMID:40044995
+- PMID:40925965
+- PMID:41080575
+
+## Detected DOIs
+
+- DOI:10.1002/bies.201200169
+- DOI:10.1007/s12035
+- DOI:10.1016/j.ajhg.2012.05.023
+- DOI:10.1016/j.bbamcr.2016.04.023
+- DOI:10.1016/j.semcancer.2021.05.019
+- DOI:10.1074/jbc.M115.669580
+- DOI:10.1126/sciadv.adg8369
+- DOI:10.1371/journal.pone.0091093
+- DOI:10.3390/ijms232113346

--- a/genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/prompt.md
+++ b/genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: KCTD14 CUL3 substrate-adaptor or alternative function
+
+Investigate the evidence for human KCTD14 molecular function, especially whether it acts as a CUL3-RING ubiquitin ligase substrate adaptor like several KCTD paralogs or instead has another activity.
+
+Focus on:
+
+- direct evidence for KCTD14 binding to CUL3, oligomerization, substrates, ubiquitination, degradation, or CRL3 complex membership;
+- the reliability of reported high-throughput KCTD14 `protein binding` interactors and whether any are plausible physiological substrates or partners;
+- family-level KCTD/BTB evidence that can or cannot be transferred to KCTD14;
+- whether current GO-style curation should remain MF-dark/non-core binding only, support protein homooligomerization, or support a specific adaptor/substrate-recognition function.
+
+Please include PMIDs and DOIs, flag uncached or suspect citations, and avoid relying on previously reported KCTD14 citations unless they resolve correctly in PubMed.


### PR DESCRIPTION
Adds an OpenScientist hypothesis-exploration report for the KCTD14 Cul3-adaptor knowledge gap, with the prompt and citation sidecar.\n\nLocal checks:\n- git diff --check -- genes/human/KCTD14/KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other