### PR TITLE
Add AI review for S. pombe tam14

### DIFF
--- a/genes/SCHPO/tam14/tam14-ai-review.yaml
+++ b/genes/SCHPO/tam14/tam14-ai-review.yaml
@@ -1,0 +1,343 @@
+id: G2TRT3
+gene_symbol: tam14
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: >-
+  tam14 (systematic name SPCC330.20) is a small (70-residue) single-pass endoplasmic
+  reticulum membrane protein of the RAMP4/SERP1 family (Pfam PF06624; InterPro IPR010580,
+  "ER stress-associated"). Its architecture is a short polar/disordered N-terminal segment
+  followed by a single C-terminal transmembrane helix, characteristic of the tail-anchored
+  RAMP4/SERP1 proteins. It is a curated ortholog of human SERP1 (RAMP4) and SERP2 and of
+  budding-yeast Ysy6. In its better-characterized mammalian and budding-yeast orthologs, this
+  family constitutes a small accessory component of the ribosome-associated Sec61 translocon
+  that contacts nascent polypeptides during co-translational translocation and stabilizes
+  newly synthesized membrane proteins during endoplasmic reticulum stress, facilitating their
+  subsequent glycosylation. The corresponding molecular activity, subcellular localization, and
+  biological role of tam14 in fission yeast have not been directly measured; annotations rest on
+  family/orthology inference. tam14 was identified as a novel gene whose transcript levels are
+  altered during meiosis, but no meiotic function has been demonstrated.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+      mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: PMID:21270388
+    title: Augmented annotation of the Schizosaccharomyces pombe genome reveals additional genes
+      required for growth and viability
+    findings:
+      - statement: tam14 is one of 14 novel S. pombe loci named for having transcript levels
+          altered during meiosis (tam1-tam14); this is an expression observation, not a functional
+          determination.
+        supporting_text: We refer to the novel protein-coding genes with no apparent induction
+          in meiosis as new1–new25 , and the 14 genes with t ranscripts a ltered in m eiosis
+          as tam1–tam14
+        reference_section_type: RESULTS
+      - statement: Fourteen novel-gene transcripts, including tam14, were differentially expressed
+          across a synchronized meiotic time course.
+        supporting_text: Fourteen transcripts were differentially expressed during meiosis.
+        reference_section_type: RESULTS
+      - statement: tam14 was NOT among the seven genes selected for deletion/functional
+          assessment (tam2, new1, new5, tam7, new8, tam11, new21), so no tam14 deletion phenotype
+          was reported.
+        supporting_text: three criteria were used to select seven genes ( tam2 , new1 , new5
+          , tam7 , new8 , tam11 , and new21 ) for functional assessment
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: >-
+        Full text cached and verified. This is the discovery paper for tam14 and the only
+        publication with S. pombe-specific data on the gene. It establishes tam14 as a bona fide,
+        meiotically-regulated protein-coding gene but provides only transcript-level (expression)
+        evidence; tam14 was explicitly excluded from the deletion-phenotyping set, so no meiotic
+        or other function was demonstrated.
+  - id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+    title: Falcon deep research report for tam14 (G2TRT3, SPCC330.20)
+    findings:
+      - statement: The functional annotation of tam14 rests on domain/family-level inference from
+          orthologs (RAMP4/SERP1, Ysy6); no deletion, localization, or biochemical study exists
+          for tam14 itself.
+        supporting_text: rests primarily on **domain and family-level inference** from
+          well-characterized orthologs
+      - statement: No targeted deletion, localization, or biochemical study has been published
+          specifically for tam14/SPCC330.20.
+        supporting_text: no targeted deletion, localization, or biochemical study has been
+          published specifically for tam14/SPCC330.20
+      - statement: By family inference tam14 is a small accessory component of the Sec61 translocon
+          at the ER membrane; RAMP4/SERP1 is a tail-anchored ER protein that intercalates the
+          Sec61 lateral gate and contacts translocating nascent chains.
+        supporting_text: predicted to function as a **small accessory component of the Sec61
+          translocon** at the endoplasmic reticulum membrane
+      - statement: No direct localization data for tam14 in S. pombe cells has been reported.
+        supporting_text: No direct localization data for tam14 in *S. pombe* cells has been reported
+      - statement: The meiotic expression change reflected in the gene's name does not imply a
+          meiosis-specific biochemical function.
+        supporting_text: the meiotic expression change alone does not imply a meiosis-specific
+          biochemical function
+      - statement: S. pombe UPR is mechanistically divergent (no Hac1/XBP1; Ire1-dependent RIDD),
+          so the mammalian ER-stress-induction paradigm for RAMP4/SERP1 may not transfer.
+        supporting_text: "*S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on
+          Ire1-dependent mRNA decay (RIDD)"
+      - statement: Overall functional confidence is moderate at the family level but low for
+          gene-specific detail.
+        supporting_text: Moderate for family-level annotation, low for gene-specific detail
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: >-
+        Genuine falcon/Edison deep-research output (17 citations, cached:false). Conclusions were
+        cross-checked against the UniProt record and the PomBase curated ortholog set and agree:
+        real conserved RAMP4/SERP1 family, no S. pombe-specific experimental characterization. Its
+        mechanistic sources (Lewis et al. 2024 eLife; Pool 2009 JCB) concern mammalian
+        RAMP4/SERP1, not tam14, and are used here only as family context, not as tam14-specific
+        evidence.
+existing_annotations:
+  - term:
+      id: GO:0005783
+      label: endoplasmic reticulum
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: located_in
+    review:
+      summary: >-
+        Endoplasmic reticulum localization inferred electronically from the InterPro RAMP4/
+        ER-stress-associated domain (IPR010580). This is consistent with the family assignment and
+        the single C-terminal transmembrane helix, but is more general than the endoplasmic
+        reticulum membrane term that better captures a single-pass RAMP4/SERP1 protein.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Correct in direction and family-supported, but subsumed by the more specific
+        "endoplasmic reticulum membrane" annotations; retained as non-core because the membrane
+        term is the precise location.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: predicted to function as a **small accessory component of the Sec61
+            translocon** at the endoplasmic reticulum membrane
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: >-
+        Endoplasmic reticulum membrane localization from UniProt Subcellular-Location mapping.
+        This is the electronic counterpart of the ISS annotation below and is well-grounded by the
+        RAMP4/SERP1 family assignment plus the single predicted transmembrane helix (residues
+        45-65). No direct localization has been shown in S. pombe, but the family/topology basis is
+        strong.
+      action: ACCEPT
+      reason: >-
+        The single-pass, tail-anchored RAMP4/SERP1 architecture localizes to the ER membrane;
+        this is the most specific, best-supported location for tam14 and represents its core
+        cellular component.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: >-
+        Generic "membrane" localization from Subcellular-Location mapping. This is a high-level
+        parent of the endoplasmic reticulum membrane term and adds no specific information beyond
+        it.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Uninformative parent term redundant with the more specific "endoplasmic reticulum
+        membrane" annotation; the specific term should carry the localization.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: >-
+        Root molecular_function placeholder with ND (No Data) evidence, reflecting that no
+        molecular function has been experimentally determined for tam14 in S. pombe. Although the
+        RAMP4/SERP1 family has a described activity (accessory Sec61-translocon component that
+        contacts translocating nascent chains and stabilizes membrane proteins during ER stress),
+        that activity has never been assayed for tam14, and it has no clean, well-scoped GO
+        molecular-function term to which it could be confidently transferred.
+      action: ACCEPT
+      reason: >-
+        The ND molecular_function annotation honestly reflects the current MF-dark state: family
+        membership is clear but the specific in vivo molecular activity of tam14 is unmeasured and
+        not cleanly expressible in GO. No specific MF term is asserted.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: no targeted deletion, localization, or biochemical study has been
+            published specifically for tam14/SPCC330.20
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: rests primarily on **domain and family-level inference** from
+            well-characterized orthologs
+      knowledge_gaps:
+        - gap_statement: >-
+            The molecular function of tam14 in S. pombe is undetermined. Whether it acts, like its
+            RAMP4/SERP1 orthologs, as an accessory subunit of the Sec61 translocon that contacts
+            translocating nascent chains and stabilizes newly synthesized membrane proteins during
+            ER stress has never been assayed for the fission-yeast protein.
+          boundary: >-
+            Firmly established: tam14 is a genuine RAMP4/SERP1-family, single-pass (C-terminal TM)
+            small ER-membrane protein by curated reciprocal orthology (human SERP1/SERP2;
+            S. cerevisiae Ysy6) and Pfam PF06624. Undetermined: any tam14-specific biochemical
+            activity, substrate, or translocon association measured in S. pombe.
+          gap_kind:
+            - BIOLOGY
+            - ONTOLOGY
+          dark_aspect: MF_DARK
+          status: OPEN
+          significance: >-
+            RAMP4/SERP1 is a near-constitutive accessory of the ER protein-biogenesis machinery in
+            other eukaryotes; whether fission yeast uses tam14 the same way bears on the
+            conservation of translocon accessory factors, and the family activity has no adequate
+            GO MF term (an ontology shadow).
+          resolution: >-
+            Assay tam14-Sec61 association and nascent-chain crosslinking in S. pombe; a
+            separation-of-function analysis of the TM helix vs the N-terminal region. Ontology:
+            a molecular-function term for "Sec61 translocon accessory / nascent-chain
+            stabilization" activity would let the family role be expressed.
+          provenance:
+            - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+              supporting_text: no targeted deletion, localization, or biochemical study has been
+                published specifically for tam14/SPCC330.20
+            - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+              supporting_text: Moderate for family-level annotation, low for gene-specific detail
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: >-
+        Curator sequence-similarity transfer of ER membrane localization from the mammalian
+        ortholog (UniProtKB:Q9R2C1, rat SERP1/RAMP4). Unlike the dubious orthology transfers seen
+        for some fission-yeast orphan genes, this rests on a genuine, curated, reciprocal ortholog
+        relationship (human SERP1/SERP2; S. cerevisiae Ysy6) and on the conserved single-pass
+        tail-anchored topology. It is the best-supported location annotation and duplicates the
+        IEA ER membrane row with stronger (ISS) evidence.
+      action: ACCEPT
+      reason: >-
+        Well-grounded ISS transfer within a real, conserved family; the ER membrane is the core
+        cellular component of tam14.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: >-
+        Generic "membrane" localization transferred by sequence similarity from the mammalian
+        ortholog. As with the IEA membrane row, this is a high-level parent that is subsumed by
+        the specific endoplasmic reticulum membrane annotation.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Uninformative parent term redundant with "endoplasmic reticulum membrane"; the specific
+        term should carry the localization.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+core_functions:
+  - description: >-
+      Single-pass endoplasmic reticulum membrane protein of the RAMP4/SERP1 family. The
+      well-supported, family/orthology-grounded statement about tam14 is its subcellular
+      localization: a tail-anchored small protein of the ER membrane. No specific molecular
+      function is asserted, because the RAMP4/SERP1 accessory-translocon activity has not been
+      measured for tam14 in S. pombe and has no adequate GO molecular-function term.
+    supported_by:
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: By family inference, tam14 is predicted to localize to the
+          **endoplasmic reticulum membrane**
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: predicted to function as a **small accessory component of the Sec61
+          translocon** at the endoplasmic reticulum membrane
+    locations:
+      - id: GO:0005789
+        label: endoplasmic reticulum membrane
+knowledge_gaps:
+  - gap_statement: >-
+      No biological process has been established for tam14 in S. pombe. Despite its name (altered
+      transcripts in meiosis), no meiotic — or any other — function has been demonstrated: tam14
+      was excluded from the deletion-phenotyping set in its discovery study, and no deletion,
+      localization, or biochemical characterization has since been published.
+    boundary: >-
+      Firmly established: tam14 is a bona fide, meiotically-regulated protein-coding gene of the
+      conserved RAMP4/SERP1 family; its transcript level changes during a synchronized meiotic
+      program. Undetermined: whether that expression change reflects any meiotic role, and whether
+      tam14 participates (as its orthologs do) in co-translational ER protein biogenesis / ER
+      proteostasis in fission yeast.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Distinguishing an incidental meiotic expression change from a genuine meiotic or
+      ER-proteostasis role would settle whether the "tam" name reflects biology, and would test
+      whether the conserved RAMP4/SERP1 translocon-accessory role operates in an organism whose
+      UPR is mechanistically divergent (S. pombe lacks Hac1/XBP1 and uses Ire1-dependent RIDD).
+    resolution: >-
+      Phenotype a tam14 deletion for growth, ER-stress sensitivity (e.g. tunicamycin/DTT),
+      secretion/glycosylation defects, and sporulation/spore viability; GFP localization across
+      the cell cycle and meiosis; measure tam14-Sec61 association.
+    provenance:
+      - reference_id: PMID:21270388
+        supporting_text: three criteria were used to select seven genes ( tam2 , new1 , new5
+          , tam7 , new8 , tam11 , and new21 ) for functional assessment
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: the meiotic expression change alone does not imply a meiosis-specific
+          biochemical function
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: "*S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on
+          Ire1-dependent mRNA decay (RIDD)"
+suggested_questions:
+  - question: Does tam14 associate with the Sec61 translocon and contact translocating nascent
+      chains in S. pombe, as its RAMP4/SERP1 orthologs do?
+    experts: []
+  - question: Does the meiotic transcript change reflect a functional meiotic role (e.g. increased
+      ER protein-biogenesis demand during sporulation), or is it an incidental expression change
+      with no phenotype?
+    experts: []
+  - question: Given that S. pombe uses an Ire1/RIDD-based UPR without Hac1/XBP1, is tam14 regulated
+      by, or required for, the fission-yeast ER stress response at all?
+    experts: []
+suggested_experiments:
+  - hypothesis: tam14 is an accessory component of the S. pombe Sec61 translocon.
+    description: Affinity-purify tagged tam14 from S. pombe and test co-purification with Sec61
+      complex subunits; site-specific crosslinking to translocating nascent chains.
+    experiment_type: co-immunoprecipitation / crosslinking-MS
+  - hypothesis: tam14 contributes to ER proteostasis / stress tolerance.
+    description: Phenotype a tam14 deletion (and overexpression) for growth and viability, ER-stress
+      sensitivity (tunicamycin, DTT), and membrane-protein secretion/glycosylation.
+    experiment_type: genetics / stress phenotyping
+  - hypothesis: tam14 localizes to the ER membrane and its distribution changes during meiosis.
+    description: GFP-tag tam14 and image localization in vegetative and meiotic/sporulating cells.
+    experiment_type: live-cell fluorescence microscopy

