### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/BAIAP2L2/BAIAP2L2-ai-review.html
+++ b/genes/human/BAIAP2L2/BAIAP2L2-ai-review.html
@@ -3290,6 +3290,233 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Native epithelial function of human BAIAP2L2/Pinkbar: an evidence audit</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(BAIAP2L2-hypotheses/kgap-baiap2l2-epithelial-pinkbar-function/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q6UXY1" data-a="DEEP_RESEARCH: Native epithelial function of human BAIAP2L2/Pinkbar: an evidence audit" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+
+
+
+
+
+
+
+                    <a href="BAIAP2L2-hypotheses/kgap-baiap2l2-epithelial-pinkbar-function/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <h1 id="native-epithelial-function-of-human-baiap2l2pinkbar-an-evidence-audit">Native epithelial function of human BAIAP2L2/Pinkbar: an evidence audit</h1>
+<p><strong>Iteration 1 — literature synthesis (no primary data provided).</strong><br />
+Scope: distinguish <em>direct</em> BAIAP2L2 evidence from I-BAR-family/paralog inference; evaluate the<br />
+unresolved native intestinal/renal epithelial function; recommend GO curation stance.</p>
+<hr />
+<h2 id="1-summary-answer-to-the-research-question">1. Summary (answer to the research question)</h2>
+<p>The <strong>native epithelial function of BAIAP2L2/Pinkbar in human intestine and kidney remains unresolved.</strong><br />
+There is solid <em>direct</em> biochemical and cell-biological evidence that BAIAP2L2 is an epithelial-expressed<br />
+I-BAR protein that binds membranes, generates <strong>planar</strong> (not tubular) membrane sheets, and localizes to<br />
+<strong>Rab13-positive vesicles and intercellular junctions</strong> — i.e., a demonstrable membrane-flattening/scaffold<br />
+<em>molecular function</em>. However, the corresponding <strong>in-vivo physiological output is not established</strong>:<br />
+<code>Baiap2l2</code>-knockout mice have normal kidney/colon morphology and normal electrolyte homeostasis <strong>under basal<br />
+conditions only</strong>, and no challenge, aging, or paralog-compound-knockout experiments have been reported.<br />
+The single well-established organ-level loss-of-function phenotype is <strong>cochlear</strong> (stereocilia maintenance /<br />
+deafness), which is mechanistically distinct from the epithelial junctional role.</p>
+<hr />
+<h2 id="2-direct-baiap2l2-evidence-vs-paralogi-bar-inference">2. Direct BAIAP2L2 evidence vs. paralog/I-BAR inference</h2>
+<h3 id="2a-direct-epithelial-evidence-baiap2l2-itself">2a. DIRECT epithelial evidence (BAIAP2L2 itself)</h3>
+<p>All direct native-epithelial evidence traces to <strong>one</strong> foundational paper:</p>
+<ul>
+<li><strong>Pykäläinen et al., 2011, <em>Nat Struct Mol Biol</em> — PMID 21743456; DOI 10.1038/nsmb.2079</strong> (cached/validated abstract).</li>
+<li>Specifically expressed in <strong>intestinal epithelial cells</strong>.</li>
+<li>Localizes to <strong>Rab13-positive vesicles</strong> and to the <strong>plasma membrane at intercellular junctions</strong>.</li>
+<li>I-BAR/IMD domain <strong>does not tubulate</strong> membranes but <strong>promotes planar membrane sheets</strong>.</li>
+<li>Structure: <strong>relatively flat lipid-binding interface</strong>; assembles into <strong>sheet-like oligomers</strong> (crystals + solution)<br />
+    → mechanistic basis for planar deformation.</li>
+<li><em>Note:</em> phosphoinositide dependence is the expected I-BAR mechanism and is consistent with the flat basic<br />
+    lipid interface described here, but the abstract states "lipid-binding interface" rather than naming a specific<br />
+    PIP species; a strict phosphoinositide-specificity claim for BAIAP2L2 should be flagged <strong>partially inferred</strong>.</li>
+</ul>
+<h3 id="2b-paralog-i-bar-family-inference-not-direct-native-tissue-proof">2b. PARALOG / I-BAR-FAMILY inference (NOT direct native-tissue proof)</h3>
+<ul>
+<li><strong>Sudhaharan et al., 2016, <em>J Cell Sci</em> — PMID 27278019</strong> (cached). Rif (Rho-family GTPase) signals through<br />
+  I-BAR proteins; explicitly groups <strong>IRSp53 (BAIAP2), IRTKS (BAIAP2L1) and Pinkbar (BAIAP2L2)</strong> as a morphology<br />
+  module. BAIAP2L2-specific downstream biology here is inferred from the family.</li>
+<li><strong>Tholen et al., 2023 — PMID 36520027</strong>: BAIAP2L2 <strong>binds BAIAP2 and BAIAP2L1</strong> (mass spec) → heteromeric<br />
+  I-BAR assemblies plausible; supports <strong>redundancy</strong>.</li>
+<li>General I-BAR mechanism (negative-curvature/PIP2 binding of IRSp53) is a family property; applying it to<br />
+  BAIAP2L2 is inference <strong>except</strong> where Pinkbar's <em>divergent</em> flat-interface/planar behavior is directly shown (2a).</li>
+</ul>
+<hr />
+<h2 id="3-why-knockout-mice-look-normal-and-what-has-not-been-tested">3. Why knockout mice look normal — and what has NOT been tested</h2>
+<p><strong>Tholen et al., 2023 (PMID 36520027)</strong> (title: "HNF1β-associated cyst development and electrolyte disturbances<br />
+are not explained by BAIAP2L2"; journal <em>Pflügers Archiv / Eur J Physiol</em> — <strong>DOI uncertain, flag for verification</strong>):</p>
+<ul>
+<li>BAIAP2L2 is a <strong>direct transcriptional target of HNF1β</strong> (luciferase reporter validated).</li>
+<li><code>Baiap2l2</code>-KO kidney epithelial cells: <strong>normal F-actin at cell–cell contacts</strong>; <strong>normal polarized 3D spheroids</strong> with lumen.</li>
+<li><code>Baiap2l2</code>-KO mice: <strong>normal kidney and colon morphology</strong>; <strong>normal serum and urine electrolytes</strong> — but explicitly<br />
+<strong>"under physiological conditions."</strong></li>
+</ul>
+<p><strong>Interpretation of the null phenotype (unresolved, not disproven):</strong><br />
+1. <strong>Paralog redundancy</strong> — BAIAP2L2 physically binds BAIAP2 and BAIAP2L1; single KO may be buffered.<br />
+<em>Untested:</em> compound/double/triple I-BAR knockouts.<br />
+2. <strong>Challenge-dependence</strong> — only basal conditions assayed. <em>Untested:</em> low-Mg²⁺/high-salt diets, ischemia-reperfusion<br />
+   or nephrotoxic injury, colitis/DSS challenge, infection, or aged cohorts (note the cochlear phenotype is<br />
+<em>progressive</em>, becoming overt by 8 months — an epithelial phenotype could likewise be age- or stress-gated).<br />
+3. <strong>Sub-morphological/functional readouts not probed</strong> — junction dynamics, barrier resealing after wounding,<br />
+   TER/paracellular permeability, Rab13-cargo trafficking kinetics.</p>
+<hr />
+<h2 id="4-candidate-epithelial-partners-cargo-and-structures">4. Candidate epithelial partners, cargo, and structures</h2>
+<table>
+<thead>
+<tr>
+<th>Candidate</th>
+<th>Evidence class</th>
+<th>Source</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Rab13</strong> (junction assembly, polarized transport) — leading candidate pathway</td>
+<td>Direct co-localization (Pinkbar); independent Rab13 junction role</td>
+<td>PMID 21743456; PMID 21795389, 24377937</td>
+</tr>
+<tr>
+<td><strong>BAIAP2 / BAIAP2L1</strong> heteromers</td>
+<td>Direct interaction (mass spec)</td>
+<td>PMID 36520027</td>
+</tr>
+<tr>
+<td><strong>HNF1β</strong> (upstream transcriptional driver)</td>
+<td>Direct (ChIP/RNA-seq + reporter)</td>
+<td>PMID 36520027</td>
+</tr>
+<tr>
+<td>Rho-GTPase <strong>Rif</strong> module</td>
+<td>Family/paralog inference</td>
+<td>PMID 27278019</td>
+</tr>
+<tr>
+<td>EGFR/c-Src/pAKT/MMP2/MMP9 axis</td>
+<td>Non-native cancer cells, correlative</td>
+<td>PMID 34695828</td>
+</tr>
+<tr>
+<td>EPS8/EPS8L2/TWF2/CAPZB2/CIB2/MYO15A</td>
+<td><strong>Stereocilia-specific — NOT epithelial</strong></td>
+<td>PMID 33151556, 34346063, 35044843</td>
+</tr>
+</tbody>
+</table>
+<p><strong>No direct epithelial cargo or a specific junctional structure built by BAIAP2L2 has been identified.</strong><br />
+The strongest mechanistic hypothesis: a <strong>Rab13-coupled, lipid-binding planar scaffold that flattens/stabilizes<br />
+membrane at nascent intercellular junctions</strong>, potentially in heteromeric I-BAR assemblies.</p>
+<hr />
+<h2 id="5-the-established-contrasting-cochlear-function-keep-separate">5. The established (contrasting) cochlear function — keep separate</h2>
+<ul>
+<li><strong>Carlton et al., 2021 — PMID 33151556</strong>: KO mice lose stereocilia rows 2/3, lose MET current, deaf by 8 months;<br />
+  tip localization requires MYO15A + EPS8. (eLife/PLoS-class; <strong>DOI flag for verification</strong>.)</li>
+<li><strong>Yan et al., 2022 — PMID 34346063</strong>: BAIAP2L2 is a "row 2 complex" component (binds EPS8L2, TWF2, CAPZB2, CIB2);<br />
+  tip localization requires CIB2.</li>
+<li><strong>Halford et al., 2022 — PMID 35044843</strong>: BAIAP2L2–EPS8–MYO15A tripartite complex; row-2 tip retention depends on<br />
+  Ca²⁺ influx through transduction channels.</li>
+<li><strong>Ikäheimo et al., 2024 — PMID 39037943</strong>: in stereocilia-fusion pathology BAIAP2L2 mislocalizes from tips.</li>
+</ul>
+<p>These describe a <strong>protrusion-tip actin-scaffold</strong> function (negative-curvature geometry), mechanistically distinct<br />
+from the <strong>planar-junction</strong> epithelial activity. BAIAP2L2 thus operates in two different membrane geometries.</p>
+<hr />
+<h2 id="6-supported-vs-refuted-hypotheses">6. Supported vs. refuted hypotheses</h2>
+<p><strong>Supported (direct evidence):</strong><br />
+- BAIAP2L2 binds membranes and generates <strong>planar sheets</strong> via a flat lipid interface + sheet oligomers (PMID 21743456).<br />
+- BAIAP2L2 localizes to <strong>Rab13 vesicles and epithelial junctions</strong> (PMID 21743456).<br />
+- BAIAP2L2 is an <strong>HNF1β target</strong> and binds I-BAR paralogs (PMID 36520027).<br />
+- BAIAP2L2 maintains <strong>cochlear stereocilia</strong> (PMID 33151556, 34346063, 35044843).</p>
+<p><strong>Refuted / not supported (basal conditions):</strong><br />
+- BAIAP2L2 is <strong>required for basal renal/colonic morphology or electrolyte homeostasis</strong> — <strong>refuted</strong> (PMID 36520027).<br />
+- BAIAP2L2 explains <strong>HNF1β cyst/electrolyte phenotype</strong> — <strong>refuted</strong> (PMID 36520027).</p>
+<p><strong>Unresolved (open):</strong><br />
+- A specific native epithelial <em>biological process</em> / cargo / junctional structure.<br />
+- Challenge- or age-dependent epithelial phenotypes.<br />
+- Strict phosphoinositide-species specificity of BAIAP2L2 membrane binding.</p>
+<hr />
+<h2 id="7-go-style-curation-recommendation">7. GO-style curation recommendation</h2>
+<ol>
+<li><strong>Support a membrane-bending/scaffold molecular function.</strong> Direct structural + in-vitro data justify MF terms such as<br />
+<em>phosphatidylinositol/phospholipid binding</em> (with the caveat that a specific PIP species is inferred) and a<br />
+<em>membrane deformation / planar membrane-sheet scaffolding</em> activity. This is the best-evidenced, BAIAP2L2-specific claim.</li>
+<li><strong>Keep epithelial biological-process terms as inferred / non-core.</strong> Localization to junctions/Rab13 vesicles is<br />
+   direct, but the <em>process</em> (junction assembly, epithelial morphogenesis, barrier function) has <strong>no in-vivo support</strong> and<br />
+   a KO shows no basal phenotype → annotate as <strong>inferred/IEA-or-IMP-pending / non-core</strong>, not established.</li>
+<li><strong>Native epithelial function = "unresolved."</strong> Do not assert a core epithelial physiological role; the honest curation<br />
+   status is <em>candidate/unresolved pending challenge and compound-KO data.</em></li>
+<li><strong>Do not transfer stereocilia partners (EPS8/CIB2/MYO15A etc.) to epithelium</strong> — these are tissue-specific and would<br />
+   be an over-annotation.</li>
+</ol>
+<hr />
+<h2 id="8-limitations-future-directions">8. Limitations &amp; future directions</h2>
+<ul>
+<li><strong>Limitation:</strong> the entire direct epithelial case rests on a single 2011 paper; independent replication of planar-sheet<br />
+  activity and junction localization in human intestinal/renal tissue is lacking.</li>
+<li><strong>DOI caveat:</strong> PMIDs are validated against cached PubMed abstracts. DOIs are provided where confidently known<br />
+  (Pykäläinen 2011 = 10.1038/nsmb.2079); other DOIs are <strong>flagged uncertain</strong> and should be verified before publication.</li>
+<li><strong>Priority experiments:</strong> (i) compound BAIAP2/BAIAP2L1/BAIAP2L2 knockouts in gut/kidney; (ii) epithelial challenge<br />
+  models (injury, colitis, low-Mg/high-salt, aging); (iii) barrier/junction-dynamics and Rab13-cargo trafficking assays;<br />
+  (iv) defined phosphoinositide-binding specificity for the BAIAP2L2 I-BAR domain; (v) human intestinal/renal organoid<br />
+  localization and knockout phenotyping.</li>
+</ul>
+<hr />
+<h3 id="key-citations-pmid-doi-cache-status">Key citations (PMID / DOI / cache status)</h3>
+<ul>
+<li>PMID <strong>21743456</strong> — Pykäläinen 2011, <em>Nat Struct Mol Biol</em> — DOI <strong>10.1038/nsmb.2079</strong> — cached ✔ (core direct evidence)</li>
+<li>PMID <strong>36520027</strong> — Tholen 2023 — DOI <strong>uncertain (flag)</strong> — cached ✔ (KO phenotype, HNF1β, paralog binding)</li>
+<li>PMID <strong>27278019</strong> — Sudhaharan 2016, <em>J Cell Sci</em> — DOI uncertain (flag) — cached ✔ (I-BAR/Rif family inference)</li>
+<li>PMID <strong>33151556</strong> — Carlton 2021 — DOI uncertain (flag) — cached ✔ (cochlear KO)</li>
+<li>PMID <strong>34346063</strong> — Yan 2022 — DOI uncertain (flag) — cached ✔ (row-2 complex)</li>
+<li>PMID <strong>35044843</strong> — Halford 2022 — DOI uncertain (flag) — cached ✔ (tripartite complex, Ca²⁺-dependent tip retention)</li>
+<li>PMID <strong>39037943</strong> — Ikäheimo 2024 — DOI uncertain (flag) — cached ✔ (stereocilia fusion mislocalization)</li>
+<li>PMID <strong>34695828</strong> — Shakery 2023 — DOI uncertain (flag) — cached ✔ (non-native cancer-cell, correlative)</li>
+<li>PMID <strong>21795389</strong> — Abou-Zeid 2011 / PMID <strong>24377937</strong> — Zahraoui 2014 — cached ✔ (Rab13 junction biology, context)</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist prompt: BAIAP2L2/Pinkbar epithelial membrane function</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(BAIAP2L2-hypotheses/kgap-baiap2l2-epithelial-pinkbar-function/prompt.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q6UXY1" data-a="DEEP_RESEARCH: OpenScientist prompt: BAIAP2L2/Pinkbar epithelial membrane function" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+
+                <h1 id="openscientist-prompt-baiap2l2pinkbar-epithelial-membrane-function">OpenScientist prompt: BAIAP2L2/Pinkbar epithelial membrane function</h1>
+<p>Investigate the unresolved native epithelial function of human BAIAP2L2/Pinkbar in intestinal and renal epithelial tissues, distinct from better-established membrane-binding and cochlear stereocilia observations.</p>
+<p>Focus on:</p>
+<ul>
+<li>direct evidence that BAIAP2L2 binds phosphoinositide membranes, generates planar membrane sheets, localizes to Rab13 vesicles/junctions, or shapes epithelial membrane architecture;</li>
+<li>why knockout mice can have normal kidney/colon morphology and electrolyte homeostasis under basal conditions, and whether challenge-condition or tissue-specific phenotypes have been tested;</li>
+<li>candidate epithelial partners, cargo, or junctional structures that could define a specific molecular function in native tissue;</li>
+<li>whether GO-style curation should keep epithelial terms as inferred/non-core, support a membrane-bending/scaffold MF, or treat native epithelial function as unresolved.</li>
+</ul>
+<p>Please include PMIDs and DOIs, flag uncached or uncertain citations, and distinguish direct BAIAP2L2 evidence from I-BAR-family or paralog inference.</p>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/human/KCTD14/KCTD14-ai-review.html
+++ b/genes/human/KCTD14/KCTD14-ai-review.html
@@ -2200,6 +2200,165 @@ Human KCTD14 (Q9BQ13) is a BTB/POZ-domain protein of the KCTD family with predic
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">KCTD14: CUL3 Substrate-Adaptor or Alternative Function?</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BQ13" data-a="DEEP_RESEARCH: KCTD14: CUL3 Substrate-Adaptor or Alternative Function?" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+
+
+
+
+
+
+
+                    <a href="KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <h1 id="kctd14-cul3-substrate-adaptor-or-alternative-function">KCTD14: CUL3 Substrate-Adaptor or Alternative Function?</h1>
+<p><strong>Research question:</strong> What is the evidence for human KCTD14 molecular function—specifically, does it act as a CUL3‑RING ubiquitin ligase (CRL3) substrate adaptor like several KCTD paralogs, or does it have another activity? What GO‑style curation posture is justified?</p>
+<p><strong>Date:</strong> 2026‑07‑07 · Iteration 1 (literature synthesis; no primary data files provided)</p>
+<hr />
+<h2 id="1-summary-answer">1. Summary (answer)</h2>
+<p>There is <strong>no direct experimental evidence</strong> that human KCTD14 binds CUL3, oligomerizes (beyond prediction), recognizes a substrate, or participates in a CRL3 complex. The entire KCTD14 primary literature is transcriptomic/biomarker work with no biochemical characterization. Its BTB/T1 fold and its close relationship to the validated Cul3 adaptor <strong>KCTD7</strong> make a CRL3 substrate‑adaptor role a <strong>plausible, high‑priority hypothesis</strong>, but family membership is <em>not</em> sufficient to assert it, because Cul3 binding is demonstrably <strong>not universal</strong> among KCTDs (KCTD1 and KCTD16 do not bind Cul3). The only functionally defensible molecular‑function annotation today is <strong>protein homo‑oligomerization</strong> via the BTB/T1 domain, and even that rests on AlphaFold prediction plus family‑level inference rather than KCTD14‑specific experiment. <strong>KCTD14 should remain largely MF‑dark</strong>: keep non‑core "protein binding," optionally add homo‑oligomerization at an inferred (IBA/computational) evidence level, and do <strong>not</strong> annotate a specific adaptor/substrate‑recognition function.</p>
+<hr />
+<h2 id="2-key-findings-and-evidence">2. Key findings and evidence</h2>
+<h3 id="21-the-kctd14-primary-literature-is-functionally-empty">2.1 The KCTD14 primary literature is functionally empty</h3>
+<p>A systematic PubMed search returns only ~9 records mentioning KCTD14. All are transcriptomic signature / prognostic‑biomarker studies:<br />
+- Pancreatic‑cancer DC signature, "KCTD14–TNF axis" (correlative, not mechanistic) — PMID <strong>41080575</strong> (2025).<br />
+- Ovarian‑cancer methylation prognostic panel — PMID <strong>36978087</strong> (2023).<br />
+- Prostate‑cancer CAF signature — PMID <strong>36195908</strong> (2022).<br />
+- Dengue transcriptome biomarkers — PMIDs <strong>39397194</strong> (2025), <strong>35220956</strong> (2022).<br />
+- Diabetic rat ileal/colon transcriptome — PMID <strong>34806320</strong> (2021).<br />
+- Mouse oocyte/follicle expression — PMID <strong>40044995</strong> (2025).<br />
+- Incidental co‑regulation in a Znf230‑KO transcriptome — PMID <strong>25505846</strong> (2014).</p>
+<p>None report protein interactions, enzymatic activity, oligomerization, or a CUL3 relationship. → <strong>KCTD14 is MF‑dark.</strong></p>
+<h3 id="22-no-kctd14cul3-binding-has-ever-been-tested">2.2 No KCTD14–CUL3 binding has ever been tested</h3>
+<p>The definitive family binding survey — Ji, Chu, Nielsen, Benlekbir, Rubinstein &amp; Privé, <em>"Structural Insights into KCTD Protein Assembly and Cullin3 Recognition"</em> (PMID <strong>26334369</strong>, 2016) — measured Cul3 binding for KCTD1, 5, 6, 9, 16, 17 but <strong>did not include KCTD14</strong>. No pulldown, ITC, cryo‑EM, or proteomic study places KCTD14 in a CRL3 complex.</p>
+<h3 id="23-cul3-binding-is-memberspecific-family-transfer-is-unreliable">2.3 Cul3 binding is member‑specific → family transfer is unreliable</h3>
+<p>From the same study (PMID <strong>26334369</strong>): <em>"the KCTD proteins 5, 6, 9 and 17 bind to Cul3 with high affinity, while the KCTD proteins 1 and 16 do not have detectable binding,"</em> and KCTDs <em>"do not share many of the previously identified determinants for Cul3 binding."</em> Because two tested KCTDs (KCTD1, KCTD16) fail to bind Cul3 despite the shared BTB fold, <strong>homology‑based inference of adaptor function to the untested KCTD14 is not safe.</strong></p>
+<h3 id="24-kctd14-oligomerization-is-predicted-not-observed">2.4 KCTD14 oligomerization is predicted, not observed</h3>
+<p>Esposito, Balasco &amp; Vitagliano, <em>"AlphaFold Predictions Provide Insights into the Structural Features of the Functional Oligomers of All Members of the KCTD Family"</em> (PMID <strong>36362127</strong>, 2022) predict a reliable <strong>pentameric</strong> KCTD14 assembly, but with an <strong>atypical CTD</strong>: <em>"the structure of the related proteins KCTD7 and KCTD14, although pentameric, appears to be characterized by a different organization of the CTD region, with the five chains forming a circle‑like structure with a large cavity."</em> Family‑wide negative‑stain EM (Smaldone et al., PMID <strong>27152988</strong>, 2016) shows KCTD BTB domains across five clades "prevalently assume pentameric states." Together these support homo‑oligomerization as an <strong>inherited fold property</strong>, but there is <strong>no KCTD14‑specific experimental oligomerization data</strong>, and the atypical CTD hints KCTD14/KCTD7 may engage partners non‑canonically.</p>
+<h3 id="25-the-closest-paralog-kctd7-is-a-validated-cul3-partner-hypothesis-not-proof">2.5 The closest paralog KCTD7 <em>is</em> a validated Cul3 partner (hypothesis, not proof)</h3>
+<ul>
+<li>Staropoli et al. (PMID <strong>22748208</strong>, 2012): an NCL/PME disease mutation <em>"abrogated interaction with cullin‑3, a ubiquitin‑ligase component and known KCTD7 interactor."</em></li>
+<li>Jiang, Wang, Kong &amp; Zheng (PMID <strong>37450587</strong>, 2023): cryo‑EM structures of the <em>"KCTD5–Gβγ fusion complex and the KCTD7–Cul3 complex."</em></li>
+</ul>
+<p>Because AlphaFold groups KCTD14 with KCTD7 by CTD architecture, KCTD7's proven Cul3 partnership makes a CRL3 role for KCTD14 a <strong>strong, testable prediction</strong> — but strictly a prediction, especially given §2.3.</p>
+<h3 id="26-reliability-of-highthroughput-protein-binding-interactors">2.6 Reliability of high‑throughput "protein binding" interactors</h3>
+<p>Reported KCTD14 GO "protein binding" annotations trace to high‑throughput/curated PPI compilations (e.g., Skoblov et al., PMID <strong>23592240</strong>, 2013, which explicitly notes <em>"The value of manual curation of PPIs and analysis of existing high‑throughput data should not be underestimated"</em> but offers only hypotheses). Such Y2H/AP‑MS hits for a low‑expression, uncharacterized protein are prone to false positives, are non‑reciprocated, and none has been validated as a physiological KCTD14 substrate or partner. They justify only a <strong>non‑core, low‑confidence "protein binding"</strong> annotation, not a substrate‑recognition function.</p>
+<hr />
+<h2 id="3-hypotheses-supported-vs-refuted">3. Hypotheses: supported vs. refuted</h2>
+<table>
+<thead>
+<tr>
+<th>Hypothesis</th>
+<th>Verdict</th>
+<th>Basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>KCTD14 is a proven CUL3/CRL3 substrate adaptor</td>
+<td><strong>Not supported (no evidence)</strong></td>
+<td>No KCTD14–CUL3 data exist (§2.2)</td>
+</tr>
+<tr>
+<td>KCTD14 homo‑oligomerizes (BTB/T1 pentamer)</td>
+<td><strong>Provisionally supported (computational + family IBA)</strong></td>
+<td>AlphaFold pentamer + family EM (§2.4)</td>
+</tr>
+<tr>
+<td>Family membership alone proves adaptor function</td>
+<td><strong>Refuted</strong></td>
+<td>KCTD1/KCTD16 don't bind Cul3 (§2.3)</td>
+</tr>
+<tr>
+<td>CRL3 adaptor role is a worthwhile hypothesis to test</td>
+<td><strong>Supported as hypothesis</strong></td>
+<td>KCTD7 paralogy (§2.5)</td>
+</tr>
+<tr>
+<td>Reported HT "protein binding" partners are physiological substrates</td>
+<td><strong>Not supported</strong></td>
+<td>Unvalidated HT hits (§2.6)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="4-recommended-gostyle-curation-posture">4. Recommended GO‑style curation posture</h2>
+<ol>
+<li><strong>Keep KCTD14 essentially MF‑dark.</strong> Retain only non‑core, low‑confidence <strong><code>protein binding</code> (GO:0005515)</strong> from HT data, clearly flagged as unvalidated.</li>
+<li><strong>Best‑justified positive annotation:</strong> <strong><code>protein homo‑oligomerization</code> (GO:0051260)</strong> / identical protein binding, at an <strong>inferred/computational</strong> evidence level (AlphaFold prediction + family IBA), <em>not</em> IDA.</li>
+<li><strong>Do NOT annotate</strong> <code>Cul3‑RING ubiquitin ligase binding</code>, <code>ubiquitin‑protein transferase/ligase adaptor activity</code>, or any specific substrate‑recognition MF. These are unsupported and would over‑annotate.</li>
+<li>Record the CRL3 substrate‑adaptor role as an <strong>open hypothesis</strong> (paralogy to KCTD7), pending direct experiment.</li>
+</ol>
+<hr />
+<h2 id="5-limitations-and-future-directions">5. Limitations and future directions</h2>
+<p><strong>Limitations.</strong> This is a literature‑only synthesis (no primary data). PMIDs below were confirmed to resolve via the PubMed search tool; <strong>DOIs are supplied from model knowledge and should be independently verified</strong> before publication‑grade use (flagged). Absence of evidence for KCTD14 reflects the field's neglect of this gene, not a demonstrated negative.</p>
+<p><strong>Experiments that would resolve the question.</strong><br />
+- Co‑IP / ITC / AP‑MS of tagged KCTD14 vs. CUL3 (± the BTB determinants mutated) — the exact assay Ji 2016 applied to other KCTDs.<br />
+- Reconstituted in‑vitro ubiquitination with CUL3–RBX1–E2 to test ligase‑adaptor activity.<br />
+- SEC‑MALS/native‑MS/cryo‑EM to confirm the predicted pentamer and the atypical CTD cavity.<br />
+- Unbiased BioID/TurboID interactome in a physiologically relevant tissue to identify candidate substrates and test whether any HT "protein binding" hits reciprocate.</p>
+<hr />
+<h2 id="6-citations-pmids-confirmed-via-pubmed-dois-to-be-verified">6. Citations (PMIDs confirmed via PubMed; DOIs to be verified)</h2>
+<ul>
+<li><strong>PMID 26334369</strong> — Ji et al. 2016, <em>J Biol Chem</em> — KCTD assembly &amp; Cul3 recognition; member‑specific binding. DOI (verify): 10.1074/jbc.M115.669580.</li>
+<li><strong>PMID 36362127</strong> — Esposito, Balasco, Vitagliano 2022, <em>Int J Mol Sci</em> — AlphaFold oligomers of all KCTDs incl. KCTD14. DOI (verify): 10.3390/ijms232113346.</li>
+<li><strong>PMID 27152988</strong> — Smaldone et al. 2016, <em>Biochim Biophys Acta Mol Cell Res</em> — KCTD BTB domains are pentameric; KCTD6–Cul3 pinwheel. DOI (verify): 10.1016/j.bbamcr.2016.04.023.</li>
+<li><strong>PMID 22748208</strong> — Staropoli et al. 2012, <em>Am J Hum Genet</em> — KCTD7–cullin‑3 interaction; NCL/PME. DOI (verify): 10.1016/j.ajhg.2012.05.023.</li>
+<li><strong>PMID 37450587</strong> — Jiang, Wang, Kong, Zheng 2023, <em>Sci Adv</em> — cryo‑EM KCTD5–Gβγ and KCTD7–Cul3. DOI (verify): 10.1126/sciadv.adg8369.</li>
+<li><strong>PMID 24747150</strong> — Balasco et al. 2014, <em>PLoS One</em> — KCTD5–Cul3 5:5 heterodecamer, Kd ≈ 59 nM. DOI (verify): 10.1371/journal.pone.0091093.</li>
+<li><strong>PMID 23592240</strong> — Skoblov et al. 2013, <em>BioEssays</em> — KCTD PPI curation (hypothesis‑generating). DOI (verify): 10.1002/bies.201200169.</li>
+<li><strong>PMID 24268103</strong> — Liu, Xiang, Sun 2013 — KCTD family review (structure/function/disease). DOI (verify): 10.1007/s12035‑013‑8555‑y.</li>
+<li><strong>PMID 34001146</strong> — Angrisani et al. 2021, <em>Semin Cancer Biol</em> — KCTDs in cancer review. DOI (verify): 10.1016/j.semcancer.2021.05.019.</li>
+<li><strong>PMID 40925965</strong> — Jiang &amp; Zheng 2026 — KCTDs as regulators of GPCR biased signaling (Gβγ degradation). DOI: not confirmed (flag as uncached).</li>
+<li>KCTD14 transcriptomic references: PMIDs 41080575, 40044995, 39397194, 36978087, 36195908, 35220956, 34806320, 25505846.</li>
+</ul>
+<p><strong>Suspect/uncached flags:</strong> All DOIs above are reconstructed from model knowledge and must be verified against CrossRef/PubMed. PMID 40925965 (2026) and PMID 41080575 (2025) are recent; treat their DOIs as unconfirmed. No previously reported KCTD14 citation was accepted without re‑confirmation in this PubMed session; any claim of a direct KCTD14–CUL3 experiment in secondary sources should be treated as <strong>suspect</strong> because none was found here.</p>
+            </div>
+        </details>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist prompt: KCTD14 CUL3 substrate-adaptor or alternative function</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(KCTD14-hypotheses/kgap-kctd14-cul3-adaptor-or-other/prompt.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BQ13" data-a="DEEP_RESEARCH: OpenScientist prompt: KCTD14 CUL3 substrate-adaptor or alternative function" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+
+                <h1 id="openscientist-prompt-kctd14-cul3-substrate-adaptor-or-alternative-function">OpenScientist prompt: KCTD14 CUL3 substrate-adaptor or alternative function</h1>
+<p>Investigate the evidence for human KCTD14 molecular function, especially whether it acts as a CUL3-RING ubiquitin ligase substrate adaptor like several KCTD paralogs or instead has another activity.</p>
+<p>Focus on:</p>
+<ul>
+<li>direct evidence for KCTD14 binding to CUL3, oligomerization, substrates, ubiquitination, degradation, or CRL3 complex membership;</li>
+<li>the reliability of reported high-throughput KCTD14 <code>protein binding</code> interactors and whether any are plausible physiological substrates or partners;</li>
+<li>family-level KCTD/BTB evidence that can or cannot be transferred to KCTD14;</li>
+<li>whether current GO-style curation should remain MF-dark/non-core binding only, support protein homooligomerization, or support a specific adaptor/substrate-recognition function.</li>
+</ul>
+<p>Please include PMIDs and DOIs, flag uncached or suspect citations, and avoid relying on previously reported KCTD14 citations unless they resolve correctly in PubMed.</p>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/human/RAB9A/RAB9A-ai-review.html
+++ b/genes/human/RAB9A/RAB9A-ai-review.html
@@ -6337,6 +6337,156 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">RAB9A GEF/GAP Switch-Control: A Residual Knowledge Gap</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P51151" data-a="DEEP_RESEARCH: RAB9A GEF/GAP Switch-Control: A Residual Knowledge Gap" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+
+
+
+
+
+
+
+                    <a href="RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <h1 id="rab9a-gefgap-switch-control-a-residual-knowledge-gap">RAB9A GEF/GAP Switch-Control: A Residual Knowledge Gap</h1>
+<p><strong>Research question:</strong> Which guanine-nucleotide exchange factor(s) (GEFs) activate human RAB9A on late endosomes, and which GTPase-activating protein(s) (GAPs) inactivate it?</p>
+<p><strong>Iteration 1 — literature-based mechanistic synthesis.</strong> No primary datasets were provided; this report synthesizes published biochemistry, cell biology, and curated Rab-regulator catalogs, distinguishing validated RAB9A-specific evidence from paralog/family extrapolation. Citations retrieved and verified against the local PubMed cache are marked <strong>[cached]</strong>; citations drawn from domain knowledge that could not be confirmed against the cache are marked <strong>[UNCACHED — verify]</strong>.</p>
+<hr />
+<h2 id="1-summary-direct-answer">1. Summary (direct answer)</h2>
+<p>There is <strong>no validated, RAB9A-specific GEF or GAP</strong> in the literature. RAB9A's activating exchange factor on late endosomes is <strong>unidentified</strong> — no in vitro nucleotide-exchange assay, localization, or knockdown/rescue study assigns a GEF to RAB9A. On the GAP side, the proteins most often linked to RAB9A — <strong>RUTBC1 (SGSM2) and RUTBC2 (SGSM1)</strong> — are RAB9A <strong>effectors/binding partners</strong> whose TBC GAP activity is directed at <strong>other Rabs</strong> (Rab32/38, Rab33B, Rab34/36), <strong>not at RAB9A itself</strong>. The RAB9A on/off switch machinery should therefore be curated as an <strong>explicit residual knowledge gap</strong>, with regulator relationships added only for the (well-supported) <em>downstream</em> GAP-cascade role of RAB9A.</p>
+<hr />
+<h2 id="2-key-findings">2. Key findings</h2>
+<h3 id="finding-1-no-rab9a-gef-is-identified-residual-gap">Finding 1 — No RAB9A GEF is identified (residual gap)</h3>
+<ul>
+<li>Authoritative Rab-GEF catalogs enumerate every known GEF class — DENN, VPS9, Sec2, TRAPP, Mon1-Ccz1, BLOC-3 (HPS1-HPS4), Ric1-Rgp1, Rab3GAP1/2, REI-1, RPGR — and their substrate Rabs. <strong>RAB9A is not assigned a GEF.</strong> <em>(Ishida, Oguchi &amp; Fukuda 2016, PMID 27246931 [cached]; Marat, Dokainish &amp; McPherson 2011, PMID 21330364 [cached].)</em></li>
+<li>The systematic DENN-domain GEF–Rab mapping screen did not identify a RAB9A activator. <em>(Yoshimura, Gerondopoulos, Linford, Rigden &amp; Barr, J Cell Biol 2010, PMID 20937701, DOI 10.1083/jcb.201008090 [UNCACHED — verify].)</em></li>
+<li>The specific late-endosomal GEF <strong>Mon1-Ccz1 activates RAB7, not RAB9A</strong> <em>(Kiontke et al. 2017, PMID 28051187 [cached]; Borchers et al. 2023, PMID 37463208 [cached])</em>, so RAB9A's activation is not explained by the known LE-maturation GEF.</li>
+<li><strong>Verdict:</strong> GEF assignment for RAB9A rests only on family-level inference. No RAB9A-specific biochemistry exists.</li>
+</ul>
+<h3 id="finding-2-rutbc1rutbc2-are-rab9a-effectors-not-rab9a-gaps">Finding 2 — RUTBC1/RUTBC2 are RAB9A effectors, not RAB9A GAPs</h3>
+<ul>
+<li><strong>RUTBC1 (SGSM2)</strong> was originally characterized as a <strong>Rab9-binding protein</strong> and is a TBC-GAP for <strong>Rab32 and Rab33B</strong> in vitro; in melanocytes it is the physiological GAP for <strong>Rab32/38</strong>, and <strong>RAB9A regulates RUTBC1 localization</strong> and melanogenic-enzyme trafficking. <em>(Marubashi, Shimada, Fukuda &amp; Ohbayashi 2016, PMID 26620560 [cached].)</em></li>
+<li>RUTBC1 is recruited by <strong>RAB9A-GTP</strong> but shows <strong>no GAP activity toward RAB9A</strong>; its catalytic activity is on Rab32/33B. <em>(Nottingham, Ganley, Barr, Lambright &amp; Pfeffer, JBC 2011, PMID 21808068, DOI 10.1074/jbc.M111.246900 [UNCACHED — verify].)</em></li>
+<li><strong>RUTBC2 (SGSM1)</strong> is likewise a RAB9A-bound TBC-GAP acting on <strong>Rab34/Rab36</strong>. <em>(Nottingham, Pusapati, Ganley, Barr, Lambright &amp; Pfeffer, JBC 2012, PMID 22637480, DOI 10.1074/jbc.M112.372458 [UNCACHED — verify].)</em></li>
+<li>TBC-domain GAPs catalyze GTP hydrolysis via a <strong>dual-finger (arginine + glutamine)</strong> transition-state mechanism <em>(Pan, Eathiraj, Munson &amp; Lambright 2006, PMID 16855591 [cached])</em> — mechanistic context that constrains which TBC proteins could, in principle, act on RAB9A.</li>
+<li><strong>Interpretation:</strong> RAB9A sits at the <strong>top of a GAP cascade</strong> — RAB9A-GTP positions RUTBC1/2 on membranes to inactivate <em>downstream</em> Rabs. This is the <strong>opposite</strong> of a RAB9A-inactivating relationship and must not be mis-curated as "GAP for RAB9A."</li>
+</ul>
+<h3 id="finding-3-effectorspathways-constrain-but-dont-identify-the-regulators">Finding 3 — Effectors/pathways constrain but don't identify the regulators</h3>
+<ul>
+<li>RAB9A recruits <strong>TIP47/PLIN3</strong> onto late endosomes to drive <strong>CI-/CD-MPR (mannose-6-phosphate receptor) retrograde transport to the TGN</strong> <em>(Burguete, Sivars &amp; Pfeffer 2005, PMID 16473602 [cached]; TIP47 identification Diaz &amp; Pfeffer 1998, PMID 9463366 [UNCACHED — verify]).</em></li>
+<li>Other RAB9A effectors: TGN golgin <strong>GCC185</strong> <em>(Reddy et al. 2006, PMID 16967564 [UNCACHED — verify])</em>, <strong>RhoBTB3</strong> <em>(Espinosa et al. 2009, PMID 19273613 [UNCACHED — verify])</em>, and RUTBC1/2. RAB9A also supports <strong>ATG5/ATG7-independent "alternative" autophagy</strong> <em>(Nishida et al. 2009, PMID 19794493 [UNCACHED — verify]).</em></li>
+<li>These define <strong>where</strong> an activating GEF must act (late-endosome membrane) and <strong>when</strong> a GAP must terminate signaling (after MPR delivery), bounding the search space without naming a regulator.</li>
+</ul>
+<hr />
+<h2 id="3-supported-vs-refuted-hypotheses">3. Supported vs. refuted hypotheses</h2>
+<table>
+<thead>
+<tr>
+<th>Hypothesis</th>
+<th>Status</th>
+<th>Basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A validated RAB9A-specific GEF exists in the literature</td>
+<td><strong>Refuted / unsupported</strong></td>
+<td>Absent from all Rab-GEF catalogs; no exchange assay on RAB9A</td>
+</tr>
+<tr>
+<td>RUTBC1/RUTBC2 are the GAPs that inactivate RAB9A</td>
+<td><strong>Refuted</strong></td>
+<td>They bind RAB9A but hydrolyze Rab32/33B/34/36; RAB9A regulates <em>their</em> localization</td>
+</tr>
+<tr>
+<td>RAB9A acts upstream in a GAP cascade (RAB9A-GTP → RUTBC1/2 → other Rabs)</td>
+<td><strong>Supported</strong></td>
+<td>PMID 26620560; PMID 21808068/22637480 [uncached]</td>
+</tr>
+<tr>
+<td>Mon1-Ccz1 activates RAB9A on late endosomes</td>
+<td><strong>Refuted</strong></td>
+<td>Mon1-Ccz1 is RAB7-specific (PMID 28051187, 37463208)</td>
+</tr>
+<tr>
+<td>DENN- or TBC-family candidates have <em>RAB9A-specific</em> evidence</td>
+<td><strong>Unsupported</strong></td>
+<td>Only broad Rab-family inference; no RAB9A hit in DENN screen</td>
+</tr>
+<tr>
+<td>A Rab7→Rab9A handoff/cascade activates RAB9A during LE maturation</td>
+<td><strong>Untested — plausible model</strong></td>
+<td>Analogy to Rab5→Rab7; no direct RAB9A evidence</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="4-recommendation-for-go-style-curation">4. Recommendation for GO-style curation</h2>
+<ol>
+<li><strong>Do NOT add a "GEF for RAB9A" relationship.</strong> Record the RAB9A activator as an <strong>explicit residual knowledge gap</strong>.</li>
+<li><strong>Do NOT annotate RUTBC1/RUTBC2 as GAPs acting on RAB9A.</strong> Instead curate:</li>
+<li>RAB9A → RUTBC1 (SGSM2): <em>binds effector; regulates its localization</em> (PMID 26620560, 21808068).</li>
+<li>RAB9A → RUTBC2 (SGSM1): <em>binds effector</em> (PMID 22637480).</li>
+<li>RUTBC1 GAP activity → Rab32/Rab33B/Rab38; RUTBC2 GAP activity → Rab34/Rab36.</li>
+<li><strong>Add suggested curator questions:</strong></li>
+<li>What GEF loads GTP onto RAB9A at the late endosome? Is activation coupled to RAB7 (cascade/handoff)?</li>
+<li>Which TBC-domain GAP inactivates RAB9A, and where/when in the MPR-retrieval cycle?</li>
+<li>Do any DENN/VPS9-family GEFs show <em>direct</em> exchange activity on RAB9A in vitro?</li>
+<li><strong>Flag paralog caution:</strong> RAB9A and RAB9B are close paralogs; any future regulator claim must be tested for RAB9A specificity rather than assumed from Rab-family or RAB9B data.</li>
+</ol>
+<hr />
+<h2 id="5-limitations-future-directions">5. Limitations &amp; future directions</h2>
+<ul>
+<li><strong>Cache coverage:</strong> Several key primary papers (Nottingham RUTBC1/2 JBC 2011/2012; Yoshimura DENN screen 2010; Diaz &amp; Pfeffer 1998; Reddy GCC185 2006) were <strong>not retrievable</strong> in the local PubMed cache and are flagged <strong>[UNCACHED — verify]</strong>; their PMIDs/DOIs should be confirmed against NCBI before curation.</li>
+<li><strong>No wet-lab data</strong> were available; conclusions are literature-derived.</li>
+<li><strong>Definitive resolution requires:</strong> an in vitro GDP/GTP-exchange assay identifying the RAB9A GEF; a TBC-GAP screen scored directly on RAB9A; and knockdown/knockout–rescue with CI-MPR endosome-to-TGN readouts to establish physiological relevance.</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist prompt: RAB9A GEF/GAP switch-control gap</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RAB9A-hypotheses/kgap-rab9a-gefs-gaps-switch-control/prompt.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P51151" data-a="DEEP_RESEARCH: OpenScientist prompt: RAB9A GEF/GAP switch-control gap" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+
+                <h1 id="openscientist-prompt-rab9a-gefgap-switch-control-gap">OpenScientist prompt: RAB9A GEF/GAP switch-control gap</h1>
+<p>Investigate the unresolved regulatory switch machinery for human RAB9A: the specific guanine-nucleotide exchange factor(s) that activate RAB9A on late endosomes and the GTPase-activating protein(s) that inactivate it.</p>
+<p>Focus on:</p>
+<ul>
+<li>direct evidence for any RAB9A-specific GEFs or GAPs, including in vitro nucleotide-exchange/GTPase assays, localization, knockdown/knockout rescue, and CI-MPR or endosome-to-TGN trafficking readouts;</li>
+<li>whether DENN-domain or TBC-domain candidates have RAB9A-specific evidence versus broad Rab-family inference;</li>
+<li>how known RAB9A effectors and trafficking pathways constrain plausible regulators;</li>
+<li>whether GO-style curation should add regulator relationships, suggested questions, or leave the GEF/GAP mechanism as an explicit residual knowledge gap.</li>
+</ul>
+<p>Please include PMIDs and DOIs, flag uncached or uncertain citations, and distinguish validated RAB9A-specific regulators from candidate screens or paralog extrapolation.</p>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/human/RASA1/RASA1-ai-review.html
+++ b/genes/human/RASA1/RASA1-ai-review.html
@@ -8059,6 +8059,157 @@ Human RASA1 (p120RasGAP) is a modular RasGAP that integrates phosphotyrosine‑ 
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">RASA1/p120RasGAP: GAP-Independent Scaffolding Mechanism</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RASA1-hypotheses/kgap-rasa1-gap-independent-scaffold/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P20936" data-a="DEEP_RESEARCH: RASA1/p120RasGAP: GAP-Independent Scaffolding Mechanism" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+
+
+
+
+
+
+
+                    <a href="RASA1-hypotheses/kgap-rasa1-gap-independent-scaffold/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <h1 id="rasa1p120rasgap-gap-independent-scaffolding-mechanism">RASA1/p120RasGAP: GAP-Independent Scaffolding Mechanism</h1>
+<p><strong>Research question:</strong> What is the evidence for RASA1 functions independent of its catalytic Ras-GAP activity — especially p190RhoGAP recruitment, directed cell movement, and vascular development — and how should GO curation express a non-catalytic molecular function?</p>
+<p><em>Iteration 1. Literature-based synthesis. Citations are PubMed-cached abstracts (PMIDs verified); DOIs are provided where confidently known and </em><em>flagged as uncertain/uncached</em><em> otherwise.</em></p>
+<hr />
+<h2 id="1-summary-answer">1. Summary (answer)</h2>
+<p>RASA1 has a genuine, mechanistically defined <strong>GAP-independent scaffolding function</strong>: through its tandem SH2 domains it directly, phosphotyrosine-dependently recruits p190RhoGAP (and assembles a FAK–RASA1–p190RhoGAP complex) to control RhoA-dependent cytoskeletal reorientation and <strong>directed cell migration</strong>, a role explicitly shown to be <strong>separable from — and not requiring — Ras-GAP catalysis</strong>. Recruitment is direct and high-affinity (Kd ≈ 0.3 µM), and partner binding leaves catalytic activity unchanged, so the two functions are cleanly separable at the molecular level. However, the recruitment/scaffold role is <strong>not sufficient to explain the CM-AVM vascular phenotype</strong>: developmental blood/lymphatic vascular disease from RASA1 loss is driven by the <strong>catalytic (Ras-MAPK) arm</strong> via collagen IV export, and the EPHB4–RASA1 physical interaction is dispensable for angiogenesis. For GO curation, the non-catalytic role should be expressed as a <strong>specific, evidence-backed binding/scaffold molecular function</strong>, scoped to migration/polarity — not recorded merely as a residual mechanism gap.</p>
+<hr />
+<h2 id="2-catalytic-ras-gap-evidence-kept-separate">2. Catalytic Ras-GAP evidence (kept separate)</h2>
+<ul>
+<li><strong>Vascular development / CM-AVM is Ras-dependent.</strong> In endothelial cells (EC), RASA1 loss dysregulates Ras-MAPK, impairing collagen IV folding/export from the ER → EC apoptosis and defective angiogenesis. <em>Chen et al. 2019, PMID </em><em>31185000</em><em> (JCI Insight; DOI 10.1172/jci.insight.125940 — likely, uncertain).</em></li>
+<li><strong>EPHB4–RASA1 act in the same catalytic pathway; physical interaction dispensable.</strong> EPHB4-mutant mice expressing EPHB4 that cannot engage RASA1 (but retains kinase activity) had <strong>normal angiogenesis</strong>; RASA1/EPHB4 protect against CM-AVM "independent of physical interaction." <em>Chen et al. 2022, PMID </em><em>35015735</em><em> (JCI; DOI uncertain/uncached).</em></li>
+<li><strong>Review of EPHB4–RASA1 negative regulation of Ras-MAPK.</strong> <em>Chen et al. 2023, PMID </em><em>37259315</em><em> (ATVB; DOI uncertain).</em></li>
+<li><strong>Second-hit somatic RASA1 inactivation in CM-AVM EC</strong> confirms loss-of-function (catalytic) genetics. <em>Lapinski et al. 2018, PMID </em><em>29024832</em><em>.</em></li>
+</ul>
+<blockquote>
+<p>These establish the <strong>Ras-dependent (catalytic)</strong> disease mechanism and are deliberately partitioned from the scaffold evidence below.</p>
+</blockquote>
+<hr />
+<h2 id="3-gap-independent-scaffold-evidence">3. GAP-independent scaffold evidence</h2>
+<h3 id="31-direct-phosphotyrosine-dependent-p190rhogap-recruitment">3.1 Direct, phosphotyrosine-dependent p190RhoGAP recruitment</h3>
+<ul>
+<li>N-SH2 of RASA1 binds p190RhoGAP <strong>pTyr-1105</strong> via canonical FLVR arginine R207; <strong>Kd = 0.3 ± 0.1 µM</strong> (ITC). <em>Jaber Chehayeb et al. 2019, PMID </em><em>31891593</em><em> (J Struct Biol).</em></li>
+<li>The <strong>SH2-SH3-SH2 module simultaneously engages two proximal p190RhoGAP phosphotyrosines</strong> with synergistic (avidity) binding and induced compaction — a selectivity mechanism. <em>Stiegler, Vish &amp; Boggon 2022, PMID </em><em>36417908</em><em> (J Biol Chem).</em></li>
+<li>RASA1 makes <strong>distinct</strong> SH2 interactions with doubly-phosphorylated partners p190RhoGAP, Dok1, EphB4; <strong>these interactions do not impact catalytic activity.</strong> <em>Vish, Stiegler &amp; Boggon 2023, PMID </em><em>37507023</em><em> (J Biol Chem).</em> → <strong>clean biochemical separation of scaffolding from catalysis.</strong></li>
+<li>FLVR-unique C-SH2 / methods: PMIDs <strong>32540970</strong>, <strong>37668970</strong>.</li>
+</ul>
+<h3 id="32-directed-cell-movement-requires-the-scaffold-not-catalysis">3.2 Directed cell movement requires the scaffold, not catalysis</h3>
+<ul>
+<li><strong>Cornerstone separation-of-function:</strong> In RasGAP-deficient cells, growth factor rescues spreading/Golgi/transport <strong>Ras-dependently</strong>, but stress-fiber/focal-adhesion turnover producing the elongate migratory morphology depends on the <strong>constitutive RasGAP–p190 association, independent of Ras regulation</strong>; disrupting the pTyr-mediated complex with p190 peptides suppresses migration. <em>Kulkarni et al. 2000, PMID </em><em>10769036</em><em> (J Cell Biol; DOI 10.1083/jcb.149.2.457 — likely, uncertain).</em></li>
+<li><strong>FAK–RASA1–p190RhoGAP polarity complex:</strong> FAK (pY397) drives SH2-mediated RASA1 recruitment and p190A phosphorylation, targeting the complex to leading-edge focal adhesions to transiently inhibit RhoA; loss abolishes polarity in fibroblasts, <strong>endothelial</strong> and carcinoma cells. <em>Tomar et al. 2009, PMID </em><em>19435801</em><em> (Nat Cell Biol; DOI uncertain).</em></li>
+<li>Corroborating pathway/cross-talk context: β3-integrin/EGFR→Src→p190/p120 complex (<strong>21937717</strong>); Brk phosphorylation of p190 Y1105 promoting p190/p120 complex, migration, invasion (<strong>18829532</strong>); E-cadherin→membrane p190RhoGAP/p120RasGAP complex lowering RhoA (<strong>20228844</strong>).</li>
+</ul>
+<h3 id="33-other-non-catalytic-rasa1-activities-context">3.3 Other non-catalytic RASA1 activities (context)</h3>
+<ul>
+<li>Caspase-3 cleavage generates an N-terminal "fragment N" that drives an <strong>Akt-dependent anti-apoptotic</strong> response (independent of GAP catalysis). <em>Peltzer et al. 2013, PMID </em><em>23826368</em><em>.</em></li>
+</ul>
+<hr />
+<h2 id="4-supported-vs-refuted-hypotheses">4. Supported vs. refuted hypotheses</h2>
+<table>
+<thead>
+<tr>
+<th>Hypothesis</th>
+<th>Verdict</th>
+<th>Key evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>RASA1 has a Ras-GAP-catalysis-independent role in directed migration</td>
+<td><strong>Supported</strong></td>
+<td>Kulkarni 2000 (10769036); Tomar 2009 (19435801)</td>
+</tr>
+<tr>
+<td>p190RhoGAP recruitment is direct &amp; phosphotyrosine/SH2-dependent</td>
+<td><strong>Supported</strong></td>
+<td>31891593; 36417908</td>
+</tr>
+<tr>
+<td>Scaffold binding is molecularly separable from catalysis</td>
+<td><strong>Supported</strong></td>
+<td>37507023</td>
+</tr>
+<tr>
+<td>The p190 scaffold role is <em>sufficient</em> to explain CM-AVM vascular phenotype</td>
+<td><strong>Refuted / not supported</strong></td>
+<td>35015735 (physical interaction dispensable); 31185000 (catalytic collagen IV arm)</td>
+</tr>
+<tr>
+<td>GO should record the non-catalytic role only as a residual gap</td>
+<td><strong>Refuted</strong></td>
+<td>Discrete mechanism + BP link warrant a specific binding/scaffold MF annotation</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="5-go-curation-guidance">5. GO-curation guidance</h2>
+<ul>
+<li><strong>Express a specific molecular function</strong>, distinct from GAP catalysis (GO:0005096 Ras GTPase activator):</li>
+<li>phosphotyrosine residue binding (GO:0001784) / SH2 adaptor-scaffold activity, evidence PMIDs 31891593, 36417908, 37507023 (IPI/IDA + structural).</li>
+<li>Biological process: <em>regulation of cell migration / establishment of cell polarity</em> via RasGAP–p190RhoGAP, evidence 10769036, 19435801.</li>
+<li><strong>Retain as non-core binding/scaffold evidence</strong>, and <strong>scope BP annotations to migration/polarity</strong> — do <strong>not</strong> annotate the scaffold to CM-AVM/angiogenesis pathogenesis, which the genetic separation-of-function assigns to the catalytic Ras-MAPK arm (35015735, 31185000).</li>
+<li><strong>Residual mechanism gap</strong> remains for whether p190 recruitment is <em>sufficient in vivo</em> for vascular/migration phenotypes (existing in-vivo data point to catalysis for vasculature); flag this as an open annotation caveat.</li>
+</ul>
+<hr />
+<h2 id="6-coordination-separation-of-ras-dependent-vs-ras-independent-roles">6. Coordination / separation of Ras-dependent vs Ras-independent roles</h2>
+<p>Evidence supports <strong>context-partitioned</strong> roles rather than a single integrated switch: (i) <strong>catalytic Ras suppression</strong> governs EC survival and collagen IV homeostasis in developmental vasculature (CM-AVM); (ii) <strong>non-catalytic SH2 scaffolding</strong> of p190RhoGAP governs RhoA-dependent cytoskeletal reorientation for directed motility/polarity. Upstream tyrosine kinases (FAK/Src, EphB4, Brk, EGFR) generate the phosphotyrosines that toggle RASA1 between reading partners and localizing signaling — a spatial-temporal, not purely catalytic, layer of control (37507023).</p>
+<hr />
+<h2 id="7-limitations-future-directions">7. Limitations &amp; future directions</h2>
+<ul>
+<li>Synthesis is abstract-level; <strong>DOIs are flagged as uncertain/uncached</strong> and several journal/DOI attributions were inferred, not verified.</li>
+<li>No direct in-vivo "SH2-scaffold-dead but GAP-intact" RASA1 knock-in exists in the retrieved literature to prove sufficiency of p190 recruitment for vascular/migration phenotypes — the key missing separation-of-function reagent.</li>
+<li>Most migration evidence is in fibroblast/carcinoma/EC culture; in-vivo relevance of the scaffold to human vascular disease remains unresolved (residual mechanism gap).</li>
+<li>Future: knock-in RASA1 SH2-binding mutants (R207/R231) vs GAP-dead (R789-type) alleles in EC-specific models to formally dissociate scaffold vs catalytic contributions to angiogenesis and migration.</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist prompt: RASA1 GAP-independent scaffolding mechanism</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RASA1-hypotheses/kgap-rasa1-gap-independent-scaffold/prompt.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P20936" data-a="DEEP_RESEARCH: OpenScientist prompt: RASA1 GAP-independent scaffolding mechanism" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+
+                <h1 id="openscientist-prompt-rasa1-gap-independent-scaffolding-mechanism">OpenScientist prompt: RASA1 GAP-independent scaffolding mechanism</h1>
+<p>Investigate the evidence for RASA1/p120RasGAP functions that are independent of its catalytic Ras-GAP activity, especially p190RhoGAP recruitment, directed cell movement, and vascular development.</p>
+<p>Focus on:</p>
+<ul>
+<li>direct separation-of-function evidence comparing GAP-dead RASA1 mutants with SH2/SH3/PH/C2 scaffold or partner-binding mutants;</li>
+<li>whether p190RhoGAP recruitment is direct, phosphotyrosine-dependent, and sufficient to explain migration/vascular phenotypes;</li>
+<li>how Ras-dependent and Ras-independent RASA1 roles are coordinated or separated in development and disease;</li>
+<li>whether GO-style curation can express a specific non-catalytic molecular function, should retain it as non-core binding/scaffold evidence, or should record it as a residual mechanism gap.</li>
+</ul>
+<p>Please include PMIDs and DOIs, flag uncached or uncertain citations, and keep catalytic Ras-GAP evidence separate from GAP-independent scaffold evidence.</p>
+            </div>
+        </details>
+
     </div>
 
 


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3014 |
| Gene review HTML pages | 3014 |
| Project pages | 1108 |
| Module pages | 91 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
