### PR TITLE
Add AI review for S. pombe ahk1

### DIFF
--- a/genes/SCHPO/ahk1/ahk1-ai-review.yaml
+++ b/genes/SCHPO/ahk1/ahk1-ai-review.yaml
@@ -15,8 +15,8 @@ description: >-
   sub-branch of the Hog1 osmostress-activated MAPK pathway that binds the Hkr1 cytoplasmic domain
   together with Sho1, Ste11 and Pbs2 and prevents aberrant cross-talk signalling to the Kss1 MAPK.
   On the basis of that orthology (shared UPF0592 domain family), the fission-yeast protein is
-  annotated as a putative MAP-kinase-cascade scaffold; PomBase classifies its biological role as
-  inferred. The gene is non-essential (ahk1 deletion is viable), and in genome-wide phenotypic
+  proposed to be a putative MAP-kinase-cascade scaffold, though this role has not been tested in
+  fission yeast. The gene is non-essential (ahk1 deletion is viable), and in genome-wide phenotypic
   screens its deletion is associated with altered stress responses (sensitivity or resistance to
   osmotic, cell-wall, and genotoxic agents) and abnormalities in mating and shmoo morphology, a
   fingerprint broadly compatible with a role in stress-responsive signalling. No direct molecular

--- a/genes/SCHPO/ahk1/ahk1-ai-review.yaml
+++ b/genes/SCHPO/ahk1/ahk1-ai-review.yaml
@@ -1,0 +1,350 @@
+id: O14260
+gene_symbol: ahk1
+product_type: PROTEIN
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: >-
+  ahk1 (SPAC7D4.03c; UniProt O14260) is a large (886-residue) fungal-specific protein of the
+  UPF0592 family, defined by a single DUF1765 domain (Pfam PF08578; InterPro IPR013887; PANTHER
+  PTHR37988). It is predicted to be a multi-pass membrane protein (three predicted transmembrane
+  helices) and contains a disordered, low-complexity region near its N-terminus, but it carries
+  no recognizable catalytic motif, consistent with a non-catalytic role. The DUF1765 domain has
+  no experimentally assigned biochemical function. Its budding-yeast homolog, Saccharomyces
+  cerevisiae Ahk1 (YDL073W), is an experimentally validated scaffold protein of the HKR1
+  sub-branch of the Hog1 osmostress-activated MAPK pathway that binds the Hkr1 cytoplasmic domain
+  together with Sho1, Ste11 and Pbs2 and prevents aberrant cross-talk signalling to the Kss1 MAPK.
+  On the basis of that orthology (shared UPF0592 domain family), the fission-yeast protein is
+  annotated as a putative MAP-kinase-cascade scaffold; PomBase classifies its biological role as
+  inferred. The gene is non-essential (ahk1 deletion is viable), and in genome-wide phenotypic
+  screens its deletion is associated with altered stress responses (sensitivity or resistance to
+  osmotic, cell-wall, and genotoxic agents) and abnormalities in mating and shmoo morphology, a
+  fingerprint broadly compatible with a role in stress-responsive signalling. No direct molecular
+  function, binding partner, localization, or specific pathway role has been demonstrated for the
+  fission-yeast protein itself.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: >-
+        Standard GO reference documenting the ND (No biological Data) evidence code; supports the
+        root cellular_component placeholder annotation.
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: >-
+        The GO reference describing curator-judged ISO transfer to orthologs; it is the basis for
+        the MAP-kinase scaffold activity (GO:0005078) annotation transferred from S. cerevisiae
+        AHK1 (SGD:S000002231). Correctly applied as a mechanism, but the transferred function
+        remains unverified in S. pombe.
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: >-
+        Standard UniProt SubCell-to-GO mapping reference; supports the low-resolution, prediction
+        based membrane (GO:0016020) annotation.
+  - id: PMID:26787842
+    title: Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2,
+      Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated
+      Protein Kinase.
+    findings:
+      - statement: >-
+          S. cerevisiae Ahk1 is a scaffold protein of the HKR1 sub-branch of the Hog1 osmostress
+          MAPK pathway that binds the cytoplasmic domain of the Hkr1 osmosensor and also binds
+          Sho1, Ste11 and Pbs2, preventing incorrect signal flow from Hkr1 to the Kss1 MAPK.
+        supporting_text: >-
+          Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal
+          flow from Hkr1 to Kss1.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: >-
+        PubMed-verified; the defining paper for the scaffold function, but it characterizes the
+        Saccharomyces cerevisiae protein (Ahk1/YDL073W = SGD:S000002231), not the S. pombe protein.
+        Cache is abstract-only (full_text_available: false). It is the experimental source for the
+        ISO annotations transferred to S. pombe ahk1, so it is highly relevant as the orthology
+        anchor, while the fission-yeast function itself remains inferred.
+existing_annotations:
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: >-
+        Low-resolution, prediction-based localization. UniProt predicts three transmembrane
+        helices and annotates the protein as a multi-pass membrane protein by ECO:0000305
+        inference. This is consistent with the sequence but is not experimentally demonstrated in
+        S. pombe, and the term is the generic root-level "membrane". Retain as non-core.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Supported by UniProt transmembrane-helix predictions but unverified experimentally and
+        uninformative as to which membrane; a plausible prediction-based localization rather than
+        a demonstrated core function.
+      supported_by:
+        - reference_id: GO_REF:0000044
+          supporting_text: >-
+            Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: >-
+        Root-level "cellular_component" with the ND (No biological Data) evidence code, a standard
+        PomBase placeholder recording that no specific cellular component is known. It carries no
+        biological content and should be retained only as a placeholder.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Root placeholder term with ND evidence; represents absence of specific localization
+        knowledge rather than a substantive annotation.
+  - term:
+      id: GO:0000165
+      label: MAPK cascade
+    evidence_type: ISO
+    original_reference_id: PMID:26787842
+    qualifier: involved_in
+    review:
+      summary: >-
+        Process annotation transferred by orthology (ISO, with-from SGD:S000002231) from
+        S. cerevisiae AHK1, which is an experimentally validated scaffold in the Hog1 osmostress
+        MAPK pathway. The orthology rests on the shared UPF0592/DUF1765 domain family
+        (InterPro:IPR013887). The assignment is a plausible, curator-made transfer, but the
+        involvement of the S. pombe protein in a MAPK cascade has not been demonstrated directly;
+        the fission-yeast stress core (Wis1 to Sty1/Spc1) does not reproduce the budding-yeast
+        Hkr1/Kss1 cross-talk architecture. Retain as a reasonable orthology-based hypothesis, but
+        mark non-core and flag as a knowledge gap.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Orthology-based (ISO) transfer from a verified S. cerevisiae scaffold; biologically
+        plausible and consistent with the deletion stress/mating phenotype fingerprint, but
+        unproven in S. pombe. Per PomBase reliability, retained rather than removed; treated as
+        non-core because it is inferred, not demonstrated for this gene.
+      supported_by:
+        - reference_id: PMID:26787842
+          supporting_text: >-
+            Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal
+            flow from Hkr1 to Kss1.
+  - term:
+      id: GO:0005078
+      label: MAP kinase scaffold activity
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: enables
+    review:
+      summary: >-
+        The single molecular-function annotation, transferred by orthology (ISO, GO_REF:0000024,
+        with-from SGD:S000002231) from S. cerevisiae AHK1. It is more informative than "protein
+        binding" and captures the best available functional hypothesis: that ahk1 acts as a
+        physical scaffold assembling components of a MAPK signalling module. However, the scaffold
+        activity has never been tested for the S. pombe protein and no fission-yeast binding
+        partners are known. Retain as a plausible orthology-based hypothesis; mark non-core and
+        flag as a molecular-function knowledge gap.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Orthology-based (ISO) transfer of an experimentally established S. cerevisiae molecular
+        function; retained per PomBase reliability and because it is the most informative available
+        MF term (preferable to protein binding), but it is inferred rather than demonstrated for
+        S. pombe and so is treated as non-core with an explicit knowledge gap.
+      supported_by:
+        - reference_id: PMID:26787842
+          supporting_text: >-
+            we identified a protein, termed Ahk1 (Associated with Hkr1), that binds to Hkr1-cyto.
+core_functions:
+  - description: >-
+      Putative non-catalytic scaffold/adaptor of a mitogen-activated protein kinase (MAPK)
+      signalling module. This is inferred for ahk1 from its membership of the UPF0592/DUF1765
+      family (InterPro:IPR013887) shared with the experimentally validated S. cerevisiae scaffold
+      Ahk1 (YDL073W), which assembles Hkr1, Sho1, Ste11 and Pbs2 in the Hog1 osmostress MAPK
+      pathway. The absence of any catalytic motif in ahk1 is consistent with a scaffolding rather
+      than an enzymatic role. Direct demonstration of scaffold activity, of binding partners, and
+      of MAPK-pathway participation in S. pombe is lacking; this core function is therefore a
+      well-motivated hypothesis, not an established fission-yeast activity.
+    molecular_function:
+      id: GO:0005078
+      label: MAP kinase scaffold activity
+    directly_involved_in:
+      - id: GO:0000165
+        label: MAPK cascade
+    supported_by:
+      - reference_id: PMID:26787842
+        supporting_text: >-
+          Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal
+          flow from Hkr1 to Kss1.
+      - reference_id: GO_REF:0000024
+        supporting_text: >-
+          Manual transfer of experimentally-verified manual GO annotation data to orthologs
+knowledge_gaps:
+  - gap_statement: >-
+      Whether S. pombe ahk1 (SPAC7D4.03c) actually functions as a MAP-kinase scaffold, or has any
+      scaffold activity at all, has never been tested. The molecular function is inferred entirely
+      from the S. cerevisiae ortholog via the shared UPF0592/DUF1765 domain family; no in vivo or
+      in vitro assay of scaffold activity, and no identification of assembled kinase-module
+      components, has been reported for the fission-yeast protein.
+    boundary: >-
+      Scaffold activity in the Hog1 osmostress MAPK pathway is experimentally established for
+      S. cerevisiae Ahk1 (YDL073W = SGD:S000002231), which binds Hkr1-cyto, Sho1, Ste11 and Pbs2;
+      the S. pombe protein shares the defining UPF0592/DUF1765 domain (InterPro:IPR013887) and
+      lacks any catalytic motif, so a scaffolding role is plausible but unproven.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Determines whether the propagated MAP-kinase scaffold activity (GO:0005078) annotation is
+      valid for fission yeast, or whether ahk1 has a distinct (or no) signalling function despite
+      family membership.
+    resolution: >-
+      Affinity purification / mass spectrometry of tagged ahk1 in S. pombe to identify direct
+      interactors, combined with epistasis and phospho-readout assays testing whether ahk1
+      contributes to Sty1/Spc1 (or other MAPK) activation under stress.
+    provenance:
+      - reference_id: PMID:26787842
+        supporting_text: >-
+          In the budding yeast Saccharomyces cerevisiae, osmostress activates the Hog1
+          mitogen-activated protein kinase (MAPK), which regulates diverse osmoadaptive
+      - reference_id: GO_REF:0000024
+        supporting_text: >-
+          Manual transfer of experimentally-verified manual GO annotation data to orthologs
+  - gap_statement: >-
+      The direct binding partners of ahk1 in S. pombe are unknown. It is undetermined whether it
+      interacts with the fission-yeast stress-MAPK components (Sty1/Spc1, the MAPKK Wis1, the
+      MAPKKKs Win1/Wis4, or membrane osmosensors such as Wsc1/Mtl2 and the Sho1-like adaptor),
+      or with any other proteins.
+    boundary: >-
+      In S. cerevisiae the orthologous Ahk1 binds a defined set of HKR1-subbranch proteins
+      (Hkr1-cyto, Sho1, Ste11, Pbs2); the fission-yeast interactome of ahk1 has not been mapped
+      beyond generic high-throughput interaction datasets.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Identifying partners would confirm or refute pathway membership and reveal whether ahk1
+      couples a membrane sensor to a specific MAPK module in fission yeast.
+    resolution: >-
+      Co-immunoprecipitation / proximity-labelling of endogenously tagged ahk1 followed by mass
+      spectrometry, with validation of candidate interactions by reciprocal pulldown and
+      genetic interaction analysis.
+    provenance:
+      - reference_id: PMID:26787842
+        supporting_text: >-
+          In addition to Hkr1-cyto binding, Ahk1 also bound to other signaling molecules in the
+          HKR1 subbranch, including Sho1, Ste11, and Pbs2.
+  - gap_statement: >-
+      Whether ahk1 has a specific, non-redundant role in the S. pombe Sty1/Spc1 stress-activated
+      MAPK pathway is undetermined. The budding-yeast function (preventing Hkr1-to-Kss1 cross-talk)
+      may not map onto fission yeast, whose stress core (Wis1 to Sty1) lacks the multi-branch
+      Hkr1/Kss1 architecture, so it is unclear which, if any, signalling event ahk1 controls.
+    boundary: >-
+      ahk1 deletion is viable and, in genome-wide screens, alters stress responses (osmotic/salt,
+      cell-wall, and genotoxic agents) and mating/shmoo morphology; these are consistent with a
+      stress-signalling contribution but do not localize ahk1 to a defined step or show it is
+      non-redundant.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Placing ahk1 (or excluding it) within the Sty1/Spc1 pathway would resolve whether the
+      orthology-based MAPK-cascade (GO:0000165) annotation reflects a real fission-yeast pathway
+      role.
+    resolution: >-
+      Targeted epistasis analysis of ahk1 deletion with sty1, wis1 and osmosensor mutants under
+      defined stresses, measuring Sty1 phosphorylation and downstream (e.g. atf1/gpd1) responses.
+    provenance:
+      - reference_id: PMID:26787842
+        supporting_text: >-
+          Deletion of the AHK1 gene (in the absence of other Hog1 upstream branches) only
+          partially inhibited osmostress-induced Hog1 activation.
+  - gap_statement: >-
+      The molecular activity of the DUF1765 domain that defines the UPF0592 family, and hence the
+      biochemical basis of any ahk1 function, is entirely unknown. DUF1765 is a domain of unknown
+      function with no assigned catalytic or binding activity.
+    boundary: >-
+      ahk1 is a member of the UPF0592 family (Pfam PF08578 DUF1765; PANTHER PTHR37988) and lacks
+      any recognizable enzymatic motif, but no structure-function study has assigned an activity
+      to this domain in any organism.
+    gap_kind:
+      - BIOLOGY
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      Assigning a biochemical activity to DUF1765 would provide a mechanistic basis for the
+      family, potentially replacing the generic scaffold-by-orthology inference with a defined GO
+      molecular-function term.
+    resolution: >-
+      Structural characterization (e.g. AlphaFold-guided experimental structure) and biochemical
+      assays of the DUF1765 domain; if a novel activity is found, a corresponding GO molecular
+      function term may be required.
+    provenance:
+      - reference_id: UniProt:O14260
+        supporting_text: >-
+          Belongs to the UPF0592 family.
+  - gap_statement: >-
+      The subcellular localization of ahk1 in S. pombe has not been experimentally determined. The
+      membrane / multi-pass membrane assignment is a sequence-based prediction (three predicted
+      transmembrane helices) with no microscopy or fractionation evidence in fission yeast.
+    boundary: >-
+      UniProt predicts three transmembrane helices (residues 277-297, 374-394, 400-420) and
+      annotates the protein as a multi-pass membrane protein by ECO:0000305 inference, but this
+      has not been confirmed for the endogenous fission-yeast protein.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: >-
+      Localization would test the membrane prediction and indicate whether ahk1 acts at a specific
+      membrane compartment (as a membrane-tethered scaffold) or elsewhere.
+    resolution: >-
+      Live-cell imaging of endogenously tagged ahk1 and membrane-fractionation/topology assays in
+      S. pombe.
+    provenance:
+      - reference_id: UniProt:O14260
+        supporting_text: >-
+          Multi-pass membrane
+suggested_questions:
+  - question: >-
+      Does S. pombe ahk1 physically associate with any component of the Sty1/Spc1 stress-activated
+      MAPK pathway (Sty1, Wis1, Win1/Wis4) or with membrane osmosensors, and does its deletion
+      alter stress-induced Sty1 activation?
+    experts:
+      - Nishimura A
+      - Tatebayashi K
+  - question: >-
+      What is the biochemical activity of the DUF1765 domain, and is ahk1 a bona fide scaffold or
+      does it have an as-yet-uncharacterized molecular function?
+suggested_experiments:
+  - hypothesis: >-
+      ahk1 acts as a membrane-associated scaffold that contributes to Sty1/Spc1 activation under
+      osmotic or cell-wall stress in S. pombe.
+    description: >-
+      Construct an endogenously tagged ahk1 strain; perform affinity purification-mass
+      spectrometry to identify interactors, live-cell imaging to determine localization, and
+      quantitative immunoblotting of phospho-Sty1 in wild-type vs ahk1-deletion cells across a
+      panel of stresses (osmotic, cell-wall, oxidative, genotoxic).
+    experiment_type: interactome, localization, and signalling epistasis
+  - hypothesis: >-
+      The DUF1765 domain confers a defined, conserved molecular activity that underlies ahk1
+      function.
+    description: >-
+      Determine the structure of the ahk1 DUF1765 domain (experimentally or via AlphaFold-guided
+      modelling) and test candidate activities biochemically; use structure-guided point mutants
+      to link domain features to the deletion stress/mating phenotypes.
+    experiment_type: structural biology and structure-function analysis