--- a/genes/SCHPO/tam14/tam14-deep-research-falcon.md
+++ b/genes/SCHPO/tam14/tam14-deep-research-falcon.md
@@ -1,0 +1,269 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-07-06T17:03:55.286021'
+end_time: '2026-07-06T17:23:14.352766'
+duration_seconds: 1159.07
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: SCHPO
+  gene_id: tam14
+  gene_symbol: tam14
+  uniprot_accession: G2TRT3
+  protein_description: 'RecName: Full=Protein tam14; AltName: Full=Transcripts altered
+    in meiosis protein 14;'
+  gene_info: Name=tam14; ORFNames=SPCC330.20;
+  organism_full: Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+  protein_family: Belongs to the RAMP4 family. .
+  protein_domains: ER_stress-assoc. (IPR010580); RAMP4 (PF06624)
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+    max_embedded_images: 8
+citation_count: 17
+artifact_count: 1
+artifact_sources:
+  edison_answer_artifacts: 1
+artifacts:
+- filename: artifact-00.md
+  path: tam14-deep-research-falcon_artifacts/artifact-00.md
+  media_type: text/markdown
+  source: edison_answer_artifacts
+  data_storage_id: null
+  description: Edison artifact artifact-00
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** G2TRT3
+- **Protein Description:** RecName: Full=Protein tam14; AltName: Full=Transcripts altered in meiosis protein 14;
+- **Gene Information:** Name=tam14; ORFNames=SPCC330.20;
+- **Organism (full):** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+- **Protein Family:** Belongs to the RAMP4 family. .
+- **Key Domains:** ER_stress-assoc. (IPR010580); RAMP4 (PF06624)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "tam14" matches the protein description above**
+2. **Verify the organism is correct:** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'tam14' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **tam14** (gene ID: tam14, UniProt: G2TRT3) in SCHPO.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** G2TRT3
+- **Protein Description:** RecName: Full=Protein tam14; AltName: Full=Transcripts altered in meiosis protein 14;
+- **Gene Information:** Name=tam14; ORFNames=SPCC330.20;
+- **Organism (full):** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+- **Protein Family:** Belongs to the RAMP4 family. .
+- **Key Domains:** ER_stress-assoc. (IPR010580); RAMP4 (PF06624)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "tam14" matches the protein description above**
+2. **Verify the organism is correct:** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'tam14' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **tam14** (gene ID: tam14, UniProt: G2TRT3) in SCHPO.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive Research Report: tam14 (SPCC330.20) in *Schizosaccharomyces pombe*
+
+### 1. Gene Identity and Discovery
+
+The gene *tam14* (systematic name SPCC330.20; UniProt accession G2TRT3) encodes a small protein in the fission yeast *Schizosaccharomyces pombe* (strain 972 / ATCC 24843). It was identified through a systematic reappraisal of the *S. pombe* genome conducted by Bitton et al. (2011), which used an integrated pipeline combining proteogenomics, comparative genomics, and Pfam domain scanning to discover novel small protein-coding genes that had been missed by previous annotations due to the standard 100-amino-acid cutoff threshold (bitton2011augmentedannotationof pages 1-2). The *tam14* locus was specifically identified through a Pfam domain scan that detected a RAMP4-family domain (PF06624) in an intergenic region of the genome (bitton2011augmentedannotationof pages 3-4, bitton2011augmentedannotationof pages 8-10).
+
+The gene was named "tam14" because its transcript levels fluctuate during meiosis—the name stands for "Transcripts Altered in Meiosis protein 14." In the Bitton et al. study, 14 of the 39 newly discovered genes showed altered transcript levels during the sexual differentiation program induced by temperature-dependent inactivation of the Pat1 kinase in pat1.114 diploid cultures, and these were designated tam1–tam14 (bitton2011augmentedannotationof pages 8-10). Transcription at the *tam14* locus was confirmed by RT-PCR and RNA-Seq (bitton2011augmentedannotationof pages 1-2). Importantly, *tam14* was not among the seven genes selected for functional knockout analysis in the original study, so no deletion phenotype has been reported specifically for this gene (bitton2011augmentedannotationof pages 8-10).
+
+### 2. Protein Family and Domain Architecture
+
+Tam14 belongs to the **RAMP4 protein family** (Pfam PF06624) and carries an **ER stress-associated domain** (InterPro IPR010580). This family is defined by the mammalian protein RAMP4 (Ribosome-Associated Membrane Protein 4), also known as **SERP1** (Stress-associated Endoplasmic Reticulum Protein 1), and the *Saccharomyces cerevisiae* ortholog **Ysy6** (lewis2024structuralanalysisof pages 1-2).
+
+Structural characterization of mammalian RAMP4 reveals a small (~7 kDa) protein with two key structural domains: (i) a **hook-shaped ribosome-binding domain (RBD)** consisting of an N-terminal α-helix flanked by 3₁₀-helices, which binds 28S rRNA and ribosomal proteins eL19, eL22, and eL31 through electrostatic and hydrophobic interactions; and (ii) a **kinked transmembrane domain (TMD)** connected to the RBD by a flexible linker (lewis2024structuralanalysisof pages 4-6). The TMD is kinked approximately 40° at a conserved glycine residue. The cytoplasmic half of the TMD is hydrophobic and binds the Sec61 lateral gate, while the lumenal half is amphipathic, with its hydrophilic face oriented toward the channel interior, contributing to the hydrophilic lumenal funnel of the Sec61α subunit (lewis2024structuralanalysisof pages 4-6).
+
+RAMP4 is classified as a **tail-anchored (TA) membrane protein** and can be targeted to the ER membrane via multiple redundant pathways, including the SRP, SND, and TRC/GET pathways (sicking2021complexityandspecificity pages 9-11).
+
+### 3. Predicted Molecular Function
+
+Based on its RAMP4 family membership and domain architecture, tam14 is predicted to function as a **small accessory component of the Sec61 translocon** at the endoplasmic reticulum membrane. The following functional inferences are drawn from well-characterized RAMP4/SERP1 orthologs:
+
+**Association with the Sec61 translocon:** RAMP4 is tightly associated near-stoichiometrically with ER-localized ribosome-Sec61 complexes. Cryo-EM structural analysis has revealed that RAMP4 intercalates into Sec61's lateral gate, widening the central pore and contributing to its hydrophilic interior (lewis2024structuralanalysisof pages 1-2). In native mammalian ER membranes, RAMP4 is present in approximately 81% of non-MPT (multipass translocon)-containing ribosome-translocon complexes, making it a near-constitutive component (lewis2024structuralanalysisof pages 4-6). RAMP4 can be crosslinked to nascent polypeptide chains translocating through the Sec61 channel, indicating direct interaction with substrates during protein translocation (lewis2024structuralanalysisof pages 1-2).
+
+**Facilitation of membrane protein integration:** The recruitment of RAMP4 to the translocon is triggered when a transmembrane segment enters the ribosomal exit tunnel, where ribosomal protein Rpl17 recognizes the TM segment and signals RAMP4 recruitment. This process helps remodel the translocon to facilitate the switch from translocation mode to membrane integration mode (pool2009atransmembranesegment pages 11-12, pool2009atransmembranesegment pages 1-2, pool2009atransmembranesegment pages 9-11).
+
+**"Surrogate signal peptide" function:** Lewis et al. (2024) proposed that RAMP4 functions as a "surrogate signal peptide" that maintains the Sec61 pore in a widened, hydrophilic configuration during later stages of translocation, after the original signal peptide has dissociated from the lateral gate. Unlike signal peptides, RAMP4 does not displace the plug helix—the plug moves with the widening pore ring, remaining plugged. This model suggests RAMP4 smooths protein transport through the channel and maintains translocation speed and efficiency for certain protein sequences (lewis2024structuralanalysisof pages 9-11).
+
+**Stabilization of membrane proteins and glycosylation:** RAMP4/SERP1 has been implicated in stabilizing newly synthesized membrane proteins during ER stress conditions and in facilitating their subsequent N-linked glycosylation (spasic2005posttranslationalinsertionof pages 99-99, pool2009atransmembranesegment pages 1-2). This protective function becomes particularly critical under conditions of high secretory activity or ER stress.
+
+### 4. Subcellular Localization
+
+By family inference, tam14 is predicted to localize to the **endoplasmic reticulum membrane**, specifically at the **ribosome-associated Sec61 translocon** on the rough ER. RAMP4 family members are integral ER membrane proteins that associate with active ribosome-translocon complexes, positioning them at the interface between the cytoplasmic ribosome and the ER translocation channel (lewis2024structuralanalysisof pages 1-2, lewis2024structuralanalysisof pages 4-6). No direct localization data for tam14 in *S. pombe* cells has been reported.
+
+### 5. Pathway Context and Biological Processes
+
+**ER protein biogenesis pathway:** The primary pathway in which tam14 is predicted to function is the **co-translational protein translocation and membrane insertion pathway** at the ER. This pathway involves the Sec61 translocon, the signal recognition particle (SRP) system, the oligosaccharyltransferase (OST) complex, the TRAP complex, and various accessory factors including RAMP4 family members (sicking2021complexityandspecificity pages 4-7, sicking2021complexityandspecificity pages 9-11).
+
+**ER stress response:** RAMP4/SERP1 expression in mammals is strongly upregulated by ER stress-responsive transcription factors XBP1 and Hac1p, and animals lacking RAMP4 exhibit induction of the unfolded protein response (UPR) in secretory tissues such as the pancreas and pituitary gland (pool2009atransmembranesegment pages 11-12). Notably, the UPR in *S. pombe* differs fundamentally from both *S. cerevisiae* and mammalian cells: *S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on Ire1-dependent mRNA decay (RIDD) rather than transcriptional upregulation to cope with ER stress (lewis2024structuralanalysisof pages 1-2). This means that the mechanism of tam14 transcriptional regulation during ER stress in *S. pombe* may differ from the canonical RAMP4/SERP1 paradigm in mammals.
+
+**Meiotic expression pattern:** The "tam" designation reflects the observation that *tam14* transcript levels change during the meiotic differentiation program in *S. pombe*, as detected in pat1.114-induced synchronous meiotic cultures (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10). This meiotic expression pattern could reflect increased demand for ER-associated protein biogenesis during sporulation and ascospore formation, processes that require substantial membrane remodeling and protein secretion. However, the meiotic expression change alone does not imply a meiosis-specific biochemical function.
+
+### 6. Summary of Evidence Levels
+
+The functional annotation of tam14 rests primarily on **domain and family-level inference** from well-characterized orthologs (RAMP4/SERP1 in mammals, Ysy6 in *S. cerevisiae*), rather than on direct experimental characterization of the *S. pombe* gene product itself. The gene was identified and its transcription confirmed in the Bitton et al. (2011) genome re-annotation study (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10), but no targeted deletion, localization, or biochemical study has been published specifically for tam14/SPCC330.20. The structural and functional characterization of RAMP4 orthologs—particularly recent cryo-EM work by Lewis et al. (2024) showing RAMP4 intercalated in the Sec61 lateral gate (lewis2024structuralanalysisof pages 1-2, lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 9-11) and earlier work by Pool (2009) demonstrating TM segment-triggered recruitment (pool2009atransmembranesegment pages 11-12, pool2009atransmembranesegment pages 1-2, pool2009atransmembranesegment pages 9-11)—provides a strong basis for inferring that tam14 serves an analogous role as an accessory Sec61 translocon component in *S. pombe*.
+
+The following table summarizes the key properties of tam14:
+
+| Property | Description/Value |
+|---|---|
+| Gene name | **tam14**; one of the 14 *S. pombe* loci named for having transcripts altered during meiosis in the augmented genome annotation study (bitton2011augmentedannotationof pages 8-10) |
+| Systematic name | **SPCC330.20** (UniProt entry provided by user; also listed in the augmented annotation table as the locus corresponding to tam14) (bitton2011augmentedannotationof pages 3-4) |
+| UniProt accession | **G2TRT3** (user-supplied UniProt identifier) |
+| Organism | *Schizosaccharomyces pombe* strain 972 / ATCC 24843 (fission yeast) (user-supplied target definition) |
+| Protein description | Protein tam14; alternative name: **Transcripts altered in meiosis protein 14** (user-supplied target definition) |
+| Evidence for existence in *S. pombe* | The locus was identified in the 2011 re-annotation of the *S. pombe* genome; transcription was supported by RT-PCR/RNA-seq in the study’s global validation pipeline, but tam14 was not among the genes selected for functional knockout characterization (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10) |
+| Protein family | **RAMP4 family** / ER stress-associated small membrane proteins; family-level functional inference is supported by RAMP4/SERP1 literature and domain assignment (lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2) |
+| Domain annotations | **RAMP4 / PF06624** and **ER_stress-assoc. / IPR010580**; in the Bitton et al. annotation table tam14 is associated with a Pfam-supported novel locus (bitton2011augmentedannotationof pages 3-4, bitton2011augmentedannotationof pages 8-10) |
+| Predicted molecular role | Likely a **small ER membrane accessory factor** of the **Sec61 ribosome-translocon complex**, inferred from the conserved RAMP4 family: RAMP4/SERP1 associates near-stoichiometrically with ER-localized ribosome-Sec61 complexes and can contact translocating nascent chains (lewis2024structuralanalysisof pages 1-2) |
+| Predicted mechanistic function | By family inference, likely helps **optimize membrane protein biogenesis at the ER**, especially during or after translocon remodeling for membrane protein insertion; RAMP4 is recruited when a TM segment enters the ribosome exit tunnel and can facilitate the switch to membrane integration mode (pool2009atransmembranesegment pages 11-12, pool2009atransmembranesegment pages 1-2) |
+| Predicted structural behavior | RAMP4-family proteins contain a **ribosome-binding region** and a **tail-anchored/kinked TM segment** that occupies the **Sec61 lateral gate**, widens the central pore, and contributes to the channel’s hydrophilic interior; tam14 is therefore plausibly a very small ER membrane protein with analogous architecture (lewis2024structuralanalysisof pages 4-6) |
+| Predicted subcellular localization | **Endoplasmic reticulum membrane**, specifically the **ribosome-associated Sec61 translocon** at rough ER, by conserved family function (lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2, sicking2021complexityandspecificity pages 9-11) |
+| Pathway context | Likely functions in **co-translational ER protein translocation/membrane insertion** and broader **ER proteostasis** rather than a meiosis-specific biochemical pathway; the meiosis-linked name reflects expression behavior, not proven primary function (bitton2011augmentedannotationof pages 8-10, sicking2021complexityandspecificity pages 9-11) |
+| Relation to ER stress | Family inference suggests involvement in **ER stress adaptation**: mammalian RAMP4/SERP1 is ER-stress inducible and loss causes secretion/UPR phenotypes in secretory tissues; however, this has **not been directly demonstrated for tam14 in *S. pombe*** (pool2009atransmembranesegment pages 11-12, lewis2024structuralanalysisof pages 1-2) |
+| Orthologs / homologous family members | **Mammals:** RAMP4 / SERP1; **budding yeast:** Ysy6; these are the relevant family comparators for functional inference to tam14 (lewis2024structuralanalysisof pages 1-2, sicking2021complexityandspecificity pages 9-11) |
+| Functional confidence level | **Moderate for family-level annotation, low for gene-specific detail**: there is strong domain/family evidence, but little direct experimental characterization specific to tam14/SPCC330.20 itself (bitton2011augmentedannotationof pages 8-10, lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2) |
+| Key evidence sources | Primary *S. pombe* identification: Bitton et al. 2011 genome re-annotation (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10); mechanistic family context: Pool 2009 and Lewis et al. 2024 on RAMP4/Sec61 structure-function (pool2009atransmembranesegment pages 11-12, lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2) |
+
+
+*Table: This table summarizes the verified identity, annotation, predicted function, and likely localization of tam14/SPCC330.20 in fission yeast. It distinguishes direct evidence for the *S. pombe* gene from family-based inference drawn from better-characterized RAMP4/SERP1 proteins.*
+
+### References
+
+The principal sources supporting this report include Bitton et al. (2011) *Genetics* 187:1207–1217, which identified tam14 as a novel gene in *S. pombe*; Lewis et al. (2024) *eLife* 13, which provided cryo-EM structures of RAMP4 at the Sec61 translocon; and Pool (2009) *J. Cell Biol.* 185:889–902, which characterized RAMP4 recruitment mechanisms.
+
+References
+
+1. (bitton2011augmentedannotationof pages 1-2): Danny A Bitton, Valerie Wood, Paul J Scutt, Agnes Grallert, Tim Yates, Duncan L Smith, Iain M Hagan, and Crispin J Miller. Augmented annotation of the schizosaccharomyces pombe genome reveals additional genes required for growth and viability. Genetics, 187:1207-1217, Apr 2011. URL: https://doi.org/10.1534/genetics.110.123497, doi:10.1534/genetics.110.123497. This article has 32 citations and is from a domain leading peer-reviewed journal.
+
+2. (bitton2011augmentedannotationof pages 3-4): Danny A Bitton, Valerie Wood, Paul J Scutt, Agnes Grallert, Tim Yates, Duncan L Smith, Iain M Hagan, and Crispin J Miller. Augmented annotation of the schizosaccharomyces pombe genome reveals additional genes required for growth and viability. Genetics, 187:1207-1217, Apr 2011. URL: https://doi.org/10.1534/genetics.110.123497, doi:10.1534/genetics.110.123497. This article has 32 citations and is from a domain leading peer-reviewed journal.
+
+3. (bitton2011augmentedannotationof pages 8-10): Danny A Bitton, Valerie Wood, Paul J Scutt, Agnes Grallert, Tim Yates, Duncan L Smith, Iain M Hagan, and Crispin J Miller. Augmented annotation of the schizosaccharomyces pombe genome reveals additional genes required for growth and viability. Genetics, 187:1207-1217, Apr 2011. URL: https://doi.org/10.1534/genetics.110.123497, doi:10.1534/genetics.110.123497. This article has 32 citations and is from a domain leading peer-reviewed journal.
+
+4. (lewis2024structuralanalysisof pages 1-2): Aaron J. O. Lewis, Frank Zhong, Robert J. Keenan, and Ramanujan S. Hegde. Structural analysis of the dynamic ribosome-translocon complex. eLife, May 2024. URL: https://doi.org/10.1101/2023.12.22.572959, doi:10.1101/2023.12.22.572959. This article has 23 citations and is from a domain leading peer-reviewed journal.
+
+5. (lewis2024structuralanalysisof pages 4-6): Aaron J. O. Lewis, Frank Zhong, Robert J. Keenan, and Ramanujan S. Hegde. Structural analysis of the dynamic ribosome-translocon complex. eLife, May 2024. URL: https://doi.org/10.1101/2023.12.22.572959, doi:10.1101/2023.12.22.572959. This article has 23 citations and is from a domain leading peer-reviewed journal.
+
+6. (sicking2021complexityandspecificity pages 9-11): Mark Sicking, Sven Lang, Florian Bochen, Andreas Roos, Joost P. H. Drenth, Muhammad Zakaria, Richard Zimmermann, and Maximilian Linxweiler. Complexity and specificity of sec61-channelopathies: human diseases affecting gating of the sec61 complex. Cells, 10:1036, Apr 2021. URL: https://doi.org/10.3390/cells10051036, doi:10.3390/cells10051036. This article has 48 citations.
+
+7. (pool2009atransmembranesegment pages 11-12): Martin R. Pool. A trans-membrane segment inside the ribosome exit tunnel triggers ramp4 recruitment to the sec61p translocase. The Journal of Cell Biology, 185:889-902, Jun 2009. URL: https://doi.org/10.1083/jcb.200807066, doi:10.1083/jcb.200807066. This article has 67 citations.
+
+8. (pool2009atransmembranesegment pages 1-2): Martin R. Pool. A trans-membrane segment inside the ribosome exit tunnel triggers ramp4 recruitment to the sec61p translocase. The Journal of Cell Biology, 185:889-902, Jun 2009. URL: https://doi.org/10.1083/jcb.200807066, doi:10.1083/jcb.200807066. This article has 67 citations.
+
+9. (pool2009atransmembranesegment pages 9-11): Martin R. Pool. A trans-membrane segment inside the ribosome exit tunnel triggers ramp4 recruitment to the sec61p translocase. The Journal of Cell Biology, 185:889-902, Jun 2009. URL: https://doi.org/10.1083/jcb.200807066, doi:10.1083/jcb.200807066. This article has 67 citations.
+
+10. (lewis2024structuralanalysisof pages 9-11): Aaron J. O. Lewis, Frank Zhong, Robert J. Keenan, and Ramanujan S. Hegde. Structural analysis of the dynamic ribosome-translocon complex. eLife, May 2024. URL: https://doi.org/10.1101/2023.12.22.572959, doi:10.1101/2023.12.22.572959. This article has 23 citations and is from a domain leading peer-reviewed journal.
+
+11. (spasic2005posttranslationalinsertionof pages 99-99): Milan Spasic. Post-translational insertion of a small tail-anchored protein into the membrane of the endoplasmic reticulum. ArXiv, Jan 2005. URL: https://doi.org/10.11588/heidok.00005525, doi:10.11588/heidok.00005525. This article has 0 citations.
+
+12. (sicking2021complexityandspecificity pages 4-7): Mark Sicking, Sven Lang, Florian Bochen, Andreas Roos, Joost P. H. Drenth, Muhammad Zakaria, Richard Zimmermann, and Maximilian Linxweiler. Complexity and specificity of sec61-channelopathies: human diseases affecting gating of the sec61 complex. Cells, 10:1036, Apr 2021. URL: https://doi.org/10.3390/cells10051036, doi:10.3390/cells10051036. This article has 48 citations.
+
+## Artifacts
+
+- [Edison artifact artifact-00](tam14-deep-research-falcon_artifacts/artifact-00.md)
+
+## Citations
+
+1. bitton2011augmentedannotationof pages 1-2
+2. bitton2011augmentedannotationof pages 8-10
+3. lewis2024structuralanalysisof pages 1-2
+4. lewis2024structuralanalysisof pages 4-6
+5. sicking2021complexityandspecificity pages 9-11
+6. lewis2024structuralanalysisof pages 9-11
+7. pool2009atransmembranesegment pages 11-12
+8. bitton2011augmentedannotationof pages 3-4
+9. pool2009atransmembranesegment pages 1-2
+10. pool2009atransmembranesegment pages 9-11
+11. spasic2005posttranslationalinsertionof pages 99-99
+12. sicking2021complexityandspecificity pages 4-7
+13. https://doi.org/10.1534/genetics.110.123497,
+14. https://doi.org/10.1101/2023.12.22.572959,
+15. https://doi.org/10.3390/cells10051036,
+16. https://doi.org/10.1083/jcb.200807066,
+17. https://doi.org/10.11588/heidok.00005525,

--- a/genes/SCHPO/tam14/tam14-deep-research-falcon_artifacts/artifact-00.md
+++ b/genes/SCHPO/tam14/tam14-deep-research-falcon_artifacts/artifact-00.md
@@ -1,0 +1,22 @@
+| Property | Description/Value |
+|---|---|
+| Gene name | **tam14**; one of the 14 *S. pombe* loci named for having transcripts altered during meiosis in the augmented genome annotation study (pqac-00000014) |
+| Systematic name | **SPCC330.20** (UniProt entry provided by user; also listed in the augmented annotation table as the locus corresponding to tam14) (pqac-00000008) |
+| UniProt accession | **G2TRT3** (user-supplied UniProt identifier) |
+| Organism | *Schizosaccharomyces pombe* strain 972 / ATCC 24843 (fission yeast) (user-supplied target definition) |
+| Protein description | Protein tam14; alternative name: **Transcripts altered in meiosis protein 14** (user-supplied target definition) |
+| Evidence for existence in *S. pombe* | The locus was identified in the 2011 re-annotation of the *S. pombe* genome; transcription was supported by RT-PCR/RNA-seq in the study’s global validation pipeline, but tam14 was not among the genes selected for functional knockout characterization (pqac-00000010, pqac-00000014) |
+| Protein family | **RAMP4 family** / ER stress-associated small membrane proteins; family-level functional inference is supported by RAMP4/SERP1 literature and domain assignment (pqac-00000018, pqac-00000019) |
+| Domain annotations | **RAMP4 / PF06624** and **ER_stress-assoc. / IPR010580**; in the Bitton et al. annotation table tam14 is associated with a Pfam-supported novel locus (pqac-00000008, pqac-00000014) |
+| Predicted molecular role | Likely a **small ER membrane accessory factor** of the **Sec61 ribosome-translocon complex**, inferred from the conserved RAMP4 family: RAMP4/SERP1 associates near-stoichiometrically with ER-localized ribosome-Sec61 complexes and can contact translocating nascent chains (pqac-00000000, pqac-00000019) |
+| Predicted mechanistic function | By family inference, likely helps **optimize membrane protein biogenesis at the ER**, especially during or after translocon remodeling for membrane protein insertion; RAMP4 is recruited when a TM segment enters the ribosome exit tunnel and can facilitate the switch to membrane integration mode (pqac-00000001, pqac-00000015, pqac-00000017) |
+| Predicted structural behavior | RAMP4-family proteins contain a **ribosome-binding region** and a **tail-anchored/kinked TM segment** that occupies the **Sec61 lateral gate**, widens the central pore, and contributes to the channel’s hydrophilic interior; tam14 is therefore plausibly a very small ER membrane protein with analogous architecture (pqac-00000002, pqac-00000018) |
+| Predicted subcellular localization | **Endoplasmic reticulum membrane**, specifically the **ribosome-associated Sec61 translocon** at rough ER, by conserved family function (pqac-00000018, pqac-00000019, pqac-00000023) |
+| Pathway context | Likely functions in **co-translational ER protein translocation/membrane insertion** and broader **ER proteostasis** rather than a meiosis-specific biochemical pathway; the meiosis-linked name reflects expression behavior, not proven primary function (pqac-00000014, pqac-00000023) |
+| Relation to ER stress | Family inference suggests involvement in **ER stress adaptation**: mammalian RAMP4/SERP1 is ER-stress inducible and loss causes secretion/UPR phenotypes in secretory tissues; however, this has **not been directly demonstrated for tam14 in *S. pombe*** (pqac-00000001, pqac-00000015, pqac-00000019) |
+| Orthologs / homologous family members | **Mammals:** RAMP4 / SERP1; **budding yeast:** Ysy6; these are the relevant family comparators for functional inference to tam14 (pqac-00000019, pqac-00000023) |
+| Functional confidence level | **Moderate for family-level annotation, low for gene-specific detail**: there is strong domain/family evidence, but little direct experimental characterization specific to tam14/SPCC330.20 itself (pqac-00000014, pqac-00000018, pqac-00000019) |
+| Key evidence sources | Primary *S. pombe* identification: Bitton et al. 2011 genome re-annotation (pqac-00000010, pqac-00000014); mechanistic family context: Pool 2009 and Lewis et al. 2024 on RAMP4/Sec61 structure-function (pqac-00000001, pqac-00000002, pqac-00000018, pqac-00000019) |
+
+
+*Table: This table summarizes the verified identity, annotation, predicted function, and likely localization of tam14/SPCC330.20 in fission yeast. It distinguishes direct evidence for the *S. pombe* gene from family-based inference drawn from better-characterized RAMP4/SERP1 proteins.*

--- a/genes/SCHPO/tam14/tam14-goa.tsv
+++ b/genes/SCHPO/tam14/tam14-goa.tsv
@@ -1,0 +1,7 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	G2TRT3	tam14	located_in	GO:0005783	endoplasmic reticulum	cellular_component	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR010580	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	InterPro	Protein tam14	20260616
+UniProtKB	G2TRT3	tam14	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0097	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	UniProt	Protein tam14	20260616
+UniProtKB	G2TRT3	tam14	located_in	GO:0016020	membrane	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0162	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	UniProt	Protein tam14	20260616
+UniProtKB	G2TRT3	tam14	enables	GO:0003674	molecular_function	molecular_function	ECO:0000307	ND	GO_REF:0000015		284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	PomBase	Protein tam14	20260612
+UniProtKB	G2TRT3	tam14	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:Q9R2C1	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	UniProt	Protein tam14	20231105
+UniProtKB	G2TRT3	tam14	located_in	GO:0016020	membrane	cellular_component	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:Q9R2C1	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	UniProt	Protein tam14	20231105

--- a/genes/SCHPO/tam14/tam14-notes.md
+++ b/genes/SCHPO/tam14/tam14-notes.md
@@ -1,0 +1,168 @@
+# tam14 (SPCC330.20 / G2TRT3) — curation notes
+
+Journal-style notes for the AI GO-annotation review of *S. pombe* tam14. Inline provenance
+throughout as `[SOURCE "verbatim supporting text"]`.
+
+## Identity (verified)
+
+- UniProt **G2TRT3**, `TAM14_SCHPO`, 70 aa, Swiss-Prot reviewed.
+  - RecName **Protein tam14**; AltName **Transcripts altered in meiosis protein 14**.
+  - Gene `Name=tam14; ORFNames=SPCC330.20` (chromosome III).
+  - `PE 2: Evidence at transcript level` (no protein-level evidence).
+  - [file:SCHPO/tam14/tam14-uniprot.txt]
+- PomBase: gene name **tam14**, product **"ER stress associated protein Tam14"**,
+  characterisation status **"biological role inferred"** (i.e. not experimentally
+  characterised in fission yeast; role assigned by orthology).
+  [PomBase API SPCC330.20, retrieved 2026-07]
+
+## Family / domain reasoning (verified — this is a REAL, conserved family)
+
+- Pfam **PF06624 (RAMP4)**; InterPro **IPR010580 ("ER stress-associated")**.
+  [file:SCHPO/tam14/tam14-uniprot.txt]
+- UniProt: `SIMILARITY: Belongs to the RAMP4 family. {ECO:0000305}.`
+- **Orthologs (curated, reciprocal — PomBase):**
+  - Human **SERP1** (HGNC:10759) and **SERP2** (HGNC:20607)
+  - *S. cerevisiae* **YSY6** (YBR162W-A)
+  - *S. japonicus* SJAG_03611
+  [PomBase API SPCC330.20]
+- The RAMP4/SERP1 family is a genuine, broadly conserved eukaryotic family: mammalian
+  RAMP4/SERP1, budding-yeast Ysy6, and even *Candida albicans* SERP1 have been studied.
+  This is materially DIFFERENT from the sibling gene tam10, a fission-yeast-lineage
+  "sequence orphan" whose ISS transfers were rejected. tam14's family placement rests on
+  a curated, reciprocal ortholog set, so its ER-membrane localisation inference is
+  well-grounded even though no pombe-specific function has been measured.
+
+### Domain architecture (from UniProt features)
+- CHAIN 1..70 (Protein tam14)
+- TRANSMEM 45..65 "Helical" (ECO:0000255) — a single C-terminal transmembrane helix
+- REGION 1..20 "Disordered" / COMPBIAS 1..19 "Polar residues" — short N-terminal
+  disordered, polar-biased segment
+- Architecture = short cytosolic/lumenal N-terminus + single C-terminal TM helix. This
+  tail-anchored-like, single-pass topology is exactly the RAMP4/SERP1 architecture (a
+  small Sec61-translocon-associated single-span ER membrane protein), consistent with the
+  family assignment.
+  [file:SCHPO/tam14/tam14-uniprot.txt]
+
+## The mammalian ortholog (Q9R2C1) — source of the ISS/ISO function claims
+
+- Q9R2C1 = **SERP1_RAT** (rat Serp1 / Ramp4). RAMP4 family; ER membrane; single-pass.
+  UniProt FUNCTION (verbatim): "Interacts with target proteins during their translocation
+  into the lumen of the endoplasmic reticulum. Protects unfolded target proteins against
+  degradation during ER stress." Keywords include "Unfolded protein response".
+  [UniProt Q9R2C1, retrieved 2026-07]
+- Mammalian SERP1/RAMP4 biology (background, NOT measured for tam14):
+  - Yamaguchi et al. 1999 (J Cell Biol; PMID:10601334): "Stress-Associated Endoplasmic
+    Reticulum Protein 1 (Serp1)/Ribosome-Associated Membrane Protein 4 (Ramp4) Stabilizes
+    Membrane Proteins during Stress and Facilitates Subsequent Glycosylation"; interacts
+    with Sec61alpha/Sec61beta and calnexin.
+  - Park et al. 2006 (MCB; PMID:16481402): SERP1/RAMP4 deletion → ER stress; SERP1-/- mice
+    show growth retardation, increased mortality, impaired glucose tolerance.
+  These establish the FAMILY function in mammals; they do NOT establish tam14's function
+  in *S. pombe*. The tam14 UniProt FUNCTION comment is transferred `By similarity`
+  (`ECO:0000250|UniProtKB:Q9R2C1`), not observed in pombe.
+
+## Discovery / the ONLY pombe-specific experimental evidence
+
+- tam14 is one of 14 "transcripts altered in meiosis" genes (tam1–tam14) newly annotated by
+  Bitton et al. 2011 (Genetics; PMID:21270388), a proteogenomic/comparative reappraisal.
+  - [PMID:21270388 "We refer to the novel protein-coding genes with no apparent induction
+    in meiosis as new1–new25 , and the 14 genes with t ranscripts a ltered in m eiosis as
+    tam1–tam14"]
+  - [PMID:21270388 "Fourteen transcripts were differentially expressed during meiosis."]
+- CRITICAL: tam14 was NOT among the seven genes selected for deletion phenotyping. The
+  functionally assessed set was tam2, new1, new5, tam7, new8, tam11, new21
+  [PMID:21270388 "three criteria were used to select seven genes ( tam2 , new1 , new5 ,
+  tam7 , new8 , tam11 , and new21 ) for functional assessment"]. So NO tam14 deletion
+  phenotype was reported, and no meiotic function was demonstrated — only differential
+  meiotic transcript abundance. Meiotic expression change alone does NOT establish a
+  meiotic biological process (correlation, not function).
+- UniProt INDUCTION: "Differentially expressed during meiosis.
+  {ECO:0000269|PubMed:21270388}." — this is an expression, not function, statement.
+
+## GOA annotations to review (6 rows; tam14-goa.tsv)
+
+1. GO:0005783 endoplasmic reticulum (CC) — IEA, GO_REF:0000002, InterPro:IPR010580.
+   Domain(family)-based ER localisation. Reasonable but generic; the more specific ER
+   membrane term below is preferable.
+2. GO:0005789 endoplasmic reticulum membrane (CC) — IEA, GO_REF:0000044,
+   UniProtKB-SubCell:SL-0097. From SUBCELL mapping (ultimately the SERP1 By-similarity
+   location). Well-grounded by the single TM helix + RAMP4 family. KEEP (core CC).
+3. GO:0016020 membrane (CC) — IEA, GO_REF:0000044, UniProtKB-SubCell:SL-0162. Generic
+   parent of ER membrane; redundant/over-general → MARK_AS_OVER_ANNOTATED.
+4. GO:0003674 molecular_function (MF root) — ND, GO_REF:0000015, PomBase. Correct
+   placeholder: no MF experimentally known and no MF term is confidently transferable
+   (SERP1's "chaperone-like translocon-associated" activity has no clean GO MF term).
+   ACCEPT (honest MF-dark placeholder).
+5. GO:0005789 endoplasmic reticulum membrane (CC) — ISS, GO_REF:0000024, UniProtKB:Q9R2C1.
+   Curator sequence-similarity transfer from rat SERP1. Duplicate of #2 but with the
+   stronger ISS evidence. KEEP.
+6. GO:0016020 membrane (CC) — ISS, GO_REF:0000024, UniProtKB:Q9R2C1. Over-general parent
+   → MARK_AS_OVER_ANNOTATED (same reasoning as #3).
+
+Note the UniProt DR block also lists GO:0006986 "response to unfolded protein" (IEA,
+UniProtKB-KW) — but this is NOT in the QuickGO goa.tsv snapshot (KW-derived GO may have
+been retired from GOA), so it is not in existing_annotations. PomBase itself annotates the
+BP "endoplasmic reticulum unfolded protein response" by orthology.
+
+## KNOWN vs NOT-known
+
+KNOWN (evidence-supported):
+- Bona fide, meiotically-regulated protein-coding gene [PMID:21270388].
+- Genuine RAMP4/SERP1-family, single-pass (C-terminal TM) small ER-membrane protein, by
+  curated reciprocal orthology (human SERP1/SERP2; Sc YSY6) + Pfam PF06624.
+- Differentially expressed during meiosis; low abundance (~5 copies/cell); phosphorylated
+  (S8, T6) and ubiquitinylated (K18) per PomBase modification data.
+
+NOT known (the gaps):
+- No experimentally determined molecular function IN *S. pombe* — the SERP1-family
+  translocon-associated/UPR "chaperone-like" activity is a `By similarity` transfer, never
+  assayed in fission yeast. (And even in mammals the activity has no clean GO MF term.)
+- No pombe deletion phenotype reported; tam14 was excluded from the tam-gene functional
+  assessment [PMID:21270388]. Whether it has any meiotic role (vs incidental meiotic
+  expression) is untested.
+- No direct localisation data (GFP/immuno) in pombe; ER-membrane placement is
+  orthology/topology inference.
+- The HT-Y2H interactors (Cut11, Lem2, Ima1 — nuclear-envelope/INM proteins) are
+  unvalidated single-method hits and do not by themselves establish function.
+
+## Curation plan
+
+- description: project-independent — RAMP4/SERP1-family single-pass ER-membrane protein,
+  meiotically regulated, ortholog set, function inferred not measured. No curation
+  commentary.
+- CC ER membrane (ISS + IEA): KEEP as core location. ER (IEA/InterPro): ACCEPT/keep as
+  non-core (more general than ER membrane). membrane (x2): MARK_AS_OVER_ANNOTATED (root).
+- MF root ND: ACCEPT (honest MF-dark).
+- core_functions: minimal — the confident statement is CC (ER membrane, RAMP4 family);
+  do NOT assert an MF term (no defensible, branch-correct MF for the SERP1 activity).
+- knowledge_gaps (REQUIRED): MF-dark biology gap (family known, pombe activity unmeasured)
+  + BP gap (meiotic role untested despite the gene's very name).
+- reference_review for the two verified PMIDs.
+
+## Falcon deep research (completed 2026-07-06; genuine Edison output, 17 citations)
+
+The falcon report [file:SCHPO/tam14/tam14-deep-research-falcon.md] independently reaches the
+same conclusions and adds mechanistic family context (verified against my own UniProt/PomBase
+work). Key verbatim points:
+- Family/orthologs: RAMP4 (PF06624) = mammalian RAMP4/SERP1 and Sc Ysy6; tam14 predicted to be
+  "a **small accessory component of the Sec61 translocon** at the endoplasmic reticulum
+  membrane". Mechanistic detail from Lewis et al. 2024 (eLife) cryo-EM of the
+  ribosome-translocon (RAMP4 intercalates the Sec61 lateral gate, "surrogate signal peptide")
+  and Pool 2009 (JCB) TM-segment-triggered RAMP4 recruitment. RAMP4 is a tail-anchored ER
+  membrane protein.
+- Evidence level: "rests primarily on **domain and family-level inference** from
+  well-characterized orthologs ... but no targeted deletion, localization, or biochemical study
+  has been published specifically for tam14/SPCC330.20." Confidence: "Moderate for family-level
+  annotation, low for gene-specific detail".
+- tam14 "was not among the seven genes selected for functional knockout analysis in the original
+  study, so no deletion phenotype has been reported specifically for this gene."
+- "No direct localization data for tam14 in *S. pombe* cells has been reported."
+- Important pombe-specific caveat: "*S. pombe* lacks Hac1/XBP1 orthologs and instead relies
+  primarily on Ire1-dependent mRNA decay (RIDD)" — so the mammalian ER-stress-induction /
+  UPR-transcriptional paradigm for RAMP4/SERP1 may not transfer to fission yeast.
+- "the meiotic expression change alone does not imply a meiosis-specific biochemical function".
+
+Note: falcon cites Lewis et al. 2024 and Pool 2009 by DOI/preprint. These are mammalian
+mechanism papers (not tam14). I anchor gene-specific "unknown" provenance to the falcon file:
+and to cached PMID:21270388; I do NOT add the mammalian DOIs as review references (cannot cache
+/ verify their full text here, and they are not about tam14).

--- a/genes/SCHPO/tam14/tam14-uniprot.txt
+++ b/genes/SCHPO/tam14/tam14-uniprot.txt
@@ -1,0 +1,105 @@
+ID   TAM14_SCHPO             Reviewed;          70 AA.
+AC   G2TRT3;
+DT   18-APR-2012, integrated into UniProtKB/Swiss-Prot.
+DT   16-NOV-2011, sequence version 1.
+DT   10-JUN-2026, entry version 46.
+DE   RecName: Full=Protein tam14;
+DE   AltName: Full=Transcripts altered in meiosis protein 14;
+GN   Name=tam14; ORFNames=SPCC330.20;
+OS   Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+OC   Eukaryota; Fungi; Dikarya; Ascomycota; Taphrinomycotina;
+OC   Schizosaccharomycetes; Schizosaccharomycetales; Schizosaccharomycetaceae;
+OC   Schizosaccharomyces.
+OX   NCBI_TaxID=284812;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RC   STRAIN=972 / ATCC 24843;
+RX   PubMed=11859360; DOI=10.1038/nature724;
+RA   Wood V., Gwilliam R., Rajandream M.A., Lyne M.H., Lyne R., Stewart A.,
+RA   Sgouros J.G., Peat N., Hayles J., Baker S.G., Basham D., Bowman S.,
+RA   Brooks K., Brown D., Brown S., Chillingworth T., Churcher C.M., Collins M.,
+RA   Connor R., Cronin A., Davis P., Feltwell T., Fraser A., Gentles S.,
+RA   Goble A., Hamlin N., Harris D.E., Hidalgo J., Hodgson G., Holroyd S.,
+RA   Hornsby T., Howarth S., Huckle E.J., Hunt S., Jagels K., James K.D.,
+RA   Jones L., Jones M., Leather S., McDonald S., McLean J., Mooney P.,
+RA   Moule S., Mungall K.L., Murphy L.D., Niblett D., Odell C., Oliver K.,
+RA   O'Neil S., Pearson D., Quail M.A., Rabbinowitsch E., Rutherford K.M.,
+RA   Rutter S., Saunders D., Seeger K., Sharp S., Skelton J., Simmonds M.N.,
+RA   Squares R., Squares S., Stevens K., Taylor K., Taylor R.G., Tivey A.,
+RA   Walsh S.V., Warren T., Whitehead S., Woodward J.R., Volckaert G., Aert R.,
+RA   Robben J., Grymonprez B., Weltjens I., Vanstreels E., Rieger M.,
+RA   Schaefer M., Mueller-Auer S., Gabel C., Fuchs M., Duesterhoeft A.,
+RA   Fritzc C., Holzer E., Moestl D., Hilbert H., Borzym K., Langer I., Beck A.,
+RA   Lehrach H., Reinhardt R., Pohl T.M., Eger P., Zimmermann W., Wedler H.,
+RA   Wambutt R., Purnelle B., Goffeau A., Cadieu E., Dreano S., Gloux S.,
+RA   Lelaure V., Mottier S., Galibert F., Aves S.J., Xiang Z., Hunt C.,
+RA   Moore K., Hurst S.M., Lucas M., Rochet M., Gaillardin C., Tallada V.A.,
+RA   Garzon A., Thode G., Daga R.R., Cruzado L., Jimenez J., Sanchez M.,
+RA   del Rey F., Benito J., Dominguez A., Revuelta J.L., Moreno S.,
+RA   Armstrong J., Forsburg S.L., Cerutti L., Lowe T., McCombie W.R.,
+RA   Paulsen I., Potashkin J., Shpakovski G.V., Ussery D., Barrell B.G.,
+RA   Nurse P.;
+RT   "The genome sequence of Schizosaccharomyces pombe.";
+RL   Nature 415:871-880(2002).
+RN   [2]
+RP   IDENTIFICATION, AND INDUCTION.
+RX   PubMed=21270388; DOI=10.1534/genetics.110.123497;
+RA   Bitton D.A., Wood V., Scutt P.J., Grallert A., Yates T., Smith D.L.,
+RA   Hagan I.M., Miller C.J.;
+RT   "Augmented annotation of the Schizosaccharomyces pombe genome reveals
+RT   additional genes required for growth and viability.";
+RL   Genetics 187:1207-1217(2011).
+CC   -!- FUNCTION: Interacts with target proteins during their translocation
+CC       into the lumen of the endoplasmic reticulum. Protects unfolded target
+CC       proteins against degradation during ER stress. May facilitate
+CC       glycosylation of target proteins after termination of ER stress.
+CC       {ECO:0000250|UniProtKB:Q9R2C1}.
+CC   -!- SUBCELLULAR LOCATION: Membrane {ECO:0000250|UniProtKB:Q9R2C1}; Single-
+CC       pass membrane protein {ECO:0000250|UniProtKB:Q9R2C1}. Endoplasmic
+CC       reticulum membrane {ECO:0000250|UniProtKB:Q9R2C1}; Single-pass membrane
+CC       protein {ECO:0000250|UniProtKB:Q9R2C1}.
+CC   -!- INDUCTION: Differentially expressed during meiosis.
+CC       {ECO:0000269|PubMed:21270388}.
+CC   -!- SIMILARITY: Belongs to the RAMP4 family. {ECO:0000305}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; CU329672; CCD31387.1; -; Genomic_DNA.
+DR   AlphaFoldDB; G2TRT3; -.
+DR   SMR; G2TRT3; -.
+DR   BioGRID; 4253622; 3.
+DR   STRING; 284812.G2TRT3; -.
+DR   iPTMnet; G2TRT3; -.
+DR   PaxDb; 284812-G2TRT3; -.
+DR   PomBase; SPCC330.20; tam14.
+DR   VEuPathDB; FungiDB:SPCC330.20; -.
+DR   HOGENOM; CLU_182424_0_1_1; -.
+DR   InParanoid; G2TRT3; -.
+DR   OMA; RANTQFQ; -.
+DR   PRO; PR:G2TRT3; -.
+DR   Proteomes; UP000002485; Chromosome III.
+DR   GO; GO:0005783; C:endoplasmic reticulum; ISO:PomBase.
+DR   GO; GO:0005789; C:endoplasmic reticulum membrane; IEA:UniProtKB-SubCell.
+DR   GO; GO:0006986; P:response to unfolded protein; IEA:UniProtKB-KW.
+DR   InterPro; IPR010580; ER_stress-assoc.
+DR   Pfam; PF06624; RAMP4; 1.
+PE   2: Evidence at transcript level;
+KW   Endoplasmic reticulum; Membrane; Reference proteome; Transmembrane;
+KW   Transmembrane helix; Unfolded protein response.
+FT   CHAIN           1..70
+FT                   /note="Protein tam14"
+FT                   /id="PRO_0000416523"
+FT   TRANSMEM        45..65
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255"
+FT   REGION          1..20
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        1..19
+FT                   /note="Polar residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+SQ   SEQUENCE   70 AA;  8122 MW;  7E4880E688CDC561 CRC64;
+     MPTVQTPSQR RANTQFQKNI TRRVKTNSKE RYVAKHPPTK IPRNIAMFFI LLMSGGIILG
+     ILRFLLTFFS
+//


### PR DESCRIPTION
## Summary

AI GO-annotation review for the understudied ("dark") *S. pombe* gene **tam14** (systematic name **SPCC330.20**; UniProt **G2TRT3**), a 70-residue single-pass ER-membrane protein of the **RAMP4/SERP1 family** (Pfam PF06624; InterPro IPR010580).

**Identity / domain reasoning (verified).** tam14 is a genuine, conserved RAMP4/SERP1-family protein — curated reciprocal orthologs are human **SERP1** (RAMP4) / **SERP2** and budding-yeast **YSY6** (PomBase). Architecture = short polar/disordered N-terminus + single C-terminal transmembrane helix (residues 45–65), the classic tail-anchored RAMP4/SERP1 topology. In mammals/budding yeast this family is a small accessory of the ribosome-associated **Sec61 translocon** that contacts translocating nascent chains and stabilizes newly synthesized membrane proteins during ER stress. Because the ortholog set is real (unlike a sequence orphan), the ER-membrane localization is well-grounded — but **no molecular function, biological process, localization, or phenotype has been measured for tam14 in fission yeast**; all annotations are family/orthology inference.

**Evidence caveats honestly recorded.** The gene's name ("transcripts altered in meiosis") reflects *expression*, not function: tam14 was **excluded** from the deletion-phenotyping set in its discovery study (PMID:21270388), so no meiotic (or any) phenotype was reported. Also flagged: *S. pombe* UPR is mechanistically divergent (no Hac1/XBP1; Ire1/RIDD-based), so the mammalian ER-stress-induction paradigm for RAMP4/SERP1 may not transfer.

## Annotation actions (6 total)

| Action | Count | Terms |
|---|---|---|
| ACCEPT | 3 | ER membrane (ISS + IEA); molecular_function root (ND) |
| KEEP_AS_NON_CORE | 1 | endoplasmic reticulum (IEA, generic) |
| MARK_AS_OVER_ANNOTATED | 2 | membrane (root; IEA + ISS) |

No `REMOVE`. `core_functions` is deliberately minimal: ER-membrane location only; **no MF term asserted** (the SERP1 translocon-accessory activity has no adequate GO MF term).

## Knowledge gaps (required deliverable)

Two curated, literature-grounded gaps with verbatim provenance:
1. **MF-dark (BIOLOGY + ONTOLOGY)** — tam14's molecular activity in *S. pombe* is undetermined; whether it is a Sec61-translocon accessory (as its orthologs are) has never been assayed, and the family activity has no clean GO MF term (ontology shadow).
2. **BP-dark (BIOLOGY)** — no biological process established; the meiotic transcript change may be incidental, and participation in ER protein biogenesis / proteostasis is untested (esp. given the divergent pombe UPR).

## Validation

`just validate SCHPO tam14` ✓ · `validate-references` ✓ · `validate-terms` ✓. All PMID and `file:` supporting_text quotes manually verified as verbatim substrings of the cached publication / genuine falcon deep-research report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)