### PR TITLE
[codex] Add RAB9A OpenScientist knowledge-gap report

### DIFF
--- a/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md
+++ b/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md
@@ -1,0 +1,69 @@
+# RAB9A GEF/GAP Switch-Control: A Residual Knowledge Gap
+
+**Research question:** Which guanine-nucleotide exchange factor(s) (GEFs) activate human RAB9A on late endosomes, and which GTPase-activating protein(s) (GAPs) inactivate it?
+
+**Iteration 1 — literature-based mechanistic synthesis.** No primary datasets were provided; this report synthesizes published biochemistry, cell biology, and curated Rab-regulator catalogs, distinguishing validated RAB9A-specific evidence from paralog/family extrapolation. Citations retrieved and verified against the local PubMed cache are marked **[cached]**; citations drawn from domain knowledge that could not be confirmed against the cache are marked **[UNCACHED — verify]**.
+
+---
+
+## 1. Summary (direct answer)
+
+There is **no validated, RAB9A-specific GEF or GAP** in the literature. RAB9A's activating exchange factor on late endosomes is **unidentified** — no in vitro nucleotide-exchange assay, localization, or knockdown/rescue study assigns a GEF to RAB9A. On the GAP side, the proteins most often linked to RAB9A — **RUTBC1 (SGSM2) and RUTBC2 (SGSM1)** — are RAB9A **effectors/binding partners** whose TBC GAP activity is directed at **other Rabs** (Rab32/38, Rab33B, Rab34/36), **not at RAB9A itself**. The RAB9A on/off switch machinery should therefore be curated as an **explicit residual knowledge gap**, with regulator relationships added only for the (well-supported) *downstream* GAP-cascade role of RAB9A.
+
+---
+
+## 2. Key findings
+
+### Finding 1 — No RAB9A GEF is identified (residual gap)
+- Authoritative Rab-GEF catalogs enumerate every known GEF class — DENN, VPS9, Sec2, TRAPP, Mon1-Ccz1, BLOC-3 (HPS1-HPS4), Ric1-Rgp1, Rab3GAP1/2, REI-1, RPGR — and their substrate Rabs. **RAB9A is not assigned a GEF.** *(Ishida, Oguchi & Fukuda 2016, PMID 27246931 [cached]; Marat, Dokainish & McPherson 2011, PMID 21330364 [cached].)*
+- The systematic DENN-domain GEF–Rab mapping screen did not identify a RAB9A activator. *(Yoshimura, Gerondopoulos, Linford, Rigden & Barr, J Cell Biol 2010, PMID 20937701, DOI 10.1083/jcb.201008090 [UNCACHED — verify].)*
+- The specific late-endosomal GEF **Mon1-Ccz1 activates RAB7, not RAB9A** *(Kiontke et al. 2017, PMID 28051187 [cached]; Borchers et al. 2023, PMID 37463208 [cached])*, so RAB9A's activation is not explained by the known LE-maturation GEF.
+- **Verdict:** GEF assignment for RAB9A rests only on family-level inference. No RAB9A-specific biochemistry exists.
+
+### Finding 2 — RUTBC1/RUTBC2 are RAB9A effectors, not RAB9A GAPs
+- **RUTBC1 (SGSM2)** was originally characterized as a **Rab9-binding protein** and is a TBC-GAP for **Rab32 and Rab33B** in vitro; in melanocytes it is the physiological GAP for **Rab32/38**, and **RAB9A regulates RUTBC1 localization** and melanogenic-enzyme trafficking. *(Marubashi, Shimada, Fukuda & Ohbayashi 2016, PMID 26620560 [cached].)*
+- RUTBC1 is recruited by **RAB9A-GTP** but shows **no GAP activity toward RAB9A**; its catalytic activity is on Rab32/33B. *(Nottingham, Ganley, Barr, Lambright & Pfeffer, JBC 2011, PMID 21808068, DOI 10.1074/jbc.M111.246900 [UNCACHED — verify].)*
+- **RUTBC2 (SGSM1)** is likewise a RAB9A-bound TBC-GAP acting on **Rab34/Rab36**. *(Nottingham, Pusapati, Ganley, Barr, Lambright & Pfeffer, JBC 2012, PMID 22637480, DOI 10.1074/jbc.M112.372458 [UNCACHED — verify].)*
+- TBC-domain GAPs catalyze GTP hydrolysis via a **dual-finger (arginine + glutamine)** transition-state mechanism *(Pan, Eathiraj, Munson & Lambright 2006, PMID 16855591 [cached])* — mechanistic context that constrains which TBC proteins could, in principle, act on RAB9A.
+- **Interpretation:** RAB9A sits at the **top of a GAP cascade** — RAB9A-GTP positions RUTBC1/2 on membranes to inactivate *downstream* Rabs. This is the **opposite** of a RAB9A-inactivating relationship and must not be mis-curated as "GAP for RAB9A."
+
+### Finding 3 — Effectors/pathways constrain but don't identify the regulators
+- RAB9A recruits **TIP47/PLIN3** onto late endosomes to drive **CI-/CD-MPR (mannose-6-phosphate receptor) retrograde transport to the TGN** *(Burguete, Sivars & Pfeffer 2005, PMID 16473602 [cached]; TIP47 identification Diaz & Pfeffer 1998, PMID 9463366 [UNCACHED — verify]).*
+- Other RAB9A effectors: TGN golgin **GCC185** *(Reddy et al. 2006, PMID 16967564 [UNCACHED — verify])*, **RhoBTB3** *(Espinosa et al. 2009, PMID 19273613 [UNCACHED — verify])*, and RUTBC1/2. RAB9A also supports **ATG5/ATG7-independent "alternative" autophagy** *(Nishida et al. 2009, PMID 19794493 [UNCACHED — verify]).*
+- These define **where** an activating GEF must act (late-endosome membrane) and **when** a GAP must terminate signaling (after MPR delivery), bounding the search space without naming a regulator.
+
+---
+
+## 3. Supported vs. refuted hypotheses
+
+| Hypothesis | Status | Basis |
+|---|---|---|
+| A validated RAB9A-specific GEF exists in the literature | **Refuted / unsupported** | Absent from all Rab-GEF catalogs; no exchange assay on RAB9A |
+| RUTBC1/RUTBC2 are the GAPs that inactivate RAB9A | **Refuted** | They bind RAB9A but hydrolyze Rab32/33B/34/36; RAB9A regulates *their* localization |
+| RAB9A acts upstream in a GAP cascade (RAB9A-GTP → RUTBC1/2 → other Rabs) | **Supported** | PMID 26620560; PMID 21808068/22637480 [uncached] |
+| Mon1-Ccz1 activates RAB9A on late endosomes | **Refuted** | Mon1-Ccz1 is RAB7-specific (PMID 28051187, 37463208) |
+| DENN- or TBC-family candidates have *RAB9A-specific* evidence | **Unsupported** | Only broad Rab-family inference; no RAB9A hit in DENN screen |
+| A Rab7→Rab9A handoff/cascade activates RAB9A during LE maturation | **Untested — plausible model** | Analogy to Rab5→Rab7; no direct RAB9A evidence |
+
+---
+
+## 4. Recommendation for GO-style curation
+
+1. **Do NOT add a "GEF for RAB9A" relationship.** Record the RAB9A activator as an **explicit residual knowledge gap**.
+2. **Do NOT annotate RUTBC1/RUTBC2 as GAPs acting on RAB9A.** Instead curate:
+   - RAB9A → RUTBC1 (SGSM2): *binds effector; regulates its localization* (PMID 26620560, 21808068).
+   - RAB9A → RUTBC2 (SGSM1): *binds effector* (PMID 22637480).
+   - RUTBC1 GAP activity → Rab32/Rab33B/Rab38; RUTBC2 GAP activity → Rab34/Rab36.
+3. **Add suggested curator questions:**
+   - What GEF loads GTP onto RAB9A at the late endosome? Is activation coupled to RAB7 (cascade/handoff)?
+   - Which TBC-domain GAP inactivates RAB9A, and where/when in the MPR-retrieval cycle?
+   - Do any DENN/VPS9-family GEFs show *direct* exchange activity on RAB9A in vitro?
+4. **Flag paralog caution:** RAB9A and RAB9B are close paralogs; any future regulator claim must be tested for RAB9A specificity rather than assumed from Rab-family or RAB9B data.
+
+---
+
+## 5. Limitations & future directions
+
+- **Cache coverage:** Several key primary papers (Nottingham RUTBC1/2 JBC 2011/2012; Yoshimura DENN screen 2010; Diaz & Pfeffer 1998; Reddy GCC185 2006) were **not retrievable** in the local PubMed cache and are flagged **[UNCACHED — verify]**; their PMIDs/DOIs should be confirmed against NCBI before curation.
+- **No wet-lab data** were available; conclusions are literature-derived.
+- **Definitive resolution requires:** an in vitro GDP/GTP-exchange assay identifying the RAB9A GEF; a TBC-GAP screen scored directly on RAB9A; and knockdown/knockout–rescue with CI-MPR endosome-to-TGN readouts to establish physiological relevance.

--- a/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md
+++ b/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md
@@ -42,7 +42,7 @@
 | PMID:27246931 | cached | missing | verify before reuse |
 | PMID:28051187 | cached | missing | verify before reuse |
 | PMID:37463208 | cached | missing | verify before reuse |
-| PMID:19490898 | not in raw report | missing | corrected RhoBTB3/Rab9 PMID; verify before reuse |
+| PMID:19490898 | not in raw report | present | corrected RhoBTB3/Rab9 PMID; verify before reuse |
 
 ## Detected DOIs
 

--- a/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md
+++ b/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md
@@ -1,0 +1,27 @@
+# OpenScientist citation sidecar: RAB9A
+
+- OpenScientist job: `42a8f1d2-7e95-465f-a40e-e29382ceed81`
+- Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+
+## Detected PMIDs
+
+- PMID:9463366
+- PMID:16473602
+- PMID:16855591
+- PMID:16967564
+- PMID:19273613
+- PMID:19794493
+- PMID:20937701
+- PMID:21330364
+- PMID:21808068
+- PMID:22637480
+- PMID:26620560
+- PMID:27246931
+- PMID:28051187
+- PMID:37463208
+
+## Detected DOIs
+
+- DOI:10.1074/jbc.M111.246900
+- DOI:10.1074/jbc.M112.372458
+- DOI:10.1083/jcb.201008090

--- a/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md
+++ b/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md
@@ -2,6 +2,7 @@
 
 - OpenScientist job: `42a8f1d2-7e95-465f-a40e-e29382ceed81`
 - Reviewer note: this sidecar records PMIDs/DOIs detected in the OpenScientist report for triage. Verify references against PubMed/full text before using the report to update the gene review YAML.
+- Triage update: local cache status and the RhoBTB3 citation correction below were checked on 2026-07-06; cache labels in the raw report are not authoritative.
 
 ## Detected PMIDs
 
@@ -19,6 +20,29 @@
 - PMID:27246931
 - PMID:28051187
 - PMID:37463208
+
+## Citation triage notes
+
+- The report cites RhoBTB3 as `PMID:19273613`, but that PMID resolves to an unrelated Megator/mitosis paper. The RhoBTB3/Rab9 endosome-to-Golgi transport paper is `PMID:19490898` ("RhoBTB3: a Rho GTPase-family ATPase required for endosome to Golgi transport.").
+- Local publication-cache status for detected PMIDs:
+
+| PMID | Report label | Local cache | Triage |
+| --- | --- | --- | --- |
+| PMID:9463366 | UNCACHED | missing | verify before reuse |
+| PMID:16473602 | cached | missing | verify before reuse |
+| PMID:16855591 | cached | present | cache label matches |
+| PMID:16967564 | UNCACHED | missing | verify before reuse |
+| PMID:19273613 | UNCACHED | present | wrong paper for RhoBTB3 claim; use PMID:19490898 instead |
+| PMID:19794493 | UNCACHED | missing | verify before reuse |
+| PMID:20937701 | UNCACHED | present | cache label in raw report is stale |
+| PMID:21330364 | cached | missing | verify before reuse |
+| PMID:21808068 | UNCACHED | present | cache label in raw report is stale |
+| PMID:22637480 | UNCACHED | present | cache label in raw report is stale |
+| PMID:26620560 | cached | missing | verify before reuse |
+| PMID:27246931 | cached | missing | verify before reuse |
+| PMID:28051187 | cached | missing | verify before reuse |
+| PMID:37463208 | cached | missing | verify before reuse |
+| PMID:19490898 | not in raw report | missing | corrected RhoBTB3/Rab9 PMID; verify before reuse |
 
 ## Detected DOIs
 

--- a/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/prompt.md
+++ b/genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/prompt.md
@@ -1,0 +1,12 @@
+# OpenScientist prompt: RAB9A GEF/GAP switch-control gap
+
+Investigate the unresolved regulatory switch machinery for human RAB9A: the specific guanine-nucleotide exchange factor(s) that activate RAB9A on late endosomes and the GTPase-activating protein(s) that inactivate it.
+
+Focus on:
+
+- direct evidence for any RAB9A-specific GEFs or GAPs, including in vitro nucleotide-exchange/GTPase assays, localization, knockdown/knockout rescue, and CI-MPR or endosome-to-TGN trafficking readouts;
+- whether DENN-domain or TBC-domain candidates have RAB9A-specific evidence versus broad Rab-family inference;
+- how known RAB9A effectors and trafficking pathways constrain plausible regulators;
+- whether GO-style curation should add regulator relationships, suggested questions, or leave the GEF/GAP mechanism as an explicit residual knowledge gap.
+
+Please include PMIDs and DOIs, flag uncached or uncertain citations, and distinguish validated RAB9A-specific regulators from candidate screens or paralog extrapolation.


### PR DESCRIPTION
Adds an OpenScientist hypothesis-exploration report for the RAB9A GEF/GAP switch-control knowledge gap, with the prompt and citation sidecar.\n\nLocal checks:\n- git diff --check -- genes/human/RAB9A/RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control