--- a/genes/SCHPO/ahk1/ahk1-goa.tsv
+++ b/genes/SCHPO/ahk1/ahk1-goa.tsv
@@ -1,0 +1,5 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	O14260	SPAC7D4.03c	located_in	GO:0016020	membrane	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0162	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	UniProt	UPF0592 membrane protein C7D4.03c	20260616
+UniProtKB	O14260	SPAC7D4.03c	is_active_in	GO:0005575	cellular_component	cellular_component	ECO:0000307	ND	GO_REF:0000015		284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	PomBase	UPF0592 membrane protein C7D4.03c	20260612
+UniProtKB	O14260	SPAC7D4.03c	involved_in	GO:0000165	MAPK cascade	biological_process	ECO:0000266	ISO	PMID:26787842	SGD:S000002231	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	PomBase	UPF0592 membrane protein C7D4.03c	20180427
+UniProtKB	O14260	SPAC7D4.03c	enables	GO:0005078	MAP kinase scaffold activity	molecular_function	ECO:0000266	ISO	GO_REF:0000024	SGD:S000002231	284812	Schizosaccharomyces pombe (strain 972 / ATCC 24843)	PomBase	UPF0592 membrane protein C7D4.03c	20170728

--- a/genes/SCHPO/ahk1/ahk1-notes.md
+++ b/genes/SCHPO/ahk1/ahk1-notes.md
@@ -1,0 +1,132 @@
+# Research notes: *S. pombe* ahk1 (SPAC7D4.03c / UniProt O14260)
+
+## Summary of task
+AI GO-annotation review of the understudied fission-yeast gene **ahk1** (PomBase standard
+name; systematic name **SPAC7D4.03c**; UniProt **O14260**, entry name YFP3_SCHPO). This is a
+"dark gene": PomBase characterisation status is **"biological role inferred"** and all of its
+functional GO annotations are transferred by orthology (ISO), not experimentally determined in
+*S. pombe*.
+
+## Identity / naming (verified)
+- PomBase gene page reports `name: ahk1`, `product: "MAP kinase cascade scaffold protein Ahk1"`,
+  `characterisation_status: "biological role inferred"`, `deletion_viability: viable`,
+  `taxonomic_distribution: fungi only` (PomBase JSON API, gene SPAC7D4.03c, latest dataset).
+- UniProt O14260 (YFP3_SCHPO): `RecName: Full=UPF0592 membrane protein C7D4.03c`; 886 aa;
+  `PE 3: Inferred from homology`. Belongs to the **UPF0592 family** (`-!- SIMILARITY`, ECO:0000305).
+- InterPro/domain content: **Pfam PF08578 = DUF1765**; **PANTHER PTHR37988** ("UPF0592 MEMBRANE
+  PROTEIN C7D4.03C"); InterPro **IPR013887 (UPF0592)**. (from ahk1-uniprot.txt DR lines and
+  PomBase interpro_matches).
+
+## Domain / topology reasoning (from ahk1-uniprot.txt)
+- Predicted **multi-pass membrane protein**: three TRANSMEM helices at 277–297, 374–394, 400–420
+  (all ECO:0000255, i.e. sequence-model predicted, not experimentally confirmed).
+- SUBCELLULAR LOCATION: `Membrane; Multi-pass membrane protein` (ECO:0000305, inferred).
+- A predicted disordered / low-complexity region at ~87–112 (MobiDB-lite).
+- The single defining domain is DUF1765 (domain of unknown function); no catalytic motif, no
+  recognizable kinase/phosphatase/enzymatic signature. Consistent with a non-catalytic
+  scaffold/adaptor-type role rather than an enzyme.
+
+## The orthology basis for the functional annotations (KEY)
+Both functional GO annotations on S. pombe ahk1 are **ISO** (inferred from sequence orthology),
+with-from **SGD:S000002231**:
+- GO:0005078 "MAP kinase scaffold activity" — ISO, GO_REF:0000024, with SGD:S000002231.
+- GO:0000165 "MAPK cascade" — ISO, PMID:26787842, with SGD:S000002231.
+- PomBase `ortholog_annotations` lists **YDL073W** (*S. cerevisiae* AHK1) as ortholog via
+  **InterPro:IPR013887** (the UPF0592 family), and **SJAG_04503** (*S. japonicus*) via
+  PMID:21511999. PomBase orthogroup `SOG_0639`. (Note the curated `orthologs` list is empty; the
+  cross-species relationship is captured as an InterPro-family-based ortholog_annotation, i.e. it
+  is a domain-family/homology call, not a 1:1 syntenic ortholog assertion.)
+
+*S. cerevisiae* AHK1 (YDL073W, SGD:S000002231) is a **Verified ORF** described by SGD as
+"Scaffold protein in the HKR1 sub-branch of the Hog1p-signaling pathway; physically interacts with
+the cytoplasmic domain of Hkr1p, and with Sho1p, Pbs2p, and Ste11p; prevents cross-talk signaling
+from Hkr1p of the osmotic stress MAPK cascade to the Kss1p MAPK cascade; non-essential"
+(yeastgenome.org locus S000002231).
+
+### The single primary reference (abstract-only in cache)
+[PMID:26787842 "Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2,
+Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated Protein
+Kinase."] is entirely about the **budding-yeast (*S. cerevisiae*)** Ahk1:
+- [PMID:26787842 "Here, using a mass spectrometric method, we identified a protein, termed Ahk1
+  (Associated with Hkr1), that binds to Hkr1-cyto."]
+- [PMID:26787842 "In addition to Hkr1-cyto binding, Ahk1 also bound to other signaling molecules
+  in the HKR1 subbranch, including Sho1, Ste11, and Pbs2."]
+- [PMID:26787842 "Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect
+  signal flow from Hkr1 to Kss1."]
+- [PMID:26787842 "In the budding yeast Saccharomyces cerevisiae, osmostress activates the Hog1
+  mitogen-activated protein kinase (MAPK), which regulates diverse osmoadaptive responses."]
+
+This paper does NOT assay the *S. pombe* protein. Cache marks `full_text_available: false`
+(abstract only). The paper is the experimental basis for the *S. cerevisiae* annotation that is
+then transferred to *S. pombe* by ISO.
+
+## What phenotype data exist for *S. pombe* ahk1 (all from genome-wide / high-throughput screens)
+17 single-locus (ahk1Δ) phenotypes are recorded in PomBase, all from systematic screens
+(no gene-focused study). References and phenotype highlights:
+- PMID:20473289 — genome-wide deletion set (Kim et al.). ahk1Δ **viable**.
+- PMID:23697806 — cell-cycle/cell-shape genome-wide resource.
+- PMID:28410370 — systematic screen of sexual-reproduction morphology (identifies mating/shmoo
+  abnormalities): **abnormal shmoo morphology (FYPO:0000357)**, **shmoo formation at cell side
+  (FYPO:0006011)**, **promiscuous mating (FYPO:0006014)**.
+- PMID:34250083 — chronological lifespan barcode screen: **loss of viability in stationary phase
+  (FYPO:0000245)** (ageing-associated).
+- PMID:35820914 — yeast-ageing protease study.
+- PMID:37787768 — broad phenomics/machine-learning functional profiling: stress sensitivities and
+  resistances — sensitive to caffeine (FYPO:0000097), cycloheximide (FYPO:0000104), hydroxyurea
+  (FYPO:0000088), tunicamycin (FYPO:0001457), KCl+SDS (FYPO:0007924); resistant to MMS
+  (FYPO:0000725), vanadate (FYPO:0000830), lithium (FYPO:0001583), LiCl+SDS (FYPO:0009085),
+  MgCl2+SDS (FYPO:0009087).
+
+Interpretation: the deletion phenotype fingerprint (osmotic/salt/cell-wall-stress, caffeine,
+mating/shmoo abnormalities) is broadly **consistent with** a role in stress-responsive signaling,
+which fits the orthology-based MAPK-scaffold assignment. But NONE of these screens establishes a
+molecular mechanism, a direct binding partner, or a specific, non-redundant place in the Sty1/Spc1
+(Hog1-like) SAPK pathway for the *S. pombe* protein.
+
+## KNOWN vs NOT-KNOWN
+KNOWN (or well-supported):
+- Fungal-only protein of the UPF0592/DUF1765 family; large (886 aa); predicted multi-pass membrane
+  protein with a disordered region. (UniProt, InterPro, PANTHER.)
+- Non-essential (ahk1Δ viable). (PMID:20473289.)
+- Deletion perturbs stress responses and sexual-reproduction morphology in genome-wide screens.
+- Its *S. cerevisiae* homolog (AHK1/YDL073W) is an experimentally validated scaffold in the HKR1
+  sub-branch of the Hog1 osmostress MAPK pathway. (PMID:26787842.)
+
+NOT KNOWN (the deliverable knowledge gaps):
+- Whether *S. pombe* ahk1 actually functions as a MAPK scaffold, or is a scaffold at all — this is
+  purely an orthology transfer via the shared UPF0592 domain family (IPR013887), never tested in
+  *S. pombe*.
+- Its direct binding partners in *S. pombe* (does it bind Sty1/Spc1, Wis1, Win1/Wak1, Sho1-like
+  components, or the Wsc1/Mtl2 osmosensors?). Unknown.
+- Whether it has any specific, non-redundant role in the Sty1/Spc1 SAPK pathway (the pombe
+  osmostress core is Wis1→Sty1; there is no exact Hkr1/Kss1 cross-talk architecture in pombe, so
+  the budding-yeast "prevents Hkr1→Kss1 cross-talk" role may not map directly).
+- Its precise molecular activity (DUF1765 has no assigned biochemical function).
+- Its subcellular localization in *S. pombe* (membrane prediction only; not experimentally shown).
+
+## Curation reasoning for the annotation actions
+- GO:0005078 MAP kinase scaffold activity (ISO): the only molecular-function annotation, and it is
+  more informative than "protein binding". It is orthology-based and unproven in pombe, so KEEP but
+  flag as inferred/non-core with an explicit knowledge gap; not REMOVE (it is a reasonable,
+  curator-made ISO transfer from a verified budding-yeast scaffold, and PomBase is reliable).
+- GO:0000165 MAPK cascade (ISO): same reasoning; a plausible, orthology-based process assignment;
+  keep as non-core, flag as inferred.
+- GO:0016020 membrane (IEA, UniProtKB-SubCell): supported by predicted TM helices; accept as a
+  low-resolution, prediction-based localization (non-core).
+- GO:0005575 cellular_component (ND, GO_REF:0000015): root "unknown" placeholder; standard
+  PomBase practice; keep as-is (represents absence of specific CC knowledge).
+
+## Provenance sources used
+- genes/SCHPO/ahk1/ahk1-uniprot.txt (UniProt O14260)
+- genes/SCHPO/ahk1/ahk1-goa.tsv (QuickGO GOA)
+- publications/PMID_26787842.md (abstract-only)
+- PomBase JSON API for SPAC7D4.03c (name/product/status/phenotypes/orthologs/InterPro)
+- OLS (FYPO + GO term labels/definitions)
+- SGD locus S000002231 (S. cerevisiae AHK1 = YDL073W)
+
+## Deep research note
+`scripts/deep_research_wrapper.py SCHPO SPAC7D4.03c falcon --fallback perplexity-lite` was run in
+the foreground twice; it hung (exit 124 / 550s timeout) after emitting only the
+"Using SPAC7D4.03c as gene symbol" line, producing no report. Per project policy, no
+`-deep-research-*.md` file was fabricated; this review is grounded in UniProt + GOA + PomBase +
+the cached publication, all with explicit provenance above.

--- a/genes/SCHPO/ahk1/ahk1-uniprot.txt
+++ b/genes/SCHPO/ahk1/ahk1-uniprot.txt
@@ -1,0 +1,110 @@
+ID   YFP3_SCHPO              Reviewed;         886 AA.
+AC   O14260;
+DT   10-JUN-2008, integrated into UniProtKB/Swiss-Prot.
+DT   01-JAN-1998, sequence version 1.
+DT   10-JUN-2026, entry version 100.
+DE   RecName: Full=UPF0592 membrane protein C7D4.03c;
+GN   ORFNames=SPAC7D4.03c;
+OS   Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+OC   Eukaryota; Fungi; Dikarya; Ascomycota; Taphrinomycotina;
+OC   Schizosaccharomycetes; Schizosaccharomycetales; Schizosaccharomycetaceae;
+OC   Schizosaccharomyces.
+OX   NCBI_TaxID=284812;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RC   STRAIN=972 / ATCC 24843;
+RX   PubMed=11859360; DOI=10.1038/nature724;
+RA   Wood V., Gwilliam R., Rajandream M.A., Lyne M.H., Lyne R., Stewart A.,
+RA   Sgouros J.G., Peat N., Hayles J., Baker S.G., Basham D., Bowman S.,
+RA   Brooks K., Brown D., Brown S., Chillingworth T., Churcher C.M., Collins M.,
+RA   Connor R., Cronin A., Davis P., Feltwell T., Fraser A., Gentles S.,
+RA   Goble A., Hamlin N., Harris D.E., Hidalgo J., Hodgson G., Holroyd S.,
+RA   Hornsby T., Howarth S., Huckle E.J., Hunt S., Jagels K., James K.D.,
+RA   Jones L., Jones M., Leather S., McDonald S., McLean J., Mooney P.,
+RA   Moule S., Mungall K.L., Murphy L.D., Niblett D., Odell C., Oliver K.,
+RA   O'Neil S., Pearson D., Quail M.A., Rabbinowitsch E., Rutherford K.M.,
+RA   Rutter S., Saunders D., Seeger K., Sharp S., Skelton J., Simmonds M.N.,
+RA   Squares R., Squares S., Stevens K., Taylor K., Taylor R.G., Tivey A.,
+RA   Walsh S.V., Warren T., Whitehead S., Woodward J.R., Volckaert G., Aert R.,
+RA   Robben J., Grymonprez B., Weltjens I., Vanstreels E., Rieger M.,
+RA   Schaefer M., Mueller-Auer S., Gabel C., Fuchs M., Duesterhoeft A.,
+RA   Fritzc C., Holzer E., Moestl D., Hilbert H., Borzym K., Langer I., Beck A.,
+RA   Lehrach H., Reinhardt R., Pohl T.M., Eger P., Zimmermann W., Wedler H.,
+RA   Wambutt R., Purnelle B., Goffeau A., Cadieu E., Dreano S., Gloux S.,
+RA   Lelaure V., Mottier S., Galibert F., Aves S.J., Xiang Z., Hunt C.,
+RA   Moore K., Hurst S.M., Lucas M., Rochet M., Gaillardin C., Tallada V.A.,
+RA   Garzon A., Thode G., Daga R.R., Cruzado L., Jimenez J., Sanchez M.,
+RA   del Rey F., Benito J., Dominguez A., Revuelta J.L., Moreno S.,
+RA   Armstrong J., Forsburg S.L., Cerutti L., Lowe T., McCombie W.R.,
+RA   Paulsen I., Potashkin J., Shpakovski G.V., Ussery D., Barrell B.G.,
+RA   Nurse P.;
+RT   "The genome sequence of Schizosaccharomyces pombe.";
+RL   Nature 415:871-880(2002).
+CC   -!- SUBCELLULAR LOCATION: Membrane {ECO:0000305}; Multi-pass membrane
+CC       protein {ECO:0000305}.
+CC   -!- SIMILARITY: Belongs to the UPF0592 family. {ECO:0000305}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; CU329670; CAB16720.1; -; Genomic_DNA.
+DR   PIR; T39081; T39081.
+DR   AlphaFoldDB; O14260; -.
+DR   BioGRID; 278566; 2.
+DR   STRING; 284812.O14260; -.
+DR   iPTMnet; O14260; -.
+DR   PaxDb; 284812-O14260; -.
+DR   KEGG; spo:2542089; -.
+DR   PomBase; SPAC7D4.03c; -.
+DR   VEuPathDB; FungiDB:SPAC7D4.03c; -.
+DR   eggNOG; ENOG502QWKM; Eukaryota.
+DR   HOGENOM; CLU_003877_1_0_1; -.
+DR   InParanoid; O14260; -.
+DR   OMA; FCAKILV; -.
+DR   PhylomeDB; O14260; -.
+DR   PRO; PR:O14260; -.
+DR   Proteomes; UP000002485; Chromosome I.
+DR   GO; GO:0016020; C:membrane; IEA:UniProtKB-SubCell.
+DR   GO; GO:0005078; F:MAP-kinase scaffold activity; ISO:PomBase.
+DR   GO; GO:0000165; P:MAPK cascade; ISO:PomBase.
+DR   InterPro; IPR013887; UPF0592.
+DR   PANTHER; PTHR37988; UPF0592 MEMBRANE PROTEIN C7D4.03C; 1.
+DR   PANTHER; PTHR37988:SF1; UPF0592 MEMBRANE PROTEIN C7D4.03C; 1.
+DR   Pfam; PF08578; DUF1765; 1.
+PE   3: Inferred from homology;
+KW   Membrane; Reference proteome; Transmembrane; Transmembrane helix.
+FT   CHAIN           1..886
+FT                   /note="UPF0592 membrane protein C7D4.03c"
+FT                   /id="PRO_0000339166"
+FT   TRANSMEM        277..297
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255"
+FT   TRANSMEM        374..394
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255"
+FT   TRANSMEM        400..420
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255"
+FT   REGION          87..112
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        95..112
+FT                   /note="Low complexity"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+SQ   SEQUENCE   886 AA;  101026 MW;  64462DD96392ECC6 CRC64;
+     MGDFQSRYEI LAAIMGPPNT ASFKEEEHSG SQTKNYPVVV KCIQEHDPVD TTNVLVADDL
+     DSNFEPFSIT DDYGKYENTL VSHSSTILNE PYNESPSSSS SDSSSRSTSP FSQLSSQSLR
+     LNAEEIAPSS LINKAVQSTL RLSEPLVSPI KCPLSEQFIN FINQQDSDKV VLIRGFLLPH
+     LASLTTKNVS EPELDKLRHS LYNWWVSILR RLQSNISTSE RITYTKAILA IAKHHCWNKV
+     EHSALLYLEH QLILYDTLTF VVHLLSQKSL PYSLTTFCAS ILVLSFFQLP LFADHFLSAL
+     DVKKKYIDAL GSSFDEKIMI ISHKYLAPFF TDQFSSTMHP YYPKRTSTPF TIGYNRQPIE
+     FTRAWMRRFK SSTGGFFFEF LSCYHSFLAL QFSFELPDNV IYFAPGYICL HAYLLELTIS
+     VIHISDKKPL MLPTGHEQFP CKTLPEVNPS MEEYNPKMPV TATTLSTLQQ FVGHIKDAFK
+     KIGDCRQEQM RLLAVLEQVL INVAKNTPAF NLQSCFLLCS LVEQCFGVFN DFSHRFDFSF
+     WISVAKRLIS TSHNMSIVRS ITFIYAVWPY LDIKSKELVT LQWLLEENTF QELFLHWSPL
+     VRAYFQRLVC WRFLKLDDME EFQFKGTVTL RVKNLLKHYF TAQALYHEEC LVNGRASPIT
+     KPSEPVPMRR LTIVCNHYQN YGNSESTEFE LSNYKQDDGT IQALVTDVVS ISNSFSSGLK
+     KAFGSLFKNV SGLPAETEIA YHHTLSASNS YVFTDLVDNP DSMLKSTLKY RFVFKFSPSQ
+     PLSSLGKNKE KYDALLERSS HGVLPVQSKM LLYNSNHISC PLSSIKGVSV NGKRLVYTSR
+     ALVEWALVVN EFDHALSLRK GNETEDMEAP TLTVRIPKSY ASNIYN
+//

--- a/interpro/panther/PTHR37988/PTHR37988-entries.csv
+++ b/interpro/panther/PTHR37988/PTHR37988-entries.csv
@@ -1,0 +1,2 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+O14260,UPF0592 membrane protein C7D4.03c,protein,284812,Schizosaccharomyces pombe (strain 972 / ATCC 24843),Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast),SPAC7D4.03c,886,PTHR37988:SF1,UPF0592 MEMBRANE PROTEIN C7D4.03C,True

--- a/interpro/panther/PTHR37988/PTHR37988-metadata.yaml
+++ b/interpro/panther/PTHR37988/PTHR37988-metadata.yaml
@@ -1,0 +1,43 @@
+metadata:
+  accession: PTHR37988
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: null
+  hierarchy: null
+  name:
+    name: UPF0592 MEMBRANE PROTEIN C7D4.03C
+    short: null
+  description: null
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 1
+    domain_architectures: 0
+    interactions: 0
+    matches: 1174
+    pathways: 0
+    proteins: 1174
+    proteomes: 1127
+    sets: 0
+    structural_models:
+      alphafold: 760
+    structures: 0
+    taxa: 2282
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: false
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure: null
+_fetch_info:
+  fetched_date: '2026-07-06T17:49:43.904178'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR37988/
+  database: panther
+  family_id: PTHR37988

--- a/publications/PMID_26787842.md
+++ b/publications/PMID_26787842.md
@@ -1,0 +1,77 @@
+---
+pmid: '26787842'
+title: Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2, Inhibits
+  Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated Protein
+  Kinase.
+authors:
+- Nishimura A
+- Yamamoto K
+- Oyama M
+- Kozuka-Hata H
+- Saito H
+- Tatebayashi K
+journal: Mol Cell Biol
+year: '2016'
+full_text_available: false
+pmcid: PMC4800789
+doi: 10.1128/MCB.01017-15
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2, Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated Protein Kinase.
+**Authors:** Nishimura A, Yamamoto K, Oyama M, Kozuka-Hata H, Saito H, Tatebayashi K
+**Journal:** Mol Cell Biol (2016)
+**DOI:** [10.1128/MCB.01017-15](https://doi.org/10.1128/MCB.01017-15)
+**PMC:** [PMC4800789](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4800789/)
+
+## Abstract
+
+1. Mol Cell Biol. 2016 Jan 19;36(7):1109-23. doi: 10.1128/MCB.01017-15.
+
+Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2, 
+Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 
+Mitogen-Activated Protein Kinase.
+
+Nishimura A(1), Yamamoto K(2), Oyama M(3), Kozuka-Hata H(3), Saito H(4), 
+Tatebayashi K(4).
+
+Author information:
+(1)Division of Molecular Cell Signaling, Institute of Medical Science, 
+University of Tokyo, Tokyo, Japan Department of Biological Sciences, Graduate 
+School of Science, University of Tokyo, Tokyo, Japan.
+(2)Division of Molecular Cell Signaling, Institute of Medical Science, 
+University of Tokyo, Tokyo, Japan.
+(3)Medical Proteomics Laboratory, Institute of Medical Science, University of 
+Tokyo, Tokyo, Japan.
+(4)Division of Molecular Cell Signaling, Institute of Medical Science, 
+University of Tokyo, Tokyo, Japan Department of Biological Sciences, Graduate 
+School of Science, University of Tokyo, Tokyo, Japan h-saito@ims.u-tokyo.ac.jp 
+tategone@ims.u-tokyo.ac.jp.
+
+In the budding yeast Saccharomyces cerevisiae, osmostress activates the Hog1 
+mitogen-activated protein kinase (MAPK), which regulates diverse osmoadaptive 
+responses. Hkr1 is a large, highly glycosylated, single-path transmembrane 
+protein that is a putative osmosensor in one of the Hog1 upstream pathways 
+termed the HKR1 subbranch. The extracellular region of Hkr1 contains both a 
+positive and a negative regulatory domain. However, the function of the 
+cytoplasmic domain of Hkr1 (Hkr1-cyto) is unknown. Here, using a mass 
+spectrometric method, we identified a protein, termed Ahk1 (Associated with 
+Hkr1), that binds to Hkr1-cyto. Deletion of the AHK1 gene (in the absence of 
+other Hog1 upstream branches) only partially inhibited osmostress-induced Hog1 
+activation. In contrast, Hog1 could not be activated by constitutively active 
+mutants of the Hog1 pathway signaling molecules Opy2 or Ste50 in ahk1Δ cells, 
+whereas robust Hog1 activation occurred in AHK1(+) cells. In addition to 
+Hkr1-cyto binding, Ahk1 also bound to other signaling molecules in the HKR1 
+subbranch, including Sho1, Ste11, and Pbs2. Although osmotic stimulation of Hkr1 
+does not activate the Kss1 MAPK, deletion of AHK1 allowed Hkr1 to activate Kss1 
+by cross talk. Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and 
+prevents incorrect signal flow from Hkr1 to Kss1.
+
+Copyright © 2016, American Society for Microbiology. All Rights Reserved.
+
+DOI: 10.1128/MCB.01017-15
+PMCID: PMC4800789
+PMID: 26787842 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

AI GO-annotation review of the **understudied** fission-yeast gene **ahk1** (systematic name **SPAC7D4.03c**; UniProt **O14260**; PomBase characterisation status "biological role inferred").

**Identity / domains.** A large (886 aa) fungal-specific protein of the **UPF0592 family**, defined by a single **DUF1765** domain (Pfam PF08578; InterPro IPR013887; PANTHER PTHR37988), predicted to be a multi-pass membrane protein (3 TM helices) with an N-terminal disordered region and no catalytic motif. Its budding-yeast homolog *S. cerevisiae* Ahk1 (YDL073W = SGD:S000002231) is an experimentally validated scaffold of the HKR1 sub-branch of the Hog1 osmostress MAPK pathway (PMID:26787842). The fission-yeast protein's MAP-kinase-scaffold annotations are transferred by **orthology (ISO)** from that gene; the scaffold role has **never been demonstrated in *S. pombe***.

## Annotation review (4 GOA annotations)

| Term | Evidence | Action |
|------|----------|--------|
| GO:0005078 MAP kinase scaffold activity | ISO (from SGD:S000002231) | KEEP_AS_NON_CORE |
| GO:0000165 MAPK cascade | ISO (from SGD:S000002231) | KEEP_AS_NON_CORE |
| GO:0016020 membrane | IEA (SubCell) | KEEP_AS_NON_CORE |
| GO:0005575 cellular_component | ND (root placeholder) | KEEP_AS_NON_CORE |

The two functional ISO annotations are retained (per PomBase reliability — a curator-made transfer from a verified budding-yeast scaffold) but marked **non-core** and flagged as knowledge gaps, since they are inferred rather than demonstrated for the fission-yeast protein. No experimental annotation was removed.

## Knowledge gaps (primary deliverable)

ahk1's specific molecular function is unproven in fission yeast: the MAP-kinase-scaffold assignment is derived **only** from the UPF0592/DUF1765 orthology to *S. cerevisiae* AHK1 and has never been tested. Its **direct binding partners are unknown** (no demonstrated interaction with Sty1/Spc1, Wis1, Win1/Wis4, or osmosensors), and its **non-redundant role (if any) in the Sty1/Spc1 SAPK pathway is undetermined** — the budding-yeast Hkr1→Kss1 cross-talk architecture it guards does not exist in fission yeast. Additional gaps: the DUF1765 domain has no assigned biochemical activity, and the membrane localization is prediction-only.

## Provenance / process

Deep research (falcon → perplexity-lite fallback) was run in the foreground and **hung** (no report); per project policy no `-deep-research-*.md` was fabricated. The review is grounded in UniProt + GOA + PomBase + the single cached (abstract-only) publication, with inline provenance in `ahk1-notes.md`. Validation clean: `validate`, `validate-references`, `validate-terms` all pass; every `supporting_text` verified as a verbatim substring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)