### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/SCHPO/acn1/acn1-ai-review.html
+++ b/genes/SCHPO/acn1/acn1-ai-review.html
@@ -1,0 +1,2662 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>acn1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>acn1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O74380" target="_blank" class="term-link">
+                        O74380
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "acn1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O74380" data-a="DESCRIPTION: acn1 (systematic name SPBC3H7.05c) is an uncharact..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>acn1 (systematic name SPBC3H7.05c) is an uncharacterized, non-essential polytopic integral membrane protein of the fission yeast Schizosaccharomyces pombe. Its sequence carries a single Wax_synthase_dom / MBOAT_2 domain (InterPro IPR032805, Pfam PF13813), placing it in the wax-synthase branch of the membrane-bound O-acyltransferase (MBOAT) superfamily; the protein is predicted to span the membrane with nine transmembrane helices. Characterized MBOAT enzymes are acyl-CoA-dependent acyltransferases that transfer acyl chains onto lipid, sterol, fatty-alcohol, or protein acceptors, and by homology acn1 is inferred to be an acyltransferase, most plausibly acting in neutral-lipid (e.g. wax-ester or diacylglycerol) metabolism. However, no direct biochemical, genetic, or cell-biological study of acn1 has been published: its catalytic activity, physiological substrate, and biological role are all unknown. A genome-scale GFP screen assigned it a mitochondrial membrane localization, which is atypical for an MBOAT enzyme (most localize to the endoplasmic reticulum). It has no apparent Saccharomyces cerevisiae ortholog but is conserved across fungi and more broadly in eukaryotes.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74380" data-a="GO:0031966" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation mapped from the UniProt Subcellular Location statement &#34;Mitochondrion membrane {ECO:0000305}; Multi-pass membrane protein {ECO:0000305}&#34; (SL-0171). The underlying primary evidence is a genome-wide GFP localization screen (PMID:16823372), and PomBase independently records a mitochondrion localization (HDA). This is a reasonable location call for a multi-pass membrane protein and is the only localization datum available, so it is retained; it is marked non-core because a single genome-scale screen is moderate-confidence and a mitochondrial localization is atypical for an MBOAT-family acyltransferase (family members are usually ER-resident), leaving the true compartment and topology unresolved.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported location call, but derived from a single high-throughput screen (via UniProt ECO:0000305 inference) and biologically atypical for the family; keep as a location without treating it as a core, mechanism-defining assertion.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74380
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74380" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level &#34;no data&#34; placeholder (ND, GO_REF:0000015) recording that no specific cellular-component annotation has been curated. This is a bookkeeping annotation, not a biological statement; it is superseded in practice by the mitochondrial membrane location above. No action needed beyond noting it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND root placeholder; correctly indicates absence of curated CC data and should be left as-is per GO_REF:0000015 conventions.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74380" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level &#34;no data&#34; placeholder (ND, GO_REF:0000015) recording that no biological process has been curated for acn1. This is accurate: the biological process in which acn1 acts is genuinely unknown (see knowledge_gaps). It is a bookkeeping annotation and should remain until an experimentally supported process is established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND root placeholder that correctly reflects the absence of any curated, evidence-supported biological process for this dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016747" target="_blank" class="term-link">
+                                    GO:0016747
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity, transferring groups other than amino-acyl groups</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74380" data-a="GO:0016747" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS) annotation transferred by a PomBase curator from the paralog gup1 (SPAC24H6.01c; WITH/FROM PomBase:SPAC24H6.01c), an MBOAT annotated to the same term. acn1 carries the Wax_synthase_dom / MBOAT_2 domain (IPR032805 / PF13813) and the MBOAT superfamily is defined by acyl-CoA-dependent acyltransferase activity, so a general acyltransferase MF is domain-appropriate and is retained. It is kept as non-core because (i) the transfer is from a different MBOAT subfamily (gup1 uses Pfam PF03062, MBOAT_fam, and acts in GPI-anchor biosynthesis, whereas acn1 uses the wax-synthase-domain PF13813), so it supports family-level activity but NOT gup1&#39;s specific substrate/process; and (ii) no assay has demonstrated that acn1 is catalytically active or identified its acyl donor/acceptor. This is the most specific defensible molecular-function term; anything narrower (wax-ester synthase, DGAT, GPI-anchor acyltransferase) would be over-annotation. Note the current term is GO:0016747 because the older O-acyltransferase term (GO:0008374) used in the UniProt DR line is now obsolete.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain/family-appropriate general acyltransferase activity supported by ISS from an MBOAT paralog, but unproven for acn1 and transferred from a different MBOAT subfamily; retain as a reasonable family-level MF without treating it as an established, substrate-defined core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74380
+
+                                </span>
+
+                                <div class="support-text">Pfam; PF13813; MBOAT_2; 1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74380
+
+                                </span>
+
+                                <div class="support-text">InterPro; IPR032805; Wax_synthase_dom.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Predicted acyl-CoA-dependent membrane-bound acyltransferase (MBOAT superfamily, wax-synthase branch). By homology to characterized MBOAT enzymes, acn1 is inferred to transfer an acyl group onto a lipid, sterol, or fatty-alcohol acceptor, most plausibly in neutral-lipid (wax-ester or diacylglycerol) metabolism. This is a family/domain-level inference only: the catalytic activity has not been demonstrated for acn1, and its physiological acyl donor and acceptor substrates are unknown. Included at the most general defensible level (GO:0016747) with the specific reaction deliberately left open; see knowledge_gaps.</h3>
+                <span class="vote-buttons" data-g="O74380" data-a="FUNCTION: Predicted acyl-CoA-dependent membrane-bound acyltr..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016747" target="_blank" class="term-link">
+                            acyltransferase activity, transferring groups other than amino-acyl groups
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                mitochondrial membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:O74380
+
+                        </span>
+
+                        <div class="finding-text">Pfam; PF13813; MBOAT_2; 1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:O74380
+
+                        </span>
+
+                        <div class="finding-text">SUBCELLULAR LOCATION: Mitochondrion membrane</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:O74380
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry O74380 (YNV5_SCHPO), Uncharacterized membrane protein C3H7.05c</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                            PMID:16823372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37787768" target="_blank" class="term-link">
+                            PMID:37787768
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Broad functional profiling of fission yeast proteins using phenomics and machine learning.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40424131" target="_blank" class="term-link">
+                            PMID:40424131
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Formation of giant ER sheets by pentadecanoic acid causes lipotoxicity in fission yeast.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:SCHPO/acn1/acn1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report (falcon/Edison): acn1 / SPBC3H7.05c functional annotation</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is acn1 a catalytically active acyltransferase, and what acyl-CoA donor and lipid/fatty-alcohol/sterol acceptor does it use?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74380" data-a="Q: Is acn1 a catalytically active acyltransferase, an..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does acn1 localize to the endoplasmic reticulum (as expected for an MBOAT) or genuinely to the mitochondrial membrane as suggested by the ORFeome GFP screen?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74380" data-a="Q: Does acn1 localize to the endoplasmic reticulum (a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does acn1 contribute to neutral-lipid (wax-ester or triacylglycerol/sterol-ester) metabolism in S. pombe, i.e. does an acn1 deletion or overexpression change the lipid droplet / storage-lipid profile?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74380" data-a="Q: Does acn1 contribute to neutral-lipid (wax-ester o..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express recombinant acn1 (in S. pombe or a heterologous host) and assay acyltransferase activity in vitro against a panel of acyl-CoA donors and candidate acceptors (diacylglycerol, fatty alcohols, sterols, lysophospholipids), reading out product formation by mass spectrometry.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: acn1 is an acyl-CoA-dependent acyltransferase of the wax-synthase/DGAT1-type MBOAT branch acting in neutral-lipid biosynthesis.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro enzyme assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74380" data-a="EXPERIMENT: Express recombinant acn1 (in S. pombe or a heterol..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare untargeted lipidomes of an acn1-deletion strain versus wild type (and versus dga1/plh1 mutants) under standard and lipid-stress conditions to detect changes in triacylglycerol, wax esters, sterol esters, or phospholipid species.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of acn1 alters a specific neutral-lipid or membrane-lipid pool, revealing its in vivo product.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative lipidomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74380" data-a="EXPERIMENT: Compare untargeted lipidomes of an acn1-deletion s..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine acn1 subcellular localization and topology using endogenous fluorescent tagging with co-localization against ER and mitochondrial markers, and protease-protection / topology mapping of the transmembrane helices.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: acn1 resides in the ER membrane (consistent with the MBOAT family) rather than the mitochondrion.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: fluorescence microscopy and membrane topology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74380" data-a="EXPERIMENT: Determine acn1 subcellular localization and topolo..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether acn1 is a catalytically active acyltransferase, and if so what reaction it catalyzes, is undetermined. No enzymatic assay has been performed on the acn1 protein; the acyltransferase molecular-function annotation is inferred entirely from the MBOAT/wax-synthase domain and from ISS transfer from the paralog gup1.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> acn1 unambiguously carries a Wax_synthase_dom / MBOAT_2 domain (InterPro IPR032805, Pfam PF13813) and is predicted to be a nine-transmembrane integral membrane protein, and the MBOAT superfamily is defined by acyl-CoA-dependent acyltransferase activity with a conserved catalytic histidine. The acn1 sequence retains candidate His/Asn residues, so catalytic competence is plausible. What is NOT established is any measured activity or the enzyme&#39;s substrate specificity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determines whether acn1 is a bona fide enzyme (and validates the propagated GO acyltransferase annotation) or a catalytically inactive family member, and defines which branch of lipid/protein acylation it belongs to.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Heterologous expression of acn1 and in vitro acyltransferase assays with candidate acyl-CoA donors and lipid/fatty-alcohol/sterol acceptors, plus lipidomic comparison of an acn1-deletion versus wild-type S. pombe strain.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Uncharacterized membrane protein C3H7.05c"</em> — UniProt:O74380</li>
+
+                <li><em>"Extensive literature searches did not identify any primary research articles that have directly characterized the function, enzymatic activity, or biological role of acn1/SPBC3H7.05c."</em> — file:SCHPO/acn1/acn1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological substrate(s) of acn1 (its acyl donor and acyl acceptor) are unknown. It is undetermined whether acn1 acts on diacylglycerol (DGAT-type), a fatty alcohol (wax-ester synthase-type), a sterol, a lysophospholipid, or a protein/peptide acceptor.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The MBOAT superfamily splits into subgroups by substrate — sterol/diacylglycerol acylation (ACAT/DGAT1), protein/peptide acylation (PORCN, HHAT, GOAT), and lysophospholipid re-acylation (LPCAT, MBOAT7) — and the wax-synthase branch acylates fatty alcohols to make wax esters. In S. pombe, terminal triacylglycerol synthesis is carried out by dga1 (a DGAT2-fold enzyme unrelated to MBOATs) and plh1 (PDAT), so acn1 would be a distinct enzyme class rather than a redundant copy of those. Which subgroup acn1 belongs to has not been tested.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Substrate identity would define acn1&#39;s biochemical reaction and place it in a specific lipid- or protein-acylation pathway, and would let a specific GO molecular-function term replace the current general one.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Substrate-resolved in vitro assays (panel of acyl-CoA donors versus DAG, fatty alcohols, sterols, lysophospholipids) and untargeted lipidomics of acn1-deletion cells.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"All functional predictions described herein are based on domain-based inference"</em> — file:SCHPO/acn1/acn1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process and physiological role of acn1 are unknown. No pathway, developmental role, or cellular process has been established; the only curated biological-process annotation is a root-level &#34;no data&#34; placeholder.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> acn1 deletion is viable with normal cell morphology, and available phenotypes come almost entirely from genome-wide high-throughput screens (broad drug/stress resistance and sensitivity, minor nitrogen/carbon-source growth changes; PMID:37787768) plus low-throughput overexpression phenotypes (septation defects; PMID:23695302). In a lipotoxicity screen, acn1 deletion did not alter growth on pentadecanoic acid (PMID:40424131). These pleiotropic screen hits do not converge on a mechanism. The PomBase gene name (acn1, from a proposed &#34;ACetylation of Nsf&#34; hypothesis) is not backed by any published functional study.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning acn1 to a biological process (e.g. neutral-lipid storage, membrane lipid remodeling, or an unrelated pathway) is required to move it out of the conserved-unknown set and to interpret its many screen phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Targeted loss-of-function and epistasis analysis under lipid-metabolic and stress conditions, combined with the substrate/activity assays above, to connect a defined biochemical activity to a cellular process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Most biomedical research focuses on genes that are already well-studied"</em> — PMID:37787768</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> acn1&#39;s subcellular compartment is unresolved. The family prior (MBOAT enzymes are typically ER-resident) conflicts with the single experimental datum for acn1, a genome-wide GFP screen that reported mitochondrial localization.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt records &#34;Mitochondrion membrane&#34; as a multi-pass membrane protein (ECO:0000305 curator inference from the ORFeome GFP dataset, PMID:16823372) and PomBase records a mitochondrion HDA localization; no ER localization has been reported for acn1 specifically. Characterized MBOAT/DGAT1/ACAT enzymes are ER-membrane proteins, creating a genuine tension between the location prior and the observed screen result.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Resolving whether acn1 is truly mitochondrial (which would be unusual for an MBOAT and biologically informative) or ER-localized (matching the family) constrains its likely substrates and pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous-tagged, high-resolution co-localization microscopy with mitochondrial and ER markers, and/or subcellular fractionation, in S. pombe.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"SUBCELLULAR LOCATION: Mitochondrion membrane"</em> — UniProt:O74380</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(acn1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O74380" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Research Report: acn1 / SPBC3H7.05c in *Schizosaccharomyces pombe*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">26 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T18:20:31.238393</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="acn1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-acn1-spbc3h705c-in-schizosaccharomyces-pombe">Research Report: acn1 / SPBC3H7.05c in <em>Schizosaccharomyces pombe</em></h1>
+<h2 id="gene-identity-verification">Gene Identity Verification</h2>
+<p>The gene symbol <strong>acn1</strong> corresponds to the systematic ORF name <strong>SPBC3H7.05c</strong> in the fission yeast <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843), encoding UniProt accession O74380. UniProt describes this protein as "Uncharacterized membrane protein C3H7.05c." Extensive literature searches did not identify any primary research articles that have directly characterized the function, enzymatic activity, or biological role of acn1/SPBC3H7.05c. No gene symbol ambiguity was identified—there is no well-characterized gene with the symbol "acn1" in another organism that would cause confusion. <strong>The functional annotation presented below is therefore primarily inferred from domain architecture and homology to characterized members of the MBOAT (membrane-bound O-acyltransferase) superfamily.</strong></p>
+<h2 id="summary-of-key-properties">Summary of Key Properties</h2>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene Name</td>
+<td><strong>acn1 / SPBC3H7.05c</strong>; corresponds to the S. pombe ORF encoding an uncharacterized membrane protein in UniProt (holic2020metabolismofphospholipids pages 1-4)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><strong>Schizosaccharomyces pombe</strong> (fission yeast) (holic2020metabolismofphospholipids pages 1-4)</td>
+</tr>
+<tr>
+<td>UniProt Accession</td>
+<td><strong>O74380</strong> (user-supplied target identifier; direct literature characterization not found)</td>
+</tr>
+<tr>
+<td>Protein Domains</td>
+<td><strong>Wax_synthase_dom (IPR032805)</strong> and <strong>MBOAT_2 (PF13813)</strong>, consistent with a membrane-bound O-acyltransferase-type protein; MBOAT proteins are integral membrane acyltransferases with conserved catalytic features (pierce2023arisingtide pages 2-4, chang2011membraneboundoacyltransferases(mboats) pages 1-3, cheng2022heterologousexpressionand pages 1-2)</td>
+</tr>
+<tr>
+<td>Predicted Function</td>
+<td><strong>Acyl-CoA-dependent acyltransferase</strong>, most likely involved in <strong>neutral lipid biosynthesis</strong> or lipid remodeling by analogy to MBOAT-family DGAT1/WS enzymes (pierce2023arisingtide pages 2-4, pierce2023arisingtide pages 1-2, chang2011membraneboundoacyltransferases(mboats) pages 1-3, cheng2022heterologousexpressionand pages 1-2)</td>
+</tr>
+<tr>
+<td>Predicted Reaction</td>
+<td>Likely <strong>transfer of an acyl group from acyl-CoA to a lipid or fatty alcohol acceptor</strong>; plausible activities include <strong>diacylglycerol acyltransferase-like</strong> or <strong>wax synthase-like</strong> reactions based on domain content and homologous enzyme chemistry (cheng2022heterologousexpressionand pages 1-2, turkish2009thegeneticsof pages 3-4, chang2011membraneboundoacyltransferases(mboats) pages 1-3, cheng2022heterologousexpressionand pages 13-15)</td>
+</tr>
+<tr>
+<td>Predicted Localization</td>
+<td>Most likely an <strong>integral membrane protein of the endoplasmic reticulum (ER)</strong>; MBOAT/DGAT1 enzymes commonly localize to ER membranes, and neutral lipid synthesis in S. pombe is ER-linked (chang2011membraneboundoacyltransferases(mboats) pages 3-4, chang2011membraneboundoacyltransferases(mboats) pages 1-3, cheng2022heterologousexpressionand pages 9-11, meyers2017theproteinand pages 9-13)</td>
+</tr>
+<tr>
+<td>Known Pathway Context</td>
+<td>Best placed in <strong>neutral lipid biosynthesis</strong> context in S. pombe, where <strong>dga1</strong> and <strong>plh1</strong> catalyze terminal TAG synthesis and lipid droplets store TAG and sterol esters; acn1 may represent an additional uncharacterized acyltransferase in this broader lipid-metabolic network (zhang2003schizosaccharomycespombecells pages 2-4, holic2020metabolismofphospholipids pages 24-26, meyers2017theproteinand pages 9-13)</td>
+</tr>
+<tr>
+<td>Evidence Type</td>
+<td><strong>Domain-based inference only</strong>; no direct primary literature function, localization, or biochemical characterization was identified for <strong>acn1/SPBC3H7.05c</strong> specifically (holic2020metabolismofphospholipids pages 1-4, holic2020metabolismofphospholipids pages 4-6)</td>
+</tr>
+<tr>
+<td>Protein Family</td>
+<td><strong>MBOAT (membrane-bound O-acyltransferase) superfamily</strong>, whose members catalyze acyl transfer reactions on diverse lipid substrates and typically contain multiple transmembrane segments (pierce2023arisingtide pages 2-4, chang2011membraneboundoacyltransferases(mboats) pages 1-3, pierce2023arisingtide pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, domain architecture, and evidence-based functional inferences for the uncharacterized S. pombe protein acn1/SPBC3H7.05c. It is useful because direct experimental studies are lacking, so the most reliable interpretation comes from domain composition and comparison with characterized MBOAT-family enzymes.</em></p>
+<h2 id="1-domain-architecture-and-predicted-enzymatic-function">1. Domain Architecture and Predicted Enzymatic Function</h2>
+<h3 id="mboat-superfamily-membership">MBOAT Superfamily Membership</h3>
+<p>The acn1 gene product contains two key domains: the <strong>MBOAT_2 domain</strong> (Pfam PF13813) and the <strong>Wax_synthase_dom</strong> (InterPro IPR032805). Both domains place this protein firmly within the <strong>membrane-bound O-acyltransferase (MBOAT) superfamily</strong>, first identified by Hofmann in 2000. The MBOAT superfamily encompasses a diverse group of integral membrane enzymes that share conserved features including multiple transmembrane domains and catalytically essential histidine and asparagine residues in the active site (pierce2023arisingtide pages 2-4, chang2011membraneboundoacyltransferases(mboats) pages 1-3). These enzymes catalyze acylation reactions on diverse substrates—including cholesterol, diacylglycerol, phospholipids, peptides, and proteins—using acyl-CoA thioesters as acyl donors (pierce2023arisingtide pages 1-2).</p>
+<p>The MBOAT family is divided into three functional subgroups based on substrate specificity: (1) enzymes that acylate the hydroxyl groups of cholesterol or diacylglycerol (including ACAT/SOAT and DGAT1); (2) enzymes that acylate amino acid residues in proteins or peptide hormones (including PORCN, HHAT, and GOAT); and (3) enzymes that acylate lysophospholipids to reform phospholipids (including LPCAT, LPIAT/MBOAT7) (chang2011membraneboundoacyltransferases(mboats) pages 1-3, chang2011membraneboundoacyltransferases(mboats) pages 3-4).</p>
+<h3 id="wax-synthase-domain-and-predicted-catalytic-activity">Wax Synthase Domain and Predicted Catalytic Activity</h3>
+<p>The presence of the wax synthase domain (IPR032805) is particularly informative. Wax synthase (WS) enzymes are a class of MBOAT-type proteins that catalyze the formation of <strong>wax esters</strong> through the acylation of <strong>fatty alcohols</strong> with <strong>fatty acyl-CoA</strong> substrates (cheng2022heterologousexpressionand pages 1-2). Characterized plant WS enzymes are relatively small integral membrane proteins of 333–351 amino acid residues with seven or eight predicted transmembrane spanning domains and approximately 50% sequence identity with the well-characterized jojoba WS (cheng2022heterologousexpressionand pages 2-3). These enzymes exhibit broad substrate specificity, capable of assembling not only wax esters but also ethyl and benzyl esters (cheng2022heterologousexpressionand pages 17-19, cheng2022heterologousexpressionand pages 13-15).</p>
+<p>DGAT1, a closely related MBOAT member, catalyzes the transfer of acyl groups from acyl-CoA to diacylglycerol to form triacylglycerols (TAG) and shares 15–25% amino acid sequence identity with ACATs (liu2011functionalandtopological pages 30-36). DGAT1 belongs to the same MBOAT superfamily and contains multiple transmembrane domains with a conserved histidine residue essential for catalytic function (pierce2023arisingtide pages 1-2, chang2011membraneboundoacyltransferases(mboats) pages 1-3). The combination of the MBOAT_2 and Wax_synthase_dom domains in acn1 strongly suggests that this protein functions as an <strong>acyl-CoA-dependent acyltransferase</strong>, most likely catalyzing the transfer of acyl chains from acyl-CoA to lipid or fatty alcohol acceptor substrates. The predicted reaction is most consistent with <strong>wax ester synthase</strong> and/or <strong>diacylglycerol acyltransferase</strong> activity.</p>
+<h2 id="2-biological-context-neutral-lipid-metabolism-in-s-pombe">2. Biological Context: Neutral Lipid Metabolism in <em>S. pombe</em></h2>
+<h3 id="known-acyltransferases-in-s-pombe">Known Acyltransferases in <em>S. pombe</em></h3>
+<p>To contextualize acn1, it is essential to consider the known enzymes of neutral lipid biosynthesis in <em>S. pombe</em>. Zhang et al. (2003) demonstrated that two gene products, <strong>Plh1p</strong> (a phospholipid:diacylglycerol acyltransferase homologous to <em>S. cerevisiae</em> LRO1) and <strong>Dga1p</strong> (an acyl-CoA:diacylglycerol acyltransferase homologous to human DGAT2), are responsible for the terminal step of triacylglycerol (TAG) synthesis in <em>S. pombe</em> (zhang2003schizosaccharomycespombecells pages 2-4). Deletion of <em>plh1</em> alone reduces TAG synthesis by approximately 50%, and double deletion of both <em>plh1</em> and <em>dga1</em> results in near-total loss of TAG synthesis. Additionally, <em>S. pombe</em> contains two proteins homologous to <em>S. cerevisiae</em> Are1p and Are2p that catalyze sterol esterification (zhang2003schizosaccharomycespombecells pages 2-4).</p>
+<p>Notably, <em>dga1</em> is a DGAT2-family member, which is structurally unrelated to DGAT1/MBOAT-type enzymes. The acn1 gene product, with its MBOAT_2 and wax synthase domains, represents a <strong>distinct class of acyltransferase</strong> from the known Dga1p and Plh1p enzymes. It may therefore represent an additional, as-yet-uncharacterized acyltransferase in the <em>S. pombe</em> neutral lipid biosynthetic network—potentially functioning as a DGAT1-type enzyme or wax ester synthase.</p>
+<h3 id="lipid-droplets-and-storage-lipids">Lipid Droplets and Storage Lipids</h3>
+<p>In <em>S. pombe</em>, neutral lipids are stored in lipid droplets composed primarily of sterol esters (SEs) and triacylglycerols (TAGs), with SE:TAG ratios varying from 36:64 to 56:44 depending on growth conditions (meyers2017theproteinand pages 9-13). Key lipid droplet-associated proteins include Erg6p (delta-sterol C-methyltransferase), Erg1p (squalene monooxygenase), and Lcf1p (fatty acid-CoA ligase), along with the TAG lipases Ptl1p, Ptl2p, and Ptl3p (meyers2017theproteinand pages 13-17). The acn1 gene product, if it indeed functions as an acyltransferase in neutral lipid synthesis, would likely contribute to the production of these storage lipids.</p>
+<h3 id="phospholipid-metabolism-context">Phospholipid Metabolism Context</h3>
+<p><em>S. pombe</em> phospholipid metabolism uses pathways similar to those in <em>S. cerevisiae</em>, with three gene products—Ale1 (SPBC16A3.10), Slc1 (SPAC1851.02), and Vps66 (SPAC1783.02c)—predicted to possess acylglycerol acyltransferase activities based on homology (holic2020metabolismofphospholipids pages 13-15). The acn1 protein is distinct from these enzymes in its domain architecture but may participate in related acyl-CoA-dependent lipid modification pathways.</p>
+<h2 id="3-predicted-subcellular-localization">3. Predicted Subcellular Localization</h2>
+<p>No direct experimental evidence exists for the subcellular localization of the acn1 gene product. However, inference from characterized MBOAT family members provides strong predictions. DGAT1 is an ER-resident enzyme (chang2011membraneboundoacyltransferases(mboats) pages 3-4), and ACAT1 functions to protect against excess cholesterol accumulation in ER membranes (chang2011membraneboundoacyltransferases(mboats) pages 1-3). The Arabidopsis wax synthase MBOAT enzymes localize to extra-plastidial membrane systems including the endoplasmic reticulum and plasma membrane (cheng2022heterologousexpressionand pages 9-11, cheng2022heterologousexpressionand pages 2-3). In <em>S. pombe</em>, neutral lipid synthesis occurs at the ER, with lipid droplets budding from ER membranes. Based on these considerations, acn1 is predicted to be an <strong>integral membrane protein of the endoplasmic reticulum (ER)</strong>, consistent with its multiple predicted transmembrane domains and MBOAT family membership.</p>
+<h2 id="4-structural-and-evolutionary-considerations">4. Structural and Evolutionary Considerations</h2>
+<p>The MBOAT superfamily has been extensively characterized at the structural level in recent years. All MBOAT members share a central core fold containing a catalytically essential histidine residue embedded within transmembrane domains, and a conserved asparagine residue in a hydrophilic region (chang2011membraneboundoacyltransferases(mboats) pages 1-3, pierce2023arisingtide pages 7-8). The first experimentally determined MBOAT structure (DltB from bacteria) revealed conserved structural features including ring-shaped or funnel-like transmembrane arrangements and channels connecting the lumen to the cytoplasm, which were subsequently confirmed in other family members (pierce2023arisingtide pages 7-8). These structural features are expected to be conserved in acn1.</p>
+<p>The co-occurrence of the wax synthase domain with the MBOAT_2 domain is characteristic of proteins involved in neutral lipid ester biosynthesis. Prokaryotic WS/DGAT enzymes are structurally unrelated to the eukaryotic MBOAT-type wax synthases (waltermann2007keyenzymesfor pages 1-2), indicating that acn1 represents the eukaryotic MBOAT-type lineage of acyltransferases rather than the bacterial WS/DGAT family.</p>
+<h2 id="5-limitations-and-conclusions">5. Limitations and Conclusions</h2>
+<p><strong>The gene symbol acn1 / SPBC3H7.05c encodes an uncharacterized membrane protein for which no direct functional studies have been published.</strong> The protein has not been the subject of targeted biochemical characterization, localization studies, or mutant phenotype analysis in the primary literature. All functional predictions described herein are based on domain-based inference from the Wax_synthase_dom (IPR032805) and MBOAT_2 (PF13813) domains, and from the well-characterized properties of the broader MBOAT superfamily (pierce2023arisingtide pages 2-4, chang2011membraneboundoacyltransferases(mboats) pages 1-3, pierce2023arisingtide pages 1-2).</p>
+<p>Based on the available evidence, the most parsimonious interpretation is that acn1 encodes an <strong>acyl-CoA-dependent membrane-bound acyltransferase</strong>, likely involved in <strong>neutral lipid biosynthesis</strong> (TAG and/or wax ester synthesis) or <strong>lipid remodeling</strong>. The protein is predicted to function as an integral membrane enzyme of the <strong>endoplasmic reticulum</strong>, catalyzing the transfer of acyl groups from acyl-CoA to lipid or fatty alcohol acceptor substrates. In <em>S. pombe</em>, where TAG synthesis is known to depend on Plh1p and Dga1p (zhang2003schizosaccharomycespombecells pages 2-4), acn1 may represent an additional or accessory acyltransferase with a potentially distinct substrate specificity. Biochemical characterization—including heterologous expression, enzymatic assays with defined substrates, and localization studies—will be necessary to definitively establish the function of this protein.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(holic2020metabolismofphospholipids pages 1-4): Roman Holič, Lucia Pokorná, and Peter Griač. Metabolism of phospholipids in the yeast <i>schizosaccharomyces pombe</i>. Dec 2020. URL: https://doi.org/10.1002/yea.3451, doi:10.1002/yea.3451. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pierce2023arisingtide pages 2-4): Mariah R. Pierce and James L. Hougland. A rising tide lifts all mboats: recent progress in structural and functional understanding of membrane bound o-acyltransferases. Frontiers in Physiology, May 2023. URL: https://doi.org/10.3389/fphys.2023.1167873, doi:10.3389/fphys.2023.1167873. This article has 23 citations.</p>
+</li>
+<li>
+<p>(chang2011membraneboundoacyltransferases(mboats) pages 1-3): Catherine C. Y. Chang, Jie Sun, and Ta-Yuan Chang. Membrane-bound o-acyltransferases (mboats). Frontiers in Biology, 6:177-182, Jun 2011. URL: https://doi.org/10.1007/s11515-011-1149-z, doi:10.1007/s11515-011-1149-z. This article has 82 citations.</p>
+</li>
+<li>
+<p>(cheng2022heterologousexpressionand pages 1-2): Daolin Cheng, Ling Li, Ludmila Rizhsky, Priyanka Bhandary, and Basil J. Nikolau. Heterologous expression and characterization of plant wax ester producing enzymes. Metabolites, 12:577, Jun 2022. URL: https://doi.org/10.3390/metabo12070577, doi:10.3390/metabo12070577. This article has 11 citations.</p>
+</li>
+<li>
+<p>(pierce2023arisingtide pages 1-2): Mariah R. Pierce and James L. Hougland. A rising tide lifts all mboats: recent progress in structural and functional understanding of membrane bound o-acyltransferases. Frontiers in Physiology, May 2023. URL: https://doi.org/10.3389/fphys.2023.1167873, doi:10.3389/fphys.2023.1167873. This article has 23 citations.</p>
+</li>
+<li>
+<p>(turkish2009thegeneticsof pages 3-4): Aaron R. Turkish and Stephen L. Sturley. The genetics of neutral lipid biosynthesis: an evolutionary perspective. American journal of physiology. Endocrinology and metabolism, 297 1:E19-27, Jul 2009. URL: https://doi.org/10.1152/ajpendo.90898.2008, doi:10.1152/ajpendo.90898.2008. This article has 76 citations.</p>
+</li>
+<li>
+<p>(cheng2022heterologousexpressionand pages 13-15): Daolin Cheng, Ling Li, Ludmila Rizhsky, Priyanka Bhandary, and Basil J. Nikolau. Heterologous expression and characterization of plant wax ester producing enzymes. Metabolites, 12:577, Jun 2022. URL: https://doi.org/10.3390/metabo12070577, doi:10.3390/metabo12070577. This article has 11 citations.</p>
+</li>
+<li>
+<p>(chang2011membraneboundoacyltransferases(mboats) pages 3-4): Catherine C. Y. Chang, Jie Sun, and Ta-Yuan Chang. Membrane-bound o-acyltransferases (mboats). Frontiers in Biology, 6:177-182, Jun 2011. URL: https://doi.org/10.1007/s11515-011-1149-z, doi:10.1007/s11515-011-1149-z. This article has 82 citations.</p>
+</li>
+<li>
+<p>(cheng2022heterologousexpressionand pages 9-11): Daolin Cheng, Ling Li, Ludmila Rizhsky, Priyanka Bhandary, and Basil J. Nikolau. Heterologous expression and characterization of plant wax ester producing enzymes. Metabolites, 12:577, Jun 2022. URL: https://doi.org/10.3390/metabo12070577, doi:10.3390/metabo12070577. This article has 11 citations.</p>
+</li>
+<li>
+<p>(meyers2017theproteinand pages 9-13): Alex Meyers, Karuna Chourey, Taylor M. Weiskittel, Susan Pfiffner, John R. Dunlap, Robert L. Hettich, and Paul Dalhaimer. The protein and neutral lipid composition of lipid droplets isolated from the fission yeast, schizosaccharomyces pombe. Journal of Microbiology, 55:112-122, Jan 2017. URL: https://doi.org/10.1007/s12275-017-6205-1, doi:10.1007/s12275-017-6205-1. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2003schizosaccharomycespombecells pages 2-4): Qian Zhang, Hai Kee Chieu, Choon Pei Low, Shaochong Zhang, Chew Kiat Heng, and Hongyuan Yang. Schizosaccharomyces pombe cells deficient in triacylglycerols synthesis undergo apoptosis upon entry into the stationary phase*. Journal of Biological Chemistry, 278:47145-47155, Nov 2003. URL: https://doi.org/10.1074/jbc.m306998200, doi:10.1074/jbc.m306998200. This article has 143 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holic2020metabolismofphospholipids pages 24-26): Roman Holič, Lucia Pokorná, and Peter Griač. Metabolism of phospholipids in the yeast <i>schizosaccharomyces pombe</i>. Dec 2020. URL: https://doi.org/10.1002/yea.3451, doi:10.1002/yea.3451. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holic2020metabolismofphospholipids pages 4-6): Roman Holič, Lucia Pokorná, and Peter Griač. Metabolism of phospholipids in the yeast <i>schizosaccharomyces pombe</i>. Dec 2020. URL: https://doi.org/10.1002/yea.3451, doi:10.1002/yea.3451. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cheng2022heterologousexpressionand pages 2-3): Daolin Cheng, Ling Li, Ludmila Rizhsky, Priyanka Bhandary, and Basil J. Nikolau. Heterologous expression and characterization of plant wax ester producing enzymes. Metabolites, 12:577, Jun 2022. URL: https://doi.org/10.3390/metabo12070577, doi:10.3390/metabo12070577. This article has 11 citations.</p>
+</li>
+<li>
+<p>(cheng2022heterologousexpressionand pages 17-19): Daolin Cheng, Ling Li, Ludmila Rizhsky, Priyanka Bhandary, and Basil J. Nikolau. Heterologous expression and characterization of plant wax ester producing enzymes. Metabolites, 12:577, Jun 2022. URL: https://doi.org/10.3390/metabo12070577, doi:10.3390/metabo12070577. This article has 11 citations.</p>
+</li>
+<li>
+<p>(liu2011functionalandtopological pages 30-36): Functional and Topological Analysis of Acyl-CoA:Diacylglycerol Acyltransferase 2 From Saccharomyces cerevisiae This article has 4 citations.</p>
+</li>
+<li>
+<p>(meyers2017theproteinand pages 13-17): Alex Meyers, Karuna Chourey, Taylor M. Weiskittel, Susan Pfiffner, John R. Dunlap, Robert L. Hettich, and Paul Dalhaimer. The protein and neutral lipid composition of lipid droplets isolated from the fission yeast, schizosaccharomyces pombe. Journal of Microbiology, 55:112-122, Jan 2017. URL: https://doi.org/10.1007/s12275-017-6205-1, doi:10.1007/s12275-017-6205-1. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holic2020metabolismofphospholipids pages 13-15): Roman Holič, Lucia Pokorná, and Peter Griač. Metabolism of phospholipids in the yeast <i>schizosaccharomyces pombe</i>. Dec 2020. URL: https://doi.org/10.1002/yea.3451, doi:10.1002/yea.3451. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pierce2023arisingtide pages 7-8): Mariah R. Pierce and James L. Hougland. A rising tide lifts all mboats: recent progress in structural and functional understanding of membrane bound o-acyltransferases. Frontiers in Physiology, May 2023. URL: https://doi.org/10.3389/fphys.2023.1167873, doi:10.3389/fphys.2023.1167873. This article has 23 citations.</p>
+</li>
+<li>
+<p>(waltermann2007keyenzymesfor pages 1-2): Marc Wältermann, Tim Stöveken, and Alexander Steinbüchel. Key enzymes for biosynthesis of neutral lipid storage compounds in prokaryotes: properties, function and occurrence of wax ester synthases/acyl-coa:diacylglycerol acyltransferases. Biochimie, 89(2):230-242, Feb 2007. URL: https://doi.org/10.1016/j.biochi.2006.07.013, doi:10.1016/j.biochi.2006.07.013. This article has 156 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="acn1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>holic2020metabolismofphospholipids pages 1-4</li>
+<li>pierce2023arisingtide pages 1-2</li>
+<li>cheng2022heterologousexpressionand pages 1-2</li>
+<li>cheng2022heterologousexpressionand pages 2-3</li>
+<li>liu2011functionalandtopological pages 30-36</li>
+<li>zhang2003schizosaccharomycespombecells pages 2-4</li>
+<li>meyers2017theproteinand pages 9-13</li>
+<li>meyers2017theproteinand pages 13-17</li>
+<li>holic2020metabolismofphospholipids pages 13-15</li>
+<li>pierce2023arisingtide pages 7-8</li>
+<li>waltermann2007keyenzymesfor pages 1-2</li>
+<li>pierce2023arisingtide pages 2-4</li>
+<li>turkish2009thegeneticsof pages 3-4</li>
+<li>cheng2022heterologousexpressionand pages 13-15</li>
+<li>cheng2022heterologousexpressionand pages 9-11</li>
+<li>holic2020metabolismofphospholipids pages 24-26</li>
+<li>holic2020metabolismofphospholipids pages 4-6</li>
+<li>cheng2022heterologousexpressionand pages 17-19</li>
+<li>https://doi.org/10.1002/yea.3451,</li>
+<li>https://doi.org/10.3389/fphys.2023.1167873,</li>
+<li>https://doi.org/10.1007/s11515-011-1149-z,</li>
+<li>https://doi.org/10.3390/metabo12070577,</li>
+<li>https://doi.org/10.1152/ajpendo.90898.2008,</li>
+<li>https://doi.org/10.1007/s12275-017-6205-1,</li>
+<li>https://doi.org/10.1074/jbc.m306998200,</li>
+<li>https://doi.org/10.1016/j.biochi.2006.07.013,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(acn1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O74380" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="acn1-spbc3h705c-o74380-curation-notes">acn1 (SPBC3H7.05c / O74380) — curation notes</h1>
+<p>Fission yeast (<em>Schizosaccharomyces pombe</em> 972 / ATCC 24843). UniProt entry name <strong>YNV5_SCHPO</strong>.<br />
+PomBase standard name <strong>acn1</strong>; systematic name <strong>SPBC3H7.05c</strong>; UniProt accession <strong>O74380</strong>.</p>
+<h2 id="summary-bottom-line">Summary / bottom line</h2>
+<p><code>acn1</code> is an <strong>understudied ("conserved unknown") gene</strong> encoding a polytopic<br />
+integral membrane protein of the <strong>membrane-bound O-acyltransferase (MBOAT)<br />
+superfamily</strong>. PomBase characterisation status is <em>conserved unknown</em> and UniProt<br />
+PE level is <em>4: Predicted</em>. There is <strong>no dedicated functional/biochemical study</strong><br />
+of acn1; essentially all annotations are either sequence/domain-based inference or<br />
+high-throughput screen phenotypes. The confident statements one can make are about<br />
+its <strong>domain architecture and localization</strong>; its <strong>specific molecular substrate,<br />
+biological process, and physiological role remain unknown</strong>.</p>
+<h2 id="identity-and-provenance">Identity and provenance</h2>
+<ul>
+<li>PomBase gene page (API <code>www.pombase.org/api/v1/dataset/latest/data/gene/SPBC3H7.05c</code>):</li>
+<li><code>name: acn1</code>, <code>product: "membrane bound O-Acyl transferase (MBOAT) family"</code>,<br />
+<code>characterisation_status: conserved unknown</code>, <code>deletion_viability: viable</code>,<br />
+<code>uniprot_identifier: O74380</code>.</li>
+<li><code>name_descriptions: ["ACetylation of Hy8Z (Nitrogen Signaling Factor (NSF)"]</code> —<br />
+    i.e. the symbol <em>acn1</em> was coined from a proposed "ACetylation of Nsf"<br />
+    hypothesis; this is a name derivation, <strong>not</strong> experimentally established<br />
+    function.</li>
+<li>Taxonomic distribution flags: <code>conserved in eukaryotes</code>, <code>conserved in fungi</code>,<br />
+<code>no apparent S. cerevisiae ortholog</code> (PBO:0000055).</li>
+</ul>
+<h2 id="domain-sequence-analysis-from-uniprot-o74380-record-inline">Domain / sequence analysis (from UniProt O74380 record, inline)</h2>
+<ul>
+<li>357 aa; 9 predicted TM helices (TRANSMEM 13-33, 44-64, 72-92, 148-168, 181-201,<br />
+  203-223, 266-286, 293-313, 327-347) — a <strong>multi-pass integral membrane protein</strong>.</li>
+<li>InterPro <strong>IPR032805 (Wax_synthase_dom)</strong> / Pfam <strong>PF13813 (MBOAT_2)</strong>. This is the<br />
+  wax-synthase branch of the MBOAT superfamily (distinct Pfam clan member from the<br />
+  "core" MBOAT PF03062). Pfam PF13813 = "Membrane bound O-acyl transferase family";<br />
+  associated activity is O-acyltransferase (verified via InterPro API PF13813).</li>
+<li>MBOAT enzymes carry a conserved catalytic His in a hydrophobic stretch and an<br />
+  invariant upstream Asn/His. In acn1 the His residues fall at 65/66, 250, 287, 326;<br />
+  H287 sits in the conserved <strong>"...ALFHDFAY..."</strong> block (the LYHDFAF fingerprint that<br />
+  UniProt's OMA record captured), and H250 in "...WSRDWH...". Presence of these<br />
+  His/Asn residues is <strong>consistent with</strong> a retained catalytic capacity but does not<br />
+  by itself prove activity or identify a substrate. [inline sequence inspection]</li>
+</ul>
+<h2 id="existing-go-annotations-from-acn1-goatsv-4-goa-lines">Existing GO annotations (from acn1-goa.tsv; 4 GOA lines)</h2>
+<ol>
+<li><strong>GO:0031966 mitochondrial membrane</strong> — IEA, GO_REF:0000044 (UniProtKB-SubCell<br />
+   mapping SL-0171). Derived from the UniProt subcellular-location statement<br />
+   "Mitochondrion membrane {ECO:0000305}; Multi-pass membrane protein {ECO:0000305}".<br />
+   ECO:0000305 = curator inference (not direct assay). The primary evidence for a<br />
+   mitochondrial localization is the ORFeome GFP screen <a href="https://pubmed.ncbi.nlm.nih.gov/16823372">PMID:16823372</a>.</li>
+<li><strong>GO:0005575 cellular_component</strong> — ND, GO_REF:0000015 (root "no data" placeholder).</li>
+<li><strong>GO:0008150 biological_process</strong> — ND, GO_REF:0000015 (root "no data" placeholder).</li>
+<li><strong>GO:0016747 acyltransferase activity, transferring groups other than amino-acyl<br />
+   groups</strong> — ISS, GO_REF:0000024, <code>WITH/FROM: PomBase:SPAC24H6.01c</code>. Transferred by<br />
+   curator judgment of sequence similarity from <strong>gup1</strong> (SPAC24H6.01c, Q09758), an<br />
+   MBOAT (product "membrane bound O-acyltransferase, MBOAT Gup1"; annotated to<br />
+   GO:0006506 GPI anchor biosynthetic process). NOTE: gup1 uses Pfam PF03062<br />
+   (MBOAT_fam) whereas acn1 uses PF13813 (Wax_synthase_dom) — related superfamily,<br />
+<strong>different subfamily</strong>; the ISS supports family-level acyltransferase activity but<br />
+   NOT gup1's specific GPI-anchor function.</li>
+</ol>
+<p>Also present in the UniProt DR block (not in GOA TSV): GO:0005739 mitochondrion<br />
+HDA:PomBase (from the ORFeome localization dataset), and the now-<strong>obsolete</strong><br />
+GO:0008374 O-acyltransferase (superseded by GO:0016747). Verified GO:0008374 is<br />
+obsolete via QuickGO.</p>
+<h2 id="localization-evidence">Localization evidence</h2>
+<ul>
+<li><strong>Mitochondrion / mitochondrial membrane</strong>: ORFeome-wide GFP localization study<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16823372" title="ORFeome cloning and global analysis of protein localization in the   fission yeast Schizosaccharomyces pombe">PMID:16823372</a> underlies the HDA mitochondrion call and<br />
+  the UniProt SubCell statement. This is a genome-scale screen (moderate confidence<br />
+  for any single protein); a mitochondrial <em>membrane</em> MBOAT is somewhat atypical (most<br />
+  characterized MBOATs are ER/Golgi/plasma-membrane), so localization deserves a<br />
+  caveat but is the only localization datum available.</li>
+</ul>
+<h2 id="phenotype-data-all-high-throughput-or-overexpression-pombase-fypo">Phenotype data (all high-throughput or overexpression; PomBase FYPO)</h2>
+<ul>
+<li><strong>PMID:37787768</strong> (Bähler lab broad phenomics / machine-learning profiling of fission<br />
+  yeast proteins) contributes ~20 FYPO annotations for acn1delta, e.g. multidrug<br />
+  resistance/sensitivity (resistance to diamide, KCl, terbinafine, tert-butyl<br />
+  hydroperoxide; sensitivity to cadmium, rapamycin, torin1, tunicamycin, brefeldin A,<br />
+  vanadate, X-rays), and nitrogen/carbon-source growth changes (FYPO:0009091 decreased<br />
+  growth on lysine+proline N source; FYPO:0009076 increased growth on sucrose). These<br />
+  are <strong>pleiotropic screen hits</strong>, not evidence of a specific molecular function.</li>
+<li><strong>PMID:23695302</strong> (fission-yeast TF overexpression analysis) contributes low-throughput<br />
+<strong>overexpression</strong> phenotypes (FYPO:0001406 increased septum thickness; multiseptate /<br />
+  mono-septate binucleate-anucleate cells). Overexpression phenotypes are weak evidence<br />
+  for endogenous function.</li>
+<li><strong>PMID:40424131</strong> (Formation of giant ER sheets by pentadecanoic acid causes<br />
+  lipotoxicity in fission yeast, PNAS 2025) contributes FYPO:0010042 <strong>"normal growth on<br />
+  pentadecanoic acid"</strong> for acn1delta — i.e. acn1 was screened in a lipotoxicity study<br />
+  and its deletion did <strong>not</strong> alter C15:0 sensitivity (a <em>negative</em> result). acn1 is<br />
+  not discussed in that paper's body text.</li>
+</ul>
+<h2 id="known-vs-not-known">KNOWN vs NOT-known</h2>
+<p>KNOWN (well-supported):<br />
+- It is a <strong>polytopic integral membrane protein</strong> (9 TM helices; UniProt/DeepTMHMM).<br />
+- It belongs to the <strong>MBOAT superfamily, wax-synthase (PF13813/IPR032805) branch</strong>.<br />
+- It <strong>localizes to mitochondria / mitochondrial membrane</strong> (ORFeome GFP screen; single<br />
+  moderate-confidence line of evidence).<br />
+- Deletion is <strong>viable</strong> with <strong>no gross morphology defect</strong> (FYPO:0002177), consistent<br />
+  with a non-essential gene.<br />
+- It has <strong>no apparent S. cerevisiae ortholog</strong> but is conserved across fungi/eukaryotes.</p>
+<p>NOT known (knowledge gaps):<br />
+- <strong>Molecular function / catalytic activity</strong>: whether acn1 is a <em>catalytically active</em><br />
+  acyltransferase, and if so its <strong>acyl-donor and acceptor substrates</strong>, are unknown. The<br />
+  MF annotation is ISS-from-paralog at the general "acyltransferase, non-amino-acyl"<br />
+  level only.<br />
+- <strong>Biological process</strong>: unknown. The "acn1 = ACetylation of Nsf" name is a hypothesis,<br />
+  not established. No BP annotation with experimental support exists.<br />
+- <strong>Physiological role / pathway</strong>: unknown. Phenotypes are broad pleiotropic<br />
+  screen/overexpression hits that do not converge on a mechanism.<br />
+- <strong>Localization detail</strong>: sub-mitochondrial location and topology unverified beyond a<br />
+  single genome-scale GFP dataset; a mitochondrial-membrane MBOAT is atypical.<br />
+- <strong>Direct interactors / regulation</strong>: none experimentally established for function.</p>
+<h2 id="candidate-mf-for-core_functions">Candidate MF for core_functions</h2>
+<ul>
+<li><strong>GO:0016747</strong> (acyltransferase activity, transferring groups other than amino-acyl<br />
+  groups) is the most specific <em>defensible</em> MF: it is the current (non-obsolete) term,<br />
+  it is family/domain-appropriate for an MBOAT, and it is what GOA already carries via<br />
+  ISS. Anything more specific (wax-ester synthase, DGAT, GPI-anchor acyltransferase,<br />
+  protein-serine O-palmitoleoyltransferase, etc.) would be an over-annotation given no<br />
+  substrate data. core_functions should carry at most this one MF with an explicit<br />
+  low-confidence/uncertainty note, plus the mitochondrial-membrane location; the primary<br />
+  deliverable is the knowledge_gaps section.</li>
+</ul>
+<h2 id="falcon-deep-research-acn1-deep-research-falconmd-edison-26-citations">Falcon deep research (acn1-deep-research-falcon.md, Edison, 26 citations)</h2>
+<p>The falcon report (completed 2026-07-06, 1659 s) independently reached the same<br />
+conclusion and adds useful comparative context. Key points (all secondary/inferential,<br />
+about the MBOAT family, NOT direct acn1 data):<br />
+- No primary research article has characterized acn1/SPBC3H7.05c function, activity, or<br />
+  role; all inference is domain/homology-based. (converges with my analysis.)<br />
+- MBOAT superfamily = integral-membrane acyltransferases with conserved catalytic His<br />
+  (in a TM stretch) + upstream Asn; three functional subgroups (sterol/DAG acylation<br />
+  e.g. ACAT/DGAT1; protein/peptide acylation e.g. PORCN/HHAT/GOAT; lyso-phospholipid<br />
+  re-acylation e.g. LPCAT/MBOAT7). The <strong>wax-synthase (WS) branch</strong> acylates fatty<br />
+  alcohols with fatty-acyl-CoA to make wax esters, and DGAT1-type members make TAG.<br />
+- Predicted acn1 activity: <strong>acyl-CoA-dependent acyltransferase</strong>, most consistent with<br />
+  wax-ester-synthase and/or DGAT1-type chemistry — but substrate is unknown.<br />
+- S. pombe neutral-lipid context: TAG synthesis is by dga1 (DGAT2 fold, structurally<br />
+  UNRELATED to MBOAT) and plh1 (PDAT); sterol esterification by Are1/Are2 homologs<br />
+  (Zhang et al. 2003, JBC). acn1 (MBOAT/DGAT1-type) is therefore a <strong>distinct enzyme<br />
+  class</strong> and, if catalytically active, would be an additional/accessory acyltransferase.<br />
+- Predicted localization by MBOAT analogy: <strong>endoplasmic reticulum</strong> (DGAT1/ACAT are<br />
+  ER-resident). NOTE this CONFLICTS with the only experimental localization datum for<br />
+  acn1 (mitochondrion, ORFeome GFP screen PMID:16823372). This discrepancy is itself a<br />
+  knowledge gap — the family prior says ER, the single S. pombe screen says mitochondrion.<br />
+- CAVEAT on the report: it treats "Wax_synthase_dom (IPR032805)" and "MBOAT_2 (PF13813)"<br />
+  as two domains; they are the SAME domain (InterPro IPR032805 is the InterPro entry for<br />
+  Pfam PF13813). Do not double-count. The falcon DOI citations are family reviews, not<br />
+  acn1-specific; I will NOT cite them as supporting acn1 function directly.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O74380
+gene_symbol: acn1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  acn1 (systematic name SPBC3H7.05c) is an uncharacterized, non-essential
+  polytopic integral membrane protein of the fission yeast Schizosaccharomyces
+  pombe. Its sequence carries a single Wax_synthase_dom / MBOAT_2 domain
+  (InterPro IPR032805, Pfam PF13813), placing it in the wax-synthase branch of the
+  membrane-bound O-acyltransferase (MBOAT) superfamily; the protein is predicted to
+  span the membrane with nine transmembrane helices. Characterized MBOAT enzymes are
+  acyl-CoA-dependent acyltransferases that transfer acyl chains onto lipid, sterol,
+  fatty-alcohol, or protein acceptors, and by homology acn1 is inferred to be an
+  acyltransferase, most plausibly acting in neutral-lipid (e.g. wax-ester or
+  diacylglycerol) metabolism. However, no direct biochemical, genetic, or cell-biological
+  study of acn1 has been published: its catalytic activity, physiological substrate, and
+  biological role are all unknown. A genome-scale GFP screen assigned it a mitochondrial
+  membrane localization, which is atypical for an MBOAT enzyme (most localize to the
+  endoplasmic reticulum). It has no apparent Saccharomyces cerevisiae ortholog but is
+  conserved across fungi and more broadly in eukaryotes.
+existing_annotations:
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation mapped from the UniProt Subcellular Location statement
+      &#34;Mitochondrion membrane {ECO:0000305}; Multi-pass membrane protein {ECO:0000305}&#34;
+      (SL-0171). The underlying primary evidence is a genome-wide GFP localization screen
+      (PMID:16823372), and PomBase independently records a mitochondrion localization
+      (HDA). This is a reasonable location call for a multi-pass membrane protein and is
+      the only localization datum available, so it is retained; it is marked non-core
+      because a single genome-scale screen is moderate-confidence and a mitochondrial
+      localization is atypical for an MBOAT-family acyltransferase (family members are
+      usually ER-resident), leaving the true compartment and topology unresolved.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supported location call, but derived from a single high-throughput screen (via
+      UniProt ECO:0000305 inference) and biologically atypical for the family; keep as a
+      location without treating it as a core, mechanism-defining assertion.
+    supported_by:
+    - reference_id: UniProt:O74380
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion membrane&#34;
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root-level &#34;no data&#34; placeholder (ND, GO_REF:0000015) recording that no specific
+      cellular-component annotation has been curated. This is a bookkeeping annotation,
+      not a biological statement; it is superseded in practice by the mitochondrial
+      membrane location above. No action needed beyond noting it.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND root placeholder; correctly indicates absence of curated CC data and
+      should be left as-is per GO_REF:0000015 conventions.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root-level &#34;no data&#34; placeholder (ND, GO_REF:0000015) recording that no biological
+      process has been curated for acn1. This is accurate: the biological process in which
+      acn1 acts is genuinely unknown (see knowledge_gaps). It is a bookkeeping annotation
+      and should remain until an experimentally supported process is established.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND root placeholder that correctly reflects the absence of any curated,
+      evidence-supported biological process for this dark gene.
+- term:
+    id: GO:0016747
+    label: acyltransferase activity, transferring groups other than amino-acyl groups
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity (ISS) annotation transferred by a PomBase curator from the
+      paralog gup1 (SPAC24H6.01c; WITH/FROM PomBase:SPAC24H6.01c), an MBOAT annotated to
+      the same term. acn1 carries the Wax_synthase_dom / MBOAT_2 domain (IPR032805 /
+      PF13813) and the MBOAT superfamily is defined by acyl-CoA-dependent acyltransferase
+      activity, so a general acyltransferase MF is domain-appropriate and is retained.
+      It is kept as non-core because (i) the transfer is from a different MBOAT subfamily
+      (gup1 uses Pfam PF03062, MBOAT_fam, and acts in GPI-anchor biosynthesis, whereas
+      acn1 uses the wax-synthase-domain PF13813), so it supports family-level activity
+      but NOT gup1&#39;s specific substrate/process; and (ii) no assay has demonstrated that
+      acn1 is catalytically active or identified its acyl donor/acceptor. This is the most
+      specific defensible molecular-function term; anything narrower (wax-ester synthase,
+      DGAT, GPI-anchor acyltransferase) would be over-annotation. Note the current term is
+      GO:0016747 because the older O-acyltransferase term (GO:0008374) used in the UniProt
+      DR line is now obsolete.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Domain/family-appropriate general acyltransferase activity supported by ISS from an
+      MBOAT paralog, but unproven for acn1 and transferred from a different MBOAT subfamily;
+      retain as a reasonable family-level MF without treating it as an established,
+      substrate-defined core function.
+    supported_by:
+    - reference_id: UniProt:O74380
+      supporting_text: &#34;Pfam; PF13813; MBOAT_2; 1.&#34;
+    - reference_id: UniProt:O74380
+      supporting_text: &#34;InterPro; IPR032805; Wax_synthase_dom.&#34;
+core_functions:
+- description: &gt;-
+    Predicted acyl-CoA-dependent membrane-bound acyltransferase (MBOAT superfamily,
+    wax-synthase branch). By homology to characterized MBOAT enzymes, acn1 is inferred to
+    transfer an acyl group onto a lipid, sterol, or fatty-alcohol acceptor, most plausibly
+    in neutral-lipid (wax-ester or diacylglycerol) metabolism. This is a family/domain-level
+    inference only: the catalytic activity has not been demonstrated for acn1, and its
+    physiological acyl donor and acceptor substrates are unknown. Included at the most
+    general defensible level (GO:0016747) with the specific reaction deliberately left
+    open; see knowledge_gaps.
+  molecular_function:
+    id: GO:0016747
+    label: acyltransferase activity, transferring groups other than amino-acyl groups
+  locations:
+  - id: GO:0031966
+    label: mitochondrial membrane
+  supported_by:
+  - reference_id: UniProt:O74380
+    supporting_text: &#34;Pfam; PF13813; MBOAT_2; 1.&#34;
+  - reference_id: UniProt:O74380
+    supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion membrane&#34;
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether acn1 is a catalytically active acyltransferase, and if so what reaction it
+    catalyzes, is undetermined. No enzymatic assay has been performed on the acn1 protein;
+    the acyltransferase molecular-function annotation is inferred entirely from the
+    MBOAT/wax-synthase domain and from ISS transfer from the paralog gup1.
+  boundary: &gt;-
+    acn1 unambiguously carries a Wax_synthase_dom / MBOAT_2 domain (InterPro IPR032805,
+    Pfam PF13813) and is predicted to be a nine-transmembrane integral membrane protein,
+    and the MBOAT superfamily is defined by acyl-CoA-dependent acyltransferase activity
+    with a conserved catalytic histidine. The acn1 sequence retains candidate His/Asn
+    residues, so catalytic competence is plausible. What is NOT established is any measured
+    activity or the enzyme&#39;s substrate specificity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Determines whether acn1 is a bona fide enzyme (and validates the propagated GO
+    acyltransferase annotation) or a catalytically inactive family member, and defines
+    which branch of lipid/protein acylation it belongs to.
+  resolution: &gt;-
+    Heterologous expression of acn1 and in vitro acyltransferase assays with candidate
+    acyl-CoA donors and lipid/fatty-alcohol/sterol acceptors, plus lipidomic comparison of
+    an acn1-deletion versus wild-type S. pombe strain.
+  provenance:
+  - reference_id: UniProt:O74380
+    supporting_text: &#34;Uncharacterized membrane protein C3H7.05c&#34;
+  - reference_id: file:SCHPO/acn1/acn1-deep-research-falcon.md
+    supporting_text: &gt;-
+      Extensive literature searches did not identify any primary research articles that
+      have directly characterized the function, enzymatic activity, or biological role of
+      acn1/SPBC3H7.05c.
+- gap_statement: &gt;-
+    The physiological substrate(s) of acn1 (its acyl donor and acyl acceptor) are unknown.
+    It is undetermined whether acn1 acts on diacylglycerol (DGAT-type), a fatty alcohol
+    (wax-ester synthase-type), a sterol, a lysophospholipid, or a protein/peptide acceptor.
+  boundary: &gt;-
+    The MBOAT superfamily splits into subgroups by substrate — sterol/diacylglycerol
+    acylation (ACAT/DGAT1), protein/peptide acylation (PORCN, HHAT, GOAT), and
+    lysophospholipid re-acylation (LPCAT, MBOAT7) — and the wax-synthase branch acylates
+    fatty alcohols to make wax esters. In S. pombe, terminal triacylglycerol synthesis is
+    carried out by dga1 (a DGAT2-fold enzyme unrelated to MBOATs) and plh1 (PDAT), so acn1
+    would be a distinct enzyme class rather than a redundant copy of those. Which subgroup
+    acn1 belongs to has not been tested.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Substrate identity would define acn1&#39;s biochemical reaction and place it in a specific
+    lipid- or protein-acylation pathway, and would let a specific GO molecular-function
+    term replace the current general one.
+  resolution: &gt;-
+    Substrate-resolved in vitro assays (panel of acyl-CoA donors versus DAG, fatty
+    alcohols, sterols, lysophospholipids) and untargeted lipidomics of acn1-deletion cells.
+  provenance:
+  - reference_id: file:SCHPO/acn1/acn1-deep-research-falcon.md
+    supporting_text: &gt;-
+      All functional predictions described herein are based on domain-based inference
+- gap_statement: &gt;-
+    The biological process and physiological role of acn1 are unknown. No pathway,
+    developmental role, or cellular process has been established; the only curated
+    biological-process annotation is a root-level &#34;no data&#34; placeholder.
+  boundary: &gt;-
+    acn1 deletion is viable with normal cell morphology, and available phenotypes come
+    almost entirely from genome-wide high-throughput screens (broad drug/stress
+    resistance and sensitivity, minor nitrogen/carbon-source growth changes; PMID:37787768)
+    plus low-throughput overexpression phenotypes (septation defects; PMID:23695302). In a
+    lipotoxicity screen, acn1 deletion did not alter growth on pentadecanoic acid
+    (PMID:40424131). These pleiotropic screen hits do not converge on a mechanism. The
+    PomBase gene name (acn1, from a proposed &#34;ACetylation of Nsf&#34; hypothesis) is not backed
+    by any published functional study.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning acn1 to a biological process (e.g. neutral-lipid storage, membrane lipid
+    remodeling, or an unrelated pathway) is required to move it out of the conserved-unknown
+    set and to interpret its many screen phenotypes.
+  resolution: &gt;-
+    Targeted loss-of-function and epistasis analysis under lipid-metabolic and
+    stress conditions, combined with the substrate/activity assays above, to connect a
+    defined biochemical activity to a cellular process.
+  provenance:
+  - reference_id: PMID:37787768
+    supporting_text: &gt;-
+      Most biomedical research focuses on genes that are already well-studied
+- gap_statement: &gt;-
+    acn1&#39;s subcellular compartment is unresolved. The family prior (MBOAT enzymes are
+    typically ER-resident) conflicts with the single experimental datum for acn1, a
+    genome-wide GFP screen that reported mitochondrial localization.
+  boundary: &gt;-
+    UniProt records &#34;Mitochondrion membrane&#34; as a multi-pass membrane protein (ECO:0000305
+    curator inference from the ORFeome GFP dataset, PMID:16823372) and PomBase records a
+    mitochondrion HDA localization; no ER localization has been reported for acn1
+    specifically. Characterized MBOAT/DGAT1/ACAT enzymes are ER-membrane proteins,
+    creating a genuine tension between the location prior and the observed screen result.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Resolving whether acn1 is truly mitochondrial (which would be unusual for an MBOAT and
+    biologically informative) or ER-localized (matching the family) constrains its likely
+    substrates and pathway.
+  resolution: &gt;-
+    Endogenous-tagged, high-resolution co-localization microscopy with mitochondrial and ER
+    markers, and/or subcellular fractionation, in S. pombe.
+  provenance:
+  - reference_id: UniProt:O74380
+    supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion membrane&#34;
+suggested_questions:
+- question: &gt;-
+    Is acn1 a catalytically active acyltransferase, and what acyl-CoA donor and
+    lipid/fatty-alcohol/sterol acceptor does it use?
+- question: &gt;-
+    Does acn1 localize to the endoplasmic reticulum (as expected for an MBOAT) or genuinely
+    to the mitochondrial membrane as suggested by the ORFeome GFP screen?
+- question: &gt;-
+    Does acn1 contribute to neutral-lipid (wax-ester or triacylglycerol/sterol-ester)
+    metabolism in S. pombe, i.e. does an acn1 deletion or overexpression change the lipid
+    droplet / storage-lipid profile?
+suggested_experiments:
+- description: &gt;-
+    Express recombinant acn1 (in S. pombe or a heterologous host) and assay acyltransferase
+    activity in vitro against a panel of acyl-CoA donors and candidate acceptors
+    (diacylglycerol, fatty alcohols, sterols, lysophospholipids), reading out product
+    formation by mass spectrometry.
+  hypothesis: &gt;-
+    acn1 is an acyl-CoA-dependent acyltransferase of the wax-synthase/DGAT1-type MBOAT
+    branch acting in neutral-lipid biosynthesis.
+  experiment_type: in vitro enzyme assay
+- description: &gt;-
+    Compare untargeted lipidomes of an acn1-deletion strain versus wild type (and versus
+    dga1/plh1 mutants) under standard and lipid-stress conditions to detect changes in
+    triacylglycerol, wax esters, sterol esters, or phospholipid species.
+  hypothesis: &gt;-
+    Loss of acn1 alters a specific neutral-lipid or membrane-lipid pool, revealing its
+    in vivo product.
+  experiment_type: comparative lipidomics
+- description: &gt;-
+    Determine acn1 subcellular localization and topology using endogenous fluorescent
+    tagging with co-localization against ER and mitochondrial markers, and protease-protection
+    / topology mapping of the transmembrane helices.
+  hypothesis: &gt;-
+    acn1 resides in the ER membrane (consistent with the MBOAT family) rather than the
+    mitochondrion.
+  experiment_type: fluorescence microscopy and membrane topology
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: UniProt:O74380
+  title: &#34;UniProtKB entry O74380 (YNV5_SCHPO), Uncharacterized membrane protein C3H7.05c&#34;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary record for the reviewed protein. Establishes the Wax_synthase_dom / MBOAT_2
+      domain (IPR032805 / PF13813), the nine predicted transmembrane helices, the
+      mitochondrial-membrane subcellular-location inference, and the &#34;Predicted&#34; (PE 4)
+      status. All supporting_text quotes are verbatim from the cached UniProt record.
+- id: PMID:16823372
+  title: ORFeome cloning and global analysis of protein localization in the fission yeast
+    Schizosaccharomyces pombe.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genome-wide GFP localization screen that underlies the mitochondrial localization
+      call for acn1 (via the UniProt SubCell inference and PomBase HDA annotation).
+      Cached entry is abstract-only and does not name acn1 in the abstract, so it is
+      supporting/contextual rather than a direct functional characterization.
+- id: PMID:37787768
+  title: Broad functional profiling of fission yeast proteins using phenomics and machine
+    learning.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale dark-gene phenomics study; the source of most acn1 FYPO phenotype
+      annotations (broad drug/stress resistance and sensitivity). Frames the
+      conserved-unknown (&#34;unknome&#34;) problem that acn1 exemplifies. Provides pleiotropic
+      screen phenotypes, not mechanism.
+- id: PMID:40424131
+  title: Formation of giant ER sheets by pentadecanoic acid causes lipotoxicity in fission
+    yeast.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Lipotoxicity screen contributing the FYPO annotation that acn1 deletion shows normal
+      growth on pentadecanoic acid (a negative result). acn1 is not discussed in the paper&#39;s
+      body text; relevant only as screen context linking acn1 to lipid metabolism datasets.
+- id: file:SCHPO/acn1/acn1-deep-research-falcon.md
+  title: &#34;Deep research report (falcon/Edison): acn1 / SPBC3H7.05c functional annotation&#34;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Automated deep-research synthesis. Its acn1-specific conclusion (no primary functional
+      characterization exists; function inferable only from the MBOAT/wax-synthase domain)
+      is consistent with independent inspection of UniProt, PomBase, and the primary
+      literature. Its DOI citations are MBOAT-family reviews, not acn1-specific studies, and
+      are treated as family background only. Note it double-lists IPR032805 and PF13813 as
+      two domains; they are the same domain.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/adg2/adg2-ai-review.html
+++ b/genes/SCHPO/adg2/adg2-ai-review.html
@@ -1,0 +1,2586 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>adg2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>adg2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O13854" target="_blank" class="term-link">
+                        O13854
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">mug46</span>
+
+                    <span class="badge">SPAC19G12.16c</span>
+
+                    <span class="badge">SPAC23A1.01c</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "adg2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O13854" data-a="DESCRIPTION: adg2 encodes a serine/threonine-rich, heavily N-gl..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>adg2 encodes a serine/threonine-rich, heavily N-glycosylated secretory-pathway glycoprotein of the fission yeast Schizosaccharomyces pombe. The protein carries an N-terminal signal peptide, a long internally disordered Ser/Thr-rich body (~50% Ser+Thr, 17 predicted N-glycosylation sites), and a C-terminal hydrophobic tail with the features of a glycosylphosphatidylinositol (GPI) anchor-addition signal, and it is one of the small set of predicted GPI-anchored proteins in the S. pombe genome. It has no recognizable catalytic domain. It transits the endoplasmic reticulum and is assigned to the fungal cell surface, consistent with the architecture of cell-wall/cell-surface glycoproteins. Its transcription is periodic and Ace2-dependent, peaking around cytokinesis, and it is induced during meiosis (hence the alias mug46), but no molecular activity or direct biological role has been demonstrated experimentally for the protein itself.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O13854" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad extracellular localization mapped by UniProt from the Secreted subcellular-location keyword (SL-0243). Defensible for a signal-peptide-bearing, GPI/secretion-predicted glycoprotein, but it is a coarse location term inferred electronically, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the protein&#39;s secretory architecture (N-terminal signal peptide, no internal TM domains) and its inclusion among predicted S. pombe GPI proteins (PMID:12845604). Retained as a broad, non-core cellular-component annotation; the more specific cell surface term (GO:0009986) is preferred where a surface location is intended.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O13854" data-a="GO:0005783" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER localization, mapped electronically by UniProt (SL-0095) but ultimately grounded in an experimental YFP-tagging localization screen (PMID:16823372). The ER is the expected transit compartment for a secretory-pathway glycoprotein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported localization (PMID:16823372) that is fully consistent with a secreted/surface glycoprotein transiting the ER. Retained as a legitimate, non-core cellular component; it reflects where the protein is processed, not its molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                                        PMID:16823372
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we determined the localization of 4,431 proteins, corresponding to approximately 90% of the fission yeast proteome, by tagging each ORF with the yellow fluorescent protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13854" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function with ND (No biological Data). This is the correct, honest representation: adg2 has no recognizable catalytic domain and no experimentally determined molecular activity. The InterPro/PANTHER &#34;GPI-anchor adhesion regulation&#34; family name is a computational label, not evidence of adhesin activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The molecular function of Adg2 is genuinely unknown; ND on the MF root faithfully captures this. No informative MF term (including adhesion or binding terms) is supportable from current evidence, so no replacement is proposed. See knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13854" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process with ND. adg2 is co-regulated with cell-separation genes (Ace2/Eng1 cluster, PMID:15966770) and induced during meiosis (mug46), but no biological process has been experimentally demonstrated for the protein itself, so the ND root is appropriate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cell-separation association is a cluster-level co-regulation inference, not a demonstrated adg2 function; there is no reported adg2 loss-of-function phenotype. Retaining ND on the BP root is the conservative, defensible choice. The candidate process is recorded in knowledge_gaps rather than asserted as an annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
+                                    GO:0009986
+                                </a>
+                            </span>
+                            <span class="term-label">cell surface</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12845604
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genome-wide identification of fungal GPI proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O13854" data-a="GO:0009986" data-r="PMID:12845604" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cell surface localization curated by PomBase (TAS) from the genome-wide fungal GPI-protein prediction (PMID:12845604), consistent with the Ser/Thr-rich, heavily glycosylated, GPI-signal-bearing architecture and PomBase&#39;s &#34;conserved fungal cell surface&#34; product description.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Best-supported surface localization for a predicted GPI-anchored glycoprotein; a legitimate cellular-component annotation. It is a location, not a molecular function, and GPI anchorage is predicted rather than experimentally confirmed, so it is retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                                        PMID:12845604
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">only 33 GPI candidates were identified</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                            PMID:12845604
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide identification of fungal GPI proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A genome-wide computational screen for a C-terminal GPI attachment consensus, an N-terminal secretion signal and absence of internal transmembrane domains identified only 33 GPI-protein candidates in the S. pombe genome; adg2/SPAC19G12.16c is among them, the basis for its cell-surface / GPI-anchored classification.</div>
+
+                        <div class="finding-text">"only 33 GPI candidates were identified"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                            PMID:16823372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-throughput YFP-tagging localization of ~4,431 S. pombe proteins; the per-protein dataset assigns adg2 to the endoplasmic reticulum, the experimental basis for the UniProt ER localization (ECO:0000269|PubMed:16823372).</div>
+
+                        <div class="finding-text">"we determined the localization of 4,431 proteins, corresponding to approximately 90% of the fission yeast proteome, by tagging each ORF with the yellow fluorescent protein"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15966770" target="_blank" class="term-link">
+                            PMID:15966770
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cell cycle-regulated genes of Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">adg2 is a member of the nine-gene, Ace2-regulated &#34;Eng1 cluster&#34; of cell-cycle-regulated genes described as involved in cell separation, where adg1 and adg2 are annotated as cell surface glycoproteins alongside glucan hydrolases (eng1, agn1, adg3).</div>
+
+                        <div class="finding-text">"The Eng1 cluster (Figure 8C) contains nine genes, and these are involved in cell separation. The genes are adg1 and adg2 (cell surface glycoproteins)"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23236291" target="_blank" class="term-link">
+                            PMID:23236291
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deciphering the transcriptional-regulatory network of flocculation in Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Places adg2 within the S. pombe cell-surface/flocculation transcriptional network as an Ace2-regulon target modulated by the FLO8-like activators Adn2/Adn3; regulatory context only, assigning no molecular function to Adg2.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is Adg2 an adhesin/flocculin, a passive structural cell-surface glycoprotein, or does it have another activity — and does the IPR052479 &#34;GPI-anchor adhesion regulation&#34; family designation reflect a real adhesion-related function?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Frans M. Klis, Gordon Chua</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="O13854" data-a="Q: Is Adg2 an adhesin/flocculin, a passive structural..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does adg2 deletion produce a cell-separation, cell-wall-integrity, flocculation, or sporulation phenotype, and is any such role redundant with its paralog adg1?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Janet Leatherwood</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="O13854" data-a="Q: Does adg2 deletion produce a cell-separation, cell..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenously tag adg2 at the C-terminus internal to the predicted GPI signal (or N-terminally after the signal peptide), image steady-state localization by fluorescence microscopy, and test anchor type biochemically (PI-PLC release, and alkali/glucanase extraction to distinguish plasma-membrane GPI from covalent cell-wall linkage).</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Adg2 is a GPI-anchored, cell-wall-associated surface glycoprotein rather than a soluble secreted protein.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: protein localization and biochemical anchor characterization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O13854" data-a="EXPERIMENT: Endogenously tag adg2 at the C-terminus internal t..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct adg2Δ and adg1Δ adg2Δ strains and assay cell-separation defects (cell chaining, calcofluor septum staining), cell-wall-integrity stress sensitivity, flocculation/aggregation, and sporulation efficiency, comparing to eng1Δ/agn1Δ separation phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Adg2 contributes directly to daughter-cell separation and/or cell-surface adhesion, beyond its co-regulation with the Ace2/Eng1 cluster.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: gene deletion and phenotypic analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O13854" data-a="EXPERIMENT: Construct adg2Δ and adg1Δ adg2Δ strains and assay ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of Adg2 is undetermined. No catalytic activity, ligand, adhesion target, or binding partner has been identified, and the protein has no recognizable enzymatic domain.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Sequence and family evidence firmly establish that Adg2 is a secretory-pathway serine/threonine-rich glycoprotein (N-terminal signal peptide; ~50% Ser+Thr; 17 predicted N-glycosylation sites; long disordered stalk) with a C-terminal GPI-anchor-addition-signal architecture, placing it in InterPro IPR052479 (&#34;GPI-anchor_Adhesion_Reg&#34;) and PANTHER PTHR35185. What that family name implies mechanistically — whether Adg2 is a genuine adhesin, a structural cell-wall/surface component, or something else — is not experimentally supported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Adg2 is a conserved fungal cell-surface protein of unknown activity (UniProt PE 3, inferred from homology). Assigning its molecular role would convert a coarse &#34;cell surface glycoprotein&#34; into a defined surface function and clarify what the IPR052479 &#34;GPI-anchor adhesion regulation&#34; family actually does.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical/cell-biological characterization: confirm GPI anchorage and cell-wall vs plasma-membrane residence, test for adhesion/flocculation or aggregation activity, and search for interaction partners of the mature glycoprotein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"only 33 GPI candidates were identified"</em> — PMID:12845604</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct biological role of Adg2 is not experimentally established. Its assignment to cell separation rests on transcriptional co-regulation with characterized separation genes, not on any measured adg2 loss-of-function phenotype.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> adg2 is a member of the nine-gene, Ace2-regulated, cell-cycle-periodic &#34;Eng1 cluster&#34; that peaks around cytokinesis and is described as involved in cell separation, where it is grouped with the glucan hydrolases eng1, agn1 and adg3; it is also induced during meiosis (alias mug46) and modulated within the Adn2/Adn3 flocculation network. All of this is regulatory/expression evidence about when adg2 is transcribed, not about what the protein does.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a genuine, direct contribution to daughter-cell separation (or to meiotic surface remodeling) from mere co-regulation is required before a specific biological-process term could be annotated for adg2 itself.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotypic analysis of an adg2 deletion (and adg1/adg2 double deletion) for cell-separation, cell-wall-integrity, flocculation and sporulation defects, with localization of tagged Adg2 relative to the division septum.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The Eng1 cluster (Figure 8C) contains nine genes, and these are involved in cell separation. The genes are adg1 and adg2 (cell surface glycoproteins)"</em> — PMID:15966770</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether Adg2 is actually GPI-anchored, and whether it resides at the plasma membrane or is cross-linked into the cell wall, has not been experimentally verified; the C-terminal omega (GPI-attachment) site has not been mapped.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Adg2 has a C-terminal hydrophobic tail consistent with a GPI-anchor-addition signal and was computationally predicted to be one of 33 S. pombe GPI proteins (PMID:12845604); the only experimental localization reported is endoplasmic reticulum from a genome-scale YFP screen (PMID:16823372), a transit compartment rather than a mature surface/wall location.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> GPI anchorage versus soluble secretion, and plasma-membrane versus covalent cell-wall residence, change how the surface annotation should be interpreted and constrain the protein&#39;s possible function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct biochemistry (e.g. PI-PLC sensitivity, GPI-anchor mapping, alkali/glucanase extraction of the wall fraction) and steady-state surface imaging of endogenously tagged Adg2.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"only 33 GPI candidates were identified"</em> — PMID:12845604</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(adg2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O13854" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: adg2 (mug46) in *Schizosaccharomyces pombe*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">19 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T18:19:10.104867</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="adg2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="adg2-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-adg2-mug46-in-schizosaccharomyces-pombe">Comprehensive Research Report: adg2 (mug46) in <em>Schizosaccharomyces pombe</em></h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <strong>adg2</strong> (synonyms: <strong>mug46</strong>; ORF names: <strong>SPAC19G12.16c</strong>, <strong>SPAC23A1.01c</strong>) encodes a serine/threonine-rich cell surface glycoprotein in the fission yeast <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843). The protein (UniProt: O13854) is annotated as a precursor, consistent with a secreted or surface-localized protein that undergoes signal peptide cleavage and post-translational modification. Its InterPro domain annotation includes a GPI-anchor adhesion regulation domain (IPR052479), strongly supporting classification as a GPI-anchored cell wall glycoprotein.</p>
+<p>The following table provides a summary of key properties of the adg2/mug46 gene product:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description/Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name/synonyms</td>
+<td><strong>adg2</strong>; synonym <strong>mug46</strong>; ORF names <strong>SPAC19G12.16C</strong> and <strong>SPAC23A1.01C</strong> in <em>Schizosaccharomyces pombe</em> strain 972/ATCC 24843. The mug46 alias is consistent with inclusion among meiotically upregulated genes (inamura2021expressionofmug14 pages 1-2).</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>O13854</strong> (UniProt entry for serine/threonine-rich protein Adg2 / meiotically up-regulated gene 46 protein).</td>
+</tr>
+<tr>
+<td>Protein type</td>
+<td>Predicted <strong>serine/threonine-rich cell surface glycoprotein</strong>. In cell-cycle transcription analyses, <strong>adg2</strong> is explicitly classified as a <strong>cell surface glycoprotein</strong> within a cell-separation gene cluster (oliva2005thecellcycle–regulated pages 9-11).</td>
+</tr>
+<tr>
+<td>Key domains (GPI-anchor adhesion)</td>
+<td>UniProt annotates a <strong>GPI-anchor_Adhesion_Reg.</strong> domain; genome-wide fungal GPI-protein prediction identified <strong>SPAC19G12.16C</strong> among <strong>33 S. pombe GPI-protein candidates</strong>, supporting a GPI-anchored cell-surface/cell-wall role (groot2003genome‐wideidentificationof pages 10-12). General yeast adhesin architecture indicates that serine/threonine-rich, GPI-anchored proteins typically form heavily glycosylated surface-exposed stalks suited for adhesion-related functions (dranginis2007abiochemicalguide pages 10-11, dranginis2007abiochemicalguide pages 9-10, dranginis2007abiochemicalguide pages 2-3).</td>
+</tr>
+<tr>
+<td>Predicted localization (cell surface/cell wall)</td>
+<td>Best-supported localization is <strong>cell surface / cell wall-associated</strong>, likely via a <strong>GPI anchor</strong>. This is supported by its annotation as a cell surface glycoprotein and by inclusion in predicted fungal GPI proteins of <em>S. pombe</em> (oliva2005thecellcycle–regulated pages 9-11, groot2003genome‐wideidentificationof pages 10-12).</td>
+</tr>
+<tr>
+<td>Gene regulation (Ace2, cell cycle, meiotic)</td>
+<td><strong>Ace2-regulated</strong>: each Eng1-cluster gene has at least one Ace2-binding site, and cluster genes are upregulated by <strong>ace2</strong> overexpression and downregulated by <strong>ace2</strong> deletion (oliva2005thecellcycle–regulated pages 9-11). <strong>Cell-cycle regulated</strong>: adg2 is in the strongly periodic <strong>Eng1 cluster</strong>, peaking slightly after the Cdc15/Cdc18 clusters during M-phase-associated cell separation (oliva2005thecellcycle–regulated pages 9-11). <strong>Meiotic regulation</strong>: the <strong>mug46</strong> designation indicates membership in the meiotically upregulated gene set defined in foundational transcriptome work; mug genes include at least <strong>184</strong> meiotically upregulated genes (inamura2021expressionofmug14 pages 1-2).</td>
+</tr>
+<tr>
+<td>Functional cluster (Eng1 cluster)</td>
+<td><strong>Eng1 cluster</strong>, a nine-gene module involved in <strong>cell separation</strong>. Genes listed for this cluster are <strong>adg1, adg2, adg3, agn1, eng1, cfh4, mid2, ace2,</strong> and <strong>SPCC306.11</strong> (oliva2005thecellcycle–regulated pages 9-11).</td>
+</tr>
+<tr>
+<td>Associated biological processes (cell separation, flocculation, meiosis/sporulation)</td>
+<td><strong>Cell separation</strong>: primary supported role, based on Eng1-cluster membership and Ace2 control of late cytokinetic/cell-wall-remodeling genes (oliva2005thecellcycle–regulated pages 9-11, kwon2012decipheringthetranscriptionalregulatory pages 10-11). <strong>Flocculation/adhesion</strong>: adg2 transcript decreases when <strong>adn2</strong> or <strong>adn3</strong> are overexpressed in flocculation studies, linking it to broader cell-surface/cell-wall programs affecting adhesion phenotypes (kwon2012decipheringthetranscriptionalregulatory pages 10-11). <strong>Meiosis/sporulation</strong>: mug46 alias supports meiotic upregulation, but no direct biochemical function in sporulation has been demonstrated from the retrieved evidence (inamura2021expressionofmug14 pages 1-2).</td>
+</tr>
+<tr>
+<td>Known interacting pathways (Sep1-&gt;Ace2-&gt;adg2)</td>
+<td>Best-supported regulatory pathway is <strong>Sep1 → Ace2 → adg2</strong>. Sep1 activates <strong>ace2</strong> as part of the mitotic transcriptional network; <strong>adg2</strong> downregulation in sep1 mutants is interpreted as an indirect consequence of reduced <strong>ace2</strong> expression (garg2015anewtranscription pages 8-9, garg2015anewtranscription pages 7-8). Additional modulation occurs through <strong>Adn2/Adn3</strong>, whose overexpression downregulates <strong>ace2</strong> and its targets including <strong>adg2</strong> (kwon2012decipheringthetranscriptionalregulatory pages 10-11).</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key identity, localization, regulation, and inferred biological role of the </em>S. pombe<em> adg2/mug46 gene product. It is useful as a compact reference linking UniProt annotation to primary literature on Ace2-regulated cell separation and predicted GPI-anchored cell-surface function.</em></p>
+<h2 id="2-functional-classification-cell-surface-glycoprotein-in-the-eng1-cluster">2. Functional Classification: Cell Surface Glycoprotein in the Eng1 Cluster</h2>
+<p>Adg2 is classified as a <strong>cell surface glycoprotein</strong> based on genome-wide cell cycle transcriptome analysis of <em>S. pombe</em>. In a landmark study by Oliva et al. (2005), adg2 was identified as one of nine genes in the <strong>Eng1 cluster</strong>, a tightly co-regulated module of cell cycle genes involved in <strong>cell separation</strong> (oliva2005thecellcycle–regulated pages 9-11). The Eng1 cluster peaks in expression during late G2/M, slightly after the Cdc15 and Cdc18 clusters, coinciding with the time at which daughter cells must physically separate following cytokinesis (oliva2005thecellcycle–regulated pages 9-11). The full composition of the Eng1 cluster is shown below:</p>
+<table>
+<thead>
+<tr>
+<th>Gene Name</th>
+<th>Protein Function/Description</th>
+<th>Role in Cell Separation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>adg1</td>
+<td>Cell surface glycoprotein; one of the Ace2-regulated Eng1-cluster genes (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Likely contributes to cell surface/cell wall remodeling needed for daughter-cell separation after septation (oliva2005thecellcycle–regulated pages 9-11, kwon2012decipheringthetranscriptionalregulatory pages 10-11)</td>
+</tr>
+<tr>
+<td>adg2</td>
+<td>Cell surface glycoprotein; Ace2-regulated Eng1-cluster member, also known as mug46 (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Likely functions at the cell surface/cell wall in the late cytokinetic program that enables physical separation of daughter cells (oliva2005thecellcycle–regulated pages 9-11, kwon2012decipheringthetranscriptionalregulatory pages 10-11)</td>
+</tr>
+<tr>
+<td>adg3</td>
+<td>β-glucosidase in the Eng1 cluster (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Presumed to help hydrolyze cell wall glucan components during septum dissolution and separation (oliva2005thecellcycle–regulated pages 9-11)</td>
+</tr>
+<tr>
+<td>agn1</td>
+<td>Glycosyl hydrolase / α-glucanase; previously shown to be an Ace2-regulated separation gene (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Enzymatic cell wall degradation/remodeling during separation of daughter cells (oliva2005thecellcycle–regulated pages 9-11, kwon2012decipheringthetranscriptionalregulatory pages 10-11)</td>
+</tr>
+<tr>
+<td>eng1</td>
+<td>Glycosyl hydrolase; endo-1,3-β-glucanase and representative gene of the Eng1 cluster (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Directly implicated in septum/cell wall glucan breakdown required for cell separation (oliva2005thecellcycle–regulated pages 9-11)</td>
+</tr>
+<tr>
+<td>cfh4</td>
+<td>Chitin synthase regulatory factor (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Likely coordinates septum/cell wall assembly-remodeling steps that must be properly regulated for separation to occur (oliva2005thecellcycle–regulated pages 9-11)</td>
+</tr>
+<tr>
+<td>mid2</td>
+<td>Anillin-family protein required for cell division and septin organization (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Supports cytokinetic organization and septin-dependent division structures that position or enable efficient cell separation (oliva2005thecellcycle–regulated pages 9-11, kwon2012decipheringthetranscriptionalregulatory pages 10-11)</td>
+</tr>
+<tr>
+<td>ace2</td>
+<td>Cell cycle transcription factor; master regulator of the Eng1 cluster, with cluster genes carrying Ace2-binding sites of consensus CCAGCC (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Activates the late cell-separation transcriptional program; overexpression upregulates, and deletion downregulates, Eng1-cluster genes (oliva2005thecellcycle–regulated pages 9-11, kwon2012decipheringthetranscriptionalregulatory pages 10-11)</td>
+</tr>
+<tr>
+<td>SPCC306.11</td>
+<td>Sequence orphan / unknown-function protein in the Eng1 cluster (oliva2005thecellcycle–regulated pages 9-11)</td>
+<td>Uncharacterized, but co-regulation with established separation genes strongly suggests participation in the Ace2-controlled cell-separation pathway (oliva2005thecellcycle–regulated pages 9-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the nine Ace2-regulated genes in the S. pombe Eng1 cluster and their inferred roles in cell separation. It is useful for quickly locating adg2 within the broader late-cytokinesis and cell-wall-remodeling program.</em></p>
+<p>The Eng1 cluster genes collectively encode the enzymatic and structural machinery required for dissolution of the division septum and remodeling of the cell wall during separation. While enzymes such as Eng1 (endo-1,3-β-glucanase), Agn1 (α-glucanase), and Adg3 (β-glucosidase) directly hydrolyze cell wall polysaccharides, the cell surface glycoproteins Adg1 and Adg2 are inferred to play structural or regulatory roles at the cell surface during this process (oliva2005thecellcycle–regulated pages 9-11). The Eng1 cluster also includes Mid2, an anillin required for septin ring organization and cell division, and the transcription factor Ace2 itself, which acts as the master regulator of the cluster (oliva2005thecellcycle–regulated pages 9-11).</p>
+<h2 id="3-transcriptional-regulation">3. Transcriptional Regulation</h2>
+<h3 id="31-ace2-transcription-factor">3.1 Ace2 Transcription Factor</h3>
+<p>The primary transcriptional regulator of adg2 is the <strong>Ace2 transcription factor</strong>. Each gene in the Eng1 cluster contains at least one binding site for Ace2 (consensus sequence <strong>CCAGCC</strong>), with eight of the nine genes harboring multiple such sites (oliva2005thecellcycle–regulated pages 9-11). Experimental evidence demonstrates that adg2 expression is <strong>upregulated when ace2 is overexpressed</strong> and <strong>downregulated when ace2 is deleted</strong> (oliva2005thecellcycle–regulated pages 9-11). This places adg2 firmly under direct Ace2 transcriptional control.</p>
+<h3 id="32-sep1-ace2-regulatory-cascade">3.2 Sep1-Ace2 Regulatory Cascade</h3>
+<p>The forkhead transcription factor <strong>Sep1</strong> acts upstream of Ace2 as part of the mitotic transcription network. ChIP-seq analysis by Garg et al. (2015) demonstrated that Sep1 directly binds the ace2 promoter and activates its expression (garg2015anewtranscription pages 8-9). Consequently, downregulation of adg2 in sep1 mutants is understood as an <strong>indirect effect</strong> mediated through reduced Ace2 levels, rather than direct Sep1 regulation of adg2 (garg2015anewtranscription pages 8-9). The broader mitotic transcription program involves the interplay of <strong>Sak1</strong> (an RFX family transcription factor, the major activator of mitotic gene expression), <strong>Fkh2</strong> (a forkhead factor functioning primarily as a repressor), and <strong>Sep1</strong> (a forkhead factor that activates a subset of mitotic genes, including ace2) (garg2015anewtranscription pages 8-9, garg2015anewtranscription pages 7-8).</p>
+<h3 id="33-regulation-by-adn2adn3">3.3 Regulation by Adn2/Adn3</h3>
+<p>In the context of flocculation regulation, overexpression of the transcription factors <strong>Adn2</strong> and <strong>Adn3</strong> (orthologs of <em>S. cerevisiae</em> FLO8) leads to downregulation of ace2 and its target genes, including adg2, by <strong>1.5- to 3.4-fold</strong> (kwon2012decipheringthetranscriptionalregulatory pages 10-11). This indicates that Adn2 and Adn3 negatively regulate cell separation through transcriptional repression of the Ace2 regulon. The regulation of cell separation and flocculation by Adn2/Adn3 appears to occur through independent sets of target genes, with cell separation controlled through ace2 downregulation and flocculation through induction of cell wall-remodeling enzymes such as Gas2, Psu1, and SPAC4H3.03c (kwon2012decipheringthetranscriptionalregulatory pages 10-11).</p>
+<h3 id="34-meiotic-upregulation-mug46">3.4 Meiotic Upregulation (mug46)</h3>
+<p>The alternative name <strong>mug46</strong> (meiotically up-regulated gene 46) indicates that adg2 was identified among <strong>184 meiotically upregulated genes</strong> in a genome-wide transcriptome profiling study of <em>S. pombe</em> meiosis by Mata et al. (2002) (inamura2021expressionofmug14 pages 1-2). Mug genes are classified temporally into early, middle, and late categories based on their expression patterns during meiotic progression (kok2026nucleosomepositioningshapes pages 29-30). The meiotic upregulation of mug genes is regulated in part through the <strong>cAMP/PKA pathway</strong>: the Pka1 kinase phosphorylates and inhibits the transcription factor Rst2; upon nutrient starvation and PKA pathway downregulation, Rst2 is activated and induces expression of <strong>ste11</strong>, which encodes the master transcription factor initiating sexual differentiation (inamura2021expressionofmug14 pages 2-4, inamura2021expressionofmug14 pages 1-2). However, no specific biochemical function for Adg2 during meiosis or sporulation has been experimentally demonstrated in the retrieved literature; its meiotic upregulation may reflect a requirement for cell surface remodeling during the meiotic program or ascospore wall formation.</p>
+<h2 id="4-predicted-subcellular-localization">4. Predicted Subcellular Localization</h2>
+<p>Multiple lines of evidence support localization of Adg2 to the <strong>cell surface and cell wall</strong>:</p>
+<ul>
+<li>
+<p><strong>GPI anchor prediction</strong>: A genome-wide computational survey by de Groot et al. (2003) identified <strong>SPAC19G12.16C</strong> (adg2) among <strong>33 predicted GPI protein candidates</strong> in the <em>S. pombe</em> genome (groot2003genome‐wideidentificationof pages 10-12). GPI-anchored proteins are typically transported through the secretory pathway to the plasma membrane, where many are subsequently transferred to the cell wall via transglycosylation of their GPI anchor to cell wall β-1,6-glucan (dranginis2007abiochemicalguide pages 9-10).</p>
+</li>
+<li>
+<p><strong>Serine/threonine-rich composition</strong>: The protein is annotated as serine/threonine-rich, a hallmark feature of yeast cell surface adhesins and cell wall glycoproteins. In the <em>S. pombe</em> GPI protein survey, unannotated GPI candidates had an average serine/threonine content of 41%, reinforcing identification as genuine GPI proteins (groot2003genome‐wideidentificationof pages 10-12). In the canonical yeast adhesin architecture, serine/threonine-rich regions comprise at least 300 residues with 35–55% Ser/Thr content, are heavily O-glycosylated, and form extended stalk structures that project ligand-binding or functional domains above the cell wall surface (dranginis2007abiochemicalguide pages 10-11).</p>
+</li>
+<li>
+<p><strong>InterPro domain</strong>: The GPI-anchor adhesion regulation domain (IPR052479) further supports cell surface localization and a potential role in cell-cell or cell-surface adhesion.</p>
+</li>
+</ul>
+<p>Given its membership in the Eng1 cluster, which controls cell separation, Adg2 likely localizes to the <strong>division site and/or cell poles</strong>, where cell wall remodeling enzymes concentrate during septation and separation. However, direct experimental visualization (e.g., by fluorescence microscopy of tagged protein) has not been reported in the available literature for Adg2 specifically.</p>
+<h2 id="5-structural-features-and-inferred-function">5. Structural Features and Inferred Function</h2>
+<h3 id="51-gpi-anchored-adhesin-architecture">5.1 GPI-Anchored Adhesin Architecture</h3>
+<p>Although Adg2 has not been biochemically characterized, its domain architecture is consistent with the well-characterized family of yeast GPI-anchored adhesins. These proteins share a standard modular structure: (i) an N-terminal secretion signal, (ii) a globular adhesion or functional domain, (iii) an optional threonine-rich repeat domain, (iv) a glycosylated serine/threonine-rich stalk, and (v) a C-terminal GPI addition signal (dranginis2007abiochemicalguide pages 8-9, dranginis2007abiochemicalguide pages 2-3). The serine/threonine-rich stalk region serves to elevate the N-terminal functional domain above the cell wall surface, enabling interaction with extracellular ligands or neighboring cells (dranginis2007abiochemicalguide pages 10-11). The extensive O-glycosylation of these regions contributes to the extended conformation and provides protection against proteolysis.</p>
+<h3 id="52-functional-inference">5.2 Functional Inference</h3>
+<p>Adg2 is not an enzyme in the classical sense. Its classification as a cell surface glycoprotein, rather than a hydrolase, distinguishes it from other Eng1 cluster members such as Eng1 and Agn1. By analogy to yeast adhesins, Adg2 may function as a <strong>structural component of the cell surface</strong> that facilitates proper cell wall organization during septation and cell separation. The threonine-rich repeat domains in yeast adhesins mediate <strong>cell-cell adhesion</strong> through homotypic interactions and determine the level of flocculation and aggregation (dranginis2007abiochemicalguide pages 9-10). The involvement of adg2 in the transcriptional network governing flocculation further supports a potential role in cell surface properties affecting adhesion (kwon2012decipheringthetranscriptionalregulatory pages 10-11).</p>
+<h2 id="6-biological-processes-and-pathways">6. Biological Processes and Pathways</h2>
+<h3 id="61-cell-separation">6.1 Cell Separation</h3>
+<p>The primary biological process associated with adg2 is <strong>cell separation</strong> during mitotic cell division. In <em>S. pombe</em>, which divides by binary fission, the daughter cells must physically separate after cytokinesis by enzymatic dissolution of the primary and secondary septa. This process requires coordinated expression of glucanases, glycosyl hydrolases, chitin synthase regulators, and cell surface glycoproteins—all encoded by the Eng1 cluster under Ace2 control (oliva2005thecellcycle–regulated pages 9-11). The conservation of this Ace2-controlled cell separation program is notable: <em>S. cerevisiae</em> has a functionally analogous cluster (the SIC1 cluster) also regulated by Ace2, although the specific genes differ due to divergent cell wall composition and budding versus fission modes of division (oliva2005thecellcycle–regulated pages 9-11).</p>
+<h3 id="62-flocculation">6.2 Flocculation</h3>
+<p>Flocculation in <em>S. pombe</em> is regulated by a complex transcriptional network involving multiple transcription factors (Mbx2, Cbf11, Cbf12, Rfl1, Adn2, Adn3, Sre2, Yox1) and their target genes encoding cell surface glycoproteins (flocculins) and cell wall-remodeling enzymes (kwon2012decipheringthetranscriptionalregulatory pages 10-11). Adg2, as an Ace2 target, is connected to this network: overexpression of Adn2/Adn3 downregulates ace2 and its targets including adg2, while simultaneously upregulating cell wall-remodeling enzymes that promote flocculation (kwon2012decipheringthetranscriptionalregulatory pages 10-11). This suggests that adg2 expression may contribute to the non-flocculent, separated state of cells during normal vegetative growth.</p>
+<h3 id="63-cell-wall-biogenesis">6.3 Cell Wall Biogenesis</h3>
+<p>In <em>S. pombe</em>, the cell wall is composed primarily of β-1,3-glucan and α-1,3-glucan, with galactomannan as a minor component (teparic2020evolutionaryoverviewof pages 11-13, teparic2020evolutionaryoverviewof pages 8-9). Six covalently bound cell wall proteins have been experimentally identified by mass spectrometry, including four GPI-bonded proteins (Gas1, Gas5, Ecm33, Pwp1) and two alkali-extractable proteins (Psu1, Asl1) (teparic2020evolutionaryoverviewof pages 8-9). GPI anchor biosynthesis is essential in <em>S. pombe</em>, as mutations in GPI synthesis genes are lethal, underscoring the critical importance of GPI-anchored proteins in cell wall integrity (teparic2020evolutionaryoverviewof pages 8-9).</p>
+<h3 id="64-meiosis-and-sporulation">6.4 Meiosis and Sporulation</h3>
+<p>The meiotic upregulation of adg2 (as mug46) suggests a role during sexual differentiation, potentially in <strong>cell surface remodeling during mating or ascospore wall formation</strong>. During sporulation in <em>S. pombe</em>, cells undergo dramatic morphological changes including forespore membrane assembly and spore wall biosynthesis (teparic2020evolutionaryoverviewof pages 11-13). The chitin synthase Chs1 is required for asci formation in <em>S. pombe</em>, and spore wall formation involves synthesis of specialized wall polymers (teparic2020evolutionaryoverviewof pages 5-6). A GPI-anchored cell surface glycoprotein like Adg2 could contribute to these surface remodeling processes, although direct evidence for this role is lacking.</p>
+<h2 id="7-evolutionary-context">7. Evolutionary Context</h2>
+<p>The Eng1 cluster regulatory program is evolutionarily conserved between <em>S. pombe</em> and <em>S. cerevisiae</em>, with both organisms using Ace2 transcription factor binding to CCAGCC consensus sequences to coordinate expression of cell separation genes (oliva2005thecellcycle–regulated pages 9-11). However, the specific gene complement differs between species, reflecting the divergent cell wall compositions (β-glucan in both, but with α-1,3-glucan in <em>S. pombe</em> and chitin/mannan emphasis in <em>S. cerevisiae</em>) and distinct modes of cell division (fission versus budding). Notably, only eng1 and its <em>S. cerevisiae</em> ortholog DSE4 are clearly conserved between the two clusters, while other genes, including adg2, appear to be species-specific adaptations to the fission yeast cell wall architecture (oliva2005thecellcycle–regulated pages 9-11). GPI-anchored cell wall proteins involved in adhesion and cell separation are generally not highly conserved among yeast species, in contrast to GPI-anchored enzymes involved in cell wall biosynthesis (such as Gas/Phr glucanosyltransferases), which show broad conservation (teparic2020evolutionaryoverviewof pages 8-9).</p>
+<h2 id="8-limitations-and-knowledge-gaps">8. Limitations and Knowledge Gaps</h2>
+<p>It is important to note that <strong>adg2/mug46 remains a relatively poorly characterized gene</strong>. No targeted knockout or biochemical studies specifically focused on Adg2 function have been identified in the available literature. The functional annotation as a cell surface glycoprotein involved in cell separation is based primarily on:</p>
+<ol>
+<li>Its membership in the Eng1 cluster and Ace2-dependent regulation (oliva2005thecellcycle–regulated pages 9-11)</li>
+<li>Bioinformatic prediction as a GPI-anchored protein (groot2003genome‐wideidentificationof pages 10-12)</li>
+<li>Its serine/threonine-rich composition consistent with cell wall glycoprotein architecture (dranginis2007abiochemicalguide pages 10-11, dranginis2007abiochemicalguide pages 8-9)</li>
+<li>Its involvement in the flocculation transcriptional regulatory network (kwon2012decipheringthetranscriptionalregulatory pages 10-11)</li>
+</ol>
+<p>The precise molecular function of Adg2 at the cell surface—whether it functions as an adhesin, a structural scaffold, or has other activities—remains to be determined experimentally. Similarly, the specific contribution of Adg2 to meiosis and sporulation (as implied by its mug46 designation) awaits targeted investigation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(inamura2021expressionofmug14 pages 1-2): Shin-ich Inamura, Takuma Tanabe, Makoto Kawamukai, and Yasuhiro Matsuo. Expression of mug14 is regulated by the transcription factor rst2 through the camp-dependent protein kinase pathway in schizosaccharomyces pombe. Current Genetics, 67:807-821, Jun 2021. URL: https://doi.org/10.1007/s00294-021-01194-z, doi:10.1007/s00294-021-01194-z. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(oliva2005thecellcycle–regulated pages 9-11): Anna Oliva, Adam Rosebrock, Francisco Ferrezuelo, Saumyadipta Pyne, Haiying Chen, Steve Skiena, Bruce Futcher, and Janet Leatherwood. The cell cycle–regulated genes of schizosaccharomyces pombe. PLoS Biology, 3:e225, Jun 2005. URL: https://doi.org/10.1371/journal.pbio.0030225, doi:10.1371/journal.pbio.0030225. This article has 272 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(groot2003genome‐wideidentificationof pages 10-12): Piet W. J. de Groot, Klaas J. Hellingwerf, and Frans M. Klis. Genome‐wide identification of fungal gpi proteins. Yeast, 20:781-796, Jul 2003. URL: https://doi.org/10.1002/yea.1007, doi:10.1002/yea.1007. This article has 388 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dranginis2007abiochemicalguide pages 10-11): Anne M. Dranginis, Jason M. Rauceo, Juan E. Coronado, and Peter N. Lipke. A biochemical guide to yeast adhesins: glycoproteins for social and antisocial occasions. Microbiology and Molecular Biology Reviews, 71:282-294, Jun 2007. URL: https://doi.org/10.1128/mmbr.00037-06, doi:10.1128/mmbr.00037-06. This article has 364 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dranginis2007abiochemicalguide pages 9-10): Anne M. Dranginis, Jason M. Rauceo, Juan E. Coronado, and Peter N. Lipke. A biochemical guide to yeast adhesins: glycoproteins for social and antisocial occasions. Microbiology and Molecular Biology Reviews, 71:282-294, Jun 2007. URL: https://doi.org/10.1128/mmbr.00037-06, doi:10.1128/mmbr.00037-06. This article has 364 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dranginis2007abiochemicalguide pages 2-3): Anne M. Dranginis, Jason M. Rauceo, Juan E. Coronado, and Peter N. Lipke. A biochemical guide to yeast adhesins: glycoproteins for social and antisocial occasions. Microbiology and Molecular Biology Reviews, 71:282-294, Jun 2007. URL: https://doi.org/10.1128/mmbr.00037-06, doi:10.1128/mmbr.00037-06. This article has 364 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kwon2012decipheringthetranscriptionalregulatory pages 10-11): Eun-Joo Gina Kwon, Amy Laderoute, Kate Chatfield-Reed, Lianne Vachon, Jim Karagiannis, and Gordon Chua. Deciphering the transcriptional-regulatory network of flocculation in schizosaccharomyces pombe. PLoS Genetics, 8:e1003104, Dec 2012. URL: https://doi.org/10.1371/journal.pgen.1003104, doi:10.1371/journal.pgen.1003104. This article has 55 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garg2015anewtranscription pages 8-9): Angad Garg, Bruce Futcher, and Janet Leatherwood. A new transcription factor for mitosis: in schizosaccharomyces pombe, the rfx transcription factor sak1 works with forkhead factors to regulate mitotic expression. Nucleic Acids Research, 43:6874-6888, Apr 2015. URL: https://doi.org/10.1093/nar/gkv274, doi:10.1093/nar/gkv274. This article has 41 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garg2015anewtranscription pages 7-8): Angad Garg, Bruce Futcher, and Janet Leatherwood. A new transcription factor for mitosis: in schizosaccharomyces pombe, the rfx transcription factor sak1 works with forkhead factors to regulate mitotic expression. Nucleic Acids Research, 43:6874-6888, Apr 2015. URL: https://doi.org/10.1093/nar/gkv274, doi:10.1093/nar/gkv274. This article has 41 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kok2026nucleosomepositioningshapes pages 29-30): Jian Yi Kok, Zachary H. Harvey, Elin Axelsson, and Frédéric Berger. Nucleosome positioning shapes cryptic antisense transcription. BioRxiv, Jul 2026. URL: https://doi.org/10.1101/2025.07.14.664753, doi:10.1101/2025.07.14.664753. This article has 0 citations.</p>
+</li>
+<li>
+<p>(inamura2021expressionofmug14 pages 2-4): Shin-ich Inamura, Takuma Tanabe, Makoto Kawamukai, and Yasuhiro Matsuo. Expression of mug14 is regulated by the transcription factor rst2 through the camp-dependent protein kinase pathway in schizosaccharomyces pombe. Current Genetics, 67:807-821, Jun 2021. URL: https://doi.org/10.1007/s00294-021-01194-z, doi:10.1007/s00294-021-01194-z. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dranginis2007abiochemicalguide pages 8-9): Anne M. Dranginis, Jason M. Rauceo, Juan E. Coronado, and Peter N. Lipke. A biochemical guide to yeast adhesins: glycoproteins for social and antisocial occasions. Microbiology and Molecular Biology Reviews, 71:282-294, Jun 2007. URL: https://doi.org/10.1128/mmbr.00037-06, doi:10.1128/mmbr.00037-06. This article has 364 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(teparic2020evolutionaryoverviewof pages 11-13): Renata Teparić, Mateja Lozančić, and Vladimir Mrša. Evolutionary overview of molecular interactions and enzymatic activities in the yeast cell walls. International Journal of Molecular Sciences, 21:8996, Nov 2020. URL: https://doi.org/10.3390/ijms21238996, doi:10.3390/ijms21238996. This article has 35 citations.</p>
+</li>
+<li>
+<p>(teparic2020evolutionaryoverviewof pages 8-9): Renata Teparić, Mateja Lozančić, and Vladimir Mrša. Evolutionary overview of molecular interactions and enzymatic activities in the yeast cell walls. International Journal of Molecular Sciences, 21:8996, Nov 2020. URL: https://doi.org/10.3390/ijms21238996, doi:10.3390/ijms21238996. This article has 35 citations.</p>
+</li>
+<li>
+<p>(teparic2020evolutionaryoverviewof pages 5-6): Renata Teparić, Mateja Lozančić, and Vladimir Mrša. Evolutionary overview of molecular interactions and enzymatic activities in the yeast cell walls. International Journal of Molecular Sciences, 21:8996, Nov 2020. URL: https://doi.org/10.3390/ijms21238996, doi:10.3390/ijms21238996. This article has 35 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="adg2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="adg2-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kwon2012decipheringthetranscriptionalregulatory pages 10-11</li>
+<li>garg2015anewtranscription pages 8-9</li>
+<li>kok2026nucleosomepositioningshapes pages 29-30</li>
+<li>dranginis2007abiochemicalguide pages 9-10</li>
+<li>dranginis2007abiochemicalguide pages 10-11</li>
+<li>teparic2020evolutionaryoverviewof pages 8-9</li>
+<li>teparic2020evolutionaryoverviewof pages 11-13</li>
+<li>teparic2020evolutionaryoverviewof pages 5-6</li>
+<li>dranginis2007abiochemicalguide pages 2-3</li>
+<li>garg2015anewtranscription pages 7-8</li>
+<li>dranginis2007abiochemicalguide pages 8-9</li>
+<li>https://doi.org/10.1007/s00294-021-01194-z,</li>
+<li>https://doi.org/10.1371/journal.pbio.0030225,</li>
+<li>https://doi.org/10.1002/yea.1007,</li>
+<li>https://doi.org/10.1128/mmbr.00037-06,</li>
+<li>https://doi.org/10.1371/journal.pgen.1003104,</li>
+<li>https://doi.org/10.1093/nar/gkv274,</li>
+<li>https://doi.org/10.1101/2025.07.14.664753,</li>
+<li>https://doi.org/10.3390/ijms21238996,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(adg2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O13854" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="adg2-spac19g1216c-mug46-curation-notes">adg2 (SPAC19G12.16c / mug46) — curation notes</h1>
+<p>UniProt: O13854 (ADG2_SCHPO). <em>Schizosaccharomyces pombe</em> (NCBITaxon:284812).<br />
+PomBase systematic name: SPAC19G12.16c (also SPAC23A1.01c). Standard name: adg2.<br />
+Synonym: mug46 ("meiotically up-regulated gene 46").</p>
+<p>This is an <strong>understudied ("dark") gene</strong>: PE 3 (Inferred from homology). No targeted<br />
+knockout, purification, or biochemical assay of Adg2 itself has been reported. Function<br />
+is inferred from (i) sequence/domain features, (ii) genome-wide GPI-protein prediction,<br />
+and (iii) co-regulation with characterized cell-separation genes.</p>
+<h2 id="known-evidence-supported">KNOWN (evidence-supported)</h2>
+<h3 id="protein-architecture-from-uniprot-o13854-inline-sequence-analysis">Protein architecture (from UniProt O13854 + inline sequence analysis)</h3>
+<ul>
+<li>670 aa <strong>precursor</strong> with an N-terminal <strong>signal peptide</strong> (residues 1–19, ECO:0000255)<br />
+  → enters the secretory pathway.</li>
+<li><strong>Serine/threonine-rich</strong>: RecName is literally "Serine/threonine-rich protein adg2".<br />
+  Inline compositional analysis of the mature chain gives ~50% Ser+Thr (Ser ~198, Thr ~137<br />
+  of ~670 residues). This is the hallmark composition of fungal cell-wall/cell-surface<br />
+  glycoproteins and adhesin stalks.</li>
+<li><strong>Heavily N-glycosylated</strong>: 17 predicted N-linked glycosylation sites (CARBOHYD, ECO:0000255);<br />
+  UniProt keyword "Glycoprotein"; GlyCosmos lists 17 sites. Consistent with a secreted/surface<br />
+  glycoprotein.</li>
+<li><strong>Disordered region</strong> 526–651 (MobiDB-lite) within the S/T-rich body — consistent with an<br />
+  extended, glycosylated stalk rather than a compact globular enzyme.</li>
+<li><strong>C-terminal hydrophobic tail</strong>: the last ~20 residues (…SLQRISLL<strong>CVFIPLLFLF</strong>) are ~14/20<br />
+  hydrophobic, immediately following a small-residue region — the canonical shape of a<br />
+<strong>GPI-anchor addition signal</strong> (omega site + spacer + hydrophobic tail), NOT an internal<br />
+  transmembrane helix. No internal TM domains.</li>
+<li>Family/domain calls: <strong>InterPro IPR052479 "GPI-anchor_Adhesion_Reg"</strong>;<br />
+<strong>PANTHER PTHR35185</strong> "SERINE/THREONINE-RICH PROTEIN ADG2-RELATED" (subfamily SF3 = Adg2 itself).<br />
+  There is no catalytic domain (no glycoside hydrolase, no kinase, etc.).</li>
+</ul>
+<h3 id="gpi-anchored-cell-surface-prediction">GPI-anchored cell-surface prediction</h3>
+<ul>
+<li>adg2 (SPAC19G12.16c) is one of <strong>33 predicted GPI-protein candidates</strong> in the <em>S. pombe</em><br />
+  genome identified by a genome-wide computational survey<br />
+  [PMID:12845604 "Genome-wide identification of fungal GPI proteins." De Groot et al. 2003 Yeast].<br />
+  The abstract states: <em>"In Sz. pombe … only 33 GPI candidates were identified"</em> and the method<br />
+  screens for a C-terminal GPI attachment consensus plus an N-terminal secretion signal and<br />
+  absence of internal TM domains — all of which adg2 satisfies. (Abstract-only in cache; the<br />
+  gene-level assignment is the basis of the PomBase TAS <code>cell surface</code> annotation.)</li>
+<li>This is the basis for the UniProt SubCell mapping <strong>extracellular region</strong> (SL-0243); note<br />
+  UniProt marks "Secreted {ECO:0000305}" (i.e. inferred, not experimental).</li>
+</ul>
+<h3 id="subcellular-localization">Subcellular localization</h3>
+<ul>
+<li><strong>Endoplasmic reticulum</strong> — experimental, high-throughput YFP-tagging ORFeome localization<br />
+  screen [PMID:16823372 "ORFeome cloning and global analysis of protein localization in the fission<br />
+  yeast Schizosaccharomyces pombe." Matsuyama et al. 2006 Nat Biotechnol]. This is the<br />
+  ECO:0000269 experimental basis in the UniProt SUBCELLULAR LOCATION line ("Endoplasmic reticulum<br />
+  {ECO:0000269|PubMed:16823372}"). ER localization is fully consistent with a secretory-pathway<br />
+  glycoprotein transiting the ER en route to the surface/wall. Abstract-only in cache (the<br />
+  per-protein localization is in the paper's dataset, not the abstract).</li>
+<li><strong>Cell surface</strong> — TAS (PomBase, is_active_in), original_reference PMID:12845604, i.e. the GPI<br />
+  prediction. PomBase's own product description is "conserved fungal cell surface (protein)".</li>
+</ul>
+<h3 id="transcriptional-regulation-process-association-co-regulation-inference">Transcriptional regulation / process association (co-regulation inference)</h3>
+<ul>
+<li>adg2 is a member of the <strong>"Eng1 cluster"</strong>, a nine-gene, tightly cell-cycle-regulated,<br />
+  Ace2-controlled module "involved in cell separation"<br />
+  [PMID:15966770 "The cell cycle-regulated genes of Schizosaccharomyces pombe." Oliva et al. 2005<br />
+  PLoS Biol], verbatim (full text cached):<br />
+<em>"The Eng1 cluster (Figure 8C) contains nine genes, and these are involved in cell separation.<br />
+  The genes are adg1 and adg2 (cell surface glycoproteins), adg3 (β-glucosidase), agn1 and eng1<br />
+  (glycosyl hydrolases), cfh4 (chitin synthase regulatory factor), mid2 (an anillin needed for<br />
+  cell division and septin organization), ace2 (a cell cycle transcription factor), and SPCC306.11,<br />
+  a sequence orphan of unknown function."</em><br />
+  Each cluster gene carries ≥1 Ace2 binding site (consensus CCAGCC); peak expression is slightly<br />
+  after the Cdc15/Cdc18 clusters (M/cytokinesis).</li>
+<li>Flocculation network: adg2 is an Ace2 target whose transcript is down-regulated (1.5–3.4×) when<br />
+  the FLO8-like activators Adn2/Adn3 are overexpressed<br />
+  [PMID:23236291 "Deciphering the transcriptional-regulatory network of flocculation in<br />
+  Schizosaccharomyces pombe." Kwon et al. 2012 PLoS Genet]. (Regulatory placement only; does not<br />
+  assign a molecular function to Adg2.)</li>
+<li><strong>mug46 = meiotically up-regulated gene 46</strong>: adg2 was identified in the meiotic-upregulation<br />
+  gene set (Mata et al. 2002 transcriptome). Reflects transcriptional induction during sexual<br />
+  differentiation, not a demonstrated meiotic function.</li>
+</ul>
+<h2 id="not-known-genuine-gaps">NOT known (genuine gaps)</h2>
+<ul>
+<li><strong>Molecular function is unknown.</strong> No catalytic domain; no ligand/binding partner identified;<br />
+  no adhesin binding activity demonstrated. The IPR052479/PANTHER "adhesion regulation" family<br />
+  name is a computational family label, not experimental evidence that Adg2 is an adhesin.</li>
+<li><strong>Direct biological role is inferred, not demonstrated.</strong> "Involved in cell separation" is a<br />
+<em>cluster-level co-regulation inference</em> (Oliva 2005 grouped adg2 with eng1/agn1 by expression<br />
+  timing + shared Ace2 sites + a "cell surface glycoprotein" descriptor). Adg2 itself was not<br />
+  functionally assayed; there is no adg2Δ separation phenotype in the retrieved literature.</li>
+<li><strong>GPI anchorage is predicted, not experimentally confirmed</strong> for Adg2 (the C-terminal ω-site<br />
+  has not been mapped; the anchor has not been shown biochemically). The experimental localization<br />
+  that exists (PMID:16823372) is ER, i.e. a transit/secretory compartment, not confirmation of a<br />
+  mature GPI-anchored wall protein.</li>
+<li><strong>Meiotic/sporulation function</strong> implied by the mug46 name is uncharacterized.</li>
+</ul>
+<h2 id="annotation-by-annotation-plan-goa-has-5">Annotation-by-annotation plan (GOA has 5)</h2>
+<ol>
+<li>GO:0005576 extracellular region — IEA, GO_REF:0000044 (SubCell SL-0243). KEEP_AS_NON_CORE.<br />
+   Defensible from signal peptide + GPI/secretion prediction; broad CC.</li>
+<li>GO:0005783 endoplasmic reticulum — IEA, GO_REF:0000044 (SubCell SL-0095). KEEP_AS_NON_CORE.<br />
+   Backed experimentally by PMID:16823372 (transit compartment for a secretory glycoprotein).</li>
+<li>GO:0003674 molecular_function (root) — ND, GO_REF:0000015. ACCEPT (honestly captures that MF is<br />
+   unknown; do not invent a function).</li>
+<li>GO:0008150 biological_process (root) — ND, GO_REF:0000015. ACCEPT (BP not experimentally<br />
+   established for adg2 itself; cell-separation role is co-regulation inference only).</li>
+<li>GO:0009986 cell surface — TAS (PomBase), PMID:12845604. KEEP_AS_NON_CORE. Grounded in the GPI<br />
+   prediction + S/T-rich glycoprotein architecture; location, not mechanism.</li>
+</ol>
+<p>No REMOVE actions: nothing is contradicted, and the two experimental/curated calls (ER, cell surface)<br />
+are consistent with the protein's secretory-glycoprotein architecture. No <code>protein binding</code>.</p>
+<p>core_functions: none author-able with confidence — the molecular function is genuinely unknown.<br />
+Leave core_functions empty and put the reasoning in knowledge_gaps (primary deliverable).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O13854
+gene_symbol: adg2
+product_type: PROTEIN
+aliases:
+- mug46
+- SPAC19G12.16c
+- SPAC23A1.01c
+status: DRAFT
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  adg2 encodes a serine/threonine-rich, heavily N-glycosylated secretory-pathway
+  glycoprotein of the fission yeast Schizosaccharomyces pombe. The protein carries an
+  N-terminal signal peptide, a long internally disordered Ser/Thr-rich body (~50% Ser+Thr,
+  17 predicted N-glycosylation sites), and a C-terminal hydrophobic tail with the features
+  of a glycosylphosphatidylinositol (GPI) anchor-addition signal, and it is one of the small
+  set of predicted GPI-anchored proteins in the S. pombe genome. It has no recognizable
+  catalytic domain. It transits the endoplasmic reticulum and is assigned to the fungal cell
+  surface, consistent with the architecture of cell-wall/cell-surface glycoproteins. Its
+  transcription is periodic and Ace2-dependent, peaking around cytokinesis, and it is induced
+  during meiosis (hence the alias mug46), but no molecular activity or direct biological role
+  has been demonstrated experimentally for the protein itself.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:12845604
+  title: Genome-wide identification of fungal GPI proteins.
+  findings:
+  - statement: &gt;-
+      A genome-wide computational screen for a C-terminal GPI attachment consensus, an
+      N-terminal secretion signal and absence of internal transmembrane domains identified
+      only 33 GPI-protein candidates in the S. pombe genome; adg2/SPAC19G12.16c is among them,
+      the basis for its cell-surface / GPI-anchored classification.
+    supporting_text: only 33 GPI candidates were identified
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/DOI-verified (Yeast 2003; De Groot, Hellingwerf, Klis). Abstract-only in cache;
+      the per-gene assignment of SPAC19G12.16c to the 33 S. pombe GPI candidates underlies the
+      PomBase TAS cell-surface annotation. Establishes a predicted GPI-anchored cell-surface
+      role, not an experimentally demonstrated molecular function.
+- id: PMID:16823372
+  title: ORFeome cloning and global analysis of protein localization in the fission
+    yeast Schizosaccharomyces pombe.
+  findings:
+  - statement: &gt;-
+      High-throughput YFP-tagging localization of ~4,431 S. pombe proteins; the per-protein
+      dataset assigns adg2 to the endoplasmic reticulum, the experimental basis for the
+      UniProt ER localization (ECO:0000269|PubMed:16823372).
+    supporting_text: &gt;-
+      we determined the localization of 4,431 proteins, corresponding to
+      approximately 90% of the fission yeast proteome, by tagging each ORF with the
+      yellow fluorescent protein
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/DOI-verified (Nat Biotechnol 2006; Matsuyama et al.). Genome-scale YFP
+      localization screen; the specific adg2 ER call is in the dataset rather than the
+      abstract. ER is a transit/secretory compartment consistent with a secretory glycoprotein,
+      not confirmation of a mature GPI-anchored cell-wall product.
+- id: PMID:15966770
+  title: The cell cycle-regulated genes of Schizosaccharomyces pombe.
+  findings:
+  - statement: &gt;-
+      adg2 is a member of the nine-gene, Ace2-regulated &#34;Eng1 cluster&#34; of cell-cycle-regulated
+      genes described as involved in cell separation, where adg1 and adg2 are annotated as cell
+      surface glycoproteins alongside glucan hydrolases (eng1, agn1, adg3).
+    supporting_text: &gt;-
+      The Eng1 cluster (Figure 8C) contains nine genes, and these are involved in cell
+      separation. The genes are adg1 and adg2 (cell surface glycoproteins)
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PLoS Biol 2005; Oliva et al.; PMID 15966770). Full text cached. The
+      cell-separation role of adg2 is a cluster-level co-regulation inference (shared Ace2 sites
+      + expression timing + a cell-surface-glycoprotein descriptor); adg2 itself was not
+      functionally assayed here, so this supports a plausible process association, not a
+      demonstrated adg2 function.
+- id: PMID:23236291
+  title: Deciphering the transcriptional-regulatory network of flocculation in Schizosaccharomyces
+    pombe.
+  findings:
+  - statement: &gt;-
+      Places adg2 within the S. pombe cell-surface/flocculation transcriptional network as an
+      Ace2-regulon target modulated by the FLO8-like activators Adn2/Adn3; regulatory context
+      only, assigning no molecular function to Adg2.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PLoS Genet 2012; Kwon et al.; PMID 23236291). Full text cached. Provides
+      transcriptional-network context (adg2 as an Ace2 target linked to the Adn2/Adn3 flocculation
+      program) but does not establish an Adg2 molecular activity; cited for regulatory placement,
+      not for a function claim, so no verbatim supporting_text is attached.
+existing_annotations:
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Broad extracellular localization mapped by UniProt from the Secreted subcellular-location
+      keyword (SL-0243). Defensible for a signal-peptide-bearing, GPI/secretion-predicted
+      glycoprotein, but it is a coarse location term inferred electronically, not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the protein&#39;s secretory architecture (N-terminal signal peptide, no
+      internal TM domains) and its inclusion among predicted S. pombe GPI proteins (PMID:12845604).
+      Retained as a broad, non-core cellular-component annotation; the more specific cell surface
+      term (GO:0009986) is preferred where a surface location is intended.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ER localization, mapped electronically by UniProt (SL-0095) but ultimately grounded in an
+      experimental YFP-tagging localization screen (PMID:16823372). The ER is the expected transit
+      compartment for a secretory-pathway glycoprotein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported localization (PMID:16823372) that is fully consistent with a
+      secreted/surface glycoprotein transiting the ER. Retained as a legitimate, non-core cellular
+      component; it reflects where the protein is processed, not its molecular function.
+    supported_by:
+    - reference_id: PMID:16823372
+      supporting_text: &gt;-
+        we determined the localization of 4,431 proteins, corresponding to
+        approximately 90% of the fission yeast proteome, by tagging each ORF with the
+        yellow fluorescent protein
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function with ND (No biological Data). This is the correct, honest
+      representation: adg2 has no recognizable catalytic domain and no experimentally determined
+      molecular activity. The InterPro/PANTHER &#34;GPI-anchor adhesion regulation&#34; family name is a
+      computational label, not evidence of adhesin activity.
+    action: ACCEPT
+    reason: &gt;-
+      The molecular function of Adg2 is genuinely unknown; ND on the MF root faithfully captures
+      this. No informative MF term (including adhesion or binding terms) is supportable from
+      current evidence, so no replacement is proposed. See knowledge_gaps.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process with ND. adg2 is co-regulated with cell-separation genes (Ace2/Eng1
+      cluster, PMID:15966770) and induced during meiosis (mug46), but no biological process has
+      been experimentally demonstrated for the protein itself, so the ND root is appropriate.
+    action: ACCEPT
+    reason: &gt;-
+      The cell-separation association is a cluster-level co-regulation inference, not a
+      demonstrated adg2 function; there is no reported adg2 loss-of-function phenotype. Retaining
+      ND on the BP root is the conservative, defensible choice. The candidate process is recorded
+      in knowledge_gaps rather than asserted as an annotation.
+- term:
+    id: GO:0009986
+    label: cell surface
+  evidence_type: TAS
+  original_reference_id: PMID:12845604
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cell surface localization curated by PomBase (TAS) from the genome-wide fungal GPI-protein
+      prediction (PMID:12845604), consistent with the Ser/Thr-rich, heavily glycosylated,
+      GPI-signal-bearing architecture and PomBase&#39;s &#34;conserved fungal cell surface&#34; product
+      description.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Best-supported surface localization for a predicted GPI-anchored glycoprotein; a legitimate
+      cellular-component annotation. It is a location, not a molecular function, and GPI anchorage
+      is predicted rather than experimentally confirmed, so it is retained as non-core.
+    supported_by:
+    - reference_id: PMID:12845604
+      supporting_text: only 33 GPI candidates were identified
+core_functions: []
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of Adg2 is undetermined. No catalytic activity, ligand, adhesion
+    target, or binding partner has been identified, and the protein has no recognizable
+    enzymatic domain.
+  boundary: &gt;-
+    Sequence and family evidence firmly establish that Adg2 is a secretory-pathway
+    serine/threonine-rich glycoprotein (N-terminal signal peptide; ~50% Ser+Thr; 17 predicted
+    N-glycosylation sites; long disordered stalk) with a C-terminal GPI-anchor-addition-signal
+    architecture, placing it in InterPro IPR052479 (&#34;GPI-anchor_Adhesion_Reg&#34;) and PANTHER
+    PTHR35185. What that family name implies mechanistically — whether Adg2 is a genuine adhesin,
+    a structural cell-wall/surface component, or something else — is not experimentally supported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Adg2 is a conserved fungal cell-surface protein of unknown activity (UniProt PE 3, inferred
+    from homology). Assigning its molecular role would convert a coarse &#34;cell surface glycoprotein&#34;
+    into a defined surface function and clarify what the IPR052479 &#34;GPI-anchor adhesion regulation&#34;
+    family actually does.
+  resolution: &gt;-
+    Biochemical/cell-biological characterization: confirm GPI anchorage and cell-wall vs
+    plasma-membrane residence, test for adhesion/flocculation or aggregation activity, and search
+    for interaction partners of the mature glycoprotein.
+  provenance:
+  - reference_id: PMID:12845604
+    supporting_text: only 33 GPI candidates were identified
+- gap_statement: &gt;-
+    The direct biological role of Adg2 is not experimentally established. Its assignment to cell
+    separation rests on transcriptional co-regulation with characterized separation genes, not on
+    any measured adg2 loss-of-function phenotype.
+  boundary: &gt;-
+    adg2 is a member of the nine-gene, Ace2-regulated, cell-cycle-periodic &#34;Eng1 cluster&#34; that
+    peaks around cytokinesis and is described as involved in cell separation, where it is grouped
+    with the glucan hydrolases eng1, agn1 and adg3; it is also induced during meiosis (alias mug46)
+    and modulated within the Adn2/Adn3 flocculation network. All of this is regulatory/expression
+    evidence about when adg2 is transcribed, not about what the protein does.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing a genuine, direct contribution to daughter-cell separation (or to meiotic
+    surface remodeling) from mere co-regulation is required before a specific biological-process
+    term could be annotated for adg2 itself.
+  resolution: &gt;-
+    Phenotypic analysis of an adg2 deletion (and adg1/adg2 double deletion) for cell-separation,
+    cell-wall-integrity, flocculation and sporulation defects, with localization of tagged Adg2
+    relative to the division septum.
+  provenance:
+  - reference_id: PMID:15966770
+    supporting_text: &gt;-
+      The Eng1 cluster (Figure 8C) contains nine genes, and these are involved in cell
+      separation. The genes are adg1 and adg2 (cell surface glycoproteins)
+- gap_statement: &gt;-
+    Whether Adg2 is actually GPI-anchored, and whether it resides at the plasma membrane or is
+    cross-linked into the cell wall, has not been experimentally verified; the C-terminal omega
+    (GPI-attachment) site has not been mapped.
+  boundary: &gt;-
+    Adg2 has a C-terminal hydrophobic tail consistent with a GPI-anchor-addition signal and was
+    computationally predicted to be one of 33 S. pombe GPI proteins (PMID:12845604); the only
+    experimental localization reported is endoplasmic reticulum from a genome-scale YFP screen
+    (PMID:16823372), a transit compartment rather than a mature surface/wall location.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    GPI anchorage versus soluble secretion, and plasma-membrane versus covalent cell-wall
+    residence, change how the surface annotation should be interpreted and constrain the protein&#39;s
+    possible function.
+  resolution: &gt;-
+    Direct biochemistry (e.g. PI-PLC sensitivity, GPI-anchor mapping, alkali/glucanase extraction
+    of the wall fraction) and steady-state surface imaging of endogenously tagged Adg2.
+  provenance:
+  - reference_id: PMID:12845604
+    supporting_text: only 33 GPI candidates were identified
+suggested_questions:
+- question: &gt;-
+    Is Adg2 an adhesin/flocculin, a passive structural cell-surface glycoprotein, or does it have
+    another activity — and does the IPR052479 &#34;GPI-anchor adhesion regulation&#34; family designation
+    reflect a real adhesion-related function?
+  experts:
+  - Frans M. Klis
+  - Gordon Chua
+- question: &gt;-
+    Does adg2 deletion produce a cell-separation, cell-wall-integrity, flocculation, or sporulation
+    phenotype, and is any such role redundant with its paralog adg1?
+  experts:
+  - Janet Leatherwood
+suggested_experiments:
+- hypothesis: &gt;-
+    Adg2 is a GPI-anchored, cell-wall-associated surface glycoprotein rather than a soluble
+    secreted protein.
+  description: &gt;-
+    Endogenously tag adg2 at the C-terminus internal to the predicted GPI signal (or N-terminally
+    after the signal peptide), image steady-state localization by fluorescence microscopy, and
+    test anchor type biochemically (PI-PLC release, and alkali/glucanase extraction to distinguish
+    plasma-membrane GPI from covalent cell-wall linkage).
+  experiment_type: protein localization and biochemical anchor characterization
+- hypothesis: &gt;-
+    Adg2 contributes directly to daughter-cell separation and/or cell-surface adhesion, beyond its
+    co-regulation with the Ace2/Eng1 cluster.
+  description: &gt;-
+    Construct adg2Δ and adg1Δ adg2Δ strains and assay cell-separation defects (cell chaining,
+    calcofluor septum staining), cell-wall-integrity stress sensitivity, flocculation/aggregation,
+    and sporulation efficiency, comparing to eng1Δ/agn1Δ separation phenotypes.
+  experiment_type: gene deletion and phenotypic analysis
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/ahk1/ahk1-ai-review.html
+++ b/genes/SCHPO/ahk1/ahk1-ai-review.html
@@ -1,0 +1,2352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ahk1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ahk1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O14260" target="_blank" class="term-link">
+                        O14260
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ahk1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O14260" data-a="DESCRIPTION: ahk1 (SPAC7D4.03c; UniProt O14260) is a large (886..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ahk1 (SPAC7D4.03c; UniProt O14260) is a large (886-residue) fungal-specific protein of the UPF0592 family, defined by a single DUF1765 domain (Pfam PF08578; InterPro IPR013887; PANTHER PTHR37988). It is predicted to be a multi-pass membrane protein (three predicted transmembrane helices) and contains a disordered, low-complexity region near its N-terminus, but it carries no recognizable catalytic motif, consistent with a non-catalytic role. The DUF1765 domain has no experimentally assigned biochemical function. Its budding-yeast homolog, Saccharomyces cerevisiae Ahk1 (YDL073W), is an experimentally validated scaffold protein of the HKR1 sub-branch of the Hog1 osmostress-activated MAPK pathway that binds the Hkr1 cytoplasmic domain together with Sho1, Ste11 and Pbs2 and prevents aberrant cross-talk signalling to the Kss1 MAPK. On the basis of that orthology (shared UPF0592 domain family), the fission-yeast protein is proposed to be a putative MAP-kinase-cascade scaffold, though this role has not been tested in fission yeast. The gene is non-essential (ahk1 deletion is viable), and in genome-wide phenotypic screens its deletion is associated with altered stress responses (sensitivity or resistance to osmotic, cell-wall, and genotoxic agents) and abnormalities in mating and shmoo morphology, a fingerprint broadly compatible with a role in stress-responsive signalling. No direct molecular function, binding partner, localization, or specific pathway role has been demonstrated for the fission-yeast protein itself.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O14260" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Low-resolution, prediction-based localization. UniProt predicts three transmembrane helices and annotates the protein as a multi-pass membrane protein by ECO:0000305 inference. This is consistent with the sequence but is not experimentally demonstrated in S. pombe, and the term is the generic root-level &#34;membrane&#34;. Retain as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by UniProt transmembrane-helix predictions but unverified experimentally and uninformative as to which membrane; a plausible prediction-based localization rather than a demonstrated core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000044
+
+                                </span>
+
+                                <div class="support-text">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O14260" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level &#34;cellular_component&#34; with the ND (No biological Data) evidence code, a standard PomBase placeholder recording that no specific cellular component is known. It carries no biological content and should be retained only as a placeholder.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Root placeholder term with ND evidence; represents absence of specific localization knowledge rather than a substantive annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
+                                    GO:0000165
+                                </a>
+                            </span>
+                            <span class="term-label">MAPK cascade</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26787842
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O14260" data-a="GO:0000165" data-r="PMID:26787842" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Process annotation transferred by orthology (ISO, with-from SGD:S000002231) from S. cerevisiae AHK1, which is an experimentally validated scaffold in the Hog1 osmostress MAPK pathway. The orthology rests on the shared UPF0592/DUF1765 domain family (InterPro:IPR013887). The assignment is a plausible, curator-made transfer, but the involvement of the S. pombe protein in a MAPK cascade has not been demonstrated directly; the fission-yeast stress core (Wis1 to Sty1/Spc1) does not reproduce the budding-yeast Hkr1/Kss1 cross-talk architecture. Retain as a reasonable orthology-based hypothesis, but mark non-core and flag as a knowledge gap.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Orthology-based (ISO) transfer from a verified S. cerevisiae scaffold; biologically plausible and consistent with the deletion stress/mating phenotype fingerprint, but unproven in S. pombe. Per PomBase reliability, retained rather than removed; treated as non-core because it is inferred, not demonstrated for this gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" target="_blank" class="term-link">
+                                        PMID:26787842
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal flow from Hkr1 to Kss1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005078" target="_blank" class="term-link">
+                                    GO:0005078
+                                </a>
+                            </span>
+                            <span class="term-label">MAP kinase scaffold activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O14260" data-a="GO:0005078" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The single molecular-function annotation, transferred by orthology (ISO, GO_REF:0000024, with-from SGD:S000002231) from S. cerevisiae AHK1. It is more informative than &#34;protein binding&#34; and captures the best available functional hypothesis: that ahk1 acts as a physical scaffold assembling components of a MAPK signalling module. However, the scaffold activity has never been tested for the S. pombe protein and no fission-yeast binding partners are known. Retain as a plausible orthology-based hypothesis; mark non-core and flag as a molecular-function knowledge gap.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Orthology-based (ISO) transfer of an experimentally established S. cerevisiae molecular function; retained per PomBase reliability and because it is the most informative available MF term (preferable to protein binding), but it is inferred rather than demonstrated for S. pombe and so is treated as non-core with an explicit knowledge gap.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" target="_blank" class="term-link">
+                                        PMID:26787842
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identified a protein, termed Ahk1 (Associated with Hkr1), that binds to Hkr1-cyto.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Putative non-catalytic scaffold/adaptor of a mitogen-activated protein kinase (MAPK) signalling module. This is inferred for ahk1 from its membership of the UPF0592/DUF1765 family (InterPro:IPR013887) shared with the experimentally validated S. cerevisiae scaffold Ahk1 (YDL073W), which assembles Hkr1, Sho1, Ste11 and Pbs2 in the Hog1 osmostress MAPK pathway. The absence of any catalytic motif in ahk1 is consistent with a scaffolding rather than an enzymatic role. Direct demonstration of scaffold activity, of binding partners, and of MAPK-pathway participation in S. pombe is lacking; this core function is therefore a well-motivated hypothesis, not an established fission-yeast activity.</h3>
+                <span class="vote-buttons" data-g="O14260" data-a="FUNCTION: Putative non-catalytic scaffold/adaptor of a mitog..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005078" target="_blank" class="term-link">
+                            MAP kinase scaffold activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
+                                MAPK cascade
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" target="_blank" class="term-link">
+                                PMID:26787842
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal flow from Hkr1 to Kss1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                        <div class="finding-text">Manual transfer of experimentally-verified manual GO annotation data to orthologs</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" target="_blank" class="term-link">
+                            PMID:26787842
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2, Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated Protein Kinase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">S. cerevisiae Ahk1 is a scaffold protein of the HKR1 sub-branch of the Hog1 osmostress MAPK pathway that binds the cytoplasmic domain of the Hkr1 osmosensor and also binds Sho1, Ste11 and Pbs2, preventing incorrect signal flow from Hkr1 to the Kss1 MAPK.</div>
+
+                        <div class="finding-text">"Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal flow from Hkr1 to Kss1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe ahk1 physically associate with any component of the Sty1/Spc1 stress-activated MAPK pathway (Sty1, Wis1, Win1/Wis4) or with membrane osmosensors, and does its deletion alter stress-induced Sty1 activation?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Nishimura A, Tatebayashi K</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14260" data-a="Q: Does S. pombe ahk1 physically associate with any c..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the biochemical activity of the DUF1765 domain, and is ahk1 a bona fide scaffold or does it have an as-yet-uncharacterized molecular function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14260" data-a="Q: What is the biochemical activity of the DUF1765 do..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct an endogenously tagged ahk1 strain; perform affinity purification-mass spectrometry to identify interactors, live-cell imaging to determine localization, and quantitative immunoblotting of phospho-Sty1 in wild-type vs ahk1-deletion cells across a panel of stresses (osmotic, cell-wall, oxidative, genotoxic).</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: ahk1 acts as a membrane-associated scaffold that contributes to Sty1/Spc1 activation under osmotic or cell-wall stress in S. pombe.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interactome, localization, and signalling epistasis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14260" data-a="EXPERIMENT: Construct an endogenously tagged ahk1 strain; perf..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the structure of the ahk1 DUF1765 domain (experimentally or via AlphaFold-guided modelling) and test candidate activities biochemically; use structure-guided point mutants to link domain features to the deletion stress/mating phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The DUF1765 domain confers a defined, conserved molecular activity that underlies ahk1 function.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural biology and structure-function analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14260" data-a="EXPERIMENT: Determine the structure of the ahk1 DUF1765 domain..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether S. pombe ahk1 (SPAC7D4.03c) actually functions as a MAP-kinase scaffold, or has any scaffold activity at all, has never been tested. The molecular function is inferred entirely from the S. cerevisiae ortholog via the shared UPF0592/DUF1765 domain family; no in vivo or in vitro assay of scaffold activity, and no identification of assembled kinase-module components, has been reported for the fission-yeast protein.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Scaffold activity in the Hog1 osmostress MAPK pathway is experimentally established for S. cerevisiae Ahk1 (YDL073W = SGD:S000002231), which binds Hkr1-cyto, Sho1, Ste11 and Pbs2; the S. pombe protein shares the defining UPF0592/DUF1765 domain (InterPro:IPR013887) and lacks any catalytic motif, so a scaffolding role is plausible but unproven.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determines whether the propagated MAP-kinase scaffold activity (GO:0005078) annotation is valid for fission yeast, or whether ahk1 has a distinct (or no) signalling function despite family membership.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity purification / mass spectrometry of tagged ahk1 in S. pombe to identify direct interactors, combined with epistasis and phospho-readout assays testing whether ahk1 contributes to Sty1/Spc1 (or other MAPK) activation under stress.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"In the budding yeast Saccharomyces cerevisiae, osmostress activates the Hog1 mitogen-activated protein kinase (MAPK), which regulates diverse osmoadaptive"</em> — PMID:26787842</li>
+
+                <li><em>"Manual transfer of experimentally-verified manual GO annotation data to orthologs"</em> — GO_REF:0000024</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct binding partners of ahk1 in S. pombe are unknown. It is undetermined whether it interacts with the fission-yeast stress-MAPK components (Sty1/Spc1, the MAPKK Wis1, the MAPKKKs Win1/Wis4, or membrane osmosensors such as Wsc1/Mtl2 and the Sho1-like adaptor), or with any other proteins.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In S. cerevisiae the orthologous Ahk1 binds a defined set of HKR1-subbranch proteins (Hkr1-cyto, Sho1, Ste11, Pbs2); the fission-yeast interactome of ahk1 has not been mapped beyond generic high-throughput interaction datasets.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying partners would confirm or refute pathway membership and reveal whether ahk1 couples a membrane sensor to a specific MAPK module in fission yeast.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Co-immunoprecipitation / proximity-labelling of endogenously tagged ahk1 followed by mass spectrometry, with validation of candidate interactions by reciprocal pulldown and genetic interaction analysis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"In addition to Hkr1-cyto binding, Ahk1 also bound to other signaling molecules in the HKR1 subbranch, including Sho1, Ste11, and Pbs2."</em> — PMID:26787842</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether ahk1 has a specific, non-redundant role in the S. pombe Sty1/Spc1 stress-activated MAPK pathway is undetermined. The budding-yeast function (preventing Hkr1-to-Kss1 cross-talk) may not map onto fission yeast, whose stress core (Wis1 to Sty1) lacks the multi-branch Hkr1/Kss1 architecture, so it is unclear which, if any, signalling event ahk1 controls.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ahk1 deletion is viable and, in genome-wide screens, alters stress responses (osmotic/salt, cell-wall, and genotoxic agents) and mating/shmoo morphology; these are consistent with a stress-signalling contribution but do not localize ahk1 to a defined step or show it is non-redundant.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Placing ahk1 (or excluding it) within the Sty1/Spc1 pathway would resolve whether the orthology-based MAPK-cascade (GO:0000165) annotation reflects a real fission-yeast pathway role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Targeted epistasis analysis of ahk1 deletion with sty1, wis1 and osmosensor mutants under defined stresses, measuring Sty1 phosphorylation and downstream (e.g. atf1/gpd1) responses.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Deletion of the AHK1 gene (in the absence of other Hog1 upstream branches) only partially inhibited osmostress-induced Hog1 activation."</em> — PMID:26787842</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of the DUF1765 domain that defines the UPF0592 family, and hence the biochemical basis of any ahk1 function, is entirely unknown. DUF1765 is a domain of unknown function with no assigned catalytic or binding activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ahk1 is a member of the UPF0592 family (Pfam PF08578 DUF1765; PANTHER PTHR37988) and lacks any recognizable enzymatic motif, but no structure-function study has assigned an activity to this domain in any organism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning a biochemical activity to DUF1765 would provide a mechanistic basis for the family, potentially replacing the generic scaffold-by-orthology inference with a defined GO molecular-function term.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Structural characterization (e.g. AlphaFold-guided experimental structure) and biochemical assays of the DUF1765 domain; if a novel activity is found, a corresponding GO molecular function term may be required.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Belongs to the UPF0592 family."</em> — UniProt:O14260</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of ahk1 in S. pombe has not been experimentally determined. The membrane / multi-pass membrane assignment is a sequence-based prediction (three predicted transmembrane helices) with no microscopy or fractionation evidence in fission yeast.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt predicts three transmembrane helices (residues 277-297, 374-394, 400-420) and annotates the protein as a multi-pass membrane protein by ECO:0000305 inference, but this has not been confirmed for the endogenous fission-yeast protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Localization would test the membrane prediction and indicate whether ahk1 acts at a specific membrane compartment (as a membrane-tethered scaffold) or elsewhere.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Live-cell imaging of endogenously tagged ahk1 and membrane-fractionation/topology assays in S. pombe.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Multi-pass membrane"</em> — UniProt:O14260</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ahk1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O14260" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="research-notes-s-pombe-ahk1-spac7d403c-uniprot-o14260">Research notes: <em>S. pombe</em> ahk1 (SPAC7D4.03c / UniProt O14260)</h1>
+<h2 id="summary-of-task">Summary of task</h2>
+<p>AI GO-annotation review of the understudied fission-yeast gene <strong>ahk1</strong> (PomBase standard<br />
+name; systematic name <strong>SPAC7D4.03c</strong>; UniProt <strong>O14260</strong>, entry name YFP3_SCHPO). This is a<br />
+"dark gene": PomBase characterisation status is <strong>"biological role inferred"</strong> and all of its<br />
+functional GO annotations are transferred by orthology (ISO), not experimentally determined in<br />
+<em>S. pombe</em>.</p>
+<h2 id="identity-naming-verified">Identity / naming (verified)</h2>
+<ul>
+<li>PomBase gene page reports <code>name: ahk1</code>, <code>product: "MAP kinase cascade scaffold protein Ahk1"</code>,<br />
+<code>characterisation_status: "biological role inferred"</code>, <code>deletion_viability: viable</code>,<br />
+<code>taxonomic_distribution: fungi only</code> (PomBase JSON API, gene SPAC7D4.03c, latest dataset).</li>
+<li>UniProt O14260 (YFP3_SCHPO): <code>RecName: Full=UPF0592 membrane protein C7D4.03c</code>; 886 aa;<br />
+<code>PE 3: Inferred from homology</code>. Belongs to the <strong>UPF0592 family</strong> (<code>-!- SIMILARITY</code>, ECO:0000305).</li>
+<li>InterPro/domain content: <strong>Pfam PF08578 = DUF1765</strong>; <strong>PANTHER PTHR37988</strong> ("UPF0592 MEMBRANE<br />
+  PROTEIN C7D4.03C"); InterPro <strong>IPR013887 (UPF0592)</strong>. (from ahk1-uniprot.txt DR lines and<br />
+  PomBase interpro_matches).</li>
+</ul>
+<h2 id="domain-topology-reasoning-from-ahk1-uniprottxt">Domain / topology reasoning (from ahk1-uniprot.txt)</h2>
+<ul>
+<li>Predicted <strong>multi-pass membrane protein</strong>: three TRANSMEM helices at 277–297, 374–394, 400–420<br />
+  (all ECO:0000255, i.e. sequence-model predicted, not experimentally confirmed).</li>
+<li>SUBCELLULAR LOCATION: <code>Membrane; Multi-pass membrane protein</code> (ECO:0000305, inferred).</li>
+<li>A predicted disordered / low-complexity region at ~87–112 (MobiDB-lite).</li>
+<li>The single defining domain is DUF1765 (domain of unknown function); no catalytic motif, no<br />
+  recognizable kinase/phosphatase/enzymatic signature. Consistent with a non-catalytic<br />
+  scaffold/adaptor-type role rather than an enzyme.</li>
+</ul>
+<h2 id="the-orthology-basis-for-the-functional-annotations-key">The orthology basis for the functional annotations (KEY)</h2>
+<p>Both functional GO annotations on S. pombe ahk1 are <strong>ISO</strong> (inferred from sequence orthology),<br />
+with-from <strong>SGD:S000002231</strong>:<br />
+- GO:0005078 "MAP kinase scaffold activity" — ISO, GO_REF:0000024, with SGD:S000002231.<br />
+- GO:0000165 "MAPK cascade" — ISO, PMID:26787842, with SGD:S000002231.<br />
+- PomBase <code>ortholog_annotations</code> lists <strong>YDL073W</strong> (<em>S. cerevisiae</em> AHK1) as ortholog via<br />
+<strong>InterPro:IPR013887</strong> (the UPF0592 family), and <strong>SJAG_04503</strong> (<em>S. japonicus</em>) via<br />
+  PMID:21511999. PomBase orthogroup <code>SOG_0639</code>. (Note the curated <code>orthologs</code> list is empty; the<br />
+  cross-species relationship is captured as an InterPro-family-based ortholog_annotation, i.e. it<br />
+  is a domain-family/homology call, not a 1:1 syntenic ortholog assertion.)</p>
+<p><em>S. cerevisiae</em> AHK1 (YDL073W, SGD:S000002231) is a <strong>Verified ORF</strong> described by SGD as<br />
+"Scaffold protein in the HKR1 sub-branch of the Hog1p-signaling pathway; physically interacts with<br />
+the cytoplasmic domain of Hkr1p, and with Sho1p, Pbs2p, and Ste11p; prevents cross-talk signaling<br />
+from Hkr1p of the osmotic stress MAPK cascade to the Kss1p MAPK cascade; non-essential"<br />
+(yeastgenome.org locus S000002231).</p>
+<h3 id="the-single-primary-reference-abstract-only-in-cache">The single primary reference (abstract-only in cache)</h3>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/26787842" title="Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2, Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated Protein Kinase.">PMID:26787842</a> is entirely about the <strong>budding-yeast (<em>S. cerevisiae</em>)</strong> Ahk1:<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" title="Here, using a mass spectrometric method, we identified a protein, termed Ahk1   (Associated with Hkr1), that binds to Hkr1-cyto.">PMID:26787842</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" title="In addition to Hkr1-cyto binding, Ahk1 also bound to other signaling molecules   in the HKR1 subbranch, including Sho1, Ste11, and Pbs2.">PMID:26787842</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" title="Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect   signal flow from Hkr1 to Kss1.">PMID:26787842</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/26787842" title="In the budding yeast Saccharomyces cerevisiae, osmostress activates the Hog1   mitogen-activated protein kinase (MAPK), which regulates diverse osmoadaptive responses.">PMID:26787842</a></p>
+<p>This paper does NOT assay the <em>S. pombe</em> protein. Cache marks <code>full_text_available: false</code><br />
+(abstract only). The paper is the experimental basis for the <em>S. cerevisiae</em> annotation that is<br />
+then transferred to <em>S. pombe</em> by ISO.</p>
+<h2 id="what-phenotype-data-exist-for-s-pombe-ahk1-all-from-genome-wide-high-throughput-screens">What phenotype data exist for <em>S. pombe</em> ahk1 (all from genome-wide / high-throughput screens)</h2>
+<p>17 single-locus (ahk1Δ) phenotypes are recorded in PomBase, all from systematic screens<br />
+(no gene-focused study). References and phenotype highlights:<br />
+- PMID:20473289 — genome-wide deletion set (Kim et al.). ahk1Δ <strong>viable</strong>.<br />
+- PMID:23697806 — cell-cycle/cell-shape genome-wide resource.<br />
+- PMID:28410370 — systematic screen of sexual-reproduction morphology (identifies mating/shmoo<br />
+  abnormalities): <strong>abnormal shmoo morphology (FYPO:0000357)</strong>, <strong>shmoo formation at cell side<br />
+  (FYPO:0006011)</strong>, <strong>promiscuous mating (FYPO:0006014)</strong>.<br />
+- PMID:34250083 — chronological lifespan barcode screen: <strong>loss of viability in stationary phase<br />
+  (FYPO:0000245)</strong> (ageing-associated).<br />
+- PMID:35820914 — yeast-ageing protease study.<br />
+- PMID:37787768 — broad phenomics/machine-learning functional profiling: stress sensitivities and<br />
+  resistances — sensitive to caffeine (FYPO:0000097), cycloheximide (FYPO:0000104), hydroxyurea<br />
+  (FYPO:0000088), tunicamycin (FYPO:0001457), KCl+SDS (FYPO:0007924); resistant to MMS<br />
+  (FYPO:0000725), vanadate (FYPO:0000830), lithium (FYPO:0001583), LiCl+SDS (FYPO:0009085),<br />
+  MgCl2+SDS (FYPO:0009087).</p>
+<p>Interpretation: the deletion phenotype fingerprint (osmotic/salt/cell-wall-stress, caffeine,<br />
+mating/shmoo abnormalities) is broadly <strong>consistent with</strong> a role in stress-responsive signaling,<br />
+which fits the orthology-based MAPK-scaffold assignment. But NONE of these screens establishes a<br />
+molecular mechanism, a direct binding partner, or a specific, non-redundant place in the Sty1/Spc1<br />
+(Hog1-like) SAPK pathway for the <em>S. pombe</em> protein.</p>
+<h2 id="known-vs-not-known">KNOWN vs NOT-KNOWN</h2>
+<p>KNOWN (or well-supported):<br />
+- Fungal-only protein of the UPF0592/DUF1765 family; large (886 aa); predicted multi-pass membrane<br />
+  protein with a disordered region. (UniProt, InterPro, PANTHER.)<br />
+- Non-essential (ahk1Δ viable). (PMID:20473289.)<br />
+- Deletion perturbs stress responses and sexual-reproduction morphology in genome-wide screens.<br />
+- Its <em>S. cerevisiae</em> homolog (AHK1/YDL073W) is an experimentally validated scaffold in the HKR1<br />
+  sub-branch of the Hog1 osmostress MAPK pathway. (PMID:26787842.)</p>
+<p>NOT KNOWN (the deliverable knowledge gaps):<br />
+- Whether <em>S. pombe</em> ahk1 actually functions as a MAPK scaffold, or is a scaffold at all — this is<br />
+  purely an orthology transfer via the shared UPF0592 domain family (IPR013887), never tested in<br />
+<em>S. pombe</em>.<br />
+- Its direct binding partners in <em>S. pombe</em> (does it bind Sty1/Spc1, Wis1, Win1/Wak1, Sho1-like<br />
+  components, or the Wsc1/Mtl2 osmosensors?). Unknown.<br />
+- Whether it has any specific, non-redundant role in the Sty1/Spc1 SAPK pathway (the pombe<br />
+  osmostress core is Wis1→Sty1; there is no exact Hkr1/Kss1 cross-talk architecture in pombe, so<br />
+  the budding-yeast "prevents Hkr1→Kss1 cross-talk" role may not map directly).<br />
+- Its precise molecular activity (DUF1765 has no assigned biochemical function).<br />
+- Its subcellular localization in <em>S. pombe</em> (membrane prediction only; not experimentally shown).</p>
+<h2 id="curation-reasoning-for-the-annotation-actions">Curation reasoning for the annotation actions</h2>
+<ul>
+<li>GO:0005078 MAP kinase scaffold activity (ISO): the only molecular-function annotation, and it is<br />
+  more informative than "protein binding". It is orthology-based and unproven in pombe, so KEEP but<br />
+  flag as inferred/non-core with an explicit knowledge gap; not REMOVE (it is a reasonable,<br />
+  curator-made ISO transfer from a verified budding-yeast scaffold, and PomBase is reliable).</li>
+<li>GO:0000165 MAPK cascade (ISO): same reasoning; a plausible, orthology-based process assignment;<br />
+  keep as non-core, flag as inferred.</li>
+<li>GO:0016020 membrane (IEA, UniProtKB-SubCell): supported by predicted TM helices; accept as a<br />
+  low-resolution, prediction-based localization (non-core).</li>
+<li>GO:0005575 cellular_component (ND, GO_REF:0000015): root "unknown" placeholder; standard<br />
+  PomBase practice; keep as-is (represents absence of specific CC knowledge).</li>
+</ul>
+<h2 id="provenance-sources-used">Provenance sources used</h2>
+<ul>
+<li>genes/SCHPO/ahk1/ahk1-uniprot.txt (UniProt O14260)</li>
+<li>genes/SCHPO/ahk1/ahk1-goa.tsv (QuickGO GOA)</li>
+<li>publications/PMID_26787842.md (abstract-only)</li>
+<li>PomBase JSON API for SPAC7D4.03c (name/product/status/phenotypes/orthologs/InterPro)</li>
+<li>OLS (FYPO + GO term labels/definitions)</li>
+<li>SGD locus S000002231 (S. cerevisiae AHK1 = YDL073W)</li>
+</ul>
+<h2 id="deep-research-note">Deep research note</h2>
+<p><code>scripts/deep_research_wrapper.py SCHPO SPAC7D4.03c falcon --fallback perplexity-lite</code> was run in<br />
+the foreground twice; it hung (exit 124 / 550s timeout) after emitting only the<br />
+"Using SPAC7D4.03c as gene symbol" line, producing no report. Per project policy, no<br />
+<code>-deep-research-*.md</code> file was fabricated; this review is grounded in UniProt + GOA + PomBase +<br />
+the cached publication, all with explicit provenance above.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O14260
+gene_symbol: ahk1
+product_type: PROTEIN
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  ahk1 (SPAC7D4.03c; UniProt O14260) is a large (886-residue) fungal-specific protein of the
+  UPF0592 family, defined by a single DUF1765 domain (Pfam PF08578; InterPro IPR013887; PANTHER
+  PTHR37988). It is predicted to be a multi-pass membrane protein (three predicted transmembrane
+  helices) and contains a disordered, low-complexity region near its N-terminus, but it carries
+  no recognizable catalytic motif, consistent with a non-catalytic role. The DUF1765 domain has
+  no experimentally assigned biochemical function. Its budding-yeast homolog, Saccharomyces
+  cerevisiae Ahk1 (YDL073W), is an experimentally validated scaffold protein of the HKR1
+  sub-branch of the Hog1 osmostress-activated MAPK pathway that binds the Hkr1 cytoplasmic domain
+  together with Sho1, Ste11 and Pbs2 and prevents aberrant cross-talk signalling to the Kss1 MAPK.
+  On the basis of that orthology (shared UPF0592 domain family), the fission-yeast protein is
+  proposed to be a putative MAP-kinase-cascade scaffold, though this role has not been tested in
+  fission yeast. The gene is non-essential (ahk1 deletion is viable), and in genome-wide phenotypic
+  screens its deletion is associated with altered stress responses (sensitivity or resistance to
+  osmotic, cell-wall, and genotoxic agents) and abnormalities in mating and shmoo morphology, a
+  fingerprint broadly compatible with a role in stress-responsive signalling. No direct molecular
+  function, binding partner, localization, or specific pathway role has been demonstrated for the
+  fission-yeast protein itself.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Standard GO reference documenting the ND (No biological Data) evidence code; supports the
+        root cellular_component placeholder annotation.
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        The GO reference describing curator-judged ISO transfer to orthologs; it is the basis for
+        the MAP-kinase scaffold activity (GO:0005078) annotation transferred from S. cerevisiae
+        AHK1 (SGD:S000002231). Correctly applied as a mechanism, but the transferred function
+        remains unverified in S. pombe.
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Standard UniProt SubCell-to-GO mapping reference; supports the low-resolution, prediction
+        based membrane (GO:0016020) annotation.
+  - id: PMID:26787842
+    title: Scaffold Protein Ahk1, Which Associates with Hkr1, Sho1, Ste11, and Pbs2,
+      Inhibits Cross Talk Signaling from the Hkr1 Osmosensor to the Kss1 Mitogen-Activated
+      Protein Kinase.
+    findings:
+      - statement: &gt;-
+          S. cerevisiae Ahk1 is a scaffold protein of the HKR1 sub-branch of the Hog1 osmostress
+          MAPK pathway that binds the cytoplasmic domain of the Hkr1 osmosensor and also binds
+          Sho1, Ste11 and Pbs2, preventing incorrect signal flow from Hkr1 to the Kss1 MAPK.
+        supporting_text: &gt;-
+          Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal
+          flow from Hkr1 to Kss1.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified; the defining paper for the scaffold function, but it characterizes the
+        Saccharomyces cerevisiae protein (Ahk1/YDL073W = SGD:S000002231), not the S. pombe protein.
+        Cache is abstract-only (full_text_available: false). It is the experimental source for the
+        ISO annotations transferred to S. pombe ahk1, so it is highly relevant as the orthology
+        anchor, while the fission-yeast function itself remains inferred.
+existing_annotations:
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Low-resolution, prediction-based localization. UniProt predicts three transmembrane
+        helices and annotates the protein as a multi-pass membrane protein by ECO:0000305
+        inference. This is consistent with the sequence but is not experimentally demonstrated in
+        S. pombe, and the term is the generic root-level &#34;membrane&#34;. Retain as non-core.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Supported by UniProt transmembrane-helix predictions but unverified experimentally and
+        uninformative as to which membrane; a plausible prediction-based localization rather than
+        a demonstrated core function.
+      supported_by:
+        - reference_id: GO_REF:0000044
+          supporting_text: &gt;-
+            Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Root-level &#34;cellular_component&#34; with the ND (No biological Data) evidence code, a standard
+        PomBase placeholder recording that no specific cellular component is known. It carries no
+        biological content and should be retained only as a placeholder.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Root placeholder term with ND evidence; represents absence of specific localization
+        knowledge rather than a substantive annotation.
+  - term:
+      id: GO:0000165
+      label: MAPK cascade
+    evidence_type: ISO
+    original_reference_id: PMID:26787842
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Process annotation transferred by orthology (ISO, with-from SGD:S000002231) from
+        S. cerevisiae AHK1, which is an experimentally validated scaffold in the Hog1 osmostress
+        MAPK pathway. The orthology rests on the shared UPF0592/DUF1765 domain family
+        (InterPro:IPR013887). The assignment is a plausible, curator-made transfer, but the
+        involvement of the S. pombe protein in a MAPK cascade has not been demonstrated directly;
+        the fission-yeast stress core (Wis1 to Sty1/Spc1) does not reproduce the budding-yeast
+        Hkr1/Kss1 cross-talk architecture. Retain as a reasonable orthology-based hypothesis, but
+        mark non-core and flag as a knowledge gap.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Orthology-based (ISO) transfer from a verified S. cerevisiae scaffold; biologically
+        plausible and consistent with the deletion stress/mating phenotype fingerprint, but
+        unproven in S. pombe. Per PomBase reliability, retained rather than removed; treated as
+        non-core because it is inferred, not demonstrated for this gene.
+      supported_by:
+        - reference_id: PMID:26787842
+          supporting_text: &gt;-
+            Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal
+            flow from Hkr1 to Kss1.
+  - term:
+      id: GO:0005078
+      label: MAP kinase scaffold activity
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: enables
+    review:
+      summary: &gt;-
+        The single molecular-function annotation, transferred by orthology (ISO, GO_REF:0000024,
+        with-from SGD:S000002231) from S. cerevisiae AHK1. It is more informative than &#34;protein
+        binding&#34; and captures the best available functional hypothesis: that ahk1 acts as a
+        physical scaffold assembling components of a MAPK signalling module. However, the scaffold
+        activity has never been tested for the S. pombe protein and no fission-yeast binding
+        partners are known. Retain as a plausible orthology-based hypothesis; mark non-core and
+        flag as a molecular-function knowledge gap.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Orthology-based (ISO) transfer of an experimentally established S. cerevisiae molecular
+        function; retained per PomBase reliability and because it is the most informative available
+        MF term (preferable to protein binding), but it is inferred rather than demonstrated for
+        S. pombe and so is treated as non-core with an explicit knowledge gap.
+      supported_by:
+        - reference_id: PMID:26787842
+          supporting_text: &gt;-
+            we identified a protein, termed Ahk1 (Associated with Hkr1), that binds to Hkr1-cyto.
+core_functions:
+  - description: &gt;-
+      Putative non-catalytic scaffold/adaptor of a mitogen-activated protein kinase (MAPK)
+      signalling module. This is inferred for ahk1 from its membership of the UPF0592/DUF1765
+      family (InterPro:IPR013887) shared with the experimentally validated S. cerevisiae scaffold
+      Ahk1 (YDL073W), which assembles Hkr1, Sho1, Ste11 and Pbs2 in the Hog1 osmostress MAPK
+      pathway. The absence of any catalytic motif in ahk1 is consistent with a scaffolding rather
+      than an enzymatic role. Direct demonstration of scaffold activity, of binding partners, and
+      of MAPK-pathway participation in S. pombe is lacking; this core function is therefore a
+      well-motivated hypothesis, not an established fission-yeast activity.
+    molecular_function:
+      id: GO:0005078
+      label: MAP kinase scaffold activity
+    directly_involved_in:
+      - id: GO:0000165
+        label: MAPK cascade
+    supported_by:
+      - reference_id: PMID:26787842
+        supporting_text: &gt;-
+          Thus, Ahk1 is a scaffold protein in the HKR1 subbranch and prevents incorrect signal
+          flow from Hkr1 to Kss1.
+      - reference_id: GO_REF:0000024
+        supporting_text: &gt;-
+          Manual transfer of experimentally-verified manual GO annotation data to orthologs
+knowledge_gaps:
+  - gap_statement: &gt;-
+      Whether S. pombe ahk1 (SPAC7D4.03c) actually functions as a MAP-kinase scaffold, or has any
+      scaffold activity at all, has never been tested. The molecular function is inferred entirely
+      from the S. cerevisiae ortholog via the shared UPF0592/DUF1765 domain family; no in vivo or
+      in vitro assay of scaffold activity, and no identification of assembled kinase-module
+      components, has been reported for the fission-yeast protein.
+    boundary: &gt;-
+      Scaffold activity in the Hog1 osmostress MAPK pathway is experimentally established for
+      S. cerevisiae Ahk1 (YDL073W = SGD:S000002231), which binds Hkr1-cyto, Sho1, Ste11 and Pbs2;
+      the S. pombe protein shares the defining UPF0592/DUF1765 domain (InterPro:IPR013887) and
+      lacks any catalytic motif, so a scaffolding role is plausible but unproven.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Determines whether the propagated MAP-kinase scaffold activity (GO:0005078) annotation is
+      valid for fission yeast, or whether ahk1 has a distinct (or no) signalling function despite
+      family membership.
+    resolution: &gt;-
+      Affinity purification / mass spectrometry of tagged ahk1 in S. pombe to identify direct
+      interactors, combined with epistasis and phospho-readout assays testing whether ahk1
+      contributes to Sty1/Spc1 (or other MAPK) activation under stress.
+    provenance:
+      - reference_id: PMID:26787842
+        supporting_text: &gt;-
+          In the budding yeast Saccharomyces cerevisiae, osmostress activates the Hog1
+          mitogen-activated protein kinase (MAPK), which regulates diverse osmoadaptive
+      - reference_id: GO_REF:0000024
+        supporting_text: &gt;-
+          Manual transfer of experimentally-verified manual GO annotation data to orthologs
+  - gap_statement: &gt;-
+      The direct binding partners of ahk1 in S. pombe are unknown. It is undetermined whether it
+      interacts with the fission-yeast stress-MAPK components (Sty1/Spc1, the MAPKK Wis1, the
+      MAPKKKs Win1/Wis4, or membrane osmosensors such as Wsc1/Mtl2 and the Sho1-like adaptor),
+      or with any other proteins.
+    boundary: &gt;-
+      In S. cerevisiae the orthologous Ahk1 binds a defined set of HKR1-subbranch proteins
+      (Hkr1-cyto, Sho1, Ste11, Pbs2); the fission-yeast interactome of ahk1 has not been mapped
+      beyond generic high-throughput interaction datasets.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Identifying partners would confirm or refute pathway membership and reveal whether ahk1
+      couples a membrane sensor to a specific MAPK module in fission yeast.
+    resolution: &gt;-
+      Co-immunoprecipitation / proximity-labelling of endogenously tagged ahk1 followed by mass
+      spectrometry, with validation of candidate interactions by reciprocal pulldown and
+      genetic interaction analysis.
+    provenance:
+      - reference_id: PMID:26787842
+        supporting_text: &gt;-
+          In addition to Hkr1-cyto binding, Ahk1 also bound to other signaling molecules in the
+          HKR1 subbranch, including Sho1, Ste11, and Pbs2.
+  - gap_statement: &gt;-
+      Whether ahk1 has a specific, non-redundant role in the S. pombe Sty1/Spc1 stress-activated
+      MAPK pathway is undetermined. The budding-yeast function (preventing Hkr1-to-Kss1 cross-talk)
+      may not map onto fission yeast, whose stress core (Wis1 to Sty1) lacks the multi-branch
+      Hkr1/Kss1 architecture, so it is unclear which, if any, signalling event ahk1 controls.
+    boundary: &gt;-
+      ahk1 deletion is viable and, in genome-wide screens, alters stress responses (osmotic/salt,
+      cell-wall, and genotoxic agents) and mating/shmoo morphology; these are consistent with a
+      stress-signalling contribution but do not localize ahk1 to a defined step or show it is
+      non-redundant.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Placing ahk1 (or excluding it) within the Sty1/Spc1 pathway would resolve whether the
+      orthology-based MAPK-cascade (GO:0000165) annotation reflects a real fission-yeast pathway
+      role.
+    resolution: &gt;-
+      Targeted epistasis analysis of ahk1 deletion with sty1, wis1 and osmosensor mutants under
+      defined stresses, measuring Sty1 phosphorylation and downstream (e.g. atf1/gpd1) responses.
+    provenance:
+      - reference_id: PMID:26787842
+        supporting_text: &gt;-
+          Deletion of the AHK1 gene (in the absence of other Hog1 upstream branches) only
+          partially inhibited osmostress-induced Hog1 activation.
+  - gap_statement: &gt;-
+      The molecular activity of the DUF1765 domain that defines the UPF0592 family, and hence the
+      biochemical basis of any ahk1 function, is entirely unknown. DUF1765 is a domain of unknown
+      function with no assigned catalytic or binding activity.
+    boundary: &gt;-
+      ahk1 is a member of the UPF0592 family (Pfam PF08578 DUF1765; PANTHER PTHR37988) and lacks
+      any recognizable enzymatic motif, but no structure-function study has assigned an activity
+      to this domain in any organism.
+    gap_kind:
+      - BIOLOGY
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Assigning a biochemical activity to DUF1765 would provide a mechanistic basis for the
+      family, potentially replacing the generic scaffold-by-orthology inference with a defined GO
+      molecular-function term.
+    resolution: &gt;-
+      Structural characterization (e.g. AlphaFold-guided experimental structure) and biochemical
+      assays of the DUF1765 domain; if a novel activity is found, a corresponding GO molecular
+      function term may be required.
+    provenance:
+      - reference_id: UniProt:O14260
+        supporting_text: &gt;-
+          Belongs to the UPF0592 family.
+  - gap_statement: &gt;-
+      The subcellular localization of ahk1 in S. pombe has not been experimentally determined. The
+      membrane / multi-pass membrane assignment is a sequence-based prediction (three predicted
+      transmembrane helices) with no microscopy or fractionation evidence in fission yeast.
+    boundary: &gt;-
+      UniProt predicts three transmembrane helices (residues 277-297, 374-394, 400-420) and
+      annotates the protein as a multi-pass membrane protein by ECO:0000305 inference, but this
+      has not been confirmed for the endogenous fission-yeast protein.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Localization would test the membrane prediction and indicate whether ahk1 acts at a specific
+      membrane compartment (as a membrane-tethered scaffold) or elsewhere.
+    resolution: &gt;-
+      Live-cell imaging of endogenously tagged ahk1 and membrane-fractionation/topology assays in
+      S. pombe.
+    provenance:
+      - reference_id: UniProt:O14260
+        supporting_text: &gt;-
+          Multi-pass membrane
+suggested_questions:
+  - question: &gt;-
+      Does S. pombe ahk1 physically associate with any component of the Sty1/Spc1 stress-activated
+      MAPK pathway (Sty1, Wis1, Win1/Wis4) or with membrane osmosensors, and does its deletion
+      alter stress-induced Sty1 activation?
+    experts:
+      - Nishimura A
+      - Tatebayashi K
+  - question: &gt;-
+      What is the biochemical activity of the DUF1765 domain, and is ahk1 a bona fide scaffold or
+      does it have an as-yet-uncharacterized molecular function?
+suggested_experiments:
+  - hypothesis: &gt;-
+      ahk1 acts as a membrane-associated scaffold that contributes to Sty1/Spc1 activation under
+      osmotic or cell-wall stress in S. pombe.
+    description: &gt;-
+      Construct an endogenously tagged ahk1 strain; perform affinity purification-mass
+      spectrometry to identify interactors, live-cell imaging to determine localization, and
+      quantitative immunoblotting of phospho-Sty1 in wild-type vs ahk1-deletion cells across a
+      panel of stresses (osmotic, cell-wall, oxidative, genotoxic).
+    experiment_type: interactome, localization, and signalling epistasis
+  - hypothesis: &gt;-
+      The DUF1765 domain confers a defined, conserved molecular activity that underlies ahk1
+      function.
+    description: &gt;-
+      Determine the structure of the ahk1 DUF1765 domain (experimentally or via AlphaFold-guided
+      modelling) and test candidate activities biochemically; use structure-guided point mutants
+      to link domain features to the deletion stress/mating phenotypes.
+    experiment_type: structural biology and structure-function analysis
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/cmc4/cmc4-ai-review.html
+++ b/genes/SCHPO/cmc4/cmc4-ai-review.html
@@ -1,0 +1,2423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>cmc4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>cmc4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G2TRJ8" target="_blank" class="term-link">
+                        G2TRJ8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "cmc4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G2TRJ8" data-a="DESCRIPTION: cmc4 (systematic name SPAC4F10.22; synonym tam2) i..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>cmc4 (systematic name SPAC4F10.22; synonym tam2) is a small (70-residue) mitochondrial intermembrane space (IMS) protein of the twin CX9C / coiled-coil- helix-coiled-coil-helix (CHCH) family, the sole fission-yeast member of the conserved CMC4 (Cx9C motif-containing protein 4) family (PANTHER PTHR15590, Pfam PF08991, InterPro IPR027179). Its two CX9C motifs form a helical hairpin stabilized by two intramolecular disulfide bonds; like other twin CX9C proteins it is imported into the IMS and oxidatively folded by the MIA40 (Mia40/CHCHD4)- Erv1 disulfide relay, which recognizes the cysteine motifs. CMC4 orthologs are broadly conserved from yeasts to human (human CMC4, P56277). The family is associated with cytochrome c oxidase (COX) biogenesis: in human cells CMC4 physically associates with the COX assembly factor SCO1, implicating it in COX II sub-assembly, although CMC4 is non-essential for respiration and no specific molecular activity has been demonstrated for it. In S. pombe the gene was identified as a meiotically regulated transcript (tam2), and its deletion is viable with no reported growth or respiratory phenotype.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRJ8" data-a="GO:0005758" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of mitochondrial intermembrane space localization from the CMC4 family (PANTHER PTHR15590 / PTN000400520). This is well supported: the twin CX9C / CHCH fold and the MIA40-Erv1 import route are diagnostic of soluble IMS proteins, and the human/yeast orthologs are IMS-localized. This is the single substantive, defensible annotation for cmc4 and represents its core cellular context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization is strongly supported by family membership (twin CX9C, MIA40-import) and ortholog data; the IBA inference from PTHR15590 is appropriate. Note the localization has not been demonstrated experimentally in S. pombe itself.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000400520</span>
+
+                                    &middot; CMC4 family (PTHR15590)
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Twin CX9C / MIA40-imported IMS protein family; human and yeast orthologs are IMS-localized.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" target="_blank" class="term-link">
+                                        PMID:33498264
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CMC4 is a CX9C family member that localizes to the mitochondrial IMS</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRJ8" data-a="GO:0005758" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of the same localization derived from the UniProtKB/Swiss-Prot subcellular-location keyword (SL-0169). Redundant with, and consistent with, the IBA annotation above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the family-supported IMS localization; the electronic SubCell mapping mirrors the UniProt annotation and does not overreach.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRJ8" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Molecular function is recorded as ND (no data). No specific biochemical activity has been demonstrated for cmc4 or any CMC4 ortholog: unlike the related copper chaperones Cmc1/Cmc2, CMC4 has no demonstrated metal binding or catalytic activity, and its only functional lead is a physical association with SCO1 in human cells. The ND root placeholder honestly reflects a genuine molecular-function knowledge gap.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No experimental or defensible computational molecular-function term can be asserted. Retaining the ND annotation correctly signals an undetermined molecular function rather than forcing an unsupported term.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Knowledge gap:</div>
+
+                            <div class="support-item">
+                                <div>The molecular activity of cmc4 is undetermined. It is unknown whether it acts as a metallochaperone, a redox/disulfide-relay accessory factor, or a protein-interaction adaptor within the mitochondrial IMS, and no direct binding partner has been identified in S. pombe.
+                                    <span class="badge">OPEN</span>
+                                    <span class="badge">BIOLOGY</span>
+                                    <span class="badge">MF_DARK</span>
+                                </div>
+
+                                <div class="support-text"><strong>Resolve:</strong> Affinity/proximity proteomics of tagged cmc4 in S. pombe to identify direct partners; metal-binding and thiol-redox assays on recombinant protein to test metallochaperone vs disulfide-relay-accessory models.</div>
+
+
+
+                                <div class="support-text"><em>"determined that CMC4 interacts with SCO1 in human cell cultures"</em> — PMID:33498264</div>
+
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRJ8" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biological process is recorded as ND (no data). A COX II sub-assembly role is only inferred from the human SCO1 interaction, is non-essential, and has not been tested in S. pombe; tam2Δ is viable with no reported respiratory or meiotic phenotype despite the transcript being meiotically regulated. The ND placeholder honestly reflects an undetermined biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No experimentally supported biological process for cmc4 in S. pombe. The COX-assembly link is cross-species and non-essential; the meiotic transcript regulation (tam2) has no assigned meiotic function. ND is the correct, honest annotation.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Knowledge gap:</div>
+
+                            <div class="support-item">
+                                <div>The in vivo biological role of cmc4 in S. pombe is unknown: whether it contributes to cytochrome c oxidase assembly/respiration (as suggested for the human ortholog) or has a distinct meiosis-related role implied by its tam2 expression pattern is undetermined, and no deletion phenotype has been reported.
+                                    <span class="badge">OPEN</span>
+                                    <span class="badge">BIOLOGY</span>
+                                    <span class="badge">BP_DARK</span>
+                                </div>
+
+                                <div class="support-text"><strong>Resolve:</strong> Phenotyping of cmc4Δ (respiratory growth on non-fermentable carbon, COX activity/assembly; sporulation, spore viability and meiotic timing) and epistasis with cox11/sco1 orthologs.</div>
+
+
+
+                                <div class="support-text"><em>"While tam2 .Δ was viable, new21 was not"</em> — PMID:21270388</div>
+
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Small twin CX9C / CHCH-family protein of the mitochondrial intermembrane space (CMC4 family). It is imported and oxidatively folded by the MIA40-Erv1 disulfide relay, which recognizes its two CX9C motifs to introduce the two structural disulfide bonds. Its molecular activity is undetermined; the sole functional lead is that the human ortholog associates with the COX assembly factor SCO1, implicating the family in a non-essential branch of cytochrome c oxidase (COX II) biogenesis. No specific molecular-function GO term is asserted because none is experimentally supported for cmc4 or its orthologs.</h3>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="FUNCTION: Small twin CX9C / CHCH-family protein of the mitoc..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                mitochondrial intermembrane space
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" target="_blank" class="term-link">
+                                PMID:33498264
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">CMC4 is a CX9C family member that localizes to the mitochondrial IMS</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" target="_blank" class="term-link">
+                                PMID:33498264
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">In yeast, CMC4 has eight cysteine residues, four of which comprise the twin CX9C motif.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11859360" target="_blank" class="term-link">
+                            PMID:11859360
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The genome sequence of Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Source genome-sequencing reference that established the SPAC4F10.22 locus on chromosome I of S. pombe.</div>
+
+                        <div class="finding-text">"The genome sequence of Schizosaccharomyces pombe."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21270388" target="_blank" class="term-link">
+                            PMID:21270388
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Augmented annotation of the Schizosaccharomyces pombe genome reveals additional genes required for growth and viability.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Identifies the locus as tam2 (transcripts altered in meiosis protein 2), a meiotically regulated transcript, and reports that its deletion is viable.</div>
+
+                        <div class="finding-text">"While tam2 .Δ was viable, new21 was not"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The transcript is among those differentially expressed during meiosis in fission yeast.</div>
+
+                        <div class="finding-text">"Fourteen transcripts were differentially expressed during meiosis."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" target="_blank" class="term-link">
+                            PMID:33498264
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of COX Assembly and Function by Twin CX(9)C Proteins-Implications for Human Disease.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CMC4 is a twin CX9C-family protein that localizes to the mitochondrial intermembrane space, imported via the Mia40/CHCHD4 redox relay.</div>
+
+                        <div class="finding-text">"CMC4 is a CX9C family member that localizes to the mitochondrial IMS"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Yeast CMC4 has eight cysteines, four forming the twin CX9C motif, and seven of the eight are conserved in the human ortholog.</div>
+
+                        <div class="finding-text">"In yeast, CMC4 has eight cysteine residues, four of which comprise the twin CX9C motif."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CMC4 is non-essential for respiration and its specific role is inferred from a physical interaction with the COX II assembly factor SCO1.</div>
+
+                        <div class="finding-text">"The limited studies in yeast show that CMC4 knockdown produces no defect in respiration"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A proximity/affinity study places human CMC4 with SCO1, suggesting a non-essential role in COX II sub-assembly.</div>
+
+                        <div class="finding-text">"determined that CMC4 interacts with SCO1 in human cell cultures"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does cmc4 physically associate with an S. pombe SCO1/Cox-assembly ortholog, as its human counterpart does, or with a distinct IMS partner?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="Q: Does cmc4 physically associate with an S. pombe SC..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is cmc4 required for respiratory growth or cytochrome c oxidase activity/assembly in fission yeast, or is it fully dispensable as the viability of tam2Δ and the lack of a respiratory phenotype in yeast CMC4 knockdown suggest?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="Q: Is cmc4 required for respiratory growth or cytochr..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the meiotic (tam2) regulation of cmc4 reflect a meiosis- or sporulation-specific function, or merely coordinate expression of a mitochondrial protein with increased respiratory demand during differentiation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="Q: Does the meiotic (tam2) regulation of cmc4 reflect..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does cmc4 bind a metal ion (e.g. copper) or participate directly in the MIA40-Erv1 disulfide relay as a substrate/accessory factor?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="Q: Does cmc4 bind a metal ion (e.g. copper) or partic..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity labeling (BioID/TurboID) or affinity purification of endogenously tagged cmc4 in S. pombe under fermentative and respiratory (glycerol/ethanol) growth to identify direct IMS partners and test for association with Sco1/COX assembly factors.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: cmc4 associates with a COX II copper-delivery assembly factor (Sco1 ortholog) in the IMS, conserving the human CMC4-SCO1 interaction.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="EXPERIMENT: Proximity labeling (BioID/TurboID) or affinity pur..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Phenotypic characterization of a cmc4Δ strain: growth on non-fermentable carbon sources, spectrophotometric cytochrome c oxidase activity and BN-PAGE COX assembly, and meiotic assays (sporulation efficiency, spore viability, meiotic progression timing).</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: cmc4 loss produces a subtle, condition-specific respiratory and/or meiotic phenotype consistent with a non-essential accessory role in COX assembly.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="EXPERIMENT: Phenotypic characterization of a cmc4Δ strain: gro..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Biochemical characterization of recombinant cmc4: metal-binding assays (particularly Cu(I)) and thiol-disulfide/redox assays to test whether cmc4 is a metallochaperone or a MIA40-Erv1 relay accessory factor.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: cmc4 either binds a transition-metal ion or engages the disulfide relay beyond its own oxidative folding, defining its molecular activity.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRJ8" data-a="EXPERIMENT: Biochemical characterization of recombinant cmc4: ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> cmc4 is a functionally dark gene: its molecular activity, its direct binding partner(s)/client in S. pombe, and its in vivo biological role are all undetermined. It is unresolved whether cmc4 acts in cytochrome c oxidase (COX II) assembly (as inferred from the human CMC4-SCO1 interaction) or has a distinct role connected to its meiotic (tam2) expression, and no cmc4Δ phenotype has been reported.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is firmly established: cmc4 (SPAC4F10.22 / tam2) is a small 70-residue mitochondrial intermembrane space protein of the twin CX9C / CHCH (CMC4) family, with two CX9C motifs forming a disulfide-bonded helical hairpin, imported and oxidatively folded by the MIA40-Erv1 disulfide relay. It is the sole fission-yeast member of a family conserved to human (CMC4, P56277). The human ortholog physically associates with the COX assembly factor SCO1, implicating the family in a non-essential branch of COX II sub-assembly, and the transcript is meiotically regulated in S. pombe (tam2), whose deletion is viable.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> CMC4 is a conserved member of the twin CX9C protein family that collectively governs cytochrome c oxidase biogenesis and mitochondrial redox homeostasis, yet it is one of the least characterized members. Resolving its activity and in vivo role would close a genuine unknome gap and test whether the human COX II sub-assembly association is conserved and functionally important in a genetically tractable model.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity/proximity proteomics of tagged cmc4 in S. pombe to identify direct partners (test association with Sco1/Cox-assembly orthologs); recombinant metal-binding and thiol-disulfide assays to distinguish metallochaperone from disulfide-relay-accessory models; and phenotyping of cmc4Δ for respiratory (COX activity on non-fermentable carbon) and meiotic (sporulation, spore viability, timing) defects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The limited studies in yeast show that CMC4 knockdown produces no defect in respiration"</em> — PMID:33498264</li>
+
+                <li><em>"While tam2 .Δ was viable, new21 was not"</em> — PMID:21270388</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(cmc4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G2TRJ8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cmc4-spac4f1022-tam2-s-pombe-review-notes">cmc4 (SPAC4F10.22 / tam2) — S. pombe — review notes</h1>
+<p>UniProt: G2TRJ8 (CMC4_SCHPO). 70 aa. Reviewed. PE 1 (protein-level evidence,<br />
+via MS identification in PMID:21270388). Standard name cmc4; synonym tam2<br />
+("transcripts altered in meiosis protein 2"); systematic name SPAC4F10.22.</p>
+<h2 id="identity-domain-reasoning-from-uniprot-record-inline">Identity / domain reasoning (from UniProt record, inline)</h2>
+<ul>
+<li>RecName: "Cx9C motif-containing protein 4, mitochondrial"; SIMILARITY: "Belongs<br />
+  to the CMC4 family" (ECO:0000305). PANTHER PTHR15590 / PTHR15590:SF0 =<br />
+  "CX9C MOTIF-CONTAINING PROTEIN 4" (family is dedicated to CMC4; 1673 members,<br />
+  1528 proteomes). Pfam PF08991 (CMC4). InterPro IPR027179 (CMC4) +<br />
+  IPR009069 (Cys_alpha_HP_mot_SF, cysteine alpha-hairpin motif superfamily).</li>
+<li>Domain features (UniProt): CHCH domain 1..43 (PROSITE PS51808, PRU01150);<br />
+  MOTIF "Cx9C motif 1" 4..14; MOTIF "Cx9C motif 2" 25..35; DISULFID 4..35 and<br />
+  14..25. This is the canonical <strong>twin CX9C</strong> arrangement forming a helical<br />
+  hairpin stabilized by two disulfide bonds — the diagnostic feature of the<br />
+  CHCH/twin-CX9C IMS protein class.</li>
+<li>Sequence (70 aa): MVDCQKEACN LQSCIQRNQY NQGNCEKFVN DLLLCCKRWY DKNSLTGNEA<br />
+  PHTCPELKPL LRQLSSRNLT. Cys at 4,9,14,25,30,35 (the twin CX9C: C4..C14 and<br />
+  C25..C35 spacing) plus additional Cys (C39,C40 region "LLLCCKRWY", C63). This<br />
+  matches the review's statement that yeast CMC4 has eight cysteines, four in the<br />
+  twin CX9C motif <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" title="In yeast, CMC4 has eight cysteine residues,   four of which comprise the twin CX9C motif.">PMID:33498264</a>.</li>
+<li>SUBCELLULAR LOCATION (UniProt, ECO:0000250 by similarity): "Mitochondrion<br />
+  intermembrane space"; Note "Imported into the mitochondria via the<br />
+  mitochondrial mia40-erv1 machinery." DOMAIN: "The twin Cx9C motifs are involved<br />
+  in the recognition by the mitochondrial mia40-erv1 disulfide relay system and<br />
+  the subsequent transfer of disulfide bonds by dithiol/disulfide exchange<br />
+  reactions to the newly imported protein."</li>
+</ul>
+<p>Domain reasoning: the twin CX9C + CHCH fold, the MIA40/Erv1 import route, and<br />
+membership in the CMC4/PTHR15590 family are all mutually consistent and<br />
+well-established for this protein class. IMS localization and MIA40-dependent<br />
+import are therefore domain-defensible, high-confidence inferences even though<br />
+the pombe protein itself has not been localized experimentally (the UniProt<br />
+localization is ECO:0000250 = by similarity, and the sole GOA experimental-type<br />
+support is phylogenetic IBA + IEA SubCell mapping).</p>
+<h2 id="orthology-panther-pthr15590sf0-file-interpropantherpthr15590">Orthology (PANTHER PTHR15590:SF0, file interpro/panther/PTHR15590/)</h2>
+<p>One-to-one CMC4 orthologs across fungi and animals: S. cerevisiae CMC4<br />
+(Q3E7A9, 73 aa), human CMC4 (P56277, 68 aa), mouse Cmc4 (Q61908), Candida,<br />
+Yarrowia, etc. Family is a single-subfamily (SF0) group — cmc4 is the sole<br />
+pombe member; no pombe paralog. Human/yeast ~30% identity; 7 of 8 cysteines<br />
+conserved to human <a href="https://pubmed.ncbi.nlm.nih.gov/33498264">PMID:33498264</a>.</p>
+<p>NOTE ON FAMILY NOMENCLATURE: CMC4 is a DISTINCT member of the broader<br />
+"conserved mitochondrial (twin CX9C) COX assembly / CMC" grouping. The<br />
+well-characterized copper chaperones <strong>Cmc1 and Cmc2</strong> (metallation of COX and<br />
+IMS-Sod1) are SEPARATE proteins/families — do NOT transfer their specific<br />
+copper-chaperone function to CMC4. CMC4 itself is much less characterized.</p>
+<h2 id="known-evidence-supported">KNOWN (evidence-supported)</h2>
+<ol>
+<li>It is a small (70 aa) mitochondrial IMS protein of the twin-CX9C / CHCH<br />
+   (CMC4) family, imported by the MIA40(Mia40)-Erv1 disulfide relay. Domain +<br />
+   family + orthology; GOA IBA to GO:0005758 (mitochondrial intermembrane space,<br />
+   PANTHER:PTN000400520). [UniProt G2TRJ8; PMID:33498264]</li>
+<li>cmc4 = tam2: transcript differentially expressed during meiosis in pombe;<br />
+   protein detected by MS. tam2Δ is VIABLE (no essential vegetative role).<br />
+   [PMID:21270388 "Fourteen transcripts were differentially expressed during<br />
+   meiosis"; "While tam2 .Δ was viable, new21 was not"]</li>
+<li>Across the family, CMC4 is non-essential for respiration: yeast CMC4 knockdown<br />
+   produces no respiratory defect. <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" title="The limited studies in yeast    show that CMC4 knockdown produces no defect in respiration">PMID:33498264</a></li>
+<li>Human CMC4 interacts with SCO1 (COX II copper-delivery assembly factor) in an<br />
+   affinity-purification/proximity-labeling study → suggested non-essential role<br />
+   in COX II sub-assembly. <a href="https://pubmed.ncbi.nlm.nih.gov/33498264" title="an affinity purification–mass    spectrometry proximity labeling study determined that CMC4 interacts with SCO1    in human cell cultures ... This suggests that CMC4 plays a non-essential role    in COX II sub-assembly.">PMID:33498264</a></li>
+</ol>
+<h2 id="not-known-knowledge-gaps">NOT known / knowledge gaps</h2>
+<ul>
+<li>No defined <strong>molecular function</strong> for cmc4/CMC4: GOA has GO:0003674 ND (root,<br />
+  "no data"). No enzymatic activity; no demonstrated ligand/metal binding for<br />
+  CMC4 specifically (unlike Cmc1/Cmc2 which bind Cu(I)). Whether CMC4 is a<br />
+  metallochaperone, a redox/disulfide-relay accessory, or an adaptor is unknown.</li>
+<li>No demonstrated <strong>biological process</strong> for cmc4 in pombe: GOA has GO:0008150 ND.<br />
+  The COX II sub-assembly role is (a) inferred from human, (b) non-essential,<br />
+  (c) not tested in pombe. Meiotic transcript induction (tam2) has no assigned<br />
+  meiotic function; tam2Δ viable, no reported meiotic/sporulation phenotype.</li>
+<li>No experimental <strong>localization</strong> in pombe (IMS is by-similarity / IBA / IEA).</li>
+<li>The specific <strong>client/target</strong> of CMC4 in COX assembly (does it act on SCO1,<br />
+  COX2/CuA delivery, or elsewhere?) and its <strong>in-vivo pombe phenotype</strong> are open.</li>
+</ul>
+<h2 id="annotation-plan">Annotation plan</h2>
+<p>GOA has 4 annotations:<br />
+1. GO:0005758 IMS, IBA (GO_REF:0000033) → ACCEPT (core; domain+family+orthology<br />
+   support; the one substantive annotation).<br />
+2. GO:0005758 IMS, IEA SubCell (GO_REF:0000044) → ACCEPT (redundant electronic<br />
+   version of same well-supported localization).<br />
+3. GO:0003674 MF root, ND (GO_REF:0000015) → ACCEPT (honestly reflects unknown MF;<br />
+   ND root placeholder is correct given no defined MF).<br />
+4. GO:0008150 BP root, ND (GO_REF:0000015) → ACCEPT (honestly reflects unknown BP).</p>
+<p>core_functions: one MF-less entry anchored on the IMS location + twin-CX9C<br />
+identity (avoid inventing a COX-assembly MF for pombe). Actually core_functions<br />
+requires molecular_function; use the mitochondrial IMS protein-of-the-twin-CX9C<br />
+family framing carefully — see FUNCTION_KNOWLEDGE_GAPS guidance. Emphasize<br />
+knowledge_gaps as the primary deliverable.</p>
+<p>Refs to cite: PMID:11859360 (genome), PMID:21270388 (tam2/meiosis/viable, MS),<br />
+PMID:33498264 (CMC4 review: IMS, twin CX9C, MIA40, non-essential, SCO1).</p>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>Automated deep research was attempted via<br />
+<code>scripts/deep_research_wrapper.py SCHPO cmc4 falcon --fallback perplexity-lite</code><br />
+(foreground/background, ~35 min) and produced NO output before hanging; it was<br />
+terminated (exit 144) with no <code>-deep-research-*.md</code> file generated. This review<br />
+is therefore grounded directly in: the UniProt record (G2TRJ8), the QuickGO GOA<br />
+(4 annotations), PANTHER PTHR15590 orthology (interpro/panther/PTHR15590/), and<br />
+two PubMed-verified publications with full text in the cache — PMID:21270388<br />
+(tam2 identity, meiotic regulation, tam2Δ viable) and PMID:33498264 (the twin<br />
+CX9C / COX review with the only CMC4-specific functional statements: IMS<br />
+localization, MIA40 import, non-essential for respiration, SCO1 interaction).<br />
+No function was invented; all supporting_text quotes are verbatim substrings of<br />
+the cached publications.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G2TRJ8
+gene_symbol: cmc4
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  cmc4 (systematic name SPAC4F10.22; synonym tam2) is a small (70-residue)
+  mitochondrial intermembrane space (IMS) protein of the twin CX9C / coiled-coil-
+  helix-coiled-coil-helix (CHCH) family, the sole fission-yeast member of the
+  conserved CMC4 (Cx9C motif-containing protein 4) family (PANTHER PTHR15590,
+  Pfam PF08991, InterPro IPR027179). Its two CX9C motifs form a helical hairpin
+  stabilized by two intramolecular disulfide bonds; like other twin CX9C proteins
+  it is imported into the IMS and oxidatively folded by the MIA40 (Mia40/CHCHD4)-
+  Erv1 disulfide relay, which recognizes the cysteine motifs. CMC4 orthologs are
+  broadly conserved from yeasts to human (human CMC4, P56277). The family is
+  associated with cytochrome c oxidase (COX) biogenesis: in human cells CMC4
+  physically associates with the COX assembly factor SCO1, implicating it in COX
+  II sub-assembly, although CMC4 is non-essential for respiration and no specific
+  molecular activity has been demonstrated for it. In S. pombe the gene was
+  identified as a meiotically regulated transcript (tam2), and its deletion is
+  viable with no reported growth or respiratory phenotype.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Standard GO_Central IBA phylogenetic-inference reference; supports the
+        IBA localization annotation to the mitochondrial intermembrane space via
+        PANTHER family PTHR15590 (PTN000400520), consistent with the twin CX9C /
+        MIA40-import identity of the CMC4 family.
+  - id: GO_REF:0000044
+    title: &gt;-
+      Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:11859360
+    title: The genome sequence of Schizosaccharomyces pombe.
+    findings:
+      - statement: &gt;-
+          Source genome-sequencing reference that established the SPAC4F10.22
+          locus on chromosome I of S. pombe.
+        supporting_text: &gt;-
+          The genome sequence of Schizosaccharomyces pombe.
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Genome-sequence reference for the locus; background/contextual, does not
+        speak to cmc4 function.
+  - id: PMID:21270388
+    title: &gt;-
+      Augmented annotation of the Schizosaccharomyces pombe genome reveals
+      additional genes required for growth and viability.
+    findings:
+      - statement: &gt;-
+          Identifies the locus as tam2 (transcripts altered in meiosis protein 2),
+          a meiotically regulated transcript, and reports that its deletion is
+          viable.
+        supporting_text: &gt;-
+          While tam2 .Δ was viable, new21 was not
+      - statement: &gt;-
+          The transcript is among those differentially expressed during meiosis
+          in fission yeast.
+        supporting_text: &gt;-
+          Fourteen transcripts were differentially expressed during meiosis.
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PMC full text available and PubMed-verified. Primary S. pombe reference:
+        establishes cmc4/tam2 as a bona fide meiotically regulated protein-coding
+        gene detected by mass spectrometry and shows tam2Δ is viable. Does not
+        assign a molecular or biological function.
+  - id: PMID:33498264
+    title: &gt;-
+      Regulation of COX Assembly and Function by Twin CX(9)C Proteins-Implications
+      for Human Disease.
+    findings:
+      - statement: &gt;-
+          CMC4 is a twin CX9C-family protein that localizes to the mitochondrial
+          intermembrane space, imported via the Mia40/CHCHD4 redox relay.
+        supporting_text: &gt;-
+          CMC4 is a CX9C family member that localizes to the mitochondrial IMS
+      - statement: &gt;-
+          Yeast CMC4 has eight cysteines, four forming the twin CX9C motif, and
+          seven of the eight are conserved in the human ortholog.
+        supporting_text: &gt;-
+          In yeast, CMC4 has eight cysteine residues, four of which comprise the
+          twin CX9C motif.
+      - statement: &gt;-
+          CMC4 is non-essential for respiration and its specific role is inferred
+          from a physical interaction with the COX II assembly factor SCO1.
+        supporting_text: &gt;-
+          The limited studies in yeast show that CMC4 knockdown produces no
+          defect in respiration
+      - statement: &gt;-
+          A proximity/affinity study places human CMC4 with SCO1, suggesting a
+          non-essential role in COX II sub-assembly.
+        supporting_text: &gt;-
+          determined that CMC4 interacts with SCO1 in human cell cultures
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (PMC7909247; DOI 10.3390/cells10020197). This review is
+        the most CMC4-specific source available and explicitly frames the family
+        member as largely uncharacterized: IMS localization and MIA40-dependent
+        import are firm, but the only functional lead is a non-essential
+        association with SCO1 in COX II sub-assembly. Directly grounds the
+        knowledge-gap framing for this dark gene.
+existing_annotations:
+  - term:
+      id: GO:0005758
+      label: mitochondrial intermembrane space
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Phylogenetic (IBA) inference of mitochondrial intermembrane space
+        localization from the CMC4 family (PANTHER PTHR15590 / PTN000400520).
+        This is well supported: the twin CX9C / CHCH fold and the MIA40-Erv1
+        import route are diagnostic of soluble IMS proteins, and the human/yeast
+        orthologs are IMS-localized. This is the single substantive, defensible
+        annotation for cmc4 and represents its core cellular context.
+      action: ACCEPT
+      reason: &gt;-
+        Localization is strongly supported by family membership (twin CX9C,
+        MIA40-import) and ortholog data; the IBA inference from PTHR15590 is
+        appropriate. Note the localization has not been demonstrated
+        experimentally in S. pombe itself.
+      supported_by:
+        - reference_id: PMID:33498264
+          supporting_text: &gt;-
+            CMC4 is a CX9C family member that localizes to the mitochondrial IMS
+      propagation_review:
+        root_cause: NO_FAILURE_CORE
+        source_entities:
+          - source_id: PANTHER:PTN000400520
+            source_label: CMC4 family (PTHR15590)
+            source_status: SUPPORTS_TRANSFER
+            comment: &gt;-
+              Twin CX9C / MIA40-imported IMS protein family; human and yeast
+              orthologs are IMS-localized.
+  - term:
+      id: GO:0005758
+      label: mitochondrial intermembrane space
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic annotation of the same localization derived from the
+        UniProtKB/Swiss-Prot subcellular-location keyword (SL-0169). Redundant
+        with, and consistent with, the IBA annotation above.
+      action: ACCEPT
+      reason: &gt;-
+        Consistent with the family-supported IMS localization; the electronic
+        SubCell mapping mirrors the UniProt annotation and does not overreach.
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Molecular function is recorded as ND (no data). No specific biochemical
+        activity has been demonstrated for cmc4 or any CMC4 ortholog: unlike the
+        related copper chaperones Cmc1/Cmc2, CMC4 has no demonstrated metal
+        binding or catalytic activity, and its only functional lead is a physical
+        association with SCO1 in human cells. The ND root placeholder honestly
+        reflects a genuine molecular-function knowledge gap.
+      action: ACCEPT
+      reason: &gt;-
+        No experimental or defensible computational molecular-function term can
+        be asserted. Retaining the ND annotation correctly signals an
+        undetermined molecular function rather than forcing an unsupported term.
+      knowledge_gaps:
+        - gap_statement: &gt;-
+            The molecular activity of cmc4 is undetermined. It is unknown whether
+            it acts as a metallochaperone, a redox/disulfide-relay accessory
+            factor, or a protein-interaction adaptor within the mitochondrial IMS,
+            and no direct binding partner has been identified in S. pombe.
+          boundary: &gt;-
+            cmc4 is firmly a twin CX9C / CHCH-family IMS protein imported by the
+            MIA40-Erv1 disulfide relay; in human cells the ortholog associates
+            with the COX assembly factor SCO1. No metal-binding, catalytic, or
+            defined adaptor activity has been demonstrated for any CMC4 ortholog.
+          gap_kind:
+            - BIOLOGY
+          dark_aspect: MF_DARK
+          status: OPEN
+          significance: &gt;-
+            CMC4 is a conserved but functionally dark member of the twin CX9C
+            family that governs cytochrome c oxidase biogenesis; defining its
+            molecular activity would clarify a non-essential branch of COX
+            assembly and the broader logic of IMS twin CX9C proteins.
+          resolution: &gt;-
+            Affinity/proximity proteomics of tagged cmc4 in S. pombe to identify
+            direct partners; metal-binding and thiol-redox assays on recombinant
+            protein to test metallochaperone vs disulfide-relay-accessory models.
+          provenance:
+            - reference_id: PMID:33498264
+              supporting_text: &gt;-
+                determined that CMC4 interacts with SCO1 in human cell cultures
+              reference_section_type: RESULTS
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Biological process is recorded as ND (no data). A COX II sub-assembly
+        role is only inferred from the human SCO1 interaction, is non-essential,
+        and has not been tested in S. pombe; tam2Δ is viable with no reported
+        respiratory or meiotic phenotype despite the transcript being
+        meiotically regulated. The ND placeholder honestly reflects an
+        undetermined biological process.
+      action: ACCEPT
+      reason: &gt;-
+        No experimentally supported biological process for cmc4 in S. pombe. The
+        COX-assembly link is cross-species and non-essential; the meiotic
+        transcript regulation (tam2) has no assigned meiotic function. ND is the
+        correct, honest annotation.
+      knowledge_gaps:
+        - gap_statement: &gt;-
+            The in vivo biological role of cmc4 in S. pombe is unknown: whether it
+            contributes to cytochrome c oxidase assembly/respiration (as suggested
+            for the human ortholog) or has a distinct meiosis-related role implied
+            by its tam2 expression pattern is undetermined, and no deletion
+            phenotype has been reported.
+          boundary: &gt;-
+            cmc4/tam2 is a bona fide meiotically regulated protein-coding gene
+            (detected by mass spectrometry) whose deletion is viable. In human
+            cells the ortholog associates with SCO1, implying a non-essential role
+            in COX II sub-assembly; this has not been tested in fission yeast.
+          gap_kind:
+            - BIOLOGY
+          dark_aspect: BP_DARK
+          status: OPEN
+          significance: &gt;-
+            Establishing whether cmc4 functions in respiration/COX assembly or in
+            meiosis would place a conserved dark gene into a defined pathway and
+            test whether the human COX II sub-assembly role is conserved in yeast.
+          resolution: &gt;-
+            Phenotyping of cmc4Δ (respiratory growth on non-fermentable carbon,
+            COX activity/assembly; sporulation, spore viability and meiotic timing)
+            and epistasis with cox11/sco1 orthologs.
+          provenance:
+            - reference_id: PMID:21270388
+              supporting_text: &gt;-
+                While tam2 .Δ was viable, new21 was not
+              reference_section_type: RESULTS
+core_functions:
+  - description: &gt;-
+      Small twin CX9C / CHCH-family protein of the mitochondrial intermembrane
+      space (CMC4 family). It is imported and oxidatively folded by the MIA40-Erv1
+      disulfide relay, which recognizes its two CX9C motifs to introduce the two
+      structural disulfide bonds. Its molecular activity is undetermined; the sole
+      functional lead is that the human ortholog associates with the COX assembly
+      factor SCO1, implicating the family in a non-essential branch of cytochrome
+      c oxidase (COX II) biogenesis. No specific molecular-function GO term is
+      asserted because none is experimentally supported for cmc4 or its orthologs.
+    supported_by:
+      - reference_id: PMID:33498264
+        supporting_text: &gt;-
+          CMC4 is a CX9C family member that localizes to the mitochondrial IMS
+      - reference_id: PMID:33498264
+        supporting_text: &gt;-
+          In yeast, CMC4 has eight cysteine residues, four of which comprise the
+          twin CX9C motif.
+    locations:
+      - id: GO:0005758
+        label: mitochondrial intermembrane space
+    knowledge_gaps:
+      - gap_statement: &gt;-
+          No molecular activity or direct client/partner has been demonstrated for
+          cmc4; whether it is a metallochaperone, a disulfide-relay accessory
+          factor, or an adaptor coupling to a COX assembly factor (e.g. an
+          Sco1 ortholog) is unresolved.
+        boundary: &gt;-
+          Firmly a MIA40-imported twin CX9C IMS protein of the CMC4 family; human
+          CMC4 associates with SCO1. Non-essential for respiration in yeast.
+        gap_kind:
+          - BIOLOGY
+        dark_aspect: MF_DARK
+        status: OPEN
+        significance: &gt;-
+          Defining CMC4&#39;s activity would resolve a conserved dark node in the twin
+          CX9C protein network that regulates COX biogenesis.
+        resolution: &gt;-
+          Interactome (AP-MS/proximity labeling) plus metal-binding and redox
+          assays on recombinant cmc4.
+        provenance:
+          - reference_id: PMID:33498264
+            supporting_text: &gt;-
+              This suggests that CMC4 plays a non-essential role in COX II
+              sub-assembly.
+            reference_section_type: RESULTS
+knowledge_gaps:
+  - gap_statement: &gt;-
+      cmc4 is a functionally dark gene: its molecular activity, its direct
+      binding partner(s)/client in S. pombe, and its in vivo biological role are
+      all undetermined. It is unresolved whether cmc4 acts in cytochrome c oxidase
+      (COX II) assembly (as inferred from the human CMC4-SCO1 interaction) or has a
+      distinct role connected to its meiotic (tam2) expression, and no cmc4Δ
+      phenotype has been reported.
+    boundary: &gt;-
+      What is firmly established: cmc4 (SPAC4F10.22 / tam2) is a small 70-residue
+      mitochondrial intermembrane space protein of the twin CX9C / CHCH (CMC4)
+      family, with two CX9C motifs forming a disulfide-bonded helical hairpin,
+      imported and oxidatively folded by the MIA40-Erv1 disulfide relay. It is the
+      sole fission-yeast member of a family conserved to human (CMC4, P56277). The
+      human ortholog physically associates with the COX assembly factor SCO1,
+      implicating the family in a non-essential branch of COX II sub-assembly, and
+      the transcript is meiotically regulated in S. pombe (tam2), whose deletion is
+      viable.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      CMC4 is a conserved member of the twin CX9C protein family that collectively
+      governs cytochrome c oxidase biogenesis and mitochondrial redox homeostasis,
+      yet it is one of the least characterized members. Resolving its activity and
+      in vivo role would close a genuine unknome gap and test whether the human COX
+      II sub-assembly association is conserved and functionally important in a
+      genetically tractable model.
+    resolution: &gt;-
+      Affinity/proximity proteomics of tagged cmc4 in S. pombe to identify direct
+      partners (test association with Sco1/Cox-assembly orthologs); recombinant
+      metal-binding and thiol-disulfide assays to distinguish metallochaperone from
+      disulfide-relay-accessory models; and phenotyping of cmc4Δ for respiratory
+      (COX activity on non-fermentable carbon) and meiotic (sporulation, spore
+      viability, timing) defects.
+    provenance:
+      - reference_id: PMID:33498264
+        supporting_text: &gt;-
+          The limited studies in yeast show that CMC4 knockdown produces no
+          defect in respiration
+        reference_section_type: RESULTS
+      - reference_id: PMID:21270388
+        supporting_text: &gt;-
+          While tam2 .Δ was viable, new21 was not
+        reference_section_type: RESULTS
+suggested_questions:
+  - question: &gt;-
+      Does cmc4 physically associate with an S. pombe SCO1/Cox-assembly ortholog,
+      as its human counterpart does, or with a distinct IMS partner?
+  - question: &gt;-
+      Is cmc4 required for respiratory growth or cytochrome c oxidase
+      activity/assembly in fission yeast, or is it fully dispensable as the
+      viability of tam2Δ and the lack of a respiratory phenotype in yeast CMC4
+      knockdown suggest?
+  - question: &gt;-
+      Does the meiotic (tam2) regulation of cmc4 reflect a meiosis- or
+      sporulation-specific function, or merely coordinate expression of a
+      mitochondrial protein with increased respiratory demand during
+      differentiation?
+  - question: &gt;-
+      Does cmc4 bind a metal ion (e.g. copper) or participate directly in the
+      MIA40-Erv1 disulfide relay as a substrate/accessory factor?
+suggested_experiments:
+  - description: &gt;-
+      Proximity labeling (BioID/TurboID) or affinity purification of endogenously
+      tagged cmc4 in S. pombe under fermentative and respiratory (glycerol/ethanol)
+      growth to identify direct IMS partners and test for association with Sco1/COX
+      assembly factors.
+    hypothesis: &gt;-
+      cmc4 associates with a COX II copper-delivery assembly factor (Sco1 ortholog)
+      in the IMS, conserving the human CMC4-SCO1 interaction.
+  - description: &gt;-
+      Phenotypic characterization of a cmc4Δ strain: growth on non-fermentable
+      carbon sources, spectrophotometric cytochrome c oxidase activity and BN-PAGE
+      COX assembly, and meiotic assays (sporulation efficiency, spore viability,
+      meiotic progression timing).
+    hypothesis: &gt;-
+      cmc4 loss produces a subtle, condition-specific respiratory and/or meiotic
+      phenotype consistent with a non-essential accessory role in COX assembly.
+  - description: &gt;-
+      Biochemical characterization of recombinant cmc4: metal-binding assays
+      (particularly Cu(I)) and thiol-disulfide/redox assays to test whether cmc4 is
+      a metallochaperone or a MIA40-Erv1 relay accessory factor.
+    hypothesis: &gt;-
+      cmc4 either binds a transition-metal ion or engages the disulfide relay
+      beyond its own oxidative folding, defining its molecular activity.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/cms1/cms1-ai-review.html
+++ b/genes/SCHPO/cms1/cms1-ai-review.html
@@ -1,0 +1,2285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>cms1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>cms1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O94465" target="_blank" class="term-link">
+                        O94465
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "cms1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O94465" data-a="DESCRIPTION: Conserved, non-essential nuclear protein of the CM..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Conserved, non-essential nuclear protein of the CMS1/CMSS1 family (Pfam PF14617; PANTHER PTHR24030), with single-copy orthologs from fungi to vertebrates including Saccharomyces cerevisiae CMS1 and human CMSS1. Based on orthology to the strongly characterized budding-yeast factor, Cms1 is an accessory assembly factor of the nucleolar 90S pre-ribosome (small subunit processome) that acts in ribosomal small subunit (18S rRNA) biogenesis, where the budding-yeast ortholog associates with the 18S rRNA 3&#39; major domain of an early 90S carrying the H/ACA snoRNA snR83 and coordinates stepwise local assembly with timely snR83 release. The protein carries a degenerate, catalytically inactive helicase-like fold and a basic disordered patch, but no molecular activity has been experimentally demonstrated in any species. In Schizosaccharomyces pombe the protein itself is uncharacterized (UniProt evidence level: inferred from homology; PomBase characterisation status: biological role inferred): all functional annotations are orthology transfers and deletion is viable.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94465" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) subcellular-location annotation derived from the UniProt Swiss-Prot &#34;Nucleus&#34; keyword mapping (GO_REF:0000044). It is consistent with, but redundant to, the ISO nuclear annotation (is_active_in nucleus) transferred from the S. cerevisiae ortholog. The nuclear localization is itself a by-similarity inference (UniProt SUBCELLULAR LOCATION: Nucleus, ECO:0000250); no direct localization has been reported for the S. pombe protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A defensible location call but not a core function, and redundant with the ISO nucleus annotation. The physiologically relevant compartment is more precisely the nucleolus (site of 90S pre-ribosome assembly), but nucleus is a correct, conservative parent. Retained as a non-core localization annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94465" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with ND (No Data) evidence, used by PomBase as a placeholder because no specific molecular function is known for cms1. This accurately reflects the current state of knowledge: cms1 encodes a degenerate, catalytically inactive helicase-like fold and no molecular activity has been demonstrated. Even for the well-studied S. cerevisiae ortholog, a possible RNA-binding activity is explicitly hypothetical rather than measured.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND molecular_function annotation is appropriate and honest. No specific MF should be asserted: the only proposed activity (RNA binding via an inactive helicase domain) is speculative even for the budding-yeast ortholog and has not been biochemically demonstrated in any species. This is a genuine molecular- function knowledge gap (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                        PMID:36417864
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">little is known about how the many different snoRNAs that modify the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030686" target="_blank" class="term-link">
+                                    GO:0030686
+                                </a>
+                            </span>
+                            <span class="term-label">90S preribosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94465" data-a="GO:0030686" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Part_of the 90S preribosome (small subunit processome), transferred by orthology (ISO) from S. cerevisiae CMS1 (SGD:S000003993). This is well supported for the ortholog: budding-yeast Cms1 co-precipitates with many 90S factors and is detected on early 90S particles at the 18S rRNA 3&#39; major domain. cms1 is a single-copy member of a family conserved from fungi to human (human CMSS1), so the orthology transfer is reliable. PomBase names the product &#34;U3-containing 90S preribosome complex subunit Cms1&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A well-founded core annotation. Unlike a spurious ortholog transfer, this ISO is supported by strong experimental evidence in the closely related S. cerevisiae ortholog and by robust single-copy conservation across the CMS1/CMSS1 family. The 90S preribosome is the defining complex for this protein&#39;s inferred role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                        PMID:36417864
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cms1 co-precipitates with many 90S</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                        PMID:36417864
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">detected Cms1 at the 18S rRNA 3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
+                                    GO:0042274
+                                </a>
+                            </span>
+                            <span class="term-label">ribosomal small subunit biogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94465" data-a="GO:0042274" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Involved_in ribosomal small subunit biogenesis, transferred by orthology (ISO) from S. cerevisiae CMS1 (SGD:S000003993). The ortholog is a non-essential early 90S / small-subunit-processome assembly factor that acts at the 18S rRNA 3&#39; major domain and coordinates local assembly with timely release of the H/ACA snoRNA snR83. This process assignment is the best-supported functional statement for cms1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The core biological process. Strongly supported for the S. cerevisiae ortholog and reliable to transfer given single-copy family conservation. The role is accessory/regulatory within 90S assembly rather than a distinct catalytic step, consistent with the protein&#39;s degenerate helicase-like fold and non-essentiality.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                        PMID:36417864
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                        PMID:36417864
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">restrict premature Rrp12-Enp1 binding but allows snR83 to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94465" data-a="GO:0005634" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Is_active_in nucleus, transferred by orthology (ISO) from S. cerevisiae CMS1 (SGD:S000003993), consistent with UniProt&#39;s by-similarity Nucleus localization. The functionally relevant sub-compartment is the nucleolus, where 90S pre- ribosome assembly occurs, but nucleus is a correct conservative parent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The nuclear localization is consistent with the protein&#39;s inferred role as a nucleolar 90S assembly factor and with the ortholog, and is retained as a supporting location rather than a core function. A nucleolus (GO:0005730) annotation would be more precise but is not asserted here in the absence of direct S. pombe localization data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                        PMID:36417864
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Accessory subunit of the nucleolar 90S pre-ribosome (small subunit processome) acting in ribosomal small subunit (18S rRNA) biogenesis. By orthology to the characterized S. cerevisiae factor, cms1 associates with the 18S rRNA 3&#39; major domain of an early 90S particle and helps coordinate stepwise local assembly with timely snR83 release; it is non-essential. No independent molecular activity is asserted: the protein has a catalytically inactive, degenerate helicase-like fold, and the only proposed activity (RNA binding) is hypothetical even for the budding-yeast ortholog (see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="O94465" data-a="FUNCTION: Accessory subunit of the nucleolar 90S pre-ribosom..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
+                                ribosomal small subunit biogenesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030686" target="_blank" class="term-link">
+                            90S preribosome
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                PMID:36417864
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                                PMID:36417864
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Cms1 co-precipitates with many 90S</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36417864" target="_blank" class="term-link">
+                            PMID:36417864
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cms1 coordinates stepwise local 90S pre-ribosome assembly with timely snR83 release.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction, and the study reports a role for the CMS1/CMSS1-family factor Cms1 in this process.</div>
+
+                        <div class="finding-text">"Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cms1 is detected on an early 90S pre-ribosome at the 18S rRNA 3&#39; major domain carrying the H/ACA snoRNA snR83, and co-precipitates with many 90S factors.</div>
+
+                        <div class="finding-text">"detected Cms1 at the 18S rRNA 3"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cms1 is proposed to restrict premature Rrp12-Enp1 binding while allowing snR83 to act, coordinating stepwise local 90S assembly.</div>
+
+                        <div class="finding-text">"restrict premature Rrp12-Enp1 binding but allows snR83 to"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The mechanism by which the many snoRNAs that modify pre-rRNA are guided to their target sites during early ribosome assembly is largely unknown, framing Cms1 as a poorly understood coordinating factor.</div>
+
+                        <div class="finding-text">"little is known about how the many different snoRNAs that modify the"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the degenerate helicase-like CMS1/CMSS1 fold have any real RNA-binding (or other) biochemical activity, or is cms1 a purely structural/placeholder subunit of the early 90S?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="Q: Does the degenerate helicase-like CMS1/CMSS1 fold ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe cms1 localize to the nucleolus and associate with the 90S pre- ribosome as predicted from the S. cerevisiae ortholog, and does cms1 deletion impair 18S rRNA / small-subunit maturation in fission yeast?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="Q: Does S. pombe cms1 localize to the nucleolus and a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the snR83-coordination role of the budding-yeast ortholog conserved in S. pombe (i.e. does cms1 act with the fission-yeast H/ACA snoRNA that pseudouridylates the 18S 3&#39; major domain)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="Q: Is the snR83-coordination role of the budding-yeas..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity purification of tagged S. pombe Cms1 followed by mass spectrometry and RNA identification (RIP/CLIP) to define its 90S partners and any bound rRNA/snoRNA.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="EXPERIMENT: Affinity purification of tagged S. pombe Cms1 foll..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> GFP/fluorescent tagging of cms1 to determine subcellular (nucleolar) localization in S. pombe.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="EXPERIMENT: GFP/fluorescent tagging of cms1 to determine subce..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Northern/primer-extension analysis of pre-rRNA processing intermediates and polysome/40S profiling in a cms1 deletion strain to test the small-subunit- biogenesis role directly.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="EXPERIMENT: Northern/primer-extension analysis of pre-rRNA pro..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro RNA-binding assays on recombinant Cms1 (and structure-guided mutants of the inactive helicase fold and the basic disordered patch) to test the proposed RNA-binding activity.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94465" data-a="EXPERIMENT: In vitro RNA-binding assays on recombinant Cms1 (a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(cms1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O94465" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cms1-spbc23g707c-uniprot-o94465-curation-notes">cms1 (SPBC23G7.07c, UniProt O94465) — curation notes</h1>
+<p>Fission yeast (<em>Schizosaccharomyces pombe</em>) gene, systematic name SPBC23G7.07c, standard name <strong>cms1</strong>.<br />
+Understudied ("dark") gene. This journal records what is KNOWN vs NOT-known, with inline provenance.</p>
+<blockquote>
+<p>Provenance note on deep research: the automated deep-research harness (<code>deep_research_wrapper.py</code><br />
+SCHPO cms1 falcon --fallback perplexity-lite<code>, and</code>just deep-research-falcon<code>) hung and timed out
+(&gt;550s, exit 124/no output) on two attempts and produced no report file. Per project guidance, this
+review is therefore grounded directly in the UniProt record, the QuickGO GOA TSV, the PomBase gene
+record (JSON API), the InterPro/PANTHER family data (PTHR24030), and the cached primary literature on
+the S. cerevisiae ortholog (publications/PMID_36417864.md). No</code>-deep-research-*.md` file was<br />
+fabricated.</p>
+</blockquote>
+<h2 id="identity-and-domain-reasoning-from-cms1-uniprottxt-interpro-pombase">Identity and domain reasoning (from cms1-uniprot.txt, InterPro, PomBase)</h2>
+<ul>
+<li>277 aa protein, MW ~31.6 kDa. UniProt evidence level <strong>PE 3 (Inferred from homology)</strong> — i.e. no<br />
+  direct protein-level experimental evidence for the <em>S. pombe</em> protein itself.</li>
+<li>UniProt RecName is simply "Protein cms1"; the only functional statements are inferred:</li>
+<li>FUNCTION: "May play a role in the regulation of DNA replication and cell cycle control." {ECO:0000250}<br />
+    (this is a legacy homology inference derived from the budding-yeast <em>CMS1</em> high-copy-suppressor-of-<em>MCM10</em><br />
+    history, NOT from any 90S ribosome work; see below).</li>
+<li>SUBCELLULAR LOCATION: Nucleus {ECO:0000250} (by similarity).</li>
+<li>SIMILARITY: "Belongs to the CMS1 family." {ECO:0000305}.</li>
+<li>Domain/family signatures: Pfam <strong>PF14617 (CMS1)</strong>, InterPro <strong>IPR032704 (Cms1)</strong>, PANTHER <strong>PTHR24030<br />
+  / PTHR24030:SF0 (PROTEIN CMSS1)</strong>. No catalytic-domain signature (no kinase, no methyltransferase,<br />
+  no active nuclease). The Pfam CMS1 domain corresponds to a degenerate/inactive helicase-like fold<br />
+  (see Lau et al. 2022 below).</li>
+<li>Sequence features (UniProt FT): a disordered region 28-68, with a polar-residue compositional bias<br />
+  (33-49) and a <strong>basic-residue compositional bias (53-68)</strong> — the stretch <code>KREKRKKQRQKQKERKRAK</code>. A basic<br />
+  disordered patch of this kind is a plausible (but unproven) nucleic-acid-contacting element, consistent<br />
+  with an RNP/ribosome-biogenesis context, but is not by itself an annotatable molecular function.</li>
+<li>PANTHER family PTHR24030 (interpro/panther/PTHR24030) is conserved from fungi to vertebrates; reviewed<br />
+  members include <em>S. cerevisiae</em> CMS1 (Q07897), human <strong>CMSS1</strong> (Q9BQ75, "Cms1 ribosomal small subunit<br />
+  homolog"), mouse/rat/zebrafish/Xenopus Cmss1, and <em>Thermochaetoides thermophila</em> CMS1. So cms1 is a<br />
+  genuinely conserved single-copy family member — unlike lineage-restricted orphans.</li>
+</ul>
+<h2 id="pombase-specific-facts-pombase-api-gene-spbc23g707c">PomBase-specific facts (PomBase API, gene SPBC23G7.07c)</h2>
+<ul>
+<li>PomBase product name: <strong>"U3-containing 90S preribosome complex subunit Cms1"</strong>.</li>
+<li>PomBase <code>characterisation_status</code>: <strong>"biological role inferred"</strong> — i.e. the pombe gene's role is<br />
+  inferred (from orthology), not directly demonstrated in <em>S. pombe</em>.</li>
+<li>GO annotations in PomBase mirror the GOA TSV: MF = ND (root, no data); BP = ribosomal small subunit<br />
+  biogenesis (GO:0042274); CC = 90S preribosome (GO:0030686) + nucleus (GO:0005634). All functional<br />
+  terms are ISO transfers from <em>S. cerevisiae</em> CMS1 (SGD:S000003993).</li>
+<li>Deletion phenotype: PomBase records a single-locus phenotype <strong>FYPO:0002060 "viable vegetative cell<br />
+  population"</strong> — cms1Δ is viable (non-essential), consistent with <em>S. cerevisiae</em> (below). Other<br />
+  phenotype terms are high-throughput deletion-collection screen hits (e.g. FYPO:0003743 "decreased<br />
+  cell population growth during glucose starvation"; FYPO:0001701 "sensitive to bortezomib";<br />
+  FYPO:0000763 "resistance to cadmium") — these are pleiotropic screen signals, not core-function-defining.</li>
+</ul>
+<h2 id="ortholog-evidence-the-source-of-the-iso-annotations">Ortholog evidence — the source of the ISO annotations</h2>
+<p>The ISO annotations are transferred from the <em>S. cerevisiae</em> ortholog <strong>CMS1</strong> (SGD:S000003993, Q07897).<br />
+The most informative primary study of that ortholog:</p>
+<p><strong>Lau B, Beine-Golovchuk O, Kornprobst M, Cheng J, Kressler D, Jády B, Kiss T, Beckmann R, Hurt E.<br />
+"Cms1 coordinates stepwise local 90S pre-ribosome assembly with timely snR83 release." Cell Rep. 2022;<br />
+41(8):111684. PMID:36417864</strong> (full text cached in publications/PMID_36417864.md). This paper is entirely<br />
+about <em>S. cerevisiae</em> Cms1 (no <em>S. pombe</em> data — grep found 0 "pombe" mentions), so it grounds the ORTHOLOG.</p>
+<p>Key verbatim-supported facts about <em>S. cerevisiae</em> Cms1:<br />
+- It is a bona fide <strong>90S pre-ribosome (small subunit processome) assembly factor</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36417864" title="CMS1 encodes a poorly characterized but conserved protein (human homolog CMSS1; Figure S2A)   that was initially found as a high-copy suppressor of MCM10 (Wang and Wu, 2001). However, based on other   analyses, it was implicated in 90S ribosome biogenesis">PMID:36417864</a>.<br />
+- It is <strong>conserved</strong> with a human homolog CMSS1:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36417864" title="Notably, both a human Cms1 (CMSS1; Figure S2A) and an snR83 homolog (called ACA4) exist">PMID:36417864</a>.<br />
+- It is <strong>nonessential</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36417864" title="... vulnerable mutations in Noc4 module subunits or in the Bms1-Rcl1 heterodimer can be   suppressed by disrupting CMS1 or NOP6, which both are nonessential factors implicated in the early 90S   assembly pathway">PMID:36417864</a>.<br />
+- It localizes to the 18S rRNA 3' major domain of an early 90S carrying the H/ACA snoRNA snR83 and<br />
+  coordinates local assembly with timely snR83 release (abstract).<br />
+- Proposed molecular activity is speculative/inactive-helicase-based RNA binding, NOT demonstrated:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/36417864" title="Via its inactive helicase domain, Cms1 might exert a specific RNA-binding activity toward   the H32-34 region of the 3′-major domain, thereby competing with Enp1-Rrp12 binding at a related site">PMID:36417864</a>.<br />
+  Note the hedging ("inactive helicase domain", "might exert") — no catalytic activity; MF remains open.</p>
+<h2 id="known-vs-not-known-for-s-pombe-cms1">KNOWN vs NOT-known for <em>S. pombe</em> cms1</h2>
+<p>KNOWN (well-supported, chiefly by orthology to a strongly characterized budding-yeast factor):<br />
+- Member of the conserved CMS1/CMSS1 family (Pfam PF14617; PANTHER PTHR24030), single-copy, fungi→human.<br />
+- By orthology, a nucleolar <strong>90S pre-ribosome / small-subunit-processome assembly factor</strong> involved in<br />
+<strong>ribosomal small subunit (18S rRNA) biogenesis</strong>; localizes to the nucleus.<br />
+- Non-essential in <em>S. pombe</em> (cms1Δ viable, FYPO:0002060) — matching <em>S. cerevisiae</em>.</p>
+<p>NOT-known (genuine gaps for the pombe protein):<br />
+- No direct experimental characterization of the <em>S. pombe</em> protein exists (PE 3; "biological role<br />
+  inferred"). All functional GO terms are ISO transfers.<br />
+- <strong>Molecular function is dark.</strong> No catalytic activity; the only proposed activity (RNA binding via a<br />
+  degenerate/inactive helicase fold) is a hypothesis even for the budding-yeast ortholog and has not been<br />
+  biochemically demonstrated in any species. The basic disordered patch (53-68) is a candidate<br />
+  nucleic-acid contact but unproven.<br />
+- The legacy UniProt FUNCTION line ("regulation of DNA replication and cell cycle control", by similarity)<br />
+  reflects the historical <em>MCM10</em> high-copy-suppressor origin of budding-yeast CMS1 and is superseded by<br />
+  the 90S-ribosome-biogenesis role; it is not independently supported as a <em>core</em> function.</p>
+<h2 id="curation-decisions-summary-see-cms1-ai-reviewyaml">Curation decisions (summary; see cms1-ai-review.yaml)</h2>
+<ul>
+<li>GO:0042274 ribosomal small subunit biogenesis (BP, ISO) — ACCEPT (core; ortholog strongly supports).</li>
+<li>GO:0030686 90S preribosome (CC, ISO, part_of) — ACCEPT (core; the defining complex).</li>
+<li>GO:0005634 nucleus (CC, ISO, is_active_in) — ACCEPT as location (specific compartment is nucleolar,<br />
+  but nucleus is defensible and consistent).</li>
+<li>GO:0005634 nucleus (CC, IEA, located_in, GO_REF:0000044 SubCell) — KEEP_AS_NON_CORE (redundant IEA<br />
+  duplicate of the ISO nuclear call; location, not core function).</li>
+<li>GO:0003674 molecular_function (ND) — ACCEPT (honestly reflects that MF is genuinely unknown; do not<br />
+  invent an MF).</li>
+</ul>
+<p>Core-function synthesis: cms1 is best represented as an accessory subunit of the 90S preribosome acting in<br />
+small-subunit biogenesis in the nucleus, with NO assertable molecular function (MF-dark). This is recorded<br />
+as a knowledge gap.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O94465
+gene_symbol: cms1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  Conserved, non-essential nuclear protein of the CMS1/CMSS1 family (Pfam PF14617;
+  PANTHER PTHR24030), with single-copy orthologs from fungi to vertebrates including
+  Saccharomyces cerevisiae CMS1 and human CMSS1. Based on orthology to the strongly
+  characterized budding-yeast factor, Cms1 is an accessory assembly factor of the
+  nucleolar 90S pre-ribosome (small subunit processome) that acts in ribosomal small
+  subunit (18S rRNA) biogenesis, where the budding-yeast ortholog associates with the
+  18S rRNA 3&#39; major domain of an early 90S carrying the H/ACA snoRNA snR83 and
+  coordinates stepwise local assembly with timely snR83 release. The protein carries a
+  degenerate, catalytically inactive helicase-like fold and a basic disordered patch,
+  but no molecular activity has been experimentally demonstrated in any species. In
+  Schizosaccharomyces pombe the protein itself is uncharacterized (UniProt evidence
+  level: inferred from homology; PomBase characterisation status: biological role
+  inferred): all functional annotations are orthology transfers and deletion is viable.
+existing_annotations:
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic (IEA) subcellular-location annotation derived from the UniProt
+        Swiss-Prot &#34;Nucleus&#34; keyword mapping (GO_REF:0000044). It is consistent with,
+        but redundant to, the ISO nuclear annotation (is_active_in nucleus) transferred
+        from the S. cerevisiae ortholog. The nuclear localization is itself a
+        by-similarity inference (UniProt SUBCELLULAR LOCATION: Nucleus, ECO:0000250);
+        no direct localization has been reported for the S. pombe protein.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        A defensible location call but not a core function, and redundant with the ISO
+        nucleus annotation. The physiologically relevant compartment is more precisely
+        the nucleolus (site of 90S pre-ribosome assembly), but nucleus is a correct,
+        conservative parent. Retained as a non-core localization annotation.
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root molecular_function term with ND (No Data) evidence, used by PomBase as a
+        placeholder because no specific molecular function is known for cms1. This
+        accurately reflects the current state of knowledge: cms1 encodes a degenerate,
+        catalytically inactive helicase-like fold and no molecular activity has been
+        demonstrated. Even for the well-studied S. cerevisiae ortholog, a possible
+        RNA-binding activity is explicitly hypothetical rather than measured.
+      action: ACCEPT
+      reason: &gt;-
+        The ND molecular_function annotation is appropriate and honest. No specific MF
+        should be asserted: the only proposed activity (RNA binding via an inactive
+        helicase domain) is speculative even for the budding-yeast ortholog and has not
+        been biochemically demonstrated in any species. This is a genuine molecular-
+        function knowledge gap (see knowledge_gaps).
+      supported_by:
+        - reference_id: PMID:36417864
+          supporting_text: &gt;-
+            little is known about how the many different snoRNAs that modify the
+  - term:
+      id: GO:0030686
+      label: 90S preribosome
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Part_of the 90S preribosome (small subunit processome), transferred by orthology
+        (ISO) from S. cerevisiae CMS1 (SGD:S000003993). This is well supported for the
+        ortholog: budding-yeast Cms1 co-precipitates with many 90S factors and is
+        detected on early 90S particles at the 18S rRNA 3&#39; major domain. cms1 is a
+        single-copy member of a family conserved from fungi to human (human CMSS1), so
+        the orthology transfer is reliable. PomBase names the product &#34;U3-containing 90S
+        preribosome complex subunit Cms1&#34;.
+      action: ACCEPT
+      reason: &gt;-
+        A well-founded core annotation. Unlike a spurious ortholog transfer, this ISO is
+        supported by strong experimental evidence in the closely related S. cerevisiae
+        ortholog and by robust single-copy conservation across the CMS1/CMSS1 family.
+        The 90S preribosome is the defining complex for this protein&#39;s inferred role.
+      supported_by:
+        - reference_id: PMID:36417864
+          supporting_text: &gt;-
+            Cms1 co-precipitates with many 90S
+        - reference_id: PMID:36417864
+          supporting_text: &gt;-
+            detected Cms1 at the 18S rRNA 3
+  - term:
+      id: GO:0042274
+      label: ribosomal small subunit biogenesis
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Involved_in ribosomal small subunit biogenesis, transferred by orthology (ISO)
+        from S. cerevisiae CMS1 (SGD:S000003993). The ortholog is a non-essential early
+        90S / small-subunit-processome assembly factor that acts at the 18S rRNA 3&#39;
+        major domain and coordinates local assembly with timely release of the H/ACA
+        snoRNA snR83. This process assignment is the best-supported functional
+        statement for cms1.
+      action: ACCEPT
+      reason: &gt;-
+        The core biological process. Strongly supported for the S. cerevisiae ortholog
+        and reliable to transfer given single-copy family conservation. The role is
+        accessory/regulatory within 90S assembly rather than a distinct catalytic step,
+        consistent with the protein&#39;s degenerate helicase-like fold and non-essentiality.
+      supported_by:
+        - reference_id: PMID:36417864
+          supporting_text: &gt;-
+            Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,
+        - reference_id: PMID:36417864
+          supporting_text: &gt;-
+            restrict premature Rrp12-Enp1 binding but allows snR83 to
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Is_active_in nucleus, transferred by orthology (ISO) from S. cerevisiae CMS1
+        (SGD:S000003993), consistent with UniProt&#39;s by-similarity Nucleus localization.
+        The functionally relevant sub-compartment is the nucleolus, where 90S pre-
+        ribosome assembly occurs, but nucleus is a correct conservative parent.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The nuclear localization is consistent with the protein&#39;s inferred role as a
+        nucleolar 90S assembly factor and with the ortholog, and is retained as a
+        supporting location rather than a core function. A nucleolus (GO:0005730)
+        annotation would be more precise but is not asserted here in the absence of
+        direct S. pombe localization data.
+      supported_by:
+        - reference_id: PMID:36417864
+          supporting_text: &gt;-
+            Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,
+core_functions:
+  - description: &gt;-
+      Accessory subunit of the nucleolar 90S pre-ribosome (small subunit processome)
+      acting in ribosomal small subunit (18S rRNA) biogenesis. By orthology to the
+      characterized S. cerevisiae factor, cms1 associates with the 18S rRNA 3&#39; major
+      domain of an early 90S particle and helps coordinate stepwise local assembly with
+      timely snR83 release; it is non-essential. No independent molecular activity is
+      asserted: the protein has a catalytically inactive, degenerate helicase-like fold,
+      and the only proposed activity (RNA binding) is hypothetical even for the
+      budding-yeast ortholog (see knowledge_gaps).
+    directly_involved_in:
+      - id: GO:0042274
+        label: ribosomal small subunit biogenesis
+    locations:
+      - id: GO:0005634
+        label: nucleus
+    in_complex:
+      id: GO:0030686
+      label: 90S preribosome
+    supported_by:
+      - reference_id: PMID:36417864
+        supporting_text: &gt;-
+          Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,
+      - reference_id: PMID:36417864
+        supporting_text: &gt;-
+          Cms1 co-precipitates with many 90S
+    knowledge_gaps:
+      - gap_statement: &gt;-
+          The molecular function of cms1 is undetermined: no catalytic activity, no
+          direct nucleic-acid- or protein-binding partner, and no biochemically
+          demonstrated activity are known for the protein in any species. Whether the
+          degenerate helicase-like CMS1 fold confers a real RNA-binding activity (as
+          hypothesized for the S. cerevisiae ortholog) is unproven.
+        boundary: &gt;-
+          What is established (chiefly by orthology to S. cerevisiae CMS1 and by
+          single-copy conservation across the fungi-to-human CMS1/CMSS1 family) is that
+          cms1 is a non-essential nuclear/nucleolar accessory factor of the 90S pre-
+          ribosome involved in small subunit (18S rRNA) biogenesis. The S. pombe protein
+          itself has no direct experimental characterization (UniProt PE 3; PomBase
+          &#34;biological role inferred&#34;); all functional GO terms are ISO transfers.
+        gap_kind:
+          - BIOLOGY
+          - CURATION
+        dark_aspect: MF_DARK
+        status: OPEN
+        significance: &gt;-
+          cms1/CMSS1 is a conserved-but-dark component of the ribosome-assembly
+          machinery; defining its molecular activity would clarify how snoRNA-guided
+          modification is temporally coordinated with 90S small-subunit assembly, a
+          process conserved from yeast to human.
+        resolution: &gt;-
+          Biochemical RNA-binding / activity assays on purified S. pombe (or ortholog)
+          Cms1 and its inactive-helicase fold; affinity-purification/CLIP to identify
+          direct RNA and protein partners on the 90S; GFP localization and cms1delta
+          pre-rRNA-processing phenotyping in S. pombe to confirm the transferred role.
+        provenance:
+          - reference_id: PMID:36417864
+            supporting_text: &gt;-
+              little is known about how the many different snoRNAs that modify the
+suggested_questions:
+  - question: &gt;-
+      Does the degenerate helicase-like CMS1/CMSS1 fold have any real RNA-binding (or
+      other) biochemical activity, or is cms1 a purely structural/placeholder subunit of
+      the early 90S?
+  - question: &gt;-
+      Does S. pombe cms1 localize to the nucleolus and associate with the 90S pre-
+      ribosome as predicted from the S. cerevisiae ortholog, and does cms1 deletion
+      impair 18S rRNA / small-subunit maturation in fission yeast?
+  - question: &gt;-
+      Is the snR83-coordination role of the budding-yeast ortholog conserved in S. pombe
+      (i.e. does cms1 act with the fission-yeast H/ACA snoRNA that pseudouridylates the
+      18S 3&#39; major domain)?
+suggested_experiments:
+  - description: &gt;-
+      Affinity purification of tagged S. pombe Cms1 followed by mass spectrometry and
+      RNA identification (RIP/CLIP) to define its 90S partners and any bound rRNA/snoRNA.
+  - description: &gt;-
+      GFP/fluorescent tagging of cms1 to determine subcellular (nucleolar) localization
+      in S. pombe.
+  - description: &gt;-
+      Northern/primer-extension analysis of pre-rRNA processing intermediates and
+      polysome/40S profiling in a cms1 deletion strain to test the small-subunit-
+      biogenesis role directly.
+  - description: &gt;-
+      In vitro RNA-binding assays on recombinant Cms1 (and structure-guided mutants of
+      the inactive helicase fold and the basic disordered patch) to test the proposed
+      RNA-binding activity.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:36417864
+    title: Cms1 coordinates stepwise local 90S pre-ribosome assembly with timely snR83 release.
+    findings:
+      - statement: &gt;-
+          Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,
+          and the study reports a role for the CMS1/CMSS1-family factor Cms1 in this
+          process.
+        supporting_text: &gt;-
+          Ribosome synthesis begins in the nucleolus with 90S pre-ribosome construction,
+        reference_section_type: ABSTRACT
+      - statement: &gt;-
+          Cms1 is detected on an early 90S pre-ribosome at the 18S rRNA 3&#39; major domain
+          carrying the H/ACA snoRNA snR83, and co-precipitates with many 90S factors.
+        supporting_text: &gt;-
+          detected Cms1 at the 18S rRNA 3
+        reference_section_type: ABSTRACT
+      - statement: &gt;-
+          Cms1 is proposed to restrict premature Rrp12-Enp1 binding while allowing snR83
+          to act, coordinating stepwise local 90S assembly.
+        supporting_text: &gt;-
+          restrict premature Rrp12-Enp1 binding but allows snR83 to
+        reference_section_type: ABSTRACT
+      - statement: &gt;-
+          The mechanism by which the many snoRNAs that modify pre-rRNA are guided to
+          their target sites during early ribosome assembly is largely unknown, framing
+          Cms1 as a poorly understood coordinating factor.
+        supporting_text: &gt;-
+          little is known about how the many different snoRNAs that modify the
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed/PMC-verified primary study of the S. cerevisiae ortholog CMS1 (the ISO
+        source, SGD:S000003993). It establishes the 90S small-subunit-biogenesis role
+        transferred to S. pombe cms1 and (in its full text, cached) explicitly frames
+        CMS1 as poorly characterized with only a hypothetical molecular activity,
+        supporting both the accepted process/complex annotations and the MF knowledge
+        gap. The paper concerns S. cerevisiae, not S. pombe, so it grounds the ortholog,
+        not the pombe protein directly.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/dca7/dca7-ai-review.html
+++ b/genes/SCHPO/dca7/dca7-ai-review.html
@@ -1,0 +1,2740 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dca7 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dca7</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O74763" target="_blank" class="term-link">
+                        O74763
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dca7";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O74763" data-a="DESCRIPTION: dca7 (systematic name SPBC17D11.08) is an uncharac..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>dca7 (systematic name SPBC17D11.08) is an uncharacterized WD40 repeat-containing protein of the fission yeast Schizosaccharomyces pombe. Its sequence comprises multiple WD40 repeats predicted to fold into a beta-propeller and it carries the DCAF7-like domain signature (InterPro IPR045159), identifying it as the fission yeast ortholog of the animal DCAF7/WDR68/HAN11 protein and of S. cerevisiae YPL247C; it is a predominantly single-copy protein conserved across fungi and metazoa. The protein has no recognizable catalytic, transmembrane, or signal domain, consistent with a non-enzymatic scaffold/adaptor architecture. In a genome-wide GFP-tagging survey the protein was localized to the cytoplasm and the Golgi apparatus, and it is phosphorylated on serine residues. Its molecular function and the biological process it participates in have not been experimentally determined in S. pombe; deletion of the gene is viable. Animal orthologs act as WD40 scaffolds/adaptors for DYRK-family kinases and have been reported to serve as substrate receptors for the CUL4-DDB1 (CRL4) ubiquitin ligase, but no such role has been demonstrated for the fission yeast protein.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74763" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred (IBA) nuclear localization propagated within PANTHER family PTHR19919 (DCAF7/WDR68). Animal DCAF7 is nucleocytoplasmic and its nuclear pool is functionally important, so a nuclear location is phylogenetically plausible, and PomBase independently carries this cellular component. However, the one direct S. pombe localization dataset (PMID:16823372) reported cytoplasm and Golgi, not nucleus, so this remains an inference. Retained as a plausible, non-core localization annotation; it does not describe a molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA localization consistent with the family and independently curated by PomBase, but it is a location rather than a core function and is not directly demonstrated in S. pombe.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/dca7/dca7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DCAF7/WDR68 localizes to both the nucleus and cytoplasm, with its distribution regulated by its kinase binding partners.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74763" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization mapped by UniProt from the Subcellular Location vocabulary. It is underpinned by an experimental S. pombe datum: the genome-wide GFP/YFP localization survey (PMID:16823372), recorded in UniProt as &#34;Cytoplasm {ECO:0000269|PubMed:16823372}&#34;. A well-supported localization, but a location rather than a molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization is experimentally supported (via UniProt ECO:0000269|PubMed:16823372) but is non-core; it does not describe what the protein does.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74763
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm {ECO:0000269|PubMed:16823372}</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
+                                    GO:0005794
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi apparatus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74763" data-a="GO:0005794" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Golgi localization mapped by UniProt from the Subcellular Location vocabulary, derived from the same single high-throughput GFP/YFP survey (PMID:16823372; UniProt &#34;Golgi apparatus {ECO:0000269|PubMed:16823372}&#34;). A WD40 scaffold/adaptor is not an obvious Golgi resident and this single-method observation may reflect a minor or secondary pool; it should be treated with caution and is not corroborated by any interaction or functional evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained because it derives from an experimental localization dataset, but flagged as weakly supported (single high-throughput method, no corroboration) and non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74763
+
+                                </span>
+
+                                <div class="support-text">GO:0005794; C:Golgi apparatus; IEA:UniProtKB-SubCell.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74763" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with the ND (&#34;No biological Data&#34;) evidence code, the PomBase convention for a gene whose molecular function has not been experimentally determined. For dca7 this is an accurate statement of the current state of knowledge: no primary study has assigned it a molecular activity in S. pombe. Retained as the honest placeholder marking a genuine molecular-function knowledge gap (see knowledge_gaps).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND correctly encodes that the molecular function of this dark gene is unknown; it is not a substantive term to replace or remove.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74763" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with the ND evidence code, indicating that no biological process has been experimentally assigned to dca7 in S. pombe. Deletion is viable and only broad, non-specific stress-screen phenotypes are recorded, so no defensible specific BP annotation can be made. Retained as the honest placeholder marking a genuine biological-process knowledge gap.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND correctly encodes that the biological process of this dark gene is unknown; it is not a substantive term to replace or remove.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0080008" target="_blank" class="term-link">
+                                    GO:0080008
+                                </a>
+                            </span>
+                            <span class="term-label">Cul4-RING E3 ubiquitin ligase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74763" data-a="GO:0080008" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Complex membership inferred by sequence similarity (ISS) from the human ortholog DCAF7 (UniProt P61962), which has been described as a substrate receptor of the CUL4-DDB1 (CRL4) E3 ubiquitin ligase. This is a defensible orthology-based inference given the shared DCAF7-like WD40 architecture, and it is a curator ISS transfer from a legitimate ortholog, so it is not removed. However, two caveats keep it non-core: (i) there is no S. pombe evidence that dca7 assembles into a CUL4 complex (the established fission-yeast DCAFs are Cdt2 in canonical CRL4 and Raf1/Dos1 in the CLRC heterochromatin complex; dca7 is a distinct DCAF7-like protein), and (ii) even for the human ortholog the bona fide CRL4 substrate-receptor role is debated relative to its better-established DYRK-kinase scaffold role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Legitimate ISS transfer from human DCAF7; retained but marked non-core because it is an orthology inference with no local S. pombe evidence and rests on a family role that is itself contested.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/dca7/dca7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DCAF7 functions as a substrate recognition subunit (substrate receptor) of the CUL4-DDB1-ROC1 (CRL4) E3 ubiquitin ligase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:O74763
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Uncharacterized WD repeat-containing protein C17D11.08 (dca7, SPBC17D11.08), Schizosaccharomyces pombe</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                            PMID:16823372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18257517" target="_blank" class="term-link">
+                            PMID:18257517
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoproteome analysis of fission yeast.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:SCHPO/dca7/dca7-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report: dca7 (SPBC17D11.08) as a DCAF7-like WD40 protein</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe Dca7 bind a DYRK/Yak-family kinase, as its orthologs YPL247C (with Yak1) and C. albicans Orf19.384 (with Yak1) do, thereby establishing a conserved fungal DCAF7-kinase module?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74763" data-a="Q: Does S. pombe Dca7 bind a DYRK/Yak-family kinase, ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Dca7 physically associate with the S. pombe Cul4 (Pcu4)/Ddb1 machinery, or is the ISS-transferred CUL4-RING E3 ubiquitin ligase complex membership not realized in fission yeast?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74763" data-a="Q: Does Dca7 physically associate with the S. pombe C..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the Golgi localization observed in the genome-wide GFP survey a genuine steady-state pool or a tagging/overexpression artifact, given that a WD40 scaffold has no obvious Golgi role?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74763" data-a="Q: Is the Golgi localization observed in the genome-w..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity purification of a functional epitope-tagged Dca7 from S. pombe followed by mass spectrometry to define its in vivo interactome, with reciprocal tagging/co-IP validation of the top hits and comparison against candidate DYRK/Yak kinases and Cul4/Ddb1 subunits.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Dca7 functions as a WD40 scaffold/adaptor that binds a specific fission-yeast partner protein (candidate: a DYRK/Yak-family kinase), analogous to the conserved DCAF7-DYRK module.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry (AP-MS) interactome mapping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74763" data-a="EXPERIMENT: Affinity purification of a functional epitope-tagg..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Systematic phenotypic profiling of a dca7 deletion strain (growth, stress panels, quiescence survival, and transcriptome/RNA-seq) alongside a WD40 propeller-surface point mutant to test whether phenotypes depend on the protein-binding surface, and epistasis analysis with candidate kinase and Cul4/Ddb1 partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Dca7 contributes to a specific biological process (e.g. gene expression or a stress pathway) despite being non-essential.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: reverse-genetics phenotyping, transcriptomics, and epistasis analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74763" data-a="EXPERIMENT: Systematic phenotypic profiling of a dca7 deletion..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of S. pombe dca7 (SPBC17D11.08) is undetermined: it is not known which protein(s) its WD40 beta-propeller binds in fission yeast, whether it acts as a kinase scaffold, a ubiquitin-ligase substrate receptor, or in some other adaptor capacity, and no direct activity or binding partner has been experimentally established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: the protein exists, is a phosphorylated WD40-repeat protein with a DCAF7-like domain (InterPro IPR045159), is conserved one-to-one across fungi and metazoa, localizes to the cytoplasm and Golgi in a genome-wide GFP survey, and its deletion is viable. Its animal ortholog DCAF7/WDR68 is a catalytically inactive scaffold/adaptor for DYRK-family kinases with a debated CRL4 substrate-receptor role. What is unknown is any S. pombe-specific molecular partner or activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> dca7 belongs to a deeply conserved, single-copy protein family with important roles in animal signaling and development (DYRK1A/HIPK2 regulation, transcription, DNA-repair protein turnover). A defined fission-yeast function would clarify the ancestral, pre-metazoan role of the DCAF7/WDR68 scaffold and whether the DYRK-partner or CUL4-receptor role is the conserved core.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity purification-mass spectrometry of tagged Dca7 to identify its fission-yeast interactome (testing for association with a DYRK/Yak-family kinase and/or with Cul4/Ddb1); reciprocal tagging of candidate partners; and phenotypic profiling of a dca7 deletion under conditions where DCAF7-family functions are relevant (stress signaling, DNA damage).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"No primary literature was identified that directly characterizes SPBC17D11.08/dca7 in *S. pombe*"</em> — file:SCHPO/dca7/dca7-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process dca7 participates in within S. pombe is unknown. PomBase records the biological process as ND, deletion is viable, and only broad, non-specific high-throughput stress-resistance/sensitivity and quiescence-survival phenotypes are catalogued, none of which pin the gene to a specific pathway.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Established: dca7 deletion is viable and the gene appears in numerous genome-wide phospho/phenomic datasets, and it has high-throughput physical-interaction hits (with the chromatin remodeler fft3 by affinity capture-MS, and with the kinase ppk15 by two-hybrid). Unknown: whether any of these reflect a real, dedicated biological role, and what pathway dca7 belongs to.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Assigning a biological process would move dca7 out of the fission-yeast &#34;conserved unknown&#34; set and could reveal whether the DCAF7/WDR68 scaffold has a conserved role in a specific pathway (e.g. gene expression, as suggested by the PomBase product line) predating its elaboration in animals.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Directed phenotyping of a dca7 deletion (and of a WD40-surface point mutant) in the processes where orthologs act, combined with epistasis against candidate kinase or Cul4/Ddb1 partners; transcriptome analysis to test the &#34;implicated in gene expression&#34; hypothesis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The specific SPBC17D11.08 protein is uncharacterized"</em> — file:SCHPO/dca7/dca7-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dca7-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O74763" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Research Report: dca7 (SPBC17D11.08) in *Schizosaccharomyces pombe* — A DCAF7-like WD40 Repeat Protein</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">31 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T17:24:02.643934</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="dca7-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="dca7-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-dca7-spbc17d1108-in-schizosaccharomyces-pombe-a-dcaf7-like-wd40-repeat-protein">Research Report: dca7 (SPBC17D11.08) in <em>Schizosaccharomyces pombe</em> — A DCAF7-like WD40 Repeat Protein</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <em>dca7</em> (systematic name SPBC17D11.08) in the fission yeast <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843) encodes a protein of predicted DCAF7-like function (UniProt accession O74763). The protein is annotated as an "uncharacterized WD repeat-containing protein" and possesses multiple WD40 repeats (InterPro: IPR001680, IPR019775), a WD40/YVTN repeat-like domain superfold (IPR015943, IPR036322), and critically, a DCAF7-like domain (IPR045159). This domain architecture strongly identifies it as the fission yeast ortholog of the well-characterized mammalian DCAF7/WDR68/HAN11 protein. In <em>Saccharomyces cerevisiae</em>, the DCAF7 ortholog is Ypl247c (ananthapadmanabhan2023insightsfromthe pages 6-7, glenewinkel2016theadaptorprotein pages 8-10), and in <em>Candida albicans</em>, it is Orf19.384 (pinsky2024geneticanalysisof pages 1-2, pinsky2024geneticanalysisof pages 6-9).</p>
+<p><strong>Important caveat:</strong> No primary literature was identified that directly characterizes SPBC17D11.08/dca7 in <em>S. pombe</em>. The functional annotation presented here is inferred from the extensively characterized orthologs in other organisms, supported by the conserved domain architecture and the deep evolutionary conservation of the DCAF7 protein family across eukaryotes.</p>
+<h2 id="2-protein-structure">2. Protein Structure</h2>
+<p>The mammalian DCAF7/WDR68 protein is a 342 amino acid protein containing five WD40 repeats that fold into a seven-blade β-propeller structure (yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2). This β-propeller fold is characteristic of WD40 domain proteins and provides a large, versatile surface for mediating multiple protein-protein interactions simultaneously (glenewinkel2016theadaptorprotein pages 10-12). DCAF7 possesses no intrinsic catalytic activity; rather, it functions exclusively as a scaffolding and adaptor protein (glenewinkel2016theadaptorprotein pages 1-2). The WD40 domain contains conserved WDxR motifs, which are positioned on the solvent-exposed bottom surface of the propeller and are critical for binding to DDB1, the adaptor subunit of the CUL4-based E3 ubiquitin ligase complex (lee2007dcafsthemissing pages 2-3, buscaino2012raf1isa pages 4-6). The <em>S. pombe</em> protein SPBC17D11.08 is predicted to adopt a similar β-propeller architecture based on domain annotations.</p>
+<h2 id="3-primary-functions-dual-roles-as-crl4-substrate-receptor-and-dyrk-kinase-scaffold">3. Primary Functions: Dual Roles as CRL4 Substrate Receptor and DYRK Kinase Scaffold</h2>
+<p>The DCAF7 family proteins have two major and well-established molecular functions:</p>
+<h3 id="31-substrate-receptor-for-cul4-ddb1-crl4-e3-ubiquitin-ligase">3.1 Substrate Receptor for CUL4-DDB1 (CRL4) E3 Ubiquitin Ligase</h3>
+<p>DCAF7 functions as a substrate recognition subunit (substrate receptor) of the CUL4-DDB1-ROC1 (CRL4) E3 ubiquitin ligase complex (lee2007dcafsthemissing pages 1-2, higa2007stealingthespotlight pages 1-2). In this role, DCAF7 directly binds DDB1 through its WDxR motifs and recruits specific protein substrates for ubiquitination and subsequent proteasomal degradation. The known substrates targeted by DCAF7 through the CRL4 complex include:</p>
+<ul>
+<li>
+<p><strong>DNA Ligase I (LigI):</strong> DCAF7 directly interacts with human DNA Ligase I and targets it for ubiquitylation at four lysine residues (K79, K192, K226, K376), promoting its proteasomal degradation particularly during growth arrest induced by serum starvation (peng2016humandnaligase pages 5-6).</p>
+</li>
+<li>
+<p><strong>Menin:</strong> DCAF7 facilitates the ubiquitylation and degradation of menin, an essential component of the KMT2A and KMT2B H3K4 methyltransferase complexes, through CRL4B. This is relevant to leukemia biology as menin-dependent KMT2A fusion proteins drive acute myeloid and lymphoblastic leukemias (nakagawa2025cul4basedubiquitinligases pages 14-15).</p>
+</li>
+<li>
+<p><strong>ERCC1-XPF:</strong> DCAF7 is required for maintaining cellular levels of the ERCC1-XPF heterodimer, which is essential for nucleotide excision repair (NER). Depletion of DCAF7 causes time-dependent downregulation of ERCC1-XPF and suppresses NER activity, impairing repair of UV-induced DNA damage, although this role appears partly independent of the canonical CUL4-DDB1 pathway (kawara2019dcaf7isrequired pages 5-7).</p>
+</li>
+<li>
+<p><strong>Influenza A virus PA subunit:</strong> DCAF7 acts as a substrate receptor for CRL4B to promote K48-linked polyubiquitination of the viral polymerase subunit PA at K609, targeting it for degradation and thereby restricting influenza A virus replication (higa2007stealingthespotlight pages 1-2).</p>
+</li>
+</ul>
+<h3 id="32-scaffolding-protein-for-dyrk-family-kinases">3.2 Scaffolding Protein for DYRK-Family Kinases</h3>
+<p>The second major function of DCAF7 is as a scaffold/adaptor for dual-specificity tyrosine phosphorylation-regulated kinases (DYRKs), particularly DYRK1A and DYRK1B (class 1 DYRKs), as well as HIPK2 (glenewinkel2016theadaptorprotein pages 1-2, glenewinkel2016theadaptorprotein pages 2-3, glenewinkel2016theadaptorprotein pages 8-10). DCAF7 binds to a conserved 12-amino acid motif (residues 93–104 in human DYRK1A) in the N-terminal domain of class 1 DYRKs, independently of kinase activity (glenewinkel2016theadaptorprotein pages 8-10, glenewinkel2016theadaptorprotein pages 3-5). This interaction is essential for:</p>
+<ul>
+<li>
+<p><strong>Protein stability:</strong> DCAF7 is required for maintaining normal cellular levels of DYRK1A and DYRK1B. Loss of DCAF7 leads to reduced DYRK1A protein levels through a mechanism that appears independent of proteasome-mediated degradation (yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2, yu2019acomplexbetween pages 4-5).</p>
+</li>
+<li>
+<p><strong>Substrate recruitment and kinase activity:</strong> DCAF7 tethers DYRK1A to its substrates. A critical example is the DYRK1A-DCAF7 complex's role in phosphorylating the C-terminal domain (CTD) of RNA Polymerase II at both Ser2 and Ser5 positions. DCAF7 independently binds Pol II and greatly enhances the DYRK1A-Pol II interaction, enabling the kinase to co-migrate with Pol II along gene loci and promote transcription of myogenic genes including <em>MYOG</em>, <em>MYH2</em>, and <em>CAV3</em> (yu2019acomplexbetween pages 1-1, yu2019acomplexbetween pages 5-5, yu2019acomplexbetween pages 7-8, yu2019acomplexbetween pages 4-5).</p>
+</li>
+<li>
+<p><strong>Signal integration:</strong> DCAF7 also mediates the interaction of the adenovirus E1A oncoprotein with DYRK1A and HIPK2, forming ternary complexes that enable E1A hyperphosphorylation (glenewinkel2016theadaptorprotein pages 8-10, glenewinkel2016theadaptorprotein pages 3-5).</p>
+</li>
+</ul>
+<p>The following table summarizes the dual functional roles of DCAF7/WDR68 across organisms:</p>
+<table>
+<thead>
+<tr>
+<th>Organism/System</th>
+<th>Function/Role</th>
+<th>Mechanism</th>
+<th>Known Substrates/Interactors</th>
+<th>Biological Process</th>
+<th>Key References</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Human</td>
+<td>CRL4 substrate receptor (DCAF7)</td>
+<td>WD40 protein acting as a substrate-recognition factor for CUL4-DDB1 E3 ligase; directly binds DNA ligase I and promotes its ubiquitylation and proteasomal degradation</td>
+<td>DNA ligase I (LigI); CUL4; DDB1</td>
+<td>DNA replication/repair protein turnover, especially during proliferation arrest or serum starvation</td>
+<td>(peng2016humandnaligase pages 5-6, yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2)</td>
+</tr>
+<tr>
+<td>Human</td>
+<td>Regulator of ERCC1-XPF stability linked to DNA repair</td>
+<td>Maintains ERCC1-XPF protein levels and supports nucleotide excision repair; effect appears at least partly independent of canonical CUL4-DDB1 activity</td>
+<td>ERCC1-XPF</td>
+<td>Nucleotide excision repair and UV-damage response</td>
+<td>(kawara2019dcaf7isrequired pages 5-7)</td>
+</tr>
+<tr>
+<td>Human</td>
+<td>Putative/validated CRL4B substrate receptor in chromatin regulation</td>
+<td>Functions in CRL4B complexes that control chromatin regulators; reported to promote ubiquitylation/degradation of menin and implicated in KDM6B regulation</td>
+<td>Menin; KDM6B; CRL4B components</td>
+<td>Histone methylation control, transcriptional regulation, leukemia-relevant chromatin pathways</td>
+<td>(nakagawa2025cul4basedubiquitinligases pages 14-15)</td>
+</tr>
+<tr>
+<td>Human</td>
+<td>CRL4B antiviral substrate receptor</td>
+<td>Recruits influenza A viral PA polymerase subunit to CRL4B for K48-linked polyubiquitylation and degradation</td>
+<td>Influenza A PA; CUL4B; DDB1</td>
+<td>Host antiviral defense against influenza A virus</td>
+<td>(higa2007stealingthespotlight pages 1-2)</td>
+</tr>
+<tr>
+<td>Human</td>
+<td>DYRK1A/DYRK1B kinase scaffold</td>
+<td>Stable WD40 scaffold that binds the N-terminus of class 1 DYRKs, stabilizes kinase abundance, and recruits substrates</td>
+<td>DYRK1A; DYRK1B</td>
+<td>Developmental signaling, protein stability, proliferation-differentiation balance</td>
+<td>(yu2019acomplexbetween pages 4-5, yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2, glenewinkel2016theadaptorprotein pages 8-10)</td>
+</tr>
+<tr>
+<td>Human</td>
+<td>HIPK2/DYRK1A adaptor</td>
+<td>Simultaneously binds kinases and client proteins through distinct interaction surfaces; mediates ternary complex formation</td>
+<td>HIPK2; DYRK1A; adenoviral E1A</td>
+<td>Signal integration, kinase substrate recruitment, viral-host interaction</td>
+<td>(glenewinkel2016theadaptorprotein pages 8-10, glenewinkel2016theadaptorprotein pages 1-2, glenewinkel2016theadaptorprotein pages 10-12, glenewinkel2016theadaptorprotein pages 3-5)</td>
+</tr>
+<tr>
+<td>Human muscle cells</td>
+<td>Transcriptional scaffold for DYRK1A on RNA polymerase II</td>
+<td>DCAF7 binds Pol II and tethers DYRK1A to the CTD, enabling Ser2/Ser5 phosphorylation and robust transcription of myogenic genes</td>
+<td>DYRK1A; RNA polymerase II CTD; MYOG/MYH2/CAV3 loci</td>
+<td>Myogenesis and differentiation-dependent transcription</td>
+<td>(yu2019acomplexbetween pages 1-1, yu2019acomplexbetween pages 11-12, yu2019acomplexbetween pages 5-5, yu2019acomplexbetween pages 7-8, yu2019acomplexbetween pages 4-5, yu2019acomplexbetween pages 1-2)</td>
+</tr>
+<tr>
+<td>Human/HepG2 and Drosophila</td>
+<td>Scaffold in IRS1-PI3K-AKT-FOXO signaling</td>
+<td>Acts as an IRS1 interactor/scaffold supporting AKT activation; depletion increases FOXO1 nuclear localization and cell-cycle arrest gene expression</td>
+<td>IRS1; AKT; FOXO1</td>
+<td>Cell proliferation and growth control</td>
+<td>(frendocumbo2022dcaf7regulatescell pages 4-6, frendocumbo2022dcaf7regulatescell pages 6-8)</td>
+</tr>
+<tr>
+<td>Budding yeast (S. cerevisiae)</td>
+<td>Conserved DYRK-family partner</td>
+<td>Ortholog YPL247C interacts with Yak1, supporting the idea that the DCAF7–DYRK partnership is ancestral</td>
+<td>Yak1; YPL247C</td>
+<td>Stress signaling and conserved kinase-WD40 regulation</td>
+<td>(ananthapadmanabhan2023insightsfromthe pages 6-7, glenewinkel2016theadaptorprotein pages 8-10)</td>
+</tr>
+<tr>
+<td>Candida albicans</td>
+<td>Fungal DYRK/Yak1 scaffold partner</td>
+<td>WDR68/DCAF7 ortholog Orf19.384 forms a conserved complex with Yak1; each affects the other’s localization and likely substrate targeting</td>
+<td>Yak1; Orf19.384; Sfl1</td>
+<td>Filamentation and yeast-to-hypha differentiation</td>
+<td>(pinsky2024geneticanalysisof pages 1-2, pinsky2024geneticanalysisof pages 6-9, pinsky2024geneticanalysisof pages 10-12)</td>
+</tr>
+<tr>
+<td>Schizosaccharomyces pombe context</td>
+<td>Inferred DCAF7-like WD40 scaffold/substrate receptor role</td>
+<td>The specific SPBC17D11.08 protein is uncharacterized, but S. pombe CUL4 systems use WD40 DCAFs with WDxR-like docking logic in both canonical CRL4 and CLRC-type complexes, supporting an inferred adaptor/scaffold role for the DCAF7-like protein</td>
+<td>By inference: CUL4/DDB1-like machinery; more directly, Raf1/Raf2 are example S. pombe DCAFs in CLRC</td>
+<td>Likely protein-protein scaffolding and/or regulated substrate recruitment; precise pathway unknown for SPBC17D11.08</td>
+<td>(lee2007dcafsthemissing pages 1-2, lee2007dcafsthemissing pages 2-3, buscaino2012raf1isa pages 6-8, buscaino2012raf1isa pages 2-4, nakagawa2025cul4basedubiquitinligases pages 6-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the two major molecular roles of DCAF7/WDR68 across systems: as a CRL4-family substrate receptor in ubiquitin-dependent proteolysis and as a WD40 scaffold/adaptor for DYRK-family kinase signaling. It is useful for inferring likely functions of the poorly characterized S. pombe DCAF7-like protein from conserved ortholog biology.</em></p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>DCAF7/WDR68 localizes to both the nucleus and cytoplasm, with its distribution regulated by its kinase binding partners. The DYRK1A-DCAF7 complex is predominantly nuclear, with nuclear localization driven by a nuclear localization signal (NLS) in DYRK1A that is distinct from the DCAF7 binding site (yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2, glenewinkel2016theadaptorprotein pages 1-2). DCAF7 nuclear access is functionally important; in zebrafish, nuclear localization of WDR68 is required for proper craniofacial development (ananthapadmanabhan2023insightsfromthe pages 6-7). Co-expression of DCAF7 with the adenoviral E1A protein can cause redistribution from the nucleus to the cytoplasm, suggesting that protein-protein interactions modulate its localization (glenewinkel2016theadaptorprotein pages 8-10). In <em>Candida albicans</em>, the DCAF7 ortholog Orf19.384 requires the Yak1 kinase for proper nuclear accumulation, and reciprocally, Yak1 requires Orf19.384 for cytoplasmic localization (pinsky2024geneticanalysisof pages 6-9). The cytosolic anchoring protein FAM53C can also retain the DYRK1A-DCAF7 complex in the cytoplasm in an inactive state.</p>
+<p>For the <em>S. pombe</em> protein SPBC17D11.08, no direct localization data were identified, but by analogy it is expected to localize to both the nucleus and cytoplasm, likely with nuclear accumulation dependent on interaction with a DYRK-family kinase partner.</p>
+<h2 id="5-signaling-and-biochemical-pathways">5. Signaling and Biochemical Pathways</h2>
+<h3 id="51-cul4-based-ubiquitin-proteasome-pathway">5.1 CUL4-Based Ubiquitin-Proteasome Pathway</h3>
+<p>In the context of the CRL4 E3 ubiquitin ligase, DCAF7 participates in protein quality control and regulated proteolysis. The CUL4-DDB1 ubiquitin ligase system is well-conserved in <em>S. pombe</em>, where CUL4 (Pcu4) participates in both the CLRC complex (using Rik1 as a DDB1-like adaptor and Raf1/Dos1 as a DCAF for heterochromatin formation) and a canonical CRL4 complex (using Ddb1 and the DCAF Cdt2 to target substrates such as Spd1, Cdt1, and Epe1 for degradation) (nakagawa2025cul4basedubiquitinligases pages 6-8, buscaino2012raf1isa pages 6-8, buscaino2012raf1isa pages 2-4). The SPBC17D11.08 protein, by virtue of its DCAF7-like domain and WD40 repeats, is predicted to function within this ubiquitin ligase framework, potentially assembling with Ddb1 or a DDB1-like adaptor to recruit specific substrates for ubiquitination.</p>
+<h3 id="52-dyrk-kinase-signaling">5.2 DYRK Kinase Signaling</h3>
+<p>DCAF7 is a central scaffolding component in DYRK1A-mediated signaling pathways including transcription regulation via Pol II CTD phosphorylation (yu2019acomplexbetween pages 1-1, yu2019acomplexbetween pages 1-2), cell proliferation through IRS1-PI3K-AKT-FOXO1 signaling (frendocumbo2022dcaf7regulatescell pages 4-6, frendocumbo2022dcaf7regulatescell pages 6-8), and developmental differentiation. In fungi, the DCAF7-DYRK kinase partnership (Ypl247c-Yak1 in budding yeast, Orf19.384-Yak1 in <em>C. albicans</em>) is conserved and regulates stress-responsive signaling and cell differentiation pathways (ananthapadmanabhan2023insightsfromthe pages 6-7, pinsky2024geneticanalysisof pages 1-2, pinsky2024geneticanalysisof pages 10-12).</p>
+<h3 id="53-dna-damage-response">5.3 DNA Damage Response</h3>
+<p>Through its CRL4 substrate receptor function, DCAF7 regulates levels of key DNA repair proteins. It maintains ERCC1-XPF levels required for NER (kawara2019dcaf7isrequired pages 5-7) and targets DNA Ligase I for degradation during growth arrest (peng2016humandnaligase pages 5-6), linking DCAF7 to genome maintenance pathways.</p>
+<h2 id="6-evolutionary-conservation">6. Evolutionary Conservation</h2>
+<p>The DCAF7/WDR68 protein family is deeply conserved across eukaryotes, with the DYRK kinase-DCAF7 interaction representing an ancestral feature of the DYRK family that was subsequently lost in class 2 DYRKs (glenewinkel2016theadaptorprotein pages 8-10). The following table summarizes known orthologs:</p>
+<table>
+<thead>
+<tr>
+<th>Organism</th>
+<th>Gene/Protein Name</th>
+<th>Kinase Partner (DYRK family)</th>
+<th>Known Functions</th>
+<th>References</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>Ypl247c</td>
+<td>Yak1</td>
+<td>Conserved DCAF7/WDR68 ortholog; directly interacts with Yak1 and is implicated in stress-response signaling, supporting an ancestral DYRK–WD40 partnership in fungi and animals.</td>
+<td>(ananthapadmanabhan2023insightsfromthe pages 6-7, glenewinkel2016theadaptorprotein pages 8-10)</td>
+</tr>
+<tr>
+<td><em>Schizosaccharomyces pombe</em></td>
+<td>SPBC17D11.08 / dca7</td>
+<td>Not directly established; inferred likely partner is a DYRK-family kinase by orthology</td>
+<td>DCAF7-like WD40-repeat protein predicted from domain architecture; no direct functional study found for this specific fission yeast protein, so function is inferred as a conserved adaptor/scaffold or substrate receptor from orthologs and from conserved DCAF logic in <em>S. pombe</em> CUL4 systems.</td>
+<td>(ananthapadmanabhan2023insightsfromthe pages 6-7, glenewinkel2016theadaptorprotein pages 8-10, buscaino2012raf1isa pages 6-8, nakagawa2025cul4basedubiquitinligases pages 6-8)</td>
+</tr>
+<tr>
+<td><em>Candida albicans</em></td>
+<td>Orf19.384</td>
+<td>Yak1</td>
+<td>Forms a conserved kinase–WD40 pair with Yak1; required for hyphal development/filamentation, affects reciprocal subcellular localization with Yak1, and likely helps connect Yak1 to transcriptional regulators such as Sfl1.</td>
+<td>(pinsky2024geneticanalysisof pages 1-2, pinsky2024geneticanalysisof pages 6-9, pinsky2024geneticanalysisof pages 10-12)</td>
+</tr>
+<tr>
+<td><em>Caenorhabditis elegans</em></td>
+<td>SWAN-1 / SWAN-2</td>
+<td>DYRK-family association reported for DCAF7 orthologs broadly; specific kinase partner not defined in the retrieved evidence</td>
+<td>Conserved DCAF7 orthologs involved in osmotic stress regulation and developmental/essential cellular processes, supporting broad conservation of DCAF7-family signaling roles.</td>
+<td>(ananthapadmanabhan2023insightsfromthe pages 6-7)</td>
+</tr>
+<tr>
+<td><em>Drosophila melanogaster</em></td>
+<td>Wap (wings apart)</td>
+<td>Mnb (Minibrain; DYRK-family kinase)</td>
+<td>Conserved DYRK-binding WD40 protein involved in developmental processes; cited as part of the evolutionarily conserved DCAF7–DYRK interaction module.</td>
+<td>(glenewinkel2016theadaptorprotein pages 8-10)</td>
+</tr>
+<tr>
+<td><em>Danio rerio</em> (zebrafish)</td>
+<td>wdr68</td>
+<td>Dyrk1b and functionally linked to Dyrk1a-family signaling</td>
+<td>Required for craniofacial development; regulates endothelin-1-dependent jaw cartilage development, and nuclear localization is functionally important for developmental patterning.</td>
+<td>(glenewinkel2016theadaptorprotein pages 2-3, ananthapadmanabhan2023insightsfromthe pages 6-7, glenewinkel2016theadaptorprotein pages 8-10)</td>
+</tr>
+<tr>
+<td>Human</td>
+<td>DCAF7 / WDR68 / HAN11</td>
+<td>DYRK1A, DYRK1B; also binds HIPK2</td>
+<td>Best-characterized ortholog; dual-function WD40 protein acting as (i) scaffold/adaptor for DYRK1A/DYRK1B and HIPK2, including recruitment of substrates such as RNA polymerase II, and (ii) CRL4 substrate receptor regulating protein stability; implicated in development, transcription, proliferation, DNA repair, and signaling.</td>
+<td>(glenewinkel2016theadaptorprotein pages 8-10, glenewinkel2016theadaptorprotein pages 1-2, yu2019acomplexbetween pages 4-5, yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2, kawara2019dcaf7isrequired pages 5-7, peng2016humandnaligase pages 5-6, yu2019acomplexbetween pages 1-1)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the evolutionary conservation of DCAF7/WDR68-family proteins from fungi to humans, emphasizing their recurrent association with DYRK-family kinases. It is useful for inferring likely functions of the poorly characterized </em>S. pombe<em> SPBC17D11.08/dca7 protein from better-studied orthologs.</em></p>
+<h2 id="7-context-of-cul4-and-dcaf-biology-in-s-pombe">7. Context of CUL4 and DCAF Biology in <em>S. pombe</em></h2>
+<p>While SPBC17D11.08/dca7 itself is uncharacterized, <em>S. pombe</em> has well-studied CUL4-based ubiquitin ligase complexes. The CLRC complex (Cul4-Rik1-Raf1/Raf2-Clr4) uses WD40 DCAF proteins (Raf1/Dos1) with WDxR motifs to dock onto the DDB1-like adaptor Rik1, coupling E3 ubiquitin ligase activity with histone H3K9 methylation for heterochromatin formation (buscaino2012raf1isa pages 6-8, buscaino2012raf1isa pages 2-4, buscaino2012raf1isa pages 4-6, buscaino2012raf1isa pages 1-2). CLRC catalyzes H3K14 ubiquitylation that is required for subsequent H3K9 methylation (nakagawa2025cul4basedubiquitinligases pages 6-8). The canonical <em>S. pombe</em> CRL4 complex (Cul4-Ddb1-Cdt2) targets substrates including Spd1, Cdt1, and Epe1 for degradation (nakagawa2025cul4basedubiquitinligases pages 6-8). SPBC17D11.08/dca7 likely operates within this established CUL4 ubiquitin ligase framework, potentially as an additional DCAF substrate receptor recruiting specific, as-yet-unidentified substrates.</p>
+<h2 id="8-summary-and-conclusions">8. Summary and Conclusions</h2>
+<p>The <em>S. pombe</em> protein encoded by <em>dca7</em> (SPBC17D11.08, UniProt O74763) is an uncharacterized member of the DCAF7 family of WD40 repeat-containing proteins. Based on its conserved DCAF7-like domain architecture and extensive characterization of orthologs in other organisms, the protein is predicted to have two primary molecular functions: (1) as a substrate receptor for the CUL4-DDB1 E3 ubiquitin ligase, recognizing specific proteins for ubiquitin-dependent proteasomal degradation; and (2) as a scaffolding protein for DYRK-family kinases, facilitating kinase-substrate interactions and potentially regulating kinase protein levels and localization. The protein likely localizes to both the nucleus and cytoplasm, with its distribution potentially governed by interaction with a DYRK-family kinase partner. In the broader biological context of <em>S. pombe</em>, DCAF7-like proteins are expected to participate in ubiquitin-proteasome-mediated regulation of protein stability, with potential roles in cell cycle regulation, stress response signaling, and chromatin biology. Direct experimental characterization of SPBC17D11.08 in <em>S. pombe</em> remains an important gap in the current understanding of this protein.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(ananthapadmanabhan2023insightsfromthe pages 6-7): Varsha Ananthapadmanabhan, Kathryn H. Shows, Amanda J. Dickinson, and Larisa Litovchick. Insights from the protein interaction universe of the multifunctional “goldilocks” kinase dyrk1a. Frontiers in Cell and Developmental Biology, Oct 2023. URL: https://doi.org/10.3389/fcell.2023.1277537, doi:10.3389/fcell.2023.1277537. This article has 26 citations.</p>
+</li>
+<li>
+<p>(glenewinkel2016theadaptorprotein pages 8-10): Florian Glenewinkel, Michael J. Cohen, Cason R. King, Sophie Kaspar, Simone Bamberg-Lemper, Joe S. Mymryk, and Walter Becker. The adaptor protein dcaf7 mediates the interaction of the adenovirus e1a oncoprotein with the protein kinases dyrk1a and hipk2. Scientific Reports, Jun 2016. URL: https://doi.org/10.1038/srep28241, doi:10.1038/srep28241. This article has 73 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pinsky2024geneticanalysisof pages 1-2): Mariel Pinsky and Daniel Kornitzer. Genetic analysis of candida albicans filamentation by the iron chelator bps reveals a role for a conserved kinase—wd40 protein pair. Journal of Fungi, 10:83, Jan 2024. URL: https://doi.org/10.3390/jof10010083, doi:10.3390/jof10010083. This article has 5 citations.</p>
+</li>
+<li>
+<p>(pinsky2024geneticanalysisof pages 6-9): Mariel Pinsky and Daniel Kornitzer. Genetic analysis of candida albicans filamentation by the iron chelator bps reveals a role for a conserved kinase—wd40 protein pair. Journal of Fungi, 10:83, Jan 2024. URL: https://doi.org/10.3390/jof10010083, doi:10.3390/jof10010083. This article has 5 citations.</p>
+</li>
+<li>
+<p>(yousefelahiyeh2018dcaf7wdr68isrequired pages 1-2): Mina Yousefelahiyeh, Jingyi Xu, Estibaliz Alvarado, Yang Yu, David Salven, and Robert M. Nissen. Dcaf7/wdr68 is required for normal levels of dyrk1a and dyrk1b. PLoS ONE, 13:e0207779, Nov 2018. URL: https://doi.org/10.1371/journal.pone.0207779, doi:10.1371/journal.pone.0207779. This article has 34 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(glenewinkel2016theadaptorprotein pages 10-12): Florian Glenewinkel, Michael J. Cohen, Cason R. King, Sophie Kaspar, Simone Bamberg-Lemper, Joe S. Mymryk, and Walter Becker. The adaptor protein dcaf7 mediates the interaction of the adenovirus e1a oncoprotein with the protein kinases dyrk1a and hipk2. Scientific Reports, Jun 2016. URL: https://doi.org/10.1038/srep28241, doi:10.1038/srep28241. This article has 73 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(glenewinkel2016theadaptorprotein pages 1-2): Florian Glenewinkel, Michael J. Cohen, Cason R. King, Sophie Kaspar, Simone Bamberg-Lemper, Joe S. Mymryk, and Walter Becker. The adaptor protein dcaf7 mediates the interaction of the adenovirus e1a oncoprotein with the protein kinases dyrk1a and hipk2. Scientific Reports, Jun 2016. URL: https://doi.org/10.1038/srep28241, doi:10.1038/srep28241. This article has 73 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2007dcafsthemissing pages 2-3): Jennifer Lee and Pengbo Zhou. Dcafs, the missing link of the cul4-ddb1 ubiquitin ligase. Molecular cell, 26 6:775-80, Jun 2007. URL: https://doi.org/10.1016/j.molcel.2007.06.001, doi:10.1016/j.molcel.2007.06.001. This article has 596 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(buscaino2012raf1isa pages 4-6): Alessia Buscaino, Sharon A. White, Douglas R. Houston, Erwan Lejeune, Femke Simmer, Flavia de Lima Alves, Piyush T. Diyora, Takeshi Urano, Elizabeth H. Bayne, Juri Rappsilber, and Robin C. Allshire. Raf1 is a dcaf for the rik1 ddb1-like protein and has separable roles in sirna generation and chromatin modification. PLoS Genetics, 8:e1002499, Feb 2012. URL: https://doi.org/10.1371/journal.pgen.1002499, doi:10.1371/journal.pgen.1002499. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2007dcafsthemissing pages 1-2): Jennifer Lee and Pengbo Zhou. Dcafs, the missing link of the cul4-ddb1 ubiquitin ligase. Molecular cell, 26 6:775-80, Jun 2007. URL: https://doi.org/10.1016/j.molcel.2007.06.001, doi:10.1016/j.molcel.2007.06.001. This article has 596 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(higa2007stealingthespotlight pages 1-2): Leigh Higa and Hui Zhang. Stealing the spotlight: cul4-ddb1 ubiquitin ligase docks wd40-repeat proteins to destroy. Cell Division, 2:5-5, Feb 2007. URL: https://doi.org/10.1186/1747-1028-2-5, doi:10.1186/1747-1028-2-5. This article has 150 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(peng2016humandnaligase pages 5-6): Zhimin Peng, Zhongping Liao, Yoshihiro Matsumoto, Austin Yang, and Alan E. Tomkinson. Human dna ligase i interacts with and is targeted for degradation by the dcaf7 specificity factor of the cul4-ddb1 ubiquitin ligase complex. Journal of Biological Chemistry, 291:21893-21902, Oct 2016. URL: https://doi.org/10.1074/jbc.m116.746198, doi:10.1074/jbc.m116.746198. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakagawa2025cul4basedubiquitinligases pages 14-15): Makiko Nakagawa and Tadashi Nakagawa. Cul4-based ubiquitin ligases in chromatin regulation: an evolutionary perspective. Cells, 14:63, Jan 2025. URL: https://doi.org/10.3390/cells14020063, doi:10.3390/cells14020063. This article has 10 citations.</p>
+</li>
+<li>
+<p>(kawara2019dcaf7isrequired pages 5-7): Hiroaki Kawara, Ryo Akahori, Mitsuo Wakasugi, Aziz Sancar, and Tsukasa Matsunaga. Dcaf7 is required for maintaining the cellular levels of ercc1-xpf and nucleotide excision repair. Biochemical and biophysical research communications, 519:204-210, Oct 2019. URL: https://doi.org/10.1016/j.bbrc.2019.08.147, doi:10.1016/j.bbrc.2019.08.147. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(glenewinkel2016theadaptorprotein pages 2-3): Florian Glenewinkel, Michael J. Cohen, Cason R. King, Sophie Kaspar, Simone Bamberg-Lemper, Joe S. Mymryk, and Walter Becker. The adaptor protein dcaf7 mediates the interaction of the adenovirus e1a oncoprotein with the protein kinases dyrk1a and hipk2. Scientific Reports, Jun 2016. URL: https://doi.org/10.1038/srep28241, doi:10.1038/srep28241. This article has 73 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(glenewinkel2016theadaptorprotein pages 3-5): Florian Glenewinkel, Michael J. Cohen, Cason R. King, Sophie Kaspar, Simone Bamberg-Lemper, Joe S. Mymryk, and Walter Becker. The adaptor protein dcaf7 mediates the interaction of the adenovirus e1a oncoprotein with the protein kinases dyrk1a and hipk2. Scientific Reports, Jun 2016. URL: https://doi.org/10.1038/srep28241, doi:10.1038/srep28241. This article has 73 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2019acomplexbetween pages 4-5): Dan Yu, Claudia Cattoglio, Yuhua Xue, and Qiang Zhou. A complex between dyrk1a and dcaf7 phosphorylates the c-terminal domain of rna polymerase ii to promote myogenesis. Nucleic Acids Research, 47:4462-4475, Mar 2019. URL: https://doi.org/10.1093/nar/gkz162, doi:10.1093/nar/gkz162. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2019acomplexbetween pages 1-1): Dan Yu, Claudia Cattoglio, Yuhua Xue, and Qiang Zhou. A complex between dyrk1a and dcaf7 phosphorylates the c-terminal domain of rna polymerase ii to promote myogenesis. Nucleic Acids Research, 47:4462-4475, Mar 2019. URL: https://doi.org/10.1093/nar/gkz162, doi:10.1093/nar/gkz162. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2019acomplexbetween pages 5-5): Dan Yu, Claudia Cattoglio, Yuhua Xue, and Qiang Zhou. A complex between dyrk1a and dcaf7 phosphorylates the c-terminal domain of rna polymerase ii to promote myogenesis. Nucleic Acids Research, 47:4462-4475, Mar 2019. URL: https://doi.org/10.1093/nar/gkz162, doi:10.1093/nar/gkz162. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2019acomplexbetween pages 7-8): Dan Yu, Claudia Cattoglio, Yuhua Xue, and Qiang Zhou. A complex between dyrk1a and dcaf7 phosphorylates the c-terminal domain of rna polymerase ii to promote myogenesis. Nucleic Acids Research, 47:4462-4475, Mar 2019. URL: https://doi.org/10.1093/nar/gkz162, doi:10.1093/nar/gkz162. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2019acomplexbetween pages 11-12): Dan Yu, Claudia Cattoglio, Yuhua Xue, and Qiang Zhou. A complex between dyrk1a and dcaf7 phosphorylates the c-terminal domain of rna polymerase ii to promote myogenesis. Nucleic Acids Research, 47:4462-4475, Mar 2019. URL: https://doi.org/10.1093/nar/gkz162, doi:10.1093/nar/gkz162. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2019acomplexbetween pages 1-2): Dan Yu, Claudia Cattoglio, Yuhua Xue, and Qiang Zhou. A complex between dyrk1a and dcaf7 phosphorylates the c-terminal domain of rna polymerase ii to promote myogenesis. Nucleic Acids Research, 47:4462-4475, Mar 2019. URL: https://doi.org/10.1093/nar/gkz162, doi:10.1093/nar/gkz162. This article has 44 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(frendocumbo2022dcaf7regulatescell pages 4-6): Scott Frendo-Cumbo, Taoyingnan Li, Dustin A. Ammendolia, Etienne Coyaud, Estelle M.N. Laurent, Yuan Liu, Philip J. Bilan, Gordon Polevoy, Brian Raught, Julie A. Brill, Amira Klip, and John H. Brumell. Dcaf7 regulates cell proliferation through irs1-foxo1 signaling. Dec 2022. URL: https://doi.org/10.1016/j.isci.2022.105668, doi:10.1016/j.isci.2022.105668. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(frendocumbo2022dcaf7regulatescell pages 6-8): Scott Frendo-Cumbo, Taoyingnan Li, Dustin A. Ammendolia, Etienne Coyaud, Estelle M.N. Laurent, Yuan Liu, Philip J. Bilan, Gordon Polevoy, Brian Raught, Julie A. Brill, Amira Klip, and John H. Brumell. Dcaf7 regulates cell proliferation through irs1-foxo1 signaling. Dec 2022. URL: https://doi.org/10.1016/j.isci.2022.105668, doi:10.1016/j.isci.2022.105668. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pinsky2024geneticanalysisof pages 10-12): Mariel Pinsky and Daniel Kornitzer. Genetic analysis of candida albicans filamentation by the iron chelator bps reveals a role for a conserved kinase—wd40 protein pair. Journal of Fungi, 10:83, Jan 2024. URL: https://doi.org/10.3390/jof10010083, doi:10.3390/jof10010083. This article has 5 citations.</p>
+</li>
+<li>
+<p>(buscaino2012raf1isa pages 6-8): Alessia Buscaino, Sharon A. White, Douglas R. Houston, Erwan Lejeune, Femke Simmer, Flavia de Lima Alves, Piyush T. Diyora, Takeshi Urano, Elizabeth H. Bayne, Juri Rappsilber, and Robin C. Allshire. Raf1 is a dcaf for the rik1 ddb1-like protein and has separable roles in sirna generation and chromatin modification. PLoS Genetics, 8:e1002499, Feb 2012. URL: https://doi.org/10.1371/journal.pgen.1002499, doi:10.1371/journal.pgen.1002499. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(buscaino2012raf1isa pages 2-4): Alessia Buscaino, Sharon A. White, Douglas R. Houston, Erwan Lejeune, Femke Simmer, Flavia de Lima Alves, Piyush T. Diyora, Takeshi Urano, Elizabeth H. Bayne, Juri Rappsilber, and Robin C. Allshire. Raf1 is a dcaf for the rik1 ddb1-like protein and has separable roles in sirna generation and chromatin modification. PLoS Genetics, 8:e1002499, Feb 2012. URL: https://doi.org/10.1371/journal.pgen.1002499, doi:10.1371/journal.pgen.1002499. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nakagawa2025cul4basedubiquitinligases pages 6-8): Makiko Nakagawa and Tadashi Nakagawa. Cul4-based ubiquitin ligases in chromatin regulation: an evolutionary perspective. Cells, 14:63, Jan 2025. URL: https://doi.org/10.3390/cells14020063, doi:10.3390/cells14020063. This article has 10 citations.</p>
+</li>
+<li>
+<p>(buscaino2012raf1isa pages 1-2): Alessia Buscaino, Sharon A. White, Douglas R. Houston, Erwan Lejeune, Femke Simmer, Flavia de Lima Alves, Piyush T. Diyora, Takeshi Urano, Elizabeth H. Bayne, Juri Rappsilber, and Robin C. Allshire. Raf1 is a dcaf for the rik1 ddb1-like protein and has separable roles in sirna generation and chromatin modification. PLoS Genetics, 8:e1002499, Feb 2012. URL: https://doi.org/10.1371/journal.pgen.1002499, doi:10.1371/journal.pgen.1002499. This article has 35 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="dca7-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="dca7-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>glenewinkel2016theadaptorprotein pages 10-12</li>
+<li>glenewinkel2016theadaptorprotein pages 1-2</li>
+<li>peng2016humandnaligase pages 5-6</li>
+<li>higa2007stealingthespotlight pages 1-2</li>
+<li>ananthapadmanabhan2023insightsfromthe pages 6-7</li>
+<li>glenewinkel2016theadaptorprotein pages 8-10</li>
+<li>pinsky2024geneticanalysisof pages 6-9</li>
+<li>pinsky2024geneticanalysisof pages 1-2</li>
+<li>lee2007dcafsthemissing pages 2-3</li>
+<li>lee2007dcafsthemissing pages 1-2</li>
+<li>glenewinkel2016theadaptorprotein pages 2-3</li>
+<li>glenewinkel2016theadaptorprotein pages 3-5</li>
+<li>yu2019acomplexbetween pages 4-5</li>
+<li>yu2019acomplexbetween pages 1-1</li>
+<li>yu2019acomplexbetween pages 5-5</li>
+<li>yu2019acomplexbetween pages 7-8</li>
+<li>yu2019acomplexbetween pages 11-12</li>
+<li>yu2019acomplexbetween pages 1-2</li>
+<li>pinsky2024geneticanalysisof pages 10-12</li>
+<li>https://doi.org/10.3389/fcell.2023.1277537,</li>
+<li>https://doi.org/10.1038/srep28241,</li>
+<li>https://doi.org/10.3390/jof10010083,</li>
+<li>https://doi.org/10.1371/journal.pone.0207779,</li>
+<li>https://doi.org/10.1016/j.molcel.2007.06.001,</li>
+<li>https://doi.org/10.1371/journal.pgen.1002499,</li>
+<li>https://doi.org/10.1186/1747-1028-2-5,</li>
+<li>https://doi.org/10.1074/jbc.m116.746198,</li>
+<li>https://doi.org/10.3390/cells14020063,</li>
+<li>https://doi.org/10.1016/j.bbrc.2019.08.147,</li>
+<li>https://doi.org/10.1093/nar/gkz162,</li>
+<li>https://doi.org/10.1016/j.isci.2022.105668,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dca7-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O74763" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dca7-spbc17d1108-o74763-curation-notes">dca7 (SPBC17D11.08 / O74763) — curation notes</h1>
+<p>Journal for the AI GO-annotation review of the <em>S. pombe</em> gene <strong>dca7</strong><br />
+(systematic name SPBC17D11.08; UniProt O74763; PomBase standard name <code>dca7</code>).</p>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li>UniProt: <strong>O74763</strong> (<code>YBE8_SCHPO</code>), 435 aa, "Uncharacterized WD repeat-containing<br />
+  protein C17D11.08" [dca7-uniprot.txt].</li>
+<li>PomBase standard name <strong>dca7</strong>, systematic name <strong>SPBC17D11.08</strong>; product line:<br />
+  "WD repeat protein, DDB1 and CUL4-associated factor Dca7, implicated in gene<br />
+  expression" (PomBase API, <code>dataset/latest/data/gene/SPBC17D11.08</code>).</li>
+<li>PomBase characterisation status: <strong>"conserved unknown"</strong> — i.e. a <em>dark</em> gene.</li>
+<li>Deletion viability: <strong>viable</strong> (PomBase).</li>
+<li>Taxonomic distribution: "eukaryotes only, fungi and metazoa"; PomBase species-distribution<br />
+  terms: conserved in eukaryotes / fungi / metazoa / vertebrates; "predominantly single copy<br />
+  (one to one)" (PomBase).</li>
+</ul>
+<h2 id="domain-architecture-verified-from-uniprot">Domain architecture (verified from UniProt)</h2>
+<ul>
+<li>InterPro: <strong>IPR045159 DCAF7-like</strong>; IPR015943 WD40/YVTN repeat-like domain superfamily;<br />
+  IPR019775 WD40 repeat CS; IPR036322 WD40 repeat domain superfamily; IPR001680 WD40 repeat.</li>
+<li>Pfam PF00400 (WD40, x2); SMART SM00320 (WD40, x4); SUPFAM SSF50978 (WD40 repeat-like);<br />
+  PROSITE WD_REPEATS.</li>
+<li>UniProt FT: 4 WD repeats annotated (105–149, 164–204, 207–247, 313–353); disordered/low-complexity<br />
+  region ~352–371.</li>
+<li>PANTHER <strong>PTHR19919</strong> (WD REPEAT CONTAINING PROTEIN).</li>
+<li>No catalytic domain, no transmembrane region, no signal peptide. Consistent with a<br />
+  β-propeller scaffold/adaptor architecture rather than an enzyme.</li>
+</ul>
+<h2 id="orthology-verified">Orthology (verified)</h2>
+<ul>
+<li>Human ortholog: <strong>HGNC:30915 = DCAF7 / WDR68 / HAN11</strong> (UniProt P61962) — the accession used<br />
+  in the S. pombe ISS annotation <code>GO:0080008</code> (PomBase ortholog_annotations, UniProt DR line).</li>
+<li><em>S. cerevisiae</em>: <strong>YPL247C</strong>; <em>S. japonicus</em>: SJAG_04087 (PomBase ortholog_annotations).</li>
+<li>Reactome mapping: R-SPO-8951664 "Neddylation" (UniProt DR).</li>
+</ul>
+<h2 id="what-is-known-about-the-dcaf7wdr68-family-from-orthologs-not-s-pombe-direct">What is KNOWN about the DCAF7/WDR68 family (from orthologs; NOT S. pombe-direct)</h2>
+<p>Grounded in the falcon deep-research report (dca7-deep-research-falcon.md), which cites<br />
+peer-reviewed DOI sources. The human/animal ortholog DCAF7/WDR68/HAN11 is a WD40 seven-blade<br />
+β-propeller with <strong>no intrinsic catalytic activity</strong>, acting as a scaffold/adaptor. Two recurrent<br />
+family roles are described in the literature:</p>
+<ol>
+<li><strong>Scaffold/adaptor for DYRK-family kinases</strong> (DYRK1A, DYRK1B) and HIPK2. This DYRK–WD40<br />
+   partnership is described as ancestral and conserved down to fungi — <em>S. cerevisiae</em> YPL247C<br />
+   interacts with Yak1, and <em>C. albicans</em> Orf19.384 forms a conserved complex with Yak1<br />
+   [Ananthapadmanabhan 2023, DOI:10.3389/fcell.2023.1277537; Glenewinkel 2016,<br />
+   DOI:10.1038/srep28241; Pinsky 2024, DOI:10.3390/jof10010083]. In humans the DYRK1A–DCAF7<br />
+   complex phosphorylates RNA Pol II CTD to promote myogenic transcription [Yu 2019,<br />
+   DOI:10.1093/nar/gkz162] — a plausible basis for PomBase's "implicated in gene expression"<br />
+   product tag.</li>
+<li><strong>Substrate receptor for the CUL4–DDB1 (CRL4) E3 ubiquitin ligase</strong> — this is the basis of<br />
+   the "DCAF" name; reported substrates include DNA ligase I, menin, ERCC1-XPF, and influenza PA<br />
+   [Peng 2016 DOI:10.1074/jbc.m116.746198; Kawara 2019 DOI:10.1016/j.bbrc.2019.08.147; Higa 2007<br />
+   DOI:10.1186/1747-1028-2-5; Lee &amp; Zhou 2007 DOI:10.1016/j.molcel.2007.06.001]. NOTE: whether<br />
+   DCAF7 truly acts as a bona fide CRL4 substrate receptor versus primarily a kinase scaffold is<br />
+<em>debated</em> in the literature (the DYRK-scaffold role is the more firmly established one).</li>
+</ol>
+<h2 id="what-is-not-known-the-dark-part">What is NOT known (the dark part)</h2>
+<ul>
+<li><strong>No primary literature characterizes S. pombe dca7 / SPBC17D11.08 directly.</strong> The falcon<br />
+  report states explicitly: "No primary literature was identified that directly characterizes<br />
+  SPBC17D11.08/dca7 in <em>S. pombe</em>." All functional inference is by orthology + domain.</li>
+<li>GOA records <strong>MF = GO:0003674 (ND)</strong> and <strong>BP = GO:0008150 (ND)</strong> for this gene: PomBase has<br />
+  formally declared molecular function and biological process <strong>unknown</strong>.</li>
+<li>No S. pombe DYRK partner has been demonstrated for dca7. (S. pombe encodes candidate<br />
+  DYRK/Yak-family kinases, but no dca7–kinase complex is reported.)</li>
+<li>Whether dca7 acts in a CUL4/DDB1 complex in fission yeast is <strong>not experimentally shown</strong>; the<br />
+  known S. pombe DCAFs are Cdt2 (canonical CRL4) and Raf1/Dos1 (CLRC heterochromatin) — dca7 is a<br />
+<em>distinct</em> DCAF7-like protein, so the <code>GO:0080008</code> complex membership is an ISS inference from<br />
+  human P61962, not local evidence.</li>
+</ul>
+<h2 id="existing-annotations-from-dca7-goatsv-review-plan">Existing annotations (from dca7-goa.tsv) — review plan</h2>
+<ol>
+<li><code>GO:0005634 nucleus</code> — <strong>IBA</strong> (GO_REF:0000033, PANTHER PTN000460287). Ortholog DCAF7 is<br />
+   nucleocytoplasmic; nuclear localization is plausible and phylogenetically supported. PomBase<br />
+   also carries this CC. KEEP as non-core (localization, not core function; no direct S. pombe<br />
+   localization datum for the nucleus — the direct large-scale localization study reported<br />
+   cytoplasm + Golgi).</li>
+<li><code>GO:0005737 cytoplasm</code> — <strong>IEA</strong> (GO_REF:0000044, UniProtKB-SubCell SL-0086). Backed by the<br />
+   S. pombe ORFeome-GFP localization study PMID:16823372 (UniProt SUBCELLULAR LOCATION: Cytoplasm<br />
+   {ECO:0000269|PubMed:16823372}). KEEP as non-core.</li>
+<li><code>GO:0005794 Golgi apparatus</code> — <strong>IEA</strong> (GO_REF:0000044, UniProtKB-SubCell SL-0132). Same<br />
+   PMID:16823372 source (UniProt: Golgi apparatus {ECO:0000269|PubMed:16823372}). This is a<br />
+   single high-throughput GFP localization; a WD40 scaffold is not an obvious Golgi resident and<br />
+   this may be a minor/secondary pool. KEEP as non-core but flag as weakly supported /<br />
+   over-interpretable.</li>
+<li><code>GO:0003674 molecular_function</code> — <strong>ND</strong> (GO_REF:0000015). This is the ND root placeholder =<br />
+   "MF unknown". Not something to ACCEPT/REMOVE as a real term; represents the knowledge gap.<br />
+   Mark accordingly (KEEP_AS_NON_CORE is inappropriate for a root; use the ND convention — action<br />
+   reflects that this is the honest "unknown" placeholder).</li>
+<li><code>GO:0008150 biological_process</code> — <strong>ND</strong> (GO_REF:0000015). Same: "BP unknown" placeholder.</li>
+<li><code>GO:0080008 Cul4-RING E3 ubiquitin ligase complex</code> — <strong>ISS</strong> from human DCAF7 P61962<br />
+   (GO_REF:0000024). Defensible orthology-based complex inference, but note the CRL4-receptor role<br />
+   of DCAF7 is itself debated, and there is no S. pombe evidence. KEEP_AS_NON_CORE (inferred,<br />
+   not core; do not upgrade to core without local evidence). Do NOT REMOVE — it is a<br />
+   curator ISS transfer from a legitimate ortholog, and the complex is real in the family.</li>
+</ol>
+<h2 id="localization-datum-detail">Localization datum detail</h2>
+<p>UniProt SUBCELLULAR LOCATION: "Cytoplasm {ECO:0000269|PubMed:16823372}. Golgi apparatus<br />
+{ECO:0000269|PubMed:16823372}." — both from the Matsuyama 2006 ORFeome-GFP global localization<br />
+screen (abstract-only in cache; individual-gene call is in supplementary data, curated by<br />
+UniProt/PomBase). PMID:18257517 (Wilson-Grady 2008 phosphoproteome) supports Ser266/Ser388<br />
+phosphorylation (UniProt MOD_RES).</p>
+<h2 id="interactions-pombase-high-throughput-context-only">Interactions (PomBase, high-throughput; context only)</h2>
+<ul>
+<li>fft3 (SPAC25A8.01c, Fun30-family chromatin remodeler) — Affinity Capture-MS <a href="https://pubmed.ncbi.nlm.nih.gov/28218250">PMID:28218250</a>.</li>
+<li>ppk15 (SPAC823.03, protein kinase) — Two-hybrid <a href="https://pubmed.ncbi.nlm.nih.gov/26771498">PMID:26771498</a>. (Of note: ppk15 is a kinase,<br />
+  loosely consistent with the family kinase-scaffold theme, but this single Y2H hit is not<br />
+  sufficient to assert a DYRK-scaffold function in S. pombe.)<br />
+None of these full texts mention dca7/SPBC17D11.08 in prose (screen data only); they are not used<br />
+as supporting_text.</li>
+</ul>
+<h2 id="curation-decisions-summary">Curation decisions summary</h2>
+<ul>
+<li>Dark gene: MF and BP officially ND. <code>core_functions</code> kept <strong>empty</strong> — there is no direct<br />
+  evidence of any S. pombe molecular function, and the strongest signal (WD40 scaffold/adaptor)<br />
+  is an orthology hypothesis, not established fission-yeast function. The scaffold/DCAF hypothesis<br />
+  is captured in <code>knowledge_gaps</code> and <code>suggested_experiments</code> instead.</li>
+<li><code>description</code>: project-independent, states it is an uncharacterized DCAF7-family WD40 protein,<br />
+  its domain architecture, its verified localization, and its conservation — without asserting a<br />
+  proven function.</li>
+<li><code>knowledge_gaps</code> (REQUIRED): the MF is genuinely unknown (BIOLOGY gap, WHOLLY_DARK / MF_DARK).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O74763
+gene_symbol: dca7
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  dca7 (systematic name SPBC17D11.08) is an uncharacterized WD40 repeat-containing
+  protein of the fission yeast Schizosaccharomyces pombe. Its sequence comprises
+  multiple WD40 repeats predicted to fold into a beta-propeller and it carries the
+  DCAF7-like domain signature (InterPro IPR045159), identifying it as the fission
+  yeast ortholog of the animal DCAF7/WDR68/HAN11 protein and of S. cerevisiae
+  YPL247C; it is a predominantly single-copy protein conserved across fungi and
+  metazoa. The protein has no recognizable catalytic, transmembrane, or signal
+  domain, consistent with a non-enzymatic scaffold/adaptor architecture. In a
+  genome-wide GFP-tagging survey the protein was localized to the cytoplasm and the
+  Golgi apparatus, and it is phosphorylated on serine residues. Its molecular
+  function and the biological process it participates in have not been experimentally
+  determined in S. pombe; deletion of the gene is viable. Animal orthologs act as
+  WD40 scaffolds/adaptors for DYRK-family kinases and have been reported to serve as
+  substrate receptors for the CUL4-DDB1 (CRL4) ubiquitin ligase, but no such role has
+  been demonstrated for the fission yeast protein.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: UniProt:O74763
+  title: &#34;Uncharacterized WD repeat-containing protein C17D11.08 (dca7, SPBC17D11.08), Schizosaccharomyces pombe&#34;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Swiss-Prot record (reviewed). Source of the DCAF7-like/WD40 domain architecture,
+      the cytoplasm + Golgi subcellular localization (both ECO:0000269|PubMed:16823372),
+      and Ser266/Ser388 phosphorylation (ECO:0000269|PubMed:18257517). Verified by
+      direct inspection of dca7-uniprot.txt.
+- id: PMID:16823372
+  title: &#34;ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.&#34;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Genome-wide YFP-tagging localization survey (Matsuyama et al. 2006). The
+      individual localization call for SPBC17D11.08 (cytoplasm, Golgi) is in the
+      supplementary dataset; the cached record is abstract-only and does not name the
+      gene in prose. This is the ECO:0000269 experimental source underlying the
+      cytoplasm and Golgi GO annotations via UniProt Subcellular Location mapping.
+- id: PMID:18257517
+  title: &#34;Phosphoproteome analysis of fission yeast.&#34;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale S. pombe phosphoproteome (Wilson-Grady et al. 2008); supports the
+      Ser266/Ser388 phosphorylation sites recorded in UniProt. Provides no functional
+      information on dca7 beyond the fact that it is a phosphoprotein.
+- id: file:SCHPO/dca7/dca7-deep-research-falcon.md
+  title: &#34;Deep research report: dca7 (SPBC17D11.08) as a DCAF7-like WD40 protein&#34;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Literature synthesis (falcon/Edison) grounded in peer-reviewed DOI sources on the
+      DCAF7/WDR68 family. Used ONLY for orthology-based context (family is a
+      catalytically inactive WD40 scaffold/adaptor for DYRK kinases, with a debated CRL4
+      substrate-receptor role) and for the explicit, verifiable statement that no primary
+      literature directly characterizes the S. pombe protein. Not used to assert any
+      established S. pombe function.
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred (IBA) nuclear localization propagated within PANTHER
+      family PTHR19919 (DCAF7/WDR68). Animal DCAF7 is nucleocytoplasmic and its
+      nuclear pool is functionally important, so a nuclear location is phylogenetically
+      plausible, and PomBase independently carries this cellular component. However,
+      the one direct S. pombe localization dataset (PMID:16823372) reported cytoplasm
+      and Golgi, not nucleus, so this remains an inference. Retained as a plausible,
+      non-core localization annotation; it does not describe a molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA localization consistent with the family and independently curated by PomBase,
+      but it is a location rather than a core function and is not directly demonstrated
+      in S. pombe.
+    supported_by:
+    - reference_id: file:SCHPO/dca7/dca7-deep-research-falcon.md
+      supporting_text: &gt;-
+        DCAF7/WDR68 localizes to both the nucleus and cytoplasm, with its distribution
+        regulated by its kinase binding partners.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization mapped by UniProt from the Subcellular Location
+      vocabulary. It is underpinned by an experimental S. pombe datum: the genome-wide
+      GFP/YFP localization survey (PMID:16823372), recorded in UniProt as
+      &#34;Cytoplasm {ECO:0000269|PubMed:16823372}&#34;. A well-supported localization, but a
+      location rather than a molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Localization is experimentally supported (via UniProt ECO:0000269|PubMed:16823372)
+      but is non-core; it does not describe what the protein does.
+    supported_by:
+    - reference_id: UniProt:O74763
+      supporting_text: &#34;Cytoplasm {ECO:0000269|PubMed:16823372}&#34;
+- term:
+    id: GO:0005794
+    label: Golgi apparatus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Golgi localization mapped by UniProt from the Subcellular Location vocabulary,
+      derived from the same single high-throughput GFP/YFP survey (PMID:16823372;
+      UniProt &#34;Golgi apparatus {ECO:0000269|PubMed:16823372}&#34;). A WD40
+      scaffold/adaptor is not an obvious Golgi resident and this single-method
+      observation may reflect a minor or secondary pool; it should be treated with
+      caution and is not corroborated by any interaction or functional evidence.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained because it derives from an experimental localization dataset, but flagged
+      as weakly supported (single high-throughput method, no corroboration) and non-core.
+    supported_by:
+    - reference_id: UniProt:O74763
+      supporting_text: &#34;GO:0005794; C:Golgi apparatus; IEA:UniProtKB-SubCell.&#34;
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function term with the ND (&#34;No biological Data&#34;) evidence code,
+      the PomBase convention for a gene whose molecular function has not been
+      experimentally determined. For dca7 this is an accurate statement of the current
+      state of knowledge: no primary study has assigned it a molecular activity in
+      S. pombe. Retained as the honest placeholder marking a genuine molecular-function
+      knowledge gap (see knowledge_gaps).
+    action: ACCEPT
+    reason: &gt;-
+      ND correctly encodes that the molecular function of this dark gene is unknown; it
+      is not a substantive term to replace or remove.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with the ND evidence code, indicating that no
+      biological process has been experimentally assigned to dca7 in S. pombe. Deletion
+      is viable and only broad, non-specific stress-screen phenotypes are recorded, so
+      no defensible specific BP annotation can be made. Retained as the honest
+      placeholder marking a genuine biological-process knowledge gap.
+    action: ACCEPT
+    reason: &gt;-
+      ND correctly encodes that the biological process of this dark gene is unknown; it
+      is not a substantive term to replace or remove.
+- term:
+    id: GO:0080008
+    label: Cul4-RING E3 ubiquitin ligase complex
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Complex membership inferred by sequence similarity (ISS) from the human ortholog
+      DCAF7 (UniProt P61962), which has been described as a substrate receptor of the
+      CUL4-DDB1 (CRL4) E3 ubiquitin ligase. This is a defensible orthology-based
+      inference given the shared DCAF7-like WD40 architecture, and it is a curator ISS
+      transfer from a legitimate ortholog, so it is not removed. However, two caveats
+      keep it non-core: (i) there is no S. pombe evidence that dca7 assembles into a
+      CUL4 complex (the established fission-yeast DCAFs are Cdt2 in canonical CRL4 and
+      Raf1/Dos1 in the CLRC heterochromatin complex; dca7 is a distinct DCAF7-like
+      protein), and (ii) even for the human ortholog the bona fide CRL4 substrate-receptor
+      role is debated relative to its better-established DYRK-kinase scaffold role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Legitimate ISS transfer from human DCAF7; retained but marked non-core because it
+      is an orthology inference with no local S. pombe evidence and rests on a
+      family role that is itself contested.
+    supported_by:
+    - reference_id: file:SCHPO/dca7/dca7-deep-research-falcon.md
+      supporting_text: &gt;-
+        DCAF7 functions as a substrate recognition subunit (substrate receptor) of the
+        CUL4-DDB1-ROC1 (CRL4) E3 ubiquitin ligase complex
+core_functions: []
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of S. pombe dca7 (SPBC17D11.08) is undetermined: it is not
+    known which protein(s) its WD40 beta-propeller binds in fission yeast, whether it acts
+    as a kinase scaffold, a ubiquitin-ligase substrate receptor, or in some other adaptor
+    capacity, and no direct activity or binding partner has been experimentally established.
+  boundary: &gt;-
+    Firmly established: the protein exists, is a phosphorylated WD40-repeat protein with a
+    DCAF7-like domain (InterPro IPR045159), is conserved one-to-one across fungi and metazoa,
+    localizes to the cytoplasm and Golgi in a genome-wide GFP survey, and its deletion is
+    viable. Its animal ortholog DCAF7/WDR68 is a catalytically inactive scaffold/adaptor for
+    DYRK-family kinases with a debated CRL4 substrate-receptor role. What is unknown is any
+    S. pombe-specific molecular partner or activity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    dca7 belongs to a deeply conserved, single-copy protein family with important roles in
+    animal signaling and development (DYRK1A/HIPK2 regulation, transcription, DNA-repair
+    protein turnover). A defined fission-yeast function would clarify the ancestral,
+    pre-metazoan role of the DCAF7/WDR68 scaffold and whether the DYRK-partner or CUL4-receptor
+    role is the conserved core.
+  resolution: &gt;-
+    Affinity purification-mass spectrometry of tagged Dca7 to identify its fission-yeast
+    interactome (testing for association with a DYRK/Yak-family kinase and/or with Cul4/Ddb1);
+    reciprocal tagging of candidate partners; and phenotypic profiling of a dca7 deletion under
+    conditions where DCAF7-family functions are relevant (stress signaling, DNA damage).
+  provenance:
+  - reference_id: file:SCHPO/dca7/dca7-deep-research-falcon.md
+    supporting_text: &gt;-
+      No primary literature was identified that directly characterizes SPBC17D11.08/dca7 in
+      *S. pombe*
+- gap_statement: &gt;-
+    The biological process dca7 participates in within S. pombe is unknown. PomBase records the
+    biological process as ND, deletion is viable, and only broad, non-specific high-throughput
+    stress-resistance/sensitivity and quiescence-survival phenotypes are catalogued, none of
+    which pin the gene to a specific pathway.
+  boundary: &gt;-
+    Established: dca7 deletion is viable and the gene appears in numerous genome-wide
+    phospho/phenomic datasets, and it has high-throughput physical-interaction hits (with the
+    chromatin remodeler fft3 by affinity capture-MS, and with the kinase ppk15 by two-hybrid).
+    Unknown: whether any of these reflect a real, dedicated biological role, and what pathway
+    dca7 belongs to.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Assigning a biological process would move dca7 out of the fission-yeast &#34;conserved unknown&#34;
+    set and could reveal whether the DCAF7/WDR68 scaffold has a conserved role in a specific
+    pathway (e.g. gene expression, as suggested by the PomBase product line) predating its
+    elaboration in animals.
+  resolution: &gt;-
+    Directed phenotyping of a dca7 deletion (and of a WD40-surface point mutant) in the
+    processes where orthologs act, combined with epistasis against candidate kinase or Cul4/Ddb1
+    partners; transcriptome analysis to test the &#34;implicated in gene expression&#34; hypothesis.
+  provenance:
+  - reference_id: file:SCHPO/dca7/dca7-deep-research-falcon.md
+    supporting_text: &gt;-
+      The specific SPBC17D11.08 protein is uncharacterized
+suggested_questions:
+- question: &gt;-
+    Does S. pombe Dca7 bind a DYRK/Yak-family kinase, as its orthologs YPL247C (with Yak1) and
+    C. albicans Orf19.384 (with Yak1) do, thereby establishing a conserved fungal DCAF7-kinase
+    module?
+- question: &gt;-
+    Does Dca7 physically associate with the S. pombe Cul4 (Pcu4)/Ddb1 machinery, or is the
+    ISS-transferred CUL4-RING E3 ubiquitin ligase complex membership not realized in fission
+    yeast?
+- question: &gt;-
+    Is the Golgi localization observed in the genome-wide GFP survey a genuine steady-state
+    pool or a tagging/overexpression artifact, given that a WD40 scaffold has no obvious Golgi
+    role?
+suggested_experiments:
+- hypothesis: &gt;-
+    Dca7 functions as a WD40 scaffold/adaptor that binds a specific fission-yeast partner
+    protein (candidate: a DYRK/Yak-family kinase), analogous to the conserved DCAF7-DYRK module.
+  description: &gt;-
+    Affinity purification of a functional epitope-tagged Dca7 from S. pombe followed by mass
+    spectrometry to define its in vivo interactome, with reciprocal tagging/co-IP validation of
+    the top hits and comparison against candidate DYRK/Yak kinases and Cul4/Ddb1 subunits.
+  experiment_type: affinity purification-mass spectrometry (AP-MS) interactome mapping
+- hypothesis: &gt;-
+    Dca7 contributes to a specific biological process (e.g. gene expression or a stress
+    pathway) despite being non-essential.
+  description: &gt;-
+    Systematic phenotypic profiling of a dca7 deletion strain (growth, stress panels, quiescence
+    survival, and transcriptome/RNA-seq) alongside a WD40 propeller-surface point mutant to test
+    whether phenotypes depend on the protein-binding surface, and epistasis analysis with
+    candidate kinase and Cul4/Ddb1 partners.
+  experiment_type: reverse-genetics phenotyping, transcriptomics, and epistasis analysis
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/fmc1/fmc1-ai-review.html
+++ b/genes/SCHPO/fmc1/fmc1-ai-review.html
@@ -1,0 +1,2670 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>fmc1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>fmc1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G2TRM0" target="_blank" class="term-link">
+                        G2TRM0
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "fmc1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G2TRM0" data-a="DESCRIPTION: fmc1 (Formation of Mitochondrial Complexes protein..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>fmc1 (Formation of Mitochondrial Complexes protein 1; systematic name SPAC1486.11) is a small (104-residue) mitochondrial protein of fission yeast belonging to the FMC1 family (InterPro IPR039196; PANTHER PTHR28015), a group within the LYR-motif protein (LYRM / Complex1_LYR_2, Pfam PF13233) superfamily of mitochondrial accessory and assembly factors. It carries a predicted N-terminal mitochondrial targeting sequence and is imported into the mitochondrion. By orthology to the well-characterized Saccharomyces cerevisiae Fmc1p, it is inferred to be a soluble matrix protein that acts as an accessory assembly factor for the F1 sector (the catalytic alpha3beta3 head) of the mitochondrial F1Fo-ATP synthase (Complex V), most plausibly by assisting the folding, stability or function of the dedicated F1 assembly chaperone Atp12 (human ATPAF2). In budding yeast this requirement is conditional, becoming critical at elevated temperature, where loss of Fmc1p causes the newly imported alpha-F1 and beta-F1 subunits to aggregate in the matrix instead of assembling into functional F1. The fission-yeast protein itself has not been functionally characterized; its specific molecular activity, partners and loss-of-function phenotype remain undetermined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRM0" data-a="GO:0005759" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Matrix localization is well supported at the family level: the characterized S. cerevisiae ortholog is a soluble matrix protein, and the matrix is the compartment where the F1 alpha3beta3 head is assembled. fmc1 carries a predicted mitochondrial transit peptide. Kept as a correct, informative localization, but treated as non-core because it has not been shown experimentally for the pombe protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA propagated from SGD:S000001360; consistent with the founding paper showing Fmc1p is a soluble matrix protein, and with the predicted N-terminal transit peptide. Correct and specific, but the localization of the pombe protein is inferred, not experimentally demonstrated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link">
+                                        PMID:11096112
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Fmc1p is a soluble protein located in the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
+                                    GO:0033615
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial proton-transporting ATP synthase complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRM0" data-a="GO:0033615" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the best-supported functional statement for fmc1 and represents its core biological role: participation in assembly of the mitochondrial proton-transporting ATP synthase (Complex V). The term is directly supported by the family-defining function established for the S. cerevisiae ortholog and by the InterPro/PANTHER family assignment. Retained as core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Family-defining biological process, propagated by phylogeny (IBA from SGD:S000001360) and independently supported by the InterPro Fmc1 signature. Matches the founding paper, in which Fmc1p is required for assembly/stability of the F1 sector of ATP synthase.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link">
+                                        PMID:11096112
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have identified a yeast nuclear gene (FMC1) that is required at elevated temperatures (37 degrees C) for the formation/stability of the F(1) sector of the mitochondrial ATP synthase.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRM0" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general parent term derived from the UniProt Subcellular Location mapping (SL-0173, Mitochondrion). It is subsumed by the more specific mitochondrial matrix annotation, so it is kept as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate compartment assignment consistent with the predicted transit peptide, but less informative than GO:0005759 (mitochondrial matrix); redundant parent.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
+                                    GO:0033615
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial proton-transporting ATP synthase complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRM0" data-a="GO:0033615" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO annotation from the Fmc1 signature (IPR039196), giving the same ATP-synthase-assembly process as the IBA annotation. It corroborates the core biological process from an independent (domain-based) line of evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain-based support (InterPro IPR039196 -&gt; GO:0033615) that is concordant with the phylogenetic (IBA) annotation and with the family function; a well-founded electronic annotation to the core process.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRM0" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function annotation with the ND (No biological Data) evidence code, correctly flagging that no specific molecular activity has been determined for fmc1. This honestly reflects the state of knowledge: the molecular function is genuinely dark. See knowledge_gaps and core_functions for the orthology-based inference of a chaperone-like assembly-factor activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Legitimate ND placeholder; the specific molecular function of fmc1 is undetermined. It should not be removed, as it accurately records that the MF aspect is uncurated/unknown rather than annotated to a specific activity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    GO:0044183
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding chaperone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11096112
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a nuclear gene (FMC1) required for the ass...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRM0" data-a="GO:0044183" data-r="PMID:11096112" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed molecular function inferred by orthology (not present in the current GOA). The characterized S. cerevisiae ortholog assists the folding/stability or function of the F1 assembly chaperone Atp12p, a non-catalytic chaperone-like activity that fits the FMC1/LYR-motif family (no catalytic domain). Offered as the most defensible specific MF to replace the ND placeholder, pending experimental confirmation in fission yeast.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> fmc1 has no annotated specific molecular function (MF is ND). A protein-folding chaperone activity is the best-supported inference from the family-defining function of the S. cerevisiae ortholog and from the domain architecture; not ATP-dependent (no ATPase), so GO:0044183 rather than GO:0140662. Marked ISS and non-verified for the pombe protein. Note this is a second-order inference: the founding data show Fmc1p acts on the F1 assembly chaperone Atp12p, so a competing hypothesis is that fmc1 is not itself the folding chaperone but an adaptor/stabilizer of a partner chaperone (e.g. GO:0051087 protein-folding chaperone binding); the two cannot be distinguished without direct assays (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link">
+                                        PMID:11096112
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We propose that Fmc1p is required for the proper folding/stability or functioning of Atp12p in heat stress conditions.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Mitochondrial accessory assembly factor for the F1Fo-ATP synthase (Complex V). By orthology to S. cerevisiae Fmc1p and consistent with its LYR-motif/FMC1-family domain architecture, fmc1 is inferred to act as a chaperone-like factor in the mitochondrial matrix that assists assembly of the catalytic F1 (alpha3beta3) head of ATP synthase, most plausibly by supporting the folding, stability or function of the dedicated F1 assembly chaperone Atp12 (human ATPAF2). It has no catalytic domain, consistent with a non-enzymatic, non-ATP-dependent chaperone role. This core function is inferred, not yet demonstrated in fission yeast.</h3>
+                <span class="vote-buttons" data-g="G2TRM0" data-a="FUNCTION: Mitochondrial accessory assembly factor for the F1..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
+                                mitochondrial proton-transporting ATP synthase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link">
+                                PMID:11096112
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We propose that Fmc1p is required for the proper folding/stability or functioning of Atp12p in heat stress conditions.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link">
+                                PMID:11096112
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We have identified a yeast nuclear gene (FMC1) that is required at elevated temperatures (37 degrees C) for the formation/stability of the F(1) sector of the mitochondrial ATP synthase.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11096112" target="_blank" class="term-link">
+                            PMID:11096112
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a nuclear gene (FMC1) required for the assembly/stability of yeast mitochondrial F(1)-ATPase in heat stress conditions.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The founding, and only directly characterized, family member — S. cerevisiae Fmc1p — is a soluble mitochondrial matrix protein required at elevated temperature for formation/stability of the F1 sector of ATP synthase; in its absence the alpha-F1 and beta-F1 subunits aggregate in the matrix rather than assembling into F1.</div>
+
+                        <div class="finding-text">"We have identified a yeast nuclear gene (FMC1) that is required at elevated temperatures (37 degrees C) for the formation/stability of the F(1) sector of the mitochondrial ATP synthase."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Fmc1p acts genetically upstream of, or together with, the F1 assembly chaperone Atp12p: overexpression of Atp12p rescues loss of Fmc1p, leading to the model that Fmc1p is needed for proper folding/stability or function of Atp12p.</div>
+
+                        <div class="finding-text">"We propose that Fmc1p is required for the proper folding/stability or functioning of Atp12p in heat stress conditions."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe fmc1 physically interact with a fission-yeast Atp12/ATPAF2 ortholog and with the F1 alpha/beta subunits, and is its requirement for ATP synthase assembly conditional (e.g. heat-stress specific) as in budding yeast?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRM0" data-a="Q: Does S. pombe fmc1 physically interact with a fiss..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct an fmc1-null strain and assess respiratory competence and growth on a non-fermentable carbon source at normal and elevated temperature; quantify assembled F1Fo-ATP synthase (blue-native PAGE / activity assays) and test for accumulation/aggregation of unassembled alpha-F1 and beta-F1 subunits in the matrix. Complement with tagged-protein pulldowns to identify the pombe Atp12 ortholog and F1 subunits as interaction partners.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: fmc1 is required for assembly of the F1 sector of mitochondrial ATP synthase in S. pombe, acting through the Atp12/ATPAF2 assembly chaperone.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics and biochemistry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRM0" data-a="EXPERIMENT: Construct an fmc1-null strain and assess respirato..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The specific molecular activity of the fission-yeast fmc1 protein is undetermined. Whether it acts as a protein-folding chaperone in its own right, as an adaptor that stabilizes a partner chaperone (an Atp12/ATPAF2 ortholog), or in some other capacity has not been shown; the GO molecular_function is ND.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The protein is confidently placed in the FMC1 family (InterPro IPR039196, PANTHER PTHR28015) and carries a single LYR-motif (Complex1_LYR_2) module and a predicted mitochondrial transit peptide, implying a non-catalytic accessory role in ATP synthase assembly. The founding S. cerevisiae study established that the ortholog assists folding/stability or function of the F1 assembly chaperone Atp12p.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Pinning down the molecular activity would convert an orthology-based inference into an experimentally grounded function and clarify how the LYR-motif fold of FMC1-family proteins contributes to Complex V biogenesis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of the pombe protein (e.g. interaction/complex assays with the pombe Atp12/ATPAF2 ortholog and F1 subunits; in-organello F1 assembly assays in an fmc1-null background).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We propose that Fmc1p is required for the proper folding/stability or functioning of Atp12p in heat stress conditions."</em> — PMID:11096112</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is not known whether the F1-ATP-synthase-assembly role attributed to fmc1 is demonstrated in S. pombe or is purely inferred by orthology. All fission-yeast GO annotations are electronic or phylogenetic (IBA/IEA); none are experimental.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In S. cerevisiae the assembly role is experimentally established, including the aggregation of alpha/beta-F1 subunits on loss of Fmc1p and rescue by Atp12p overexpression. UniProt records the pombe protein only at transcript level (Evidence at transcript level, PE 2).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing demonstrated from inferred function prevents over-reading the IBA/IEA annotations as direct evidence and identifies the pombe protein as a target for experimental validation.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Identification of a nuclear gene (FMC1) required for the assembly/stability of"</em> — PMID:11096112</li>
+
+                <li><em>"No direct experimental studies on *fmc1* in *S. pombe* were identified during this review"</em> — file:SCHPO/fmc1/fmc1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No loss-of-function phenotype has been reported for S. pombe fmc1, and it is unknown whether (as in budding yeast) its requirement is conditional (heat-stress specific) or broader, and whether a functional Atp12/ATPAF2 partner exists and is engaged in fission yeast.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In S. cerevisiae, Fmc1p is dispensable at normal growth temperature (28-30 C) but required at 37 C, and its loss is compensated by Atp12p overexpression; no equivalent conditional-phenotype or partner data exist for the pombe gene.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> A conditional (stress-dependent) versus constitutive requirement changes how the gene should be annotated for biological process and regulation, and whether an ATP-synthase-assembly defect is the primary phenotype.</p>
+
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"unlike Atp12p and Atp11p, Fmc1p is not required in normal growth conditions (28--30 degrees C)."</em> — PMID:11096112</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(fmc1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G2TRM0" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">31 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T17:24:13.128211</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="fmc1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-fmc1-spac148611-in-schizosaccharomyces-pombe">Comprehensive Research Report: fmc1 (SPAC1486.11) in <em>Schizosaccharomyces pombe</em></h2>
+<h3 id="gene-and-protein-identity">Gene and Protein Identity</h3>
+<p>The <em>fmc1</em> gene (synonym: <em>new3</em>; ORF: SPAC1486.11; UniProt: G2TRM0) encodes the ATP synthase assembly factor Fmc1, mitochondrial (also known as Formation of Mitochondrial Complexes protein 1), in <em>Schizosaccharomyces pombe</em> (fission yeast, strain 972 / ATCC 24843). The protein belongs to the FMC1 family and contains a Complex1_LYR_2 domain (PF13233/IPR039196), classifying it within the mitochondrial LYRM (LYR motif-containing) protein superfamily.</p>
+<p><strong>Note on literature availability:</strong> No direct experimental studies on <em>fmc1</em> in <em>S. pombe</em> were identified during this review. The functional annotation of the <em>S. pombe</em> protein is therefore inferred from the well-characterized <em>Saccharomyces cerevisiae</em> ortholog (FMC1/Fmc1p), supported by cross-genome bioinformatic analyses that confirm FMC1 homologs are present in both Ascomycota (including <em>S. pombe</em>) and Basidiomycota (pickova2005assemblyfactorsof pages 1-2, pickova2005assemblyfactorsof pages 5-7, pickova2005assemblyfactorsof pages 7-9).</p>
+<p>The following summary table provides an overview of key properties:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>fmc1</strong>; UniProt-provided synonym <strong>new3</strong>; ORF <strong>SPAC1486.11</strong> for the target protein in <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843) (user-provided UniProt context).</td>
+</tr>
+<tr>
+<td>Organism (<em>S. pombe</em>)</td>
+<td><em>Schizosaccharomyces pombe</em> (fission yeast), strain 972 / ATCC 24843; this is the correct target organism and should be distinguished from the much better studied <em>Saccharomyces cerevisiae</em> ortholog literature. Cross-genome analysis lists <em>S. pombe</em> among Ascomycota species carrying <strong>FMC1</strong> homologs (pickova2005assemblyfactorsof pages 5-7).</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>G2TRM0</strong> (user-provided UniProt accession for the target <em>S. pombe</em> protein).</td>
+</tr>
+<tr>
+<td><em>S. cerevisiae</em> ortholog</td>
+<td><strong>FMC1 / Fmc1p</strong>, the founding and experimentally characterized fungal ortholog required for mitochondrial ATP synthase F1-sector assembly/stability under heat stress (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 6-7).</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td>ATP synthase assembly factor Fmc1, mitochondrial; also called Formation of mitochondrial complexes protein 1. In <em>S. cerevisiae</em>, Fmc1p is a small, nuclear-encoded mitochondrial protein involved in ATP synthase biogenesis (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 4-5).</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Best-supported function is as an <strong>assembly/stability factor for the F1 sector of mitochondrial ATP synthase (Complex V)</strong>, especially under elevated temperature. It is not a catalytic enzyme; rather, it acts as an accessory/chaperone-like factor helping productive F1 assembly and preventing aggregation of F1 α/β subunits, likely through supporting Atp12p folding/stability/function (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 6-7, rak2009assemblyoff0 pages 2-3, lefebvrelegendre2001identificationofa pages 5-6).</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>In <em>S. cerevisiae</em>, Fmc1p is a <strong>soluble mitochondrial matrix protein</strong>, imported as a precursor with an N-terminal targeting presequence; it is either free in the matrix or loosely associated with the inner face of the inner membrane (lefebvrelegendre2001identificationofa pages 4-5, lefebvrelegendre2001identificationofa pages 1-1). The <em>S. pombe</em> protein is annotated by UniProt as mitochondrial precursor, consistent with orthology.</td>
+</tr>
+<tr>
+<td>Domain family</td>
+<td>Belongs to the <strong>FMC1/LYRM (Complex1_LYR_2)</strong> family of mitochondrial LYR-motif proteins. LYRM proteins typically act as accessory factors for OXPHOS complexes and mitochondrial biogenesis pathways; FMC1 is classified as a lineage-specific LYRM family member (angerer2013thesuperfamilyof pages 1-2, angerer2013thesuperfamilyof pages 4-5, pickova2005assemblyfactorsof pages 7-9).</td>
+</tr>
+<tr>
+<td>Key interactions (Atp12p, ACPM)</td>
+<td><strong>Atp12p:</strong> genetic and functional interaction is strong—ATP12 overexpression suppresses the <em>fmc1Δ</em> defect, and Fmc1p is proposed to support Atp12p folding/stability/function during F1 assembly (lefebvrelegendre2001identificationofa pages 6-7, rak2009assemblyoff0 pages 2-3, lefebvrelegendre2001identificationofa pages 5-6). <strong>ACPM:</strong> LYRM-family review reports direct association of FMC1-containing complexes with mitochondrial acyl-carrier protein (<strong>ACPM</strong>) by tandem affinity purification, linking FMC1 to broader mitochondrial biogenesis networks (angerer2013thesuperfamilyof pages 5-6, angerer2013thesuperfamilyof pages 4-5).</td>
+</tr>
+<tr>
+<td>Phenotype of deletion (at elevated temperature)</td>
+<td>In <em>S. cerevisiae</em>, <strong>fmc1Δ</strong> causes severe oxidative growth defects at <strong>37°C</strong> on non-fermentable carbon sources; ATP synthase biogenesis is strongly impaired, and F1 α/β subunits aggregate in the matrix instead of assembling into functional oligomers (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 6-7, lefebvrelegendre2001identificationofa pages 4-4, lefebvrelegendre2001identificationofa pages 2-3).</td>
+</tr>
+<tr>
+<td>Phenotype at normal temperature</td>
+<td>Unlike <strong>ATP11</strong> or <strong>ATP12</strong>, <strong>FMC1 is not essential under normal growth temperature (28–30°C)</strong> in budding yeast; F1 assembly can proceed sufficiently in these conditions, indicating a conditional/heat-stress requirement (lefebvrelegendre2001identificationofa pages 1-1, rak2009assemblyoff0 pages 2-3).</td>
+</tr>
+<tr>
+<td>Conservation (fungi - Ascomycota and Basidiomycota)</td>
+<td>Comparative genomics indicates <strong>Fmc1p homologs are fungal-lineage restricted</strong>, found in <strong>Ascomycota and Basidiomycota</strong> rather than broadly across eukaryotes. The same analysis explicitly lists <em>Schizosaccharomyces pombe</em> among Ascomycota taxa carrying FMC1 homologs, supporting annotation of the target gene as the fungal ATP synthase assembly factor ortholog (pickova2005assemblyfactorsof pages 1-2, pickova2005assemblyfactorsof pages 5-7, pickova2005assemblyfactorsof pages 7-9).</td>
+</tr>
+<tr>
+<td>Relevance to human disease (ATP synthase disorders)</td>
+<td>Although human cells do not use FMC1 itself as a standard disease gene analog, <strong><em>fmc1Δ</em> yeast is a well-established model of ATP synthase deficiency</strong> because its primary defect is impaired F1 assembly and ATP synthesis. It has been used in drug-repurposing and pathway-modulation studies, including identification of <strong>TIM23-dependent mitochondrial protein sorting</strong> as a therapeutic intervention point and drug-drop screening campaigns of ~12,000 compounds for ATP synthase-related mitochondrial disease phenotypes (schwimmer2006yeastmodelsof pages 8-9, aiyar2014mitochondrialproteinsorting pages 1-2, aiyar2014mitochondrialproteinsorting pages 5-6, magistrati2023drugdroptest pages 5-6, magistrati2023drugdroptest pages 2-3).</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key characteristics of the target FMC1/fmc1 protein, with emphasis on the evidence-supported function of the fungal ortholog and what can be inferred for the S. pombe protein. It is useful for quickly separating direct evidence from orthology-based inference.</em></p>
+<h3 id="1-primary-function-assembly-factor-for-the-f1-sector-of-mitochondrial-atp-synthase">1. Primary Function: Assembly Factor for the F1 Sector of Mitochondrial ATP Synthase</h3>
+<p>FMC1 was first identified and characterized in <em>S. cerevisiae</em> by Lefebvre-Legendre et al. (2001) as a nuclear gene encoding a protein required for the assembly and stability of the F1 sector of mitochondrial ATP synthase (F1FO-ATP synthase, Complex V) (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 1-2). The mitochondrial ATP synthase is a multisubunit complex in which the membrane-embedded FO domain conducts protons across the inner mitochondrial membrane, while the F1 domain (comprising an α₃β₃γδε hexamer) catalyzes ATP synthesis. FMC1 does not itself catalyze a chemical reaction; rather, it functions as an accessory assembly factor—a chaperone-like protein—that ensures the productive folding and oligomerization of the F1 α and β subunits within the mitochondrial matrix.</p>
+<p>A distinguishing feature of FMC1 is its <strong>conditional requirement</strong>: unlike the assembly factors Atp11p and Atp12p, which are essential for F1 assembly under all growth conditions, Fmc1p is specifically required at elevated temperatures (37°C) and is dispensable for F1 assembly at normal growth temperatures (28–30°C) (lefebvrelegendre2001identificationofa pages 1-1, rak2009assemblyoff0 pages 2-3). In cells lacking Fmc1p grown at 37°C, the F1 α and β subunits are properly synthesized, imported into mitochondria, and processed to their mature size, but instead of assembling into functional F1 oligomers, they aggregate into large, insoluble inclusions in the mitochondrial matrix (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 6-7, lefebvrelegendre2001identificationofa pages 4-4).</p>
+<h3 id="2-molecular-mechanism-functional-relationship-with-atp12p">2. Molecular Mechanism: Functional Relationship with Atp12p</h3>
+<p>The key mechanistic insight into FMC1 function comes from its functional relationship with Atp12p, a dedicated chaperone that binds to the F1 α subunit and prevents its non-productive aggregation (lefebvrelegendre2001identificationofa pages 6-7, rak2009assemblyoff0 pages 2-3, lefebvrelegendre2001identificationofa pages 7-8). Several lines of evidence demonstrate this relationship:</p>
+<ul>
+<li>Overexpression of <em>ATP12</em> (encoding Atp12p) efficiently compensates for the absence of Fmc1p, restoring both respiratory growth on non-fermentable carbon sources and F1-ATPase activity at elevated temperatures (lefebvrelegendre2001identificationofa pages 5-6, lefebvrelegendre2001identificationofa pages 2-3).</li>
+<li>In <em>fmc1Δ</em> cells at 37°C, Atp12p steady-state levels in mitochondria are substantially reduced, suggesting that Fmc1p is needed for the stability or proper folding of Atp12p under heat stress (lefebvrelegendre2001identificationofa pages 6-7, song2023themitochondrialhsp70 pages 6-7).</li>
+<li>The phenotype of <em>fmc1Δ</em> mutants (α/β subunit aggregation) is identical to that observed in <em>atp12Δ</em> or <em>atp11Δ</em> mutants (lefebvrelegendre2001identificationofa pages 4-4).</li>
+</ul>
+<p>Based on these findings, Fmc1p has been proposed to function as a factor that assists the folding, stability, or proper functioning of Atp12p, with this requirement becoming critical under heat stress conditions when protein folding is challenged (lefebvrelegendre2001identificationofa pages 1-1, lefebvrelegendre2001identificationofa pages 7-8).</p>
+<p>Additionally, Song et al. (2023) demonstrated a genetic interaction between <em>fmc1Δ</em> and the mitochondrial Hsp70 (<em>ssc1-62</em>) mutant. While individual <em>ssc1-62</em> and <em>fmc1Δ</em> mutants show only mild growth defects, the double mutant exhibits severe phenotypes: growth is blocked on non-fermentable carbon sources, and ATP synthase levels are dramatically diminished, with particularly severe reductions in F1 domain levels. This indicates that mitochondrial Hsp70 (mtHsp70) and Fmc1 cooperatively function in F1FO-ATP synthase assembly (song2023themitochondrialhsp70 pages 6-7).</p>
+<h3 id="3-subcellular-localization">3. Subcellular Localization</h3>
+<p>In <em>S. cerevisiae</em>, Fmc1p is a <strong>soluble protein localized in the mitochondrial matrix</strong> (lefebvrelegendre2001identificationofa pages 4-5, lefebvrelegendre2001identificationofa pages 1-1). The protein is synthesized as a precursor of approximately 18.4 kDa (155 amino acids in <em>S. cerevisiae</em>) containing an N-terminal mitochondrial targeting presequence of approximately 4 kDa, which is cleaved upon import into the matrix (lefebvrelegendre2001identificationofa pages 4-5). Biochemical fractionation experiments confirmed its soluble nature: Fmc1p is recovered in water-soluble form after osmotic disruption of mitochondrial membranes and is protected from proteinase K degradation, indicating localization within the matrix compartment, either free or loosely associated with the inner face of the inner mitochondrial membrane (lefebvrelegendre2001identificationofa pages 4-5). The <em>S. pombe</em> protein (G2TRM0) is annotated by UniProt as a mitochondrial precursor, consistent with this localization pattern.</p>
+<h3 id="4-domain-architecture-and-membership-in-the-lyrm-protein-superfamily">4. Domain Architecture and Membership in the LYRM Protein Superfamily</h3>
+<p>FMC1 is classified as a member of the Complex1_LYR_2 family within the broader LYRM (LYR motif-containing) protein superfamily (angerer2013thesuperfamilyof pages 1-2, angerer2013thesuperfamilyof pages 4-5). LYRM proteins are characterized by a conserved leucine/tyrosine/arginine (LYR) motif and function as accessory subunits or assembly factors for OXPHOS complexes (Complexes I, II, III, and V) (angerer2013thesuperfamilyof pages 1-2). LYRM proteins play diverse roles in mitochondrial homeostasis, including iron-sulfur (Fe-S) cluster biogenesis (e.g., LYRM4/Isd11) and connections to mitochondrial fatty acid synthesis type II pathways (angerer2013thesuperfamilyof pages 2-4).</p>
+<p>Notably, tandem affinity purification studies in <em>S. cerevisiae</em> demonstrated that FMC1-containing protein complexes directly associate with ACPM (the mitochondrial acyl-carrier protein of the FAS type II pathway) (angerer2013thesuperfamilyof pages 5-6, angerer2013thesuperfamilyof pages 4-5). This interaction places FMC1 within a broader network of LYRM proteins that connect OXPHOS complex assembly with mitochondrial lipid metabolism and Fe-S cluster biogenesis pathways (angerer2013thesuperfamilyof pages 1-2, angerer2013thesuperfamilyof pages 2-4). Although FMC1 itself is not known to bind or transfer Fe-S clusters, the LYR domain may facilitate interactions with the mitochondrial biosynthetic machinery that are important for its assembly function.</p>
+<h3 id="5-evolutionary-conservation">5. Evolutionary Conservation</h3>
+<p>Comparative genomic analysis by Pícková et al. (2005) established that FMC1 has a restricted phylogenetic distribution compared to other F1-assembly factors. While Atp11p and Atp12p are broadly conserved across eukaryotes possessing ATP synthase, <strong>Fmc1p homologs are found specifically in Fungi, in both Ascomycota and Basidiomycota</strong> (pickova2005assemblyfactorsof pages 1-2, pickova2005assemblyfactorsof pages 7-9). This analysis explicitly includes <em>S. pombe</em> among the Ascomycota species carrying FMC1 homologs (pickova2005assemblyfactorsof pages 5-7). Fmc1p was not identified in Metazoa, Viridiplantae, Alveolata, or other major eukaryotic lineages, leading the authors to classify it as a "lineage-specific" assembly factor, in contrast to the "general" assembly factors Atp11p and Atp12p (pickova2005assemblyfactorsof pages 7-9). The authors propose that such lineage-specific factors may have evolved to fulfill specialized roles in individual organisms or lineages but are nonetheless important for ATP production (pickova2005assemblyfactorsof pages 7-9).</p>
+<h3 id="6-biochemical-and-signaling-pathway-context">6. Biochemical and Signaling Pathway Context</h3>
+<p>FMC1 functions within the <strong>mitochondrial ATP synthase (Complex V) biogenesis pathway</strong>. The assembly of the F1 catalytic head requires several dedicated chaperones operating in the mitochondrial matrix:</p>
+<ul>
+<li><strong>Atp11p</strong> binds to the F1 β subunit, preventing its non-productive aggregation (lefebvrelegendre2001identificationofa pages 4-4).</li>
+<li><strong>Atp12p</strong> binds to the F1 α subunit with an analogous function (lefebvrelegendre2001identificationofa pages 6-7, lefebvrelegendre2001identificationofa pages 7-8).</li>
+<li><strong>Fmc1p</strong> supports Atp12p function, particularly under conditions of proteotoxic stress such as elevated temperature (lefebvrelegendre2001identificationofa pages 1-1, rak2009assemblyoff0 pages 2-3).</li>
+<li><strong>mtHsp70 (Ssc1)</strong> cooperates with Atp11p and Atp12p in F1 domain formation and also functions in linking the catalytic head with the peripheral stalk via Atp5 (song2023themitochondrialhsp70 pages 6-7).</li>
+</ul>
+<p>Loss of Fmc1p results in a cascade of downstream effects: impaired F1 assembly leads to reduced ATP synthase accumulation, a ~90% reduction in mitochondrial ATP synthesis, and secondary effects on respiratory chain biogenesis (aiyar2014mitochondrialproteinsorting pages 1-2). The <em>fmc1Δ</em> phenotype demonstrates that F1 assembly is a prerequisite for complete ATP synthase maturation and proper oxidative phosphorylation.</p>
+<h3 id="7-disease-relevance-and-translational-applications">7. Disease Relevance and Translational Applications</h3>
+<p>Although FMC1 itself has no direct human ortholog and is restricted to fungi, the <strong>fmc1Δ yeast strain has become a widely used model system for human ATP synthase disorders</strong>, including NARP syndrome (Neurogenic Ataxia and Retinitis Pigmentosa) and Leigh syndrome (schwimmer2006yeastmodelsof pages 8-9, schwimmer2006yeastmodelsof pages 6-8, aiyar2014mitochondrialproteinsorting pages 1-2, magistrati2023drugdroptest pages 5-6).</p>
+<p>Aiyar et al. (2014) used the <em>fmc1Δ</em> model to screen drug repurposing libraries and identified mitochondrial protein sorting through the TIM23 complex as a therapeutic intervention point for ATP synthase disorders. Overexpression of Tim21, a regulatory subunit of the TIM23 complex, substantially restored respiratory growth in <em>fmc1Δ</em> mutants and improved survival in human NARP patient-derived cybrids (aiyar2014mitochondrialproteinsorting pages 5-6, aiyar2014mitochondrialproteinsorting pages 4-5). Magistrati et al. (2023) further employed the <em>fmc1Δ</em> strain in "drug drop test" high-throughput screening campaigns, testing approximately 12,000 compounds to identify molecules that rescue oxidative growth defects, including chlorhexidine and sodium pyrithione (magistrati2023drugdroptest pages 5-6, magistrati2023drugdroptest pages 2-3). These findings underscore the utility of FMC1 deletion models in translational research for mitochondrial diseases (schwimmer2006yeastmodelsof pages 8-9, magistrati2023drugdroptest pages 20-21).</p>
+<h3 id="8-summary">8. Summary</h3>
+<p>The <em>S. pombe</em> fmc1 gene (SPAC1486.11, UniProt G2TRM0) encodes a small, soluble mitochondrial matrix protein that functions as an assembly factor for the F1 sector of mitochondrial ATP synthase. Based on extensive characterization of the <em>S. cerevisiae</em> ortholog, Fmc1 is not an enzyme but rather a chaperone-like accessory factor that supports the function of the F1 α-subunit assembly chaperone Atp12p, particularly under conditions of heat stress. It is a member of the LYRM protein superfamily (Complex1_LYR_2 family), associates with the mitochondrial acyl-carrier protein ACPM, and is conserved specifically within the fungal lineage. Loss of FMC1 results in aggregation of F1 α and β subunits in the matrix, severely impairing ATP synthase biogenesis and oxidative phosphorylation. While no direct experimental studies on the <em>S. pombe</em> protein exist, cross-genome analyses confirm that <em>S. pombe</em> carries an FMC1 homolog with a conserved domain architecture, and the protein's function is highly likely to be conserved as an ATP synthase assembly factor in fission yeast mitochondria.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(pickova2005assemblyfactorsof pages 1-2): Andrea Pícková, Martin Potocký, and Josef Houštěk. Assembly factors of f1fo‐atp synthase across genomes. Proteins: Structure, 59:393-402, May 2005. URL: https://doi.org/10.1002/prot.20452, doi:10.1002/prot.20452. This article has 45 citations.</p>
+</li>
+<li>
+<p>(pickova2005assemblyfactorsof pages 5-7): Andrea Pícková, Martin Potocký, and Josef Houštěk. Assembly factors of f1fo‐atp synthase across genomes. Proteins: Structure, 59:393-402, May 2005. URL: https://doi.org/10.1002/prot.20452, doi:10.1002/prot.20452. This article has 45 citations.</p>
+</li>
+<li>
+<p>(pickova2005assemblyfactorsof pages 7-9): Andrea Pícková, Martin Potocký, and Josef Houštěk. Assembly factors of f1fo‐atp synthase across genomes. Proteins: Structure, 59:393-402, May 2005. URL: https://doi.org/10.1002/prot.20452, doi:10.1002/prot.20452. This article has 45 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 1-1): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 6-7): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 4-5): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(rak2009assemblyoff0 pages 2-3): Malgorzata Rak, Xiaomei Zeng, Jean-Jacques Brière, and Alexander Tzagoloff. Assembly of f0 in saccharomyces cerevisiae. Biochimica et biophysica acta, 1793 1:108-16, Jan 2009. URL: https://doi.org/10.1016/j.bbamcr.2008.07.001, doi:10.1016/j.bbamcr.2008.07.001. This article has 79 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 5-6): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(angerer2013thesuperfamilyof pages 1-2): Heike Angerer. The superfamily of mitochondrial complex1_lyr motif-containing (lyrm) proteins. Biochemical Society transactions, 41 5:1335-41, Oct 2013. URL: https://doi.org/10.1042/bst20130116, doi:10.1042/bst20130116. This article has 70 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(angerer2013thesuperfamilyof pages 4-5): Heike Angerer. The superfamily of mitochondrial complex1_lyr motif-containing (lyrm) proteins. Biochemical Society transactions, 41 5:1335-41, Oct 2013. URL: https://doi.org/10.1042/bst20130116, doi:10.1042/bst20130116. This article has 70 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(angerer2013thesuperfamilyof pages 5-6): Heike Angerer. The superfamily of mitochondrial complex1_lyr motif-containing (lyrm) proteins. Biochemical Society transactions, 41 5:1335-41, Oct 2013. URL: https://doi.org/10.1042/bst20130116, doi:10.1042/bst20130116. This article has 70 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 4-4): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 2-3): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(schwimmer2006yeastmodelsof pages 8-9): Christine Schwimmer, Malgorzata Rak, Linnka Lefebvre‐Legendre, Stéphane Duvezin‐Caubet, Guillaume Plane, and Jean‐Paul di Rago. Yeast models of human mitochondrial diseases: from molecular mechanisms to drug screening. Biotechnology Journal, 1:270-281, Mar 2006. URL: https://doi.org/10.1002/biot.200500053, doi:10.1002/biot.200500053. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(aiyar2014mitochondrialproteinsorting pages 1-2): Raeka S. Aiyar, Maria Bohnert, Stéphane Duvezin-Caubet, Cécile Voisset, Julien Gagneur, Emilie S. Fritsch, Elodie Couplan, Karina von der Malsburg, Charlotta Funaya, Flavie Soubigou, Florence Courtin, Sundari Suresh, Roza Kucharczyk, Justine Evrard, Claude Antony, Robert P. St.Onge, Marc Blondel, Jean-Paul di Rago, Martin van der Laan, and Lars M. Steinmetz. Mitochondrial protein sorting as a therapeutic target for atp synthase disorders. Nature Communications, Dec 2014. URL: https://doi.org/10.1038/ncomms6585, doi:10.1038/ncomms6585. This article has 42 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(aiyar2014mitochondrialproteinsorting pages 5-6): Raeka S. Aiyar, Maria Bohnert, Stéphane Duvezin-Caubet, Cécile Voisset, Julien Gagneur, Emilie S. Fritsch, Elodie Couplan, Karina von der Malsburg, Charlotta Funaya, Flavie Soubigou, Florence Courtin, Sundari Suresh, Roza Kucharczyk, Justine Evrard, Claude Antony, Robert P. St.Onge, Marc Blondel, Jean-Paul di Rago, Martin van der Laan, and Lars M. Steinmetz. Mitochondrial protein sorting as a therapeutic target for atp synthase disorders. Nature Communications, Dec 2014. URL: https://doi.org/10.1038/ncomms6585, doi:10.1038/ncomms6585. This article has 42 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(magistrati2023drugdroptest pages 5-6): Martina Magistrati, Alexandru Ionut Gilea, Maria Carla Gerra, Enrico Baruffini, and Cristina Dallabona. Drug drop test: how to quickly identify potential therapeutic compounds for mitochondrial diseases using yeast saccharomyces cerevisiae. International Journal of Molecular Sciences, 24:10696, Jun 2023. URL: https://doi.org/10.3390/ijms241310696, doi:10.3390/ijms241310696. This article has 8 citations.</p>
+</li>
+<li>
+<p>(magistrati2023drugdroptest pages 2-3): Martina Magistrati, Alexandru Ionut Gilea, Maria Carla Gerra, Enrico Baruffini, and Cristina Dallabona. Drug drop test: how to quickly identify potential therapeutic compounds for mitochondrial diseases using yeast saccharomyces cerevisiae. International Journal of Molecular Sciences, 24:10696, Jun 2023. URL: https://doi.org/10.3390/ijms241310696, doi:10.3390/ijms241310696. This article has 8 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 1-2): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 7-8): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 183 citations.</p>
+</li>
+<li>
+<p>(song2023themitochondrialhsp70 pages 6-7): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(angerer2013thesuperfamilyof pages 2-4): Heike Angerer. The superfamily of mitochondrial complex1_lyr motif-containing (lyrm) proteins. Biochemical Society transactions, 41 5:1335-41, Oct 2013. URL: https://doi.org/10.1042/bst20130116, doi:10.1042/bst20130116. This article has 70 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schwimmer2006yeastmodelsof pages 6-8): Christine Schwimmer, Malgorzata Rak, Linnka Lefebvre‐Legendre, Stéphane Duvezin‐Caubet, Guillaume Plane, and Jean‐Paul di Rago. Yeast models of human mitochondrial diseases: from molecular mechanisms to drug screening. Biotechnology Journal, 1:270-281, Mar 2006. URL: https://doi.org/10.1002/biot.200500053, doi:10.1002/biot.200500053. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(aiyar2014mitochondrialproteinsorting pages 4-5): Raeka S. Aiyar, Maria Bohnert, Stéphane Duvezin-Caubet, Cécile Voisset, Julien Gagneur, Emilie S. Fritsch, Elodie Couplan, Karina von der Malsburg, Charlotta Funaya, Flavie Soubigou, Florence Courtin, Sundari Suresh, Roza Kucharczyk, Justine Evrard, Claude Antony, Robert P. St.Onge, Marc Blondel, Jean-Paul di Rago, Martin van der Laan, and Lars M. Steinmetz. Mitochondrial protein sorting as a therapeutic target for atp synthase disorders. Nature Communications, Dec 2014. URL: https://doi.org/10.1038/ncomms6585, doi:10.1038/ncomms6585. This article has 42 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(magistrati2023drugdroptest pages 20-21): Martina Magistrati, Alexandru Ionut Gilea, Maria Carla Gerra, Enrico Baruffini, and Cristina Dallabona. Drug drop test: how to quickly identify potential therapeutic compounds for mitochondrial diseases using yeast saccharomyces cerevisiae. International Journal of Molecular Sciences, 24:10696, Jun 2023. URL: https://doi.org/10.3390/ijms241310696, doi:10.3390/ijms241310696. This article has 8 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="fmc1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pickova2005assemblyfactorsof pages 5-7</li>
+<li>lefebvrelegendre2001identificationofa pages 4-4</li>
+<li>lefebvrelegendre2001identificationofa pages 4-5</li>
+<li>angerer2013thesuperfamilyof pages 1-2</li>
+<li>angerer2013thesuperfamilyof pages 2-4</li>
+<li>pickova2005assemblyfactorsof pages 7-9</li>
+<li>aiyar2014mitochondrialproteinsorting pages 1-2</li>
+<li>pickova2005assemblyfactorsof pages 1-2</li>
+<li>lefebvrelegendre2001identificationofa pages 1-1</li>
+<li>lefebvrelegendre2001identificationofa pages 6-7</li>
+<li>lefebvrelegendre2001identificationofa pages 5-6</li>
+<li>angerer2013thesuperfamilyof pages 4-5</li>
+<li>angerer2013thesuperfamilyof pages 5-6</li>
+<li>lefebvrelegendre2001identificationofa pages 2-3</li>
+<li>schwimmer2006yeastmodelsof pages 8-9</li>
+<li>aiyar2014mitochondrialproteinsorting pages 5-6</li>
+<li>magistrati2023drugdroptest pages 5-6</li>
+<li>magistrati2023drugdroptest pages 2-3</li>
+<li>lefebvrelegendre2001identificationofa pages 1-2</li>
+<li>lefebvrelegendre2001identificationofa pages 7-8</li>
+<li>schwimmer2006yeastmodelsof pages 6-8</li>
+<li>aiyar2014mitochondrialproteinsorting pages 4-5</li>
+<li>magistrati2023drugdroptest pages 20-21</li>
+<li>https://doi.org/10.1002/prot.20452,</li>
+<li>https://doi.org/10.1074/jbc.m009557200,</li>
+<li>https://doi.org/10.1016/j.bbamcr.2008.07.001,</li>
+<li>https://doi.org/10.1042/bst20130116,</li>
+<li>https://doi.org/10.1002/biot.200500053,</li>
+<li>https://doi.org/10.1038/ncomms6585,</li>
+<li>https://doi.org/10.3390/ijms241310696,</li>
+<li>https://doi.org/10.1038/s41467-022-35720-5,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(fmc1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G2TRM0" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fmc1-spac148611-s-pombe-review-notes">fmc1 (SPAC1486.11) — S. pombe — review notes</h1>
+<p>Journal for the AI GO-annotation review of the <em>S. pombe</em> gene <strong>fmc1</strong><br />
+(systematic name SPAC1486.11; synonym <em>new3</em>; UniProt <strong>G2TRM0</strong>, FMC1_SCHPO).<br />
+"Formation of Mitochondrial Complexes protein 1" — a putative mitochondrial<br />
+F1-ATP-synthase assembly factor. This is an understudied ("dark") gene: UniProt<br />
+lists it as <em>Evidence at transcript level</em> (PE 2), and there is <strong>no direct<br />
+experimental characterization of the fission-yeast protein</strong>. All GO annotations<br />
+are electronic/phylogenetic (IBA, IEA) or ND.</p>
+<h2 id="identity-confirmation-from-fmc1-uniprottxt">Identity confirmation (from fmc1-uniprot.txt)</h2>
+<ul>
+<li><code>ID   FMC1_SCHPO ... 104 AA</code>; <code>AC   G2TRM0</code>.</li>
+<li><code>DE   RecName: Full=ATP synthase assembly factor fmc1, mitochondrial;</code><br />
+<code>AltName: Full=Formation of mitochondrial complexes protein 1;</code><br />
+<code>Flags: Precursor;</code></li>
+<li><code>GN   Name=fmc1; Synonyms=new3; ORFNames=SPAC1486.11;</code></li>
+<li><code>OX   NCBI_TaxID=284812</code> (S. pombe 972 / ATCC 24843).</li>
+<li>Function (by similarity, ECO:0000250): "Needed for the assembly of the<br />
+  mitochondrial F1-F0 complex at high temperature."</li>
+<li>Subcellular location (by similarity): Mitochondrion.</li>
+<li>SIMILARITY: "Belongs to the FMC1 family." (ECO:0000305)</li>
+<li>Features: <code>TRANSIT 1..?  /note="Mitochondrion" /evidence=ECO:0000255</code>;<br />
+<code>CHAIN ?..104</code>. So it carries a predicted N-terminal mitochondrial transit<br />
+  peptide (mito targeting is sequence-predicted, not experimentally mapped).</li>
+<li>Domain/family cross-refs: InterPro <strong>IPR039196 (Fmc1)</strong>; PANTHER <strong>PTHR28015</strong><br />
+  ("ATP SYNTHASE ASSEMBLY FACTOR FMC1, MITOCHONDRIAL"); Pfam <strong>PF13233<br />
+  (Complex1_LYR_2)</strong> — i.e. it belongs to the LYR-motif protein (LYRM)<br />
+  superfamily. PomBase SPAC1486.11 → fmc1.</li>
+<li><code>PE   2: Evidence at transcript level</code> — no protein-level experimental<br />
+  evidence recorded in UniProt for the pombe protein.</li>
+</ul>
+<p>Domain reasoning (inline): 104-aa, small, matrix-soluble-type protein with a<br />
+single Complex1_LYR_2 (LYR-motif) module and a predicted mito transit peptide.<br />
+The LYRM family members typically act as small accessory/assembly factors of<br />
+OXPHOS complexes rather than as enzymes; they have no catalytic domain. This is<br />
+fully consistent with an accessory assembly-factor / chaperone-like role and<br />
+argues <em>against</em> any catalytic (enzyme) molecular function.</p>
+<h2 id="existing-go-annotations-from-fmc1-goatsv">Existing GO annotations (from fmc1-goa.tsv)</h2>
+<ol>
+<li>GO:0005759 mitochondrial matrix — IBA (is_active_in) — GO_REF:0000033<br />
+   (PANTHER PTN001997425 | SGD:S000001360).</li>
+<li>GO:0033615 mitochondrial proton-transporting ATP synthase complex assembly —<br />
+   IBA (involved_in) — GO_REF:0000033 (same PANTHER/SGD source).</li>
+<li>GO:0005739 mitochondrion — IEA (located_in) — GO_REF:0000044<br />
+   (UniProtKB-SubCell SL-0173).</li>
+<li>GO:0033615 (again) — IEA (involved_in) — GO_REF:0000002 (InterPro:IPR039196).</li>
+<li>GO:0003674 molecular_function (root) — ND — GO_REF:0000015 (PomBase). This is<br />
+   the "no biological data available" root-term placeholder: MF is genuinely<br />
+   dark for this protein.</li>
+</ol>
+<p>The IBA source is SGD:S000001360 = <em>S. cerevisiae</em> FMC1 (the founding, and only<br />
+directly-characterized, family member). So the pombe annotations propagate<br />
+budding-yeast biology through the PANTHER tree (PTN001997425).</p>
+<h2 id="family-biology-established-in-s-cerevisiae-not-in-pombe">Family biology — established in S. cerevisiae (NOT in pombe)</h2>
+<p>Founding paper, <strong>PMID:11096112</strong> (Lefebvre-Legendre et al. 2001, J Biol Chem<br />
+276:6789-6796) — <em>S. cerevisiae</em> FMC1. Cached abstract (publications/PMID_11096112.md);<br />
+full_text_available: false (abstract-only). Verbatim quotes available:<br />
+- "We have identified a yeast nuclear gene (FMC1) that is required at elevated<br />
+  temperatures (37 degrees C) for the formation/stability of the F(1) sector of<br />
+  the mitochondrial ATP synthase."<br />
+- "Fmc1p is a soluble protein located in the mitochondrial matrix."<br />
+- "instead of being incorporated into a functional F(1) oligomer, they form<br />
+  large aggregates in the mitochondrial matrix." (of alpha/beta-F1 subunits)<br />
+- "the absence of Fmc1p can be efficiently compensated for by increasing the<br />
+  expression of Atp12p."<br />
+- "unlike Atp12p and Atp11p, Fmc1p is not required in normal growth conditions<br />
+  (28--30 degrees C)."<br />
+- "We propose that Fmc1p is required for the proper folding/stability or<br />
+  functioning of Atp12p in heat stress conditions."</p>
+<p>So the mechanistic model (in budding yeast): Fmc1p is a matrix accessory factor<br />
+that stabilizes/assists the dedicated F1 assembly chaperone <strong>Atp12p</strong> (human<br />
+ATPAF2), which in turn chaperones folding/assembly of the F1 α3β3 head of ATP<br />
+synthase (Complex V). Fmc1p is conditionally required (heat stress) and<br />
+dispensable at normal temperature.</p>
+<p>Human ortholog: <strong>FMC1 / C7orf55</strong> (OMIM 620766, "Formation Of Mitochondrial<br />
+Complex V Assembly Factor 1 Homolog"); member of the LYR-motif protein<br />
+superfamily; linked to Complex V (ATP synthase) assembly and interacting with<br />
+the ATP12/ATPAF2 axis (WebSearch, GeneCards/OMIM; PMC4381221 on LYR proteins<br />
+interacting with mitochondrial complexes). This corroborates conservation of the<br />
+assembly-factor role across fungi and humans.</p>
+<h2 id="known-vs-not-known-for-s-pombe-fmc1-specifically">KNOWN vs NOT-KNOWN for S. pombe fmc1 specifically</h2>
+<p>KNOWN (defensible by orthology + domain, not by pombe experiments):<br />
+- It is a member of the FMC1 family (UniProt SIMILARITY; InterPro IPR039196;<br />
+  PANTHER PTHR28015). High-confidence family assignment.<br />
+- By orthology it is expected to localize to the mitochondrion / matrix<br />
+  (predicted transit peptide + IBA to matrix from the S. cerevisiae ortholog).<br />
+- By orthology it is expected to participate in mitochondrial F1Fo ATP synthase<br />
+  (Complex V) assembly, most plausibly as a chaperone-like accessory factor<br />
+  acting via the Atp12/ATPAF2 F1-assembly chaperone.</p>
+<p>NOT KNOWN (genuine gaps for the pombe protein):<br />
+- No experimental data on the pombe protein at all (PE 2, transcript-level). No<br />
+  IDA/IMP/IPI/IGI annotations exist.<br />
+- Its specific molecular activity is undefined (MF is ND). Whether it acts as a<br />
+  protein-folding chaperone, as an adaptor that stabilizes a partner chaperone<br />
+  (Atp12/ATPAF2 ortholog), or in some other capacity has not been shown in pombe.<br />
+- Whether the fission-yeast protein is, like budding yeast, only <em>conditionally</em><br />
+  (heat-stress) required, or has a broader role, is unknown.<br />
+- No pombe interaction partner has been demonstrated (does an Atp12/ATPAF2<br />
+  ortholog exist in pombe and does fmc1 act on it?). BioGRID lists 1 interaction<br />
+  (unverified here).<br />
+- No loss-of-function phenotype (respiratory competence, growth on non-fermentable<br />
+  carbon source, temperature sensitivity of ATP synthase assembly) has been<br />
+  reported for pombe fmc1.</p>
+<h2 id="planned-review-actions">Planned review actions</h2>
+<ul>
+<li>GO:0005759 mitochondrial matrix (IBA): KEEP_AS_NON_CORE / accept-ish. Matrix<br />
+  localization is orthology-supported (S. cerevisiae Fmc1p is a soluble matrix<br />
+  protein) and is the actual site of F1 assembly. Reasonable IBA; keep.</li>
+<li>GO:0033615 ATP synthase complex assembly (IBA): ACCEPT as the core process.<br />
+  Best-supported functional statement, matches family and the founding paper.</li>
+<li>GO:0005739 mitochondrion (IEA, SubCell): KEEP_AS_NON_CORE — correct but less<br />
+  specific than the matrix (IBA) term; general parent.</li>
+<li>GO:0033615 (IEA, InterPro): ACCEPT — redundant with the IBA but independently<br />
+  domain-supported (IPR039196). Consistent.</li>
+<li>GO:0003674 molecular_function root (ND): KEEP_AS_NON_CORE — honest placeholder;<br />
+  MF genuinely dark. Do not remove (ND root reflects the real state).</li>
+</ul>
+<p>core_functions MF: use GO:0044183 "protein folding chaperone"<br />
+(def: "Binding to a protein or a protein-containing complex to assist the protein<br />
+folding process") — NON-ATP-dependent (Fmc1 has no ATPase; so NOT GO:0140662).<br />
+This is the most defensible MF given the founding-paper mechanism (assists<br />
+folding/stability of the F1 assembly machinery), framed as inferred by orthology.<br />
+BP: GO:0033615. Location: GO:0005759.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G2TRM0
+gene_symbol: fmc1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  fmc1 (Formation of Mitochondrial Complexes protein 1; systematic name
+  SPAC1486.11) is a small (104-residue) mitochondrial protein of fission yeast
+  belonging to the FMC1 family (InterPro IPR039196; PANTHER PTHR28015), a group
+  within the LYR-motif protein (LYRM / Complex1_LYR_2, Pfam PF13233) superfamily
+  of mitochondrial accessory and assembly factors. It carries a predicted
+  N-terminal mitochondrial targeting sequence and is imported into the
+  mitochondrion. By orthology to the well-characterized Saccharomyces cerevisiae
+  Fmc1p, it is inferred to be a soluble matrix protein that acts as an accessory
+  assembly factor for the F1 sector (the catalytic alpha3beta3 head) of the
+  mitochondrial F1Fo-ATP synthase (Complex V), most plausibly by assisting the
+  folding, stability or function of the dedicated F1 assembly chaperone Atp12
+  (human ATPAF2). In budding yeast this requirement is conditional, becoming
+  critical at elevated temperature, where loss of Fmc1p causes the newly imported
+  alpha-F1 and beta-F1 subunits to aggregate in the matrix instead of assembling
+  into functional F1. The fission-yeast protein itself has not been functionally
+  characterized; its specific molecular activity, partners and loss-of-function
+  phenotype remain undetermined.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:11096112
+  title: Identification of a nuclear gene (FMC1) required for the assembly/stability
+    of yeast mitochondrial F(1)-ATPase in heat stress conditions.
+  findings:
+  - statement: &gt;-
+      The founding, and only directly characterized, family member — S. cerevisiae
+      Fmc1p — is a soluble mitochondrial matrix protein required at elevated
+      temperature for formation/stability of the F1 sector of ATP synthase; in its
+      absence the alpha-F1 and beta-F1 subunits aggregate in the matrix rather than
+      assembling into F1.
+    supporting_text: &gt;-
+      We have identified a yeast nuclear gene (FMC1) that is required at elevated
+      temperatures (37 degrees C) for the formation/stability of the F(1) sector of
+      the mitochondrial ATP synthase.
+  - statement: &gt;-
+      Fmc1p acts genetically upstream of, or together with, the F1 assembly
+      chaperone Atp12p: overexpression of Atp12p rescues loss of Fmc1p, leading to
+      the model that Fmc1p is needed for proper folding/stability or function of
+      Atp12p.
+    supporting_text: &gt;-
+      We propose that Fmc1p is required for the proper folding/stability or
+      functioning of Atp12p in heat stress conditions.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (PMID:11096112, J Biol Chem 2001; DOI 10.1074/jbc.M009557200).
+      Establishes the FMC1 family function in S. cerevisiae, from which the S. pombe
+      fmc1 annotations are propagated (the IBA source is SGD:S000001360). Abstract
+      only in cache; used strictly for family-level (orthology) support, not as
+      direct evidence about the pombe protein.
+existing_annotations:
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Matrix localization is well supported at the family level: the characterized
+      S. cerevisiae ortholog is a soluble matrix protein, and the matrix is the
+      compartment where the F1 alpha3beta3 head is assembled. fmc1 carries a
+      predicted mitochondrial transit peptide. Kept as a correct, informative
+      localization, but treated as non-core because it has not been shown
+      experimentally for the pombe protein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      IBA propagated from SGD:S000001360; consistent with the founding paper showing
+      Fmc1p is a soluble matrix protein, and with the predicted N-terminal transit
+      peptide. Correct and specific, but the localization of the pombe protein is
+      inferred, not experimentally demonstrated.
+    supported_by:
+    - reference_id: PMID:11096112
+      supporting_text: &gt;-
+        Fmc1p is a soluble protein located in the mitochondrial matrix.
+- term:
+    id: GO:0033615
+    label: mitochondrial proton-transporting ATP synthase complex assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This is the best-supported functional statement for fmc1 and represents its
+      core biological role: participation in assembly of the mitochondrial
+      proton-transporting ATP synthase (Complex V). The term is directly supported
+      by the family-defining function established for the S. cerevisiae ortholog and
+      by the InterPro/PANTHER family assignment. Retained as core.
+    action: ACCEPT
+    reason: &gt;-
+      Family-defining biological process, propagated by phylogeny (IBA from
+      SGD:S000001360) and independently supported by the InterPro Fmc1 signature.
+      Matches the founding paper, in which Fmc1p is required for assembly/stability
+      of the F1 sector of ATP synthase.
+    supported_by:
+    - reference_id: PMID:11096112
+      supporting_text: &gt;-
+        We have identified a yeast nuclear gene (FMC1) that is required at elevated
+        temperatures (37 degrees C) for the formation/stability of the F(1) sector of
+        the mitochondrial ATP synthase.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Correct but general parent term derived from the UniProt Subcellular Location
+      mapping (SL-0173, Mitochondrion). It is subsumed by the more specific
+      mitochondrial matrix annotation, so it is kept as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate compartment assignment consistent with the predicted transit peptide,
+      but less informative than GO:0005759 (mitochondrial matrix); redundant parent.
+- term:
+    id: GO:0033615
+    label: mitochondrial proton-transporting ATP synthase complex assembly
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO annotation from the Fmc1 signature (IPR039196), giving the same
+      ATP-synthase-assembly process as the IBA annotation. It corroborates the core
+      biological process from an independent (domain-based) line of evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Domain-based support (InterPro IPR039196 -&gt; GO:0033615) that is concordant with
+      the phylogenetic (IBA) annotation and with the family function; a well-founded
+      electronic annotation to the core process.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function annotation with the ND (No biological Data) evidence
+      code, correctly flagging that no specific molecular activity has been
+      determined for fmc1. This honestly reflects the state of knowledge: the
+      molecular function is genuinely dark. See knowledge_gaps and core_functions
+      for the orthology-based inference of a chaperone-like assembly-factor activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Legitimate ND placeholder; the specific molecular function of fmc1 is
+      undetermined. It should not be removed, as it accurately records that the MF
+      aspect is uncurated/unknown rather than annotated to a specific activity.
+- term:
+    id: GO:0044183
+    label: protein folding chaperone
+  evidence_type: ISS
+  original_reference_id: PMID:11096112
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed molecular function inferred by orthology (not present in the current
+      GOA). The characterized S. cerevisiae ortholog assists the folding/stability or
+      function of the F1 assembly chaperone Atp12p, a non-catalytic chaperone-like
+      activity that fits the FMC1/LYR-motif family (no catalytic domain). Offered as
+      the most defensible specific MF to replace the ND placeholder, pending
+      experimental confirmation in fission yeast.
+    action: NEW
+    reason: &gt;-
+      fmc1 has no annotated specific molecular function (MF is ND). A protein-folding
+      chaperone activity is the best-supported inference from the family-defining
+      function of the S. cerevisiae ortholog and from the domain architecture; not
+      ATP-dependent (no ATPase), so GO:0044183 rather than GO:0140662. Marked ISS and
+      non-verified for the pombe protein. Note this is a second-order inference: the
+      founding data show Fmc1p acts on the F1 assembly chaperone Atp12p, so a competing
+      hypothesis is that fmc1 is not itself the folding chaperone but an adaptor/stabilizer
+      of a partner chaperone (e.g. GO:0051087 protein-folding chaperone binding); the two
+      cannot be distinguished without direct assays (see knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:11096112
+      supporting_text: &gt;-
+        We propose that Fmc1p is required for the proper folding/stability or
+        functioning of Atp12p in heat stress conditions.
+core_functions:
+- description: &gt;-
+    Mitochondrial accessory assembly factor for the F1Fo-ATP synthase (Complex V).
+    By orthology to S. cerevisiae Fmc1p and consistent with its LYR-motif/FMC1-family
+    domain architecture, fmc1 is inferred to act as a chaperone-like factor in the
+    mitochondrial matrix that assists assembly of the catalytic F1 (alpha3beta3) head
+    of ATP synthase, most plausibly by supporting the folding, stability or function
+    of the dedicated F1 assembly chaperone Atp12 (human ATPAF2). It has no catalytic
+    domain, consistent with a non-enzymatic, non-ATP-dependent chaperone role. This
+    core function is inferred, not yet demonstrated in fission yeast.
+  molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0033615
+    label: mitochondrial proton-transporting ATP synthase complex assembly
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:11096112
+    supporting_text: &gt;-
+      We propose that Fmc1p is required for the proper folding/stability or
+      functioning of Atp12p in heat stress conditions.
+  - reference_id: PMID:11096112
+    supporting_text: &gt;-
+      We have identified a yeast nuclear gene (FMC1) that is required at elevated
+      temperatures (37 degrees C) for the formation/stability of the F(1) sector of
+      the mitochondrial ATP synthase.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The specific molecular activity of the fission-yeast fmc1 protein is
+    undetermined. Whether it acts as a protein-folding chaperone in its own right,
+    as an adaptor that stabilizes a partner chaperone (an Atp12/ATPAF2 ortholog), or
+    in some other capacity has not been shown; the GO molecular_function is ND.
+  boundary: &gt;-
+    The protein is confidently placed in the FMC1 family (InterPro IPR039196,
+    PANTHER PTHR28015) and carries a single LYR-motif (Complex1_LYR_2) module and a
+    predicted mitochondrial transit peptide, implying a non-catalytic accessory role
+    in ATP synthase assembly. The founding S. cerevisiae study established that the
+    ortholog assists folding/stability or function of the F1 assembly chaperone
+    Atp12p.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Pinning down the molecular activity would convert an orthology-based inference
+    into an experimentally grounded function and clarify how the LYR-motif fold of
+    FMC1-family proteins contributes to Complex V biogenesis.
+  resolution: &gt;-
+    Biochemical characterization of the pombe protein (e.g. interaction/complex
+    assays with the pombe Atp12/ATPAF2 ortholog and F1 subunits; in-organello F1
+    assembly assays in an fmc1-null background).
+  provenance:
+  - reference_id: PMID:11096112
+    supporting_text: &gt;-
+      We propose that Fmc1p is required for the proper folding/stability or
+      functioning of Atp12p in heat stress conditions.
+- gap_statement: &gt;-
+    It is not known whether the F1-ATP-synthase-assembly role attributed to fmc1 is
+    demonstrated in S. pombe or is purely inferred by orthology. All fission-yeast
+    GO annotations are electronic or phylogenetic (IBA/IEA); none are experimental.
+  boundary: &gt;-
+    In S. cerevisiae the assembly role is experimentally established, including the
+    aggregation of alpha/beta-F1 subunits on loss of Fmc1p and rescue by Atp12p
+    overexpression. UniProt records the pombe protein only at transcript level
+    (Evidence at transcript level, PE 2).
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing demonstrated from inferred function prevents over-reading the
+    IBA/IEA annotations as direct evidence and identifies the pombe protein as a
+    target for experimental validation.
+  provenance:
+  - reference_id: PMID:11096112
+    supporting_text: &gt;-
+      Identification of a nuclear gene (FMC1) required for the assembly/stability of
+  - reference_id: file:SCHPO/fmc1/fmc1-deep-research-falcon.md
+    supporting_text: &gt;-
+      No direct experimental studies on *fmc1* in *S. pombe* were identified during this review
+- gap_statement: &gt;-
+    No loss-of-function phenotype has been reported for S. pombe fmc1, and it is
+    unknown whether (as in budding yeast) its requirement is conditional
+    (heat-stress specific) or broader, and whether a functional Atp12/ATPAF2 partner
+    exists and is engaged in fission yeast.
+  boundary: &gt;-
+    In S. cerevisiae, Fmc1p is dispensable at normal growth temperature (28-30 C)
+    but required at 37 C, and its loss is compensated by Atp12p overexpression;
+    no equivalent conditional-phenotype or partner data exist for the pombe gene.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    A conditional (stress-dependent) versus constitutive requirement changes how the
+    gene should be annotated for biological process and regulation, and whether an
+    ATP-synthase-assembly defect is the primary phenotype.
+  provenance:
+  - reference_id: PMID:11096112
+    supporting_text: &gt;-
+      unlike Atp12p and Atp11p, Fmc1p is not required in normal growth conditions
+      (28--30 degrees C).
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does S. pombe fmc1 physically interact with a fission-yeast Atp12/ATPAF2
+    ortholog and with the F1 alpha/beta subunits, and is its requirement for ATP
+    synthase assembly conditional (e.g. heat-stress specific) as in budding yeast?
+suggested_experiments:
+- hypothesis: &gt;-
+    fmc1 is required for assembly of the F1 sector of mitochondrial ATP synthase in
+    S. pombe, acting through the Atp12/ATPAF2 assembly chaperone.
+  description: &gt;-
+    Construct an fmc1-null strain and assess respiratory competence and growth on a
+    non-fermentable carbon source at normal and elevated temperature; quantify
+    assembled F1Fo-ATP synthase (blue-native PAGE / activity assays) and test for
+    accumulation/aggregation of unassembled alpha-F1 and beta-F1 subunits in the
+    matrix. Complement with tagged-protein pulldowns to identify the pombe Atp12
+    ortholog and F1 subunits as interaction partners.
+  experiment_type: genetics and biochemistry
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/ftm3/ftm3-ai-review.html
+++ b/genes/SCHPO/ftm3/ftm3-ai-review.html
@@ -1,0 +1,2340 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ftm3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ftm3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P0CU06" target="_blank" class="term-link">
+                        P0CU06
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ftm3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P0CU06" data-a="DESCRIPTION: ftm3 (SPAC750.04c) is a small (146-residue, ~17 kD..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ftm3 (SPAC750.04c) is a small (146-residue, ~17 kDa) membrane protein of the Schizosaccharomyces pombe Ftm (&#34;sub-telomeric 5Tm&#34;) protein family, a lineage-specific family encoded in the sub-telomeric regions of the fission-yeast genome (paralogs ftm1, ftm2, ftm4, ftm5, ftm6 and ftm7). It belongs to the UPF0742 family and carries the Pombe_5TM domain (Pfam PF09437, InterPro IPR018291, &#34;Pombe specific 5TM protein&#34;), a domain of unknown function essentially restricted to Schizosaccharomyces. The protein is predicted to be membrane-integral (at least one transmembrane helix) and, by similarity to its experimentally localized paralog ftm2, is assigned to the cytoplasm and the nuclear/nuclear-envelope membrane, where the family shows cytoplasmic puncta and nuclear-rim staining. No molecular activity, substrate, ligand or interaction partner has been established for ftm3 or any Ftm-family member; its biological role is undetermined, and it is classified as a conserved protein of unknown function.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CU06" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation mapping the UniProtKB/Swiss-Prot subcellular-location &#34;Cytoplasm&#34; to GO via GO_REF:0000044. It restates the same location that is assigned to ftm3 by ISS from its paralog ftm2. Localization is a defensible, conservative call for this otherwise uncharacterized protein, but it is not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the UniProt SubCell location and with the ISS cytoplasm annotation below; redundant electronic restatement, retained as supporting localization evidence rather than a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P0CU06
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
+                                    GO:0031965
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CU06" data-a="GO:0031965" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation mapping the UniProtKB/Swiss-Prot subcellular-location &#34;Nucleus membrane&#34; to GO via GO_REF:0000044. It restates the nuclear-envelope localization assigned to ftm3 by ISS from paralog ftm2 (cytoplasmic dots and the nuclear envelope). Not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the UniProt SubCell &#34;Nucleus membrane&#34; location and with the ISS nuclear-membrane annotation below; redundant electronic restatement retained as supporting localization evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P0CU06
+
+                                </span>
+
+                                <div class="support-text">C:nuclear membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CU06" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with the ND (No biological Data available) evidence code, assigned by PomBase. The molecular function of ftm3 is genuinely unknown: the protein belongs to the UPF0742 / Pombe_5TM family, a Schizosaccharomyces-specific domain of unknown function with no established catalytic, transport, or binding activity, and no functional literature exists for ftm3 or any Ftm paralog.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND placeholder is the correct, honest representation for a conserved protein of unknown molecular function. No specific MF term is warranted from current evidence, and &#39;protein binding&#39; would be uninformative and unsupported.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P0CU06" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with the ND evidence code, assigned by PomBase. No biological process is experimentally attributed to ftm3. A high-throughput expression change under glucose availability exists at PomBase (GO:0042149, RNA-level), but it is a transcript-abundance observation, is not part of the GOA set reviewed here, and does not establish a functional role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND correctly records that the biological process of ftm3 is unknown; no process term is supported by current evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CU06" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization transferred to ftm3 by curator sequence-similarity judgment (GO_REF:0000024) with:UniProtKB:P0CU07, i.e. from the paralog ftm2 (SPAC977.02), whose cytoplasm/nuclear-membrane localization was determined experimentally in the genome-wide YFP ORFeome study (PMID:16823372). A reasonable localization inference for a close paralog, but localization is not a core function and is by-similarity for ftm3 itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Grounded in experimental localization of a close paralog via a reliable genome-wide study; defensible as supporting localization evidence but not a core molecular/biological function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P0CU06
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
+                                    GO:0031965
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P0CU06" data-a="GO:0031965" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear-membrane localization transferred to ftm3 by curator sequence-similarity judgment (GO_REF:0000024) with:UniProtKB:P0CU07 (paralog ftm2), whose nuclear-envelope localization was experimentally determined (PMID:16823372). The UniProt note records localization to cytoplasmic dots and the nuclear envelope. Localization inference, not a core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the paralog&#39;s experimental nuclear-envelope localization; retained as supporting localization evidence rather than a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P0CU06
+
+                                </span>
+
+                                <div class="support-text">C:nuclear membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>No core molecular or biological function can be assigned to ftm3 from current evidence. The only positive functional information is subcellular localization: ftm3 is a membrane-associated protein of the Ftm / UPF0742 / Pombe_5TM family localized (by similarity to its experimentally characterized paralog ftm2) to the cytoplasm and the nuclear-envelope membrane. This is a non-core localization statement, not an activity; the family&#39;s molecular function is undetermined.</h3>
+                <span class="vote-buttons" data-g="P0CU06" data-a="FUNCTION: No core molecular or biological function can be as..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
+                                nuclear membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P0CU06
+
+                        </span>
+
+                        <div class="finding-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P0CU06
+
+                        </span>
+
+                        <div class="finding-text">C:nuclear membrane</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:P0CU06
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UPF0742 protein SPAC750.04c (ftm3) - Schizosaccharomyces pombe</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                            PMID:16823372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34460892" target="_blank" class="term-link">
+                            PMID:34460892
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transcriptome sequencing and screening of genes related to glucose availability in Schizosaccharomyces pombe by RNA-seq analysis</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the Ftm / UPF0742 / Pombe_5TM family have a coherent shared molecular function, or are these rapidly-evolving sub-telomeric genes of low or conditional function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0CU06" data-a="Q: Does the Ftm / UPF0742 / Pombe_5TM family have a c..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is ftm3 functionally redundant with its paralogs, such that a phenotype only emerges in combinatorial ftm-family deletions?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0CU06" data-a="Q: Is ftm3 functionally redundant with its paralogs, ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct single and combinatorial ftm-family deletion strains (ftm1-ftm7) and screen for growth, morphology, and stress/metabolic phenotypes (including glucose limitation) to detect redundant or conditional functions.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P0CU06" data-a="EXPERIMENT: Construct single and combinatorial ftm-family dele..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine ftm3&#39;s direct subcellular localization (endogenous fluorescent tagging) and experimental membrane topology, and identify physical interaction partners (affinity purification-MS) to generate function hypotheses.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P0CU06" data-a="EXPERIMENT: Determine ftm3&#39;s direct subcellular localization (..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of ftm3 is completely unknown. No catalytic activity, transporter/channel activity, ligand, substrate, or biochemical activity has been demonstrated or is predictable for the protein.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established is family and domain membership only: ftm3 belongs to the UPF0742 family and carries the Pombe_5TM domain (Pfam PF09437 / InterPro IPR018291, &#34;Pombe specific 5TM protein&#34;). This is a domain of unknown function with no functional annotation, essentially restricted to Schizosaccharomyces, so no cross-species orthology provides a functional hypothesis. PomBase records the molecular function as ND (&#34;No biological Data&#34;).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> ftm3 is one of a lineage-specific, sub-telomeric family (ftm1-ftm7) of fission-yeast proteins with no assigned activity; establishing even the biochemical class (e.g. transporter, receptor, structural membrane protein) would open the whole family.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of purified/tagged ftm3 (or a family member), structure determination or confident structure-based fold/activity assignment, and assays guided by its membrane topology (e.g. transport/channel assays) to test candidate activities.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Belongs to the UPF0742 family."</em> — UniProt:P0CU06</li>
+
+                <li><em>"Pfam; PF09437; Pombe_5TM; 2."</em> — UniProt:P0CU06</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process and cellular role of ftm3 are unknown. It is undetermined which pathway or process the protein participates in, and no loss-of-function phenotype has been reported for an ftm3 deletion.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ftm3 is expressed during vegetative growth and its transcript level changes with glucose availability (PomBase high-throughput expression annotation, GO:0042149, derived from RNA-seq), and the closely related paralog ftm2 is dispensable (ftm2delta viable with normal morphology). These are correlative/genetic observations only; PomBase records the biological process for ftm3 as ND.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determining the process (e.g. a membrane/nuclear-envelope function, a stress or metabolic response, or a redundant/conditionally-required role) would move the Ftm family out of the conserved-unknown set.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotypic profiling of single and combinatorial ftm-family deletions across stress and metabolic conditions (including glucose limitation), genetic-interaction mapping, and identification of physical interaction partners.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Belongs to the UPF0742 family."</em> — UniProt:P0CU06</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> ftm3&#39;s own subcellular localization and membrane topology have not been measured directly. Its cytoplasm/nuclear-membrane assignment is inferred entirely by similarity from the paralog ftm2, and although the family is named &#34;5TM&#34;, the UniProt feature table annotates only a single predicted transmembrane helix, so the true topology is unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The paralog ftm2 (P0CU07/SPAC977.02) was experimentally localized to the cytoplasm and nuclear membrane (cytoplasmic dots and the nuclear envelope) in a genome-wide YFP study (PMID:16823372), and ftm3&#39;s GO localization is transferred from it by ISS (with:UniProtKB:P0CU07). No direct ftm3 localization or topology experiment is on record.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Confirming ftm3&#39;s localization and topology directly (rather than by paralog transfer) would validate the propagated annotations and constrain candidate functions (e.g. nuclear-envelope vs general-membrane roles).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Fluorescent tagging and imaging of ftm3 in S. pombe, and experimental membrane-topology mapping to resolve the transmembrane-helix count implied by the &#34;5TM&#34; family name.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"SUBCELLULAR LOCATION: Cytoplasm"</em> — UniProt:P0CU06</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ftm3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0CU06" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ftm3-spac75004c-curation-notes">ftm3 (SPAC750.04c) — curation notes</h1>
+<p>UniProt: <strong>P0CU06</strong> (secondary AC Q9P332), entry name <code>YLZ4_SCHPO</code>.<br />
+PomBase: <strong>SPAC750.04c</strong>, standard name <strong>ftm3</strong>.<br />
+Taxon: <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843), NCBITaxon:284812.</p>
+<h2 id="summary-of-identity-known">Summary of identity (KNOWN)</h2>
+<ul>
+<li><strong>146 aa</strong>, MW ~17.2 kDa. RecName in UniProt: "UPF0742 protein SPAC750.04c".</li>
+<li>PomBase product description: <strong>"sub-telomeric 5Tm protein family Ftm3"</strong>; characterisation<br />
+  status <strong>"conserved unknown"</strong> (from PomBase gene page / API).</li>
+<li>Domain content: Pfam <strong>PF09437 (Pombe_5TM, "Pombe specific 5TM protein")</strong>, matched <strong>twice</strong><br />
+  in the sequence per the UniProt record (<code>Pfam; PF09437; 2</code>); InterPro <strong>IPR018291<br />
+  ("5TM-prot_SCHPO")</strong>. UniProt SIMILARITY: "Belongs to the <strong>UPF0742 family</strong>."<br />
+  [UniProt P0CU06 record: <code>DR Pfam; PF09437; Pombe_5TM; 2.</code>; <code>CC -!- SIMILARITY: Belongs to the UPF0742 family.</code>]</li>
+<li>UniProt annotates a single TMHMM-predicted transmembrane helix (TRANSMEM 38..60, ECO:0000255),<br />
+  despite the family being called "5TM" — the "5TM" is the family/Pfam name, not a per-protein<br />
+  UniProt feature count here.</li>
+<li>Genomic context: chromosome I, sub-telomeric region; part of a telomeric segmental duplication.<br />
+  Paralogs in the Ftm family: <strong>ftm1 (SPAC977.01), ftm2 (SPAC977.02), ftm4 (SPAC750.05c),<br />
+  ftm5, ftm6, ftm7</strong> (PomBase). Also related: SPBPB2B2.17c (UPF0742).<br />
+  [PomBase gene page SPAC750.04c: "Has paralogs: ftm4, ftm1, ftm2, ftm5, ftm6, ftm7"]</li>
+</ul>
+<h2 id="localization-evidence-known-by-homology-only-for-ftm3-itself">Localization evidence (KNOWN, by homology only for ftm3 itself)</h2>
+<ul>
+<li>UniProt SUBCELLULAR LOCATION for ftm3/P0CU06: "Cytoplasm {ECO:0000250|UniProtKB:P0CU07}.<br />
+  Nucleus membrane {ECO:0000250|UniProtKB:P0CU07}; Single-pass membrane protein {ECO:0000305}.<br />
+  Note=Localizes to cytoplasmic dots and the nuclear envelope. {ECO:0000250|UniProtKB:P0CU07}."<br />
+  — i.e. ftm3's own localization is <strong>inferred by similarity (ISS/ECO:0000250) from the paralog<br />
+  P0CU07 = ftm2 (SPAC977.02)</strong>, not measured directly on ftm3.</li>
+<li>The paralog <strong>ftm2/P0CU07/SPAC977.02</strong> has <strong>experimental</strong> localization to cytoplasm and<br />
+  nuclear/nucleus membrane from the genome-wide YFP ORFeome localization study<br />
+<strong>PMID:16823372</strong> (Matsuyama et al. 2006, "ORFeome cloning and global analysis of protein<br />
+  localization in the fission yeast Schizosaccharomyces pombe", ECO:0000269|PubMed:16823372<br />
+  on the P0CU07 record). The GOA ISS annotations on ftm3 carry <code>with: UniProtKB:P0CU07</code><br />
+  (QuickGO TSV) / <code>with: SPAC977.02 (ftm2)</code> (PomBase) — same source, family transfer.</li>
+<li>The two GOA IEA CC annotations (GO:0005737 cytoplasm, GO:0031965 nuclear membrane;<br />
+  GO_REF:0000044, UniProtKB-SubCell mapping) are electronic re-statements of the same<br />
+  UniProt SubCell locations, so they are consistent with — and derivative of — the ISS calls.</li>
+</ul>
+<h2 id="expression-process-context-known-high-throughput-only">Expression / process context (KNOWN, high-throughput only)</h2>
+<ul>
+<li>PomBase carries a biological-process annotation <strong>GO:0042149 "cellular response to glucose<br />
+  starvation"</strong> for ftm3, evidence <strong>ECO:0000058 (expression microarray/RNA-level)</strong>, reference<br />
+<strong>PMID:34460892</strong> (Tarhan &amp; Çakır 2021, "Transcriptome sequencing and screening of genes<br />
+  related to glucose availability in Schizosaccharomyces pombe by RNA-seq analysis"), qualified<br />
+  as "RNA level decreased." This is a <strong>transcript-abundance response</strong>, not a demonstrated<br />
+  functional role in the glucose-starvation program; the full text does not name ftm3.</li>
+<li><strong>This GO:0042149 annotation is NOT in the QuickGO GOA TSV pulled for this review</strong> (the TSV<br />
+  contains only the two CC IEA, two CC ISS, and the ND MF/BP placeholders). Since the review<br />
+  covers the GOA set, it is not added to <code>existing_annotations</code>; it is recorded here as context.</li>
+<li>ftm2 deletion (ftm2delta) is viable with normal cell morphology under standard conditions<br />
+  (PomBase phenotype), consistent with the family being dispensable/redundant. No ftm3-specific<br />
+  deletion phenotype is documented.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>Molecular function</strong>: unknown. No enzymatic activity, no ligand/substrate, no binding partner<br />
+  is established. Pfam PF09437 (Pombe_5TM / UPF0742) has <strong>no functional annotation</strong> and is<br />
+  essentially <em>Schizosaccharomyces</em>-restricted ("Pombe specific"), so no cross-kingdom orthology<br />
+  informs function. PomBase MF = ND (GO_REF:0000015).</li>
+<li><strong>Biological process</strong>: unknown beyond the transcriptional glucose-availability response above;<br />
+  PomBase BP = ND in GOA. No pathway membership demonstrated.</li>
+<li><strong>Role of sub-telomeric location / family expansion</strong>: unknown; whether the Ftm family has a<br />
+  coherent shared function (e.g. in a membrane process) or represents rapidly-evolving<br />
+  sub-telomeric genes of low/conditional function is not established.</li>
+<li><strong>Topology / true TM count</strong>: family is named "5TM" but the UniProt feature table on ftm3<br />
+  lists only one predicted TM helix; membrane topology is not experimentally determined.</li>
+</ul>
+<h2 id="curation-decisions-rationale">Curation decisions (rationale)</h2>
+<ul>
+<li><strong>GO:0005737 cytoplasm (ISS, GO_REF:0000024, with P0CU07)</strong> and <strong>GO:0031965 nuclear membrane<br />
+  (ISS)</strong>: KEEP_AS_NON_CORE. Grounded in experimental localization of the paralog ftm2 via a<br />
+  reliable genome-wide study; a defensible localization call for an otherwise uncharacterized<br />
+  protein, but localization is not a "core function" and is by-similarity for ftm3 itself.</li>
+<li><strong>GO:0005737 cytoplasm (IEA, GO_REF:0000044)</strong> and <strong>GO:0031965 nuclear membrane (IEA)</strong>:<br />
+  KEEP_AS_NON_CORE. Electronic SubCell-&gt;GO restatements of the same UniProt locations; redundant<br />
+  with the ISS calls but not wrong.</li>
+<li><strong>GO:0003674 molecular_function (ND, GO_REF:0000015)</strong> and <strong>GO:0008150 biological_process<br />
+  (ND)</strong>: ACCEPT. ND placeholders correctly record that MF/BP are unknown; keeping them is the<br />
+  honest representation for a "conserved unknown" gene.</li>
+<li>No <code>protein binding</code> or speculative MF/BP terms are proposed. <code>core_functions</code> is intentionally<br />
+  minimal (localization only, non-core); <code>knowledge_gaps</code> carries the primary content.</li>
+</ul>
+<h2 id="provenance-of-sources-used">Provenance of sources used</h2>
+<ul>
+<li>UniProt P0CU06 record (<code>genes/SCHPO/ftm3/ftm3-uniprot.txt</code>) — domains, TM, subcell, family.</li>
+<li>QuickGO GOA TSV (<code>genes/SCHPO/ftm3/ftm3-goa.tsv</code>) — the 6 reviewed annotations.</li>
+<li>PomBase gene pages/API for SPAC750.04c (ftm3) and SPAC977.02 (ftm2) — standard name, product<br />
+  description, characterisation status "conserved unknown", paralog list, GO:0042149.</li>
+<li>UniProt P0CU07 record (rest.uniprot.org) — paralog ftm2 experimental localization (PMID:16823372).</li>
+<li>PMID:16823372 (cached, abstract-only) — genome-wide localization study underlying the ISS.</li>
+<li>PMID:34460892 (cached, full text) — glucose-availability RNA-seq behind GO:0042149 context.</li>
+<li>Pfam/InterPro PF09437 / IPR018291 — "Pombe specific 5TM protein", no functional annotation.</li>
+</ul>
+<p>Deep research: falcon and perplexity-lite both failed (falcon template-variable error;<br />
+perplexity 401 quota). Review grounded in UniProt + GOA + PomBase + cached literature per<br />
+CLAUDE.md fallback guidance; no fabricated content.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P0CU06
+gene_symbol: ftm3
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  ftm3 (SPAC750.04c) is a small (146-residue, ~17 kDa) membrane protein of the
+  Schizosaccharomyces pombe Ftm (&#34;sub-telomeric 5Tm&#34;) protein family, a lineage-specific
+  family encoded in the sub-telomeric regions of the fission-yeast genome (paralogs
+  ftm1, ftm2, ftm4, ftm5, ftm6 and ftm7). It belongs to the UPF0742 family and carries
+  the Pombe_5TM domain (Pfam PF09437, InterPro IPR018291, &#34;Pombe specific 5TM protein&#34;),
+  a domain of unknown function essentially restricted to Schizosaccharomyces. The protein
+  is predicted to be membrane-integral (at least one transmembrane helix) and, by
+  similarity to its experimentally localized paralog ftm2, is assigned to the cytoplasm
+  and the nuclear/nuclear-envelope membrane, where the family shows cytoplasmic puncta and
+  nuclear-rim staining. No molecular activity, substrate, ligand or interaction partner has
+  been established for ftm3 or any Ftm-family member; its biological role is undetermined,
+  and it is classified as a conserved protein of unknown function.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+  - id: UniProt:P0CU06
+    title: &#34;UPF0742 protein SPAC750.04c (ftm3) - Schizosaccharomyces pombe&#34;
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Primary source record for ftm3. Establishes the UPF0742 family membership, the
+        Pombe_5TM (PF09437 / IPR018291) domain content, the predicted transmembrane helix,
+        and the by-similarity subcellular localization (transferred from paralog P0CU07/ftm2).
+        Verified directly against the fetched UniProt record.
+  - id: PMID:16823372
+    title: ORFeome cloning and global analysis of protein localization in the fission
+      yeast Schizosaccharomyces pombe.
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Genome-wide YFP localization study (Matsuyama et al. 2006, Nat Biotechnol). It is
+        the experimental source of the cytoplasm/nuclear-membrane localization of the
+        paralog ftm2 (P0CU07/SPAC977.02), from which ftm3&#39;s localization is transferred by
+        ISS (GOA with:UniProtKB:P0CU07). Cached entry is abstract-only and does not name
+        ftm3 individually, so it is cited as provenance for the ISS transfer rather than as
+        direct ftm3 evidence. PubMed-verified title/authors.
+  - id: PMID:34460892
+    title: Transcriptome sequencing and screening of genes related to glucose availability
+      in Schizosaccharomyces pombe by RNA-seq analysis
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        RNA-seq study of glucose availability (Tarhan &amp; Çakır 2021). PomBase attaches a
+        high-throughput expression annotation (GO:0042149 cellular response to glucose
+        starvation, ECO:0000058, &#34;RNA level decreased&#34;) to ftm3 based on this dataset;
+        that annotation is NOT in the QuickGO GOA set reviewed here and the full text does
+        not name ftm3. Recorded only as transcript-level context, not functional evidence.
+existing_annotations:
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic annotation mapping the UniProtKB/Swiss-Prot subcellular-location
+        &#34;Cytoplasm&#34; to GO via GO_REF:0000044. It restates the same location that is
+        assigned to ftm3 by ISS from its paralog ftm2. Localization is a defensible,
+        conservative call for this otherwise uncharacterized protein, but it is not a
+        core function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Consistent with the UniProt SubCell location and with the ISS cytoplasm annotation
+        below; redundant electronic restatement, retained as supporting localization
+        evidence rather than a core function.
+      supported_by:
+        - reference_id: UniProt:P0CU06
+          supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm&#34;
+  - term:
+      id: GO:0031965
+      label: nuclear membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic annotation mapping the UniProtKB/Swiss-Prot subcellular-location &#34;Nucleus
+        membrane&#34; to GO via GO_REF:0000044. It restates the nuclear-envelope localization
+        assigned to ftm3 by ISS from paralog ftm2 (cytoplasmic dots and the nuclear
+        envelope). Not a core function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Consistent with the UniProt SubCell &#34;Nucleus membrane&#34; location and with the ISS
+        nuclear-membrane annotation below; redundant electronic restatement retained as
+        supporting localization evidence.
+      supported_by:
+        - reference_id: UniProt:P0CU06
+          supporting_text: &#34;C:nuclear membrane&#34;
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root molecular_function term with the ND (No biological Data available) evidence
+        code, assigned by PomBase. The molecular function of ftm3 is genuinely unknown: the
+        protein belongs to the UPF0742 / Pombe_5TM family, a Schizosaccharomyces-specific
+        domain of unknown function with no established catalytic, transport, or binding
+        activity, and no functional literature exists for ftm3 or any Ftm paralog.
+      action: ACCEPT
+      reason: &gt;-
+        The ND placeholder is the correct, honest representation for a conserved protein of
+        unknown molecular function. No specific MF term is warranted from current evidence,
+        and &#39;protein binding&#39; would be uninformative and unsupported.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root biological_process term with the ND evidence code, assigned by PomBase. No
+        biological process is experimentally attributed to ftm3. A high-throughput
+        expression change under glucose availability exists at PomBase (GO:0042149,
+        RNA-level), but it is a transcript-abundance observation, is not part of the GOA set
+        reviewed here, and does not establish a functional role.
+      action: ACCEPT
+      reason: &gt;-
+        ND correctly records that the biological process of ftm3 is unknown; no process
+        term is supported by current evidence.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Cytoplasmic localization transferred to ftm3 by curator sequence-similarity judgment
+        (GO_REF:0000024) with:UniProtKB:P0CU07, i.e. from the paralog ftm2 (SPAC977.02),
+        whose cytoplasm/nuclear-membrane localization was determined experimentally in the
+        genome-wide YFP ORFeome study (PMID:16823372). A reasonable localization inference
+        for a close paralog, but localization is not a core function and is by-similarity for
+        ftm3 itself.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Grounded in experimental localization of a close paralog via a reliable
+        genome-wide study; defensible as supporting localization evidence but not a core
+        molecular/biological function.
+      supported_by:
+        - reference_id: UniProt:P0CU06
+          supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm&#34;
+  - term:
+      id: GO:0031965
+      label: nuclear membrane
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Nuclear-membrane localization transferred to ftm3 by curator sequence-similarity
+        judgment (GO_REF:0000024) with:UniProtKB:P0CU07 (paralog ftm2), whose
+        nuclear-envelope localization was experimentally determined (PMID:16823372). The
+        UniProt note records localization to cytoplasmic dots and the nuclear envelope.
+        Localization inference, not a core function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Consistent with the paralog&#39;s experimental nuclear-envelope localization; retained
+        as supporting localization evidence rather than a core function.
+      supported_by:
+        - reference_id: UniProt:P0CU06
+          supporting_text: &#34;C:nuclear membrane&#34;
+core_functions:
+  - description: &gt;-
+      No core molecular or biological function can be assigned to ftm3 from current evidence.
+      The only positive functional information is subcellular localization: ftm3 is a
+      membrane-associated protein of the Ftm / UPF0742 / Pombe_5TM family localized (by
+      similarity to its experimentally characterized paralog ftm2) to the cytoplasm and the
+      nuclear-envelope membrane. This is a non-core localization statement, not an activity;
+      the family&#39;s molecular function is undetermined.
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0031965
+        label: nuclear membrane
+    supported_by:
+      - reference_id: UniProt:P0CU06
+        supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm&#34;
+      - reference_id: UniProt:P0CU06
+        supporting_text: &#34;C:nuclear membrane&#34;
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular function of ftm3 is completely unknown. No catalytic activity,
+      transporter/channel activity, ligand, substrate, or biochemical activity has been
+      demonstrated or is predictable for the protein.
+    boundary: &gt;-
+      What is established is family and domain membership only: ftm3 belongs to the UPF0742
+      family and carries the Pombe_5TM domain (Pfam PF09437 / InterPro IPR018291, &#34;Pombe
+      specific 5TM protein&#34;). This is a domain of unknown function with no functional
+      annotation, essentially restricted to Schizosaccharomyces, so no cross-species
+      orthology provides a functional hypothesis. PomBase records the molecular function as
+      ND (&#34;No biological Data&#34;).
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      ftm3 is one of a lineage-specific, sub-telomeric family (ftm1-ftm7) of fission-yeast
+      proteins with no assigned activity; establishing even the biochemical class (e.g.
+      transporter, receptor, structural membrane protein) would open the whole family.
+    resolution: &gt;-
+      Biochemical characterization of purified/tagged ftm3 (or a family member), structure
+      determination or confident structure-based fold/activity assignment, and assays guided
+      by its membrane topology (e.g. transport/channel assays) to test candidate activities.
+    provenance:
+      - reference_id: UniProt:P0CU06
+        supporting_text: &#34;Belongs to the UPF0742 family.&#34;
+      - reference_id: UniProt:P0CU06
+        supporting_text: &#34;Pfam; PF09437; Pombe_5TM; 2.&#34;
+  - gap_statement: &gt;-
+      The biological process and cellular role of ftm3 are unknown. It is undetermined which
+      pathway or process the protein participates in, and no loss-of-function phenotype has
+      been reported for an ftm3 deletion.
+    boundary: &gt;-
+      ftm3 is expressed during vegetative growth and its transcript level changes with
+      glucose availability (PomBase high-throughput expression annotation, GO:0042149,
+      derived from RNA-seq), and the closely related paralog ftm2 is dispensable (ftm2delta
+      viable with normal morphology). These are correlative/genetic observations only; PomBase
+      records the biological process for ftm3 as ND.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Determining the process (e.g. a membrane/nuclear-envelope function, a stress or
+      metabolic response, or a redundant/conditionally-required role) would move the Ftm
+      family out of the conserved-unknown set.
+    resolution: &gt;-
+      Phenotypic profiling of single and combinatorial ftm-family deletions across stress
+      and metabolic conditions (including glucose limitation), genetic-interaction mapping,
+      and identification of physical interaction partners.
+    provenance:
+      - reference_id: UniProt:P0CU06
+        supporting_text: &#34;Belongs to the UPF0742 family.&#34;
+  - gap_statement: &gt;-
+      ftm3&#39;s own subcellular localization and membrane topology have not been measured
+      directly. Its cytoplasm/nuclear-membrane assignment is inferred entirely by similarity
+      from the paralog ftm2, and although the family is named &#34;5TM&#34;, the UniProt feature
+      table annotates only a single predicted transmembrane helix, so the true topology is
+      unresolved.
+    boundary: &gt;-
+      The paralog ftm2 (P0CU07/SPAC977.02) was experimentally localized to the cytoplasm and
+      nuclear membrane (cytoplasmic dots and the nuclear envelope) in a genome-wide YFP study
+      (PMID:16823372), and ftm3&#39;s GO localization is transferred from it by ISS
+      (with:UniProtKB:P0CU07). No direct ftm3 localization or topology experiment is on record.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Confirming ftm3&#39;s localization and topology directly (rather than by paralog transfer)
+      would validate the propagated annotations and constrain candidate functions (e.g.
+      nuclear-envelope vs general-membrane roles).
+    resolution: &gt;-
+      Fluorescent tagging and imaging of ftm3 in S. pombe, and experimental membrane-topology
+      mapping to resolve the transmembrane-helix count implied by the &#34;5TM&#34; family name.
+    provenance:
+      - reference_id: UniProt:P0CU06
+        supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm&#34;
+suggested_questions:
+  - question: &gt;-
+      Does the Ftm / UPF0742 / Pombe_5TM family have a coherent shared molecular function, or
+      are these rapidly-evolving sub-telomeric genes of low or conditional function?
+  - question: &gt;-
+      Is ftm3 functionally redundant with its paralogs, such that a phenotype only emerges in
+      combinatorial ftm-family deletions?
+suggested_experiments:
+  - description: &gt;-
+      Construct single and combinatorial ftm-family deletion strains (ftm1-ftm7) and screen
+      for growth, morphology, and stress/metabolic phenotypes (including glucose limitation)
+      to detect redundant or conditional functions.
+  - description: &gt;-
+      Determine ftm3&#39;s direct subcellular localization (endogenous fluorescent tagging) and
+      experimental membrane topology, and identify physical interaction partners (affinity
+      purification-MS) to generate function hypotheses.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/hgh1/hgh1-ai-review.html
+++ b/genes/SCHPO/hgh1/hgh1-ai-review.html
@@ -1,0 +1,2684 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hgh1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>hgh1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q10498" target="_blank" class="term-link">
+                        Q10498
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "hgh1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q10498" data-a="DESCRIPTION: hgh1 is the Schizosaccharomyces pombe member of th..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>hgh1 is the Schizosaccharomyces pombe member of the conserved HGH1 protein family (orthologous to Saccharomyces cerevisiae Hgh1 and human HGH1/FAM203). It is a small (~356 aa, ~41 kDa) soluble, non-catalytic protein built on an armadillo/HEAT-like all-alpha repeat scaffold with the family-diagnostic HGH1 N- and C-terminal domains (Pfam DUF383/DUF384). In budding yeast the ortholog is a dedicated co-chaperone for the biogenesis of eukaryotic elongation factor 2 (eEF2): it binds the structurally dynamic central domain III of nascent eEF2 and recruits the chaperonin TRiC/CCT (and potentially Hsp90 via a Cns1 co-chaperone), shielding domain III and promoting productive folding of the essential eEF2 GTPase, before dissociating once folding is complete. On this basis hgh1 is annotated as a cytoplasmic protein-folding chaperone acting in co-translational protein folding. The eEF2-chaperone function has not been directly demonstrated in fission yeast; the fission-yeast gene is dispensable for viability, and its S. pombe-specific molecular activity, client range, and biological role remain to be experimentally established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10498" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization inferred by UniProt SubCell mapping. Consistent with a soluble co-chaperone lacking signal/transmembrane features and with the cytosolic site of eEF2/TRiC-assisted folding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> hgh1 has no signal peptide or transmembrane segment (UniProt Q10498) and belongs to a soluble ARM-repeat family; the cytoplasm is where the eEF2/TRiC co-translational folding it participates in occurs. Location is well supported but not itself a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                                        PMID:30876804
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with TRiC in eEF2 folding.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    GO:0044183
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding chaperone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10498" data-a="GO:0044183" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Molecular function transferred by orthology from S. cerevisiae Hgh1, which acts as a (non-ATP-dependent) co-chaperone/adaptor that binds nascent eEF2 and recruits the chaperonin TRiC. &#34;protein folding chaperone&#34; (GO:0044183, not the ATP-dependent child GO:0140662) is the appropriate molecular function for this adaptor-type role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ortholog&#39;s chaperone activity toward eEF2 is experimentally established (PMID:30876804) and the orthology (single-copy KOG2973; reciprocal PomBase ortholog calls to S. cerevisiae YGR187C and human HGH1/FAM203) is unambiguous. Hgh1 is not an ATP-driven foldase; the general MF term is correct. This is the core molecular function, though it is inferred rather than measured in S. pombe.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                                        PMID:30876804
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III of eEF2 via a bipartite interface.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
+                                    GO:0051083
+                                </a>
+                            </span>
+                            <span class="term-label">&#39;de novo&#39; cotranslational protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10498" data-a="GO:0051083" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biological process transferred by orthology. The ortholog assists folding of nascent, ribosome-associated eEF2 co-translationally, recruiting TRiC and shielding domain III until the GTPase module folds. This is consistent with the co-translational, de-novo-folding scope of GO:0051083.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches the experimentally described mechanism of the ortholog (assists folding of newly synthesized eEF2, cooperating with the chaperonin). Retained as the core biological process, inferred by orthology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                                        PMID:30876804
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the absence of Hgh1, a substantial fraction of newly synthesized eEF2 is degraded or aggregates.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10498" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization transferred by sequence similarity from UniProt P48362 (S. cerevisiae Hgh1). Redundant with the IEA SubCell annotation but concordant and well motivated by the family&#39;s soluble, cytosolic character.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same well-supported cytoplasmic location as the IEA row, from an orthology-based (ISS) source; concordant with the site of eEF2 folding. Location, non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                                        PMID:30876804
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with TRiC in eEF2 folding.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q10498" data-a="GO:0005634" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear &#34;is_active_in&#34; transferred by orthology. eEF2 biogenesis is a cytoplasmic, co-translational process, and both the fission-yeast protein and the characterized S. cerevisiae ortholog are described as cytosolic (UniProt Q10498/P48362 SUBCELLULAR LOCATION: Cytoplasm). No molecular role for HGH1 proteins in the nucleus has been demonstrated; a nuclear site of action is not supported by the established mechanism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The known function of the HGH1 family (recruiting TRiC/Hsp90 to fold nascent cytoplasmic eEF2) is incompatible with a nuclear site of action. The nuclear &#34;is_active_in&#34; appears to be an over-broad ISO transfer from a high-throughput localization dataset rather than a functionally meaningful nuclear activity. There is no evidence for a nuclear function in S. pombe; flagging as over-annotation rather than removing, since a minor nucleocytoplasmic pool cannot be excluded and the curator&#39;s source evidence has not been read.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003419</span>
+
+                                    &middot; HGH1 (S. cerevisiae, YGR187C)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The eEF2 co-chaperone activity of the S. cerevisiae ortholog is a cytoplasmic, co-translational process; an is_active_in nucleus qualifier does not reflect the site where this molecular function is executed and should not propagate as a functional (is_active_in) annotation to hgh1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10498" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic site of action transferred by orthology. This is where the eEF2/TRiC co-translational folding cycle occurs, so &#34;is_active_in cytoplasm&#34; correctly captures the compartment in which hgh1&#39;s inferred molecular function is executed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the established cytosolic mechanism of the ortholog and with the located_in cytoplasm annotations. Non-core location/site-of-action term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                                        PMID:30876804
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Hgh1 binding recruits TRiC to the C-terminal eEF2 module and prevents unproductive interactions of domain III, allowing efficient folding of the N-terminal GTPase module.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Co-chaperone / chaperonin-recruiting adaptor for the folding of nascent eukaryotic elongation factor 2 (eEF2). Built on an armadillo-repeat scaffold, hgh1 binds the dynamic central domain III of newly synthesized eEF2 and recruits the chaperonin TRiC/CCT (and potentially Hsp90) to the client, shielding domain III and promoting productive folding of the eEF2 GTPase module. It is a non-catalytic, non-ATP-dependent protein-folding chaperone. This molecular role is inferred from the diagnostic HGH1 family/ARM-repeat architecture and the experimentally established function of the S. cerevisiae and human orthologs; it has not been directly demonstrated for the fission-yeast protein.</h3>
+                <span class="vote-buttons" data-g="Q10498" data-a="FUNCTION: Co-chaperone / chaperonin-recruiting adaptor for t..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
+                                &#39;de novo&#39; cotranslational protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                                PMID:30876804
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III of eEF2 via a bipartite interface. Hgh1 binding recruits TRiC to the C-terminal eEF2 module and prevents unproductive interactions of domain III, allowing efficient folding of the N-terminal GTPase module.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30876804" target="_blank" class="term-link">
+                            PMID:30876804
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Chaperone Function of Hgh1 in the Biogenesis of Eukaryotic Elongation Factor 2.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with the chaperonin TRiC/CCT in the folding of eukaryotic elongation factor 2 (eEF2); in its absence a substantial fraction of newly synthesized eEF2 is degraded or aggregates.</div>
+
+                        <div class="finding-text">"the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with TRiC in eEF2 folding. In the absence of Hgh1, a substantial fraction of newly synthesized eEF2 is degraded or aggregates."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Hgh1 is an armadillo-repeat protein that binds the dynamic central domain III of eEF2 via a bipartite interface, recruits TRiC to the C-terminal eEF2 module, and prevents unproductive interactions of domain III, enabling folding of the N-terminal GTPase module.</div>
+
+                        <div class="finding-text">"Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III of eEF2 via a bipartite interface. Hgh1 binding recruits TRiC to the C-terminal eEF2 module and prevents unproductive interactions of domain III, allowing efficient folding of the N-terminal GTPase module."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe hgh1 physically bind eEF2 and the CCT/TRiC chaperonin, and is it required for efficient eEF2 folding and steady-state abundance in fission yeast, as its S. cerevisiae ortholog is?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Molecular chaperone / eEF2 biogenesis biochemists (e.g. authors of PMID:30876804), Fission-yeast proteostasis researchers</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10498" data-a="Q: Does S. pombe hgh1 physically bind eEF2 and the CC..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What accounts for the pleiotropic stress-response phenotypes of hgh1 deletion, and are they downstream of altered eEF2 biogenesis/translation elongation?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Fission-yeast functional-genomics / phenomics groups</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10498" data-a="Q: What accounts for the pleiotropic stress-response ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged hgh1 from S. pombe and identify interactors by mass spectrometry; specifically test for eEF2 (ef2) and CCT/TRiC subunits and Hsp90. Complement with in vitro binding to recombinant eEF2 and eEF2 domain-III fragments.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: hgh1 is a conserved co-chaperone that binds nascent eEF2 domain III and recruits TRiC, required for efficient eEF2 folding in S. pombe.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: co-immunoprecipitation / affinity-MS and in vitro binding</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10498" data-a="EXPERIMENT: Affinity-purify tagged hgh1 from S. pombe and iden..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct an hgh1-delta strain; quantify soluble vs aggregated eEF2 and total eEF2 levels, measure translation-elongation rate/fidelity (e.g. ribosome profiling, readthrough reporters), and phenotype under the stresses flagged in high-throughput screens.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of hgh1 reduces mature eEF2 and impairs translation elongation under stress.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics + proteomics + ribosome profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10498" data-a="EXPERIMENT: Construct an hgh1-delta strain; quantify soluble v..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether S. pombe hgh1 actually performs the eEF2 co-chaperone function is unmeasured: no fission-yeast experiment has shown hgh1 binds eEF2 (or its domain III), recruits TRiC/CCT or Hsp90, or is required for eEF2 folding, abundance, or stability. Every molecular-function and biological-process annotation for hgh1 is an electronic orthology transfer (ISO from S. cerevisiae; GO_REF:0000024), not a direct observation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The mechanism is firmly established for the S. cerevisiae ortholog: Hgh1 is an armadillo-repeat chaperone that binds nascent eEF2 domain III and recruits TRiC to fold the eEF2 GTPase module (PMID:30876804). Orthology of hgh1 to S. cerevisiae YGR187C and human HGH1/FAM203 is unambiguous (single-copy KOG2973; reciprocal ortholog calls), and hgh1 carries the diagnostic HGH1 domains on an ARM-type fold. What is missing is any S. pombe-specific functional assay.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> eEF2 is essential and highly abundant; a dedicated biogenesis factor for it is a node where translation capacity and proteostasis intersect. Confirming (or refuting) the conserved role in fission yeast would validate the orthology-based annotation and clarify whether the pathway is universally conserved across yeasts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test physical interaction of hgh1 with eEF2 (ef2/tef products) and with the CCT/TRiC subunits in S. pombe (co-IP, crosslinking); quantify mature eEF2 levels and aggregation in an hgh1-delta strain; assess translation-elongation and eEF2-folding phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with TRiC in eEF2 folding."</em> — PMID:30876804</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role and loss-of-function consequences of hgh1 in fission yeast are largely undefined. Deletion is viable with normal morphology, so any requirement is conditional/quantitative; the mechanistic basis for the pleiotropic stress phenotypes reported in high-throughput screens (e.g. hydroxyurea/lithium sensitivity, caffeine resistance) is unknown and not obviously connected to eEF2 folding.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> PomBase records hgh1 deletion as viable (FYPO &#34;viable vegetative cell population&#34;, &#34;viable vegetative cell with normal cell morphology&#34;) with a broad set of condition-specific stress phenotypes from genome-wide screens; characterisation status is &#34;biological role inferred&#34;. The client protein eEF2 is itself essential.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Understanding why an eEF2 biogenesis factor is dispensable, and what the stress phenotypes reflect, would reveal how much eEF2 folding depends on this dedicated co-chaperone versus general chaperone redundancy.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Targeted phenotyping of an hgh1-delta strain under the flagged stresses with eEF2 readouts; epistasis with cct/TRiC and hsp90 co-chaperone mutants; measurement of translation elongation rate/fidelity.</p>
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether HGH1-family proteins act on clients other than eEF2, and whether hgh1 has any genuine nuclear function (as an &#34;is_active_in nucleus&#34; annotation suggests) rather than being exclusively a cytoplasmic eEF2 co-chaperone, is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> All experimentally defined function of the family concerns cytoplasmic eEF2 folding; both hgh1 and its ortholog are annotated as cytoplasmic (UniProt SUBCELLULAR LOCATION). No non-eEF2 client and no nuclear molecular activity have been demonstrated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Establishing the client range would determine whether HGH1 is a dedicated eEF2 factor or a more general folding adaptor, informing how conserved this proteostasis module is.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Unbiased interactome (proximity labeling / affinity-MS) of hgh1 in S. pombe; test for any functional nuclear pool by localization and nuclear-anchoring/depletion assays.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hgh1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q10498" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *hgh1* (SPAC26F1.12c) — Co-chaperone Protein HGH1 Homolog in *Schizosaccharomyces pombe*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">12 citations</span>
+
+
+                    <span class="report-badge">3 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T16:41:11.098792</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="hgh1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="hgh1-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="hgh1-deep-research-falcon_artifacts/image-1.png" class="term-link">Image artifact created (ID artifact-01): &#39;Hgh1-Centered eEF2 Chaperone Network&#39; ![Hgh1-Centered eEF2 Chaperone Network](artifact:artifact-01) Artifact IDs that </a>
+                        <span>(image/png)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-hgh1-spac26f112c-co-chaperone-protein-hgh1-homolog-in-schizosaccharomyces-pombe">Comprehensive Research Report: <em>hgh1</em> (SPAC26F1.12c) — Co-chaperone Protein HGH1 Homolog in <em>Schizosaccharomyces pombe</em></h1>
+<h2 id="1-geneprotein-identity-and-overview">1. Gene/Protein Identity and Overview</h2>
+<p>The <em>S. pombe</em> gene <em>hgh1</em> (ORF SPAC26F1.12c; UniProt Q10498) encodes a co-chaperone protein belonging to the HGH1 family. The protein is the fission yeast ortholog of <em>Saccharomyces cerevisiae</em> Hgh1 (UniProt P48362), and the human homolog is FAM203 (monkemeyer2019structuralandfunctional pages 36-38). Hgh1/FAM203 family proteins are approximately 45 kDa in size and are conserved throughout the eukaryotic lineage (monkemeyer2019structuralandfunctional pages 36-38). The primary function of HGH1 is as a dedicated co-chaperone essential for the biogenesis and proper folding of eukaryotic elongation factor 2 (eEF2, also called Eft in <em>S. cerevisiae</em>), a critical GTP-dependent translation elongation factor required for ribosome translocation during protein synthesis (monkemeyer2019structuralandfunctional pages 110-111, yang2026emw1ttc27isa pages 1-2, fulton2024hsp90andcochaperones pages 1-2).</p>
+<p>The following table summarizes the key characteristics of HGH1:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Protein name</td>
+<td>Co-chaperone protein HGH1 homolog in <em>Schizosaccharomyces pombe</em>; characterized homolog in budding yeast is Hgh1, a co-chaperone for eEF2/Eft folding (monkemeyer2019structuralandfunctional pages 36-38, engler2025theevolutionand pages 3-5)</td>
+</tr>
+<tr>
+<td>Gene name (<em>S. pombe</em>)</td>
+<td><strong>hgh1</strong>; ORF <strong>SPAC26F1.12c</strong>; UniProt accession <strong>Q10498</strong> (user-supplied target identity)</td>
+</tr>
+<tr>
+<td>Gene name (<em>S. cerevisiae</em>)</td>
+<td><strong>HGH1</strong>; the better-characterized ortholog studied experimentally in the cited literature (monkemeyer2019structuralandfunctional pages 36-38, monkemeyer2019structuralandfunctional pages 110-111)</td>
+</tr>
+<tr>
+<td>UniProt IDs</td>
+<td><em>S. pombe</em>: <strong>Q10498</strong>; <em>S. cerevisiae</em> homolog referenced in UniProt annotation context: <strong>P48362</strong> (user-supplied target identity)</td>
+</tr>
+<tr>
+<td>Human homolog</td>
+<td><strong>FAM203</strong> (also referred to as Fam203 in the literature), identified as the human homolog of yeast Hgh1 (monkemeyer2019structuralandfunctional pages 36-38, que2024theroleof pages 5-6)</td>
+</tr>
+<tr>
+<td>Protein size</td>
+<td>Approximately <strong>45 kDa</strong> for Hgh1/Fam203 family proteins (monkemeyer2019structuralandfunctional pages 36-38)</td>
+</tr>
+<tr>
+<td>Structural fold</td>
+<td><strong>Armadillo-repeat-like / helical solenoid</strong> architecture with three-helix repeat motifs and N-terminal capping helices (monkemeyer2019structuralandfunctional pages 110-111, monkemeyer2019structuralandfunctional pages 133-135)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td>UniProt/InterPro annotation indicates <strong>ARM-like</strong>, <strong>ARM-type fold</strong>, <strong>Hgh1</strong>, <strong>Protein_HGH1_N</strong>, and <strong>Protein_HGH1_C</strong> domains; structurally, Hgh1 contains a conserved solenoid with three insertions (Ins1–3) (monkemeyer2019structuralandfunctional pages 133-135, monkemeyer2019structuralandfunctional pages 110-111)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td><strong>Dedicated co-chaperone for eEF2/Eft folding</strong>; binds eEF2 domain III during synthesis, prevents nonproductive inter-domain interactions, and promotes productive folding/maturation (monkemeyer2019structuralandfunctional pages 110-111, que2024theroleof pages 5-6, monkemeyer2019structuralandfunctional pages 133-135)</td>
+</tr>
+<tr>
+<td>Key binding partners</td>
+<td><strong>eEF2/Eft</strong>, <strong>TRiC/CCT</strong> (including <strong>Cct6</strong>), <strong>Cns1</strong>, and functionally <strong>Hsp90</strong> in an eEF2 chaperone complex/network (monkemeyer2019structuralandfunctional pages 133-135, monkemeyer2019structuralandfunctional pages 36-38, engler2025theevolutionand pages 3-5)</td>
+</tr>
+<tr>
+<td>Mechanistic role</td>
+<td>Hgh1 recognizes folding intermediates of <strong>eEF2 domain III</strong>, masks this dynamic region, and helps recruit <strong>TRiC</strong> to fold the C-terminal eEF2 module; Hgh1 also participates in a quaternary complex with <strong>Cns1-Hsp90-eEF2</strong> (monkemeyer2019structuralandfunctional pages 110-111, fulton2024hsp90andcochaperones pages 13-14, engler2025theevolutionand pages 3-5)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Best supported as <strong>cytoplasmic / translation-associated</strong>, inferred from its co-translational role in folding the cytosolic translation factor eEF2 and its participation with cytosolic chaperone systems <strong>TRiC</strong> and <strong>Hsp90</strong>; explicit localization experiments were not identified in the retrieved evidence (monkemeyer2019structuralandfunctional pages 110-111, que2024theroleof pages 5-6, monkemeyer2019structuralandfunctional pages 133-135)</td>
+</tr>
+<tr>
+<td>Deletion phenotype</td>
+<td><strong>hgh1Δ</strong> causes about <strong>30–35% reduction</strong> in total eEF2/Eft levels, increased insoluble/misfolded eEF2, mild heat-shock/proteostasis stress, and strong synthetic defects with <strong>eft2</strong>, <strong>Hsp90 machinery mutants</strong>, or impaired <strong>Emw1/TTC27</strong> function (monkemeyer2019structuralandfunctional pages 36-38, monkemeyer2019structuralandfunctional pages 110-111, fulton2024hsp90andcochaperones pages 7-9, yang2026emw1ttc27isa pages 4-8, fulton2024hsp90andcochaperones pages 4-5)</td>
+</tr>
+<tr>
+<td>Functional interactions / pathway context</td>
+<td>Acts in an <strong>eEF2 biogenesis and proteostasis pathway</strong> linked to <strong>TRiC/CCT</strong>, <strong>Hsp90</strong>, and co-chaperones such as <strong>Cns1</strong> and <strong>Cpr7</strong>; recent work places Hgh1 in a broader elongation-factor chaperone network (fulton2024hsp90andcochaperones pages 13-14, fulton2024hsp90andcochaperones pages 4-5, engler2025theevolutionand pages 3-5, sabbarini2023zincfingerproteinzpr1 pages 25-26)</td>
+</tr>
+<tr>
+<td>Conservation</td>
+<td>Hgh1/FAM203 family proteins are reported to be <strong>conserved throughout eukaryotes</strong> (monkemeyer2019structuralandfunctional pages 36-38)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, structure, function, interaction partners, and phenotype data for the HGH1 family protein, emphasizing the experimentally characterized budding yeast ortholog used to infer function for the </em>S. pombe<em> target.</em></p>
+<h2 id="2-primary-molecular-function-dedicated-co-chaperone-for-eef2-folding">2. Primary Molecular Function: Dedicated Co-chaperone for eEF2 Folding</h2>
+<h3 id="21-role-in-eef2-biogenesis">2.1 Role in eEF2 Biogenesis</h3>
+<p>The primary function of Hgh1 is to serve as a specialized, dedicated co-chaperone that assists the folding of eEF2 during its synthesis. eEF2 is a large, multi-domain protein (~95 kDa, five domains) that is prone to misfolding due to energetic interdependencies among its domains (que2024theroleof pages 5-6). Hgh1 recognizes non-native conformations of eEF2 domain III — the structurally dynamic central domain — and binds to it co-translationally, preventing aberrant inter-domain interactions that would lead to misfolding (monkemeyer2019structuralandfunctional pages 110-111, yang2026emw1ttc27isa pages 1-2, monkemeyer2019structuralandfunctional pages 133-135). Hydrogen-deuterium exchange mass spectrometry (HDX-MS) has identified specific peptides in eEF2 domain III (residues 522–538 and 536–540) that are protected upon Hgh1 binding, defining putative Hgh1 interaction sites (monkemeyer2019structuralandfunctional pages 133-135).</p>
+<p>Hgh1 is required during initial protein synthesis of eEF2 rather than for maintaining the conformational stability of already-folded eEF2. Preexisting, mature eEF2 remains stable even in cells lacking Hgh1, whereas newly synthesized eEF2 becomes misfolded and aggregated in the absence of Hgh1 (monkemeyer2019structuralandfunctional pages 110-111).</p>
+<h3 id="22-recruitment-of-triccct">2.2 Recruitment of TRiC/CCT</h3>
+<p>Beyond simply masking domain III, Hgh1 plays a critical bridging role by recruiting the TRiC/CCT chaperonin complex — the eukaryotic group II chaperonin — to the C-terminal module of eEF2. The TRiC cavity is large enough to encapsulate proteins or protein segments up to approximately 70 kDa. In the case of eEF2, TRiC encapsulates domains III–V (up to ~70 kDa) within its central cavity for stepwise folding, while the N-terminal GTPase module folds independently (yang2026emw1ttc27isa pages 1-2, que2024theroleof pages 5-6). Hgh1 physically interacts with TRiC subunit Cct6, and this interaction is essential for proper delivery of eEF2 folding intermediates to TRiC (monkemeyer2019structuralandfunctional pages 36-38).</p>
+<h3 id="23-participation-in-the-hsp90-chaperone-network">2.3 Participation in the Hsp90 Chaperone Network</h3>
+<p>Hgh1 is functionally integrated into the broader Hsp90 co-chaperone system. It forms a quaternary complex with the essential Hsp90 co-chaperone Cns1, Hsp90 itself, and eEF2 (fulton2024hsp90andcochaperones pages 13-14, engler2025theevolutionand pages 3-5). Cns1 specifically forms a complex with Hsp90, the recruiting factor Hgh1, and eEF2 to facilitate folding and stabilization of the elongation factor (engler2025theevolutionand pages 3-5). However, direct biochemical interactions between purified Hgh1 and Hsp90 have not been robustly detected, suggesting that Hgh1 may bind Hsp90 only transiently or in the context of the larger multi-protein complex (fulton2024hsp90andcochaperones pages 7-9). Genetic evidence strongly supports this functional link: deletion of <em>HGH1</em> sensitizes yeast cells to the Hsp90 inhibitor macbecin, and combined deletion of <em>HGH1</em> with Hsp90 co-chaperone genes (<em>CPR7</em>, <em>HCH1</em>, <em>STI1</em>) or Hsp90 isoform genes (<em>HSC82</em>, <em>HSP82</em>) causes synthetic growth defects or lethality (monkemeyer2019structuralandfunctional pages 36-38).</p>
+<h3 id="24-cooperation-with-other-chaperones">2.4 Cooperation with Other Chaperones</h3>
+<p>Recent work has identified Emw1/TTC27 as an additional chaperone cooperating with Hgh1 in eEF2 biogenesis. Dual impairment of Hgh1 and Emw1/TTC27 function produces an additive effect, causing a dramatic ~75–80% decline in eEF2 levels and severely restricting yeast growth (yang2026emw1ttc27isa pages 4-8). The triple mutant (<em>emw1^ts hgh1Δ eft2Δ</em>) is synthetic lethal, underscoring the essential role of this chaperone network in preventing toxic folding intermediates during eEF2 biogenesis (yang2026emw1ttc27isa pages 4-8). Hgh1 also shows functional overlap with co-chaperone Cpr7, as <em>HGH1</em> deletion enhances growth defects in cells lacking <em>CPR7</em> (fulton2024hsp90andcochaperones pages 5-7).</p>
+<p>The following diagram illustrates the central role of Hgh1 in the eEF2 chaperone network:</p>
+<p><img alt="Hgh1-Centered eEF2 Chaperone Network" src="artifact:artifact-01" /></p>
+<p><em>Image: Schematic of the cytosolic chaperone pathway that promotes eEF2 folding during translation. Hgh1 binds nascent eEF2 domain III, coordinates TRiC/CCT and Hsp90-Cns1 functions, cooperates with Emw1/TTC27, and prevents eEF2 misfolding and aggregation.</em></p>
+<h2 id="3-structural-features">3. Structural Features</h2>
+<h3 id="31-armadillo-repeat-fold">3.1 Armadillo Repeat Fold</h3>
+<p>The crystal structure of Hgh1 reveals an armadillo-repeat-like fold organized as a helical solenoid composed of three-helix repeat motifs (monkemeyer2019structuralandfunctional pages 110-111, monkemeyer2019structuralandfunctional pages 133-135). The protein contains N-terminal capping helices and three insertions (designated Ins1, Ins2, and Ins3) within the helical solenoid framework (monkemeyer2019structuralandfunctional pages 133-135). This is consistent with the InterPro domain annotations for the <em>S. pombe</em> protein, which include ARM-like (IPR011989), ARM-type fold (IPR016024), Hgh1 (IPR039717), Protein_HGH1_N (IPR007205), and Protein_HGH1_C (IPR007206).</p>
+<h3 id="32-functionally-important-surface-regions">3.2 Functionally Important Surface Regions</h3>
+<p>Surface conservation analysis across HGH1/FAM203 family members from diverse eukaryotes reveals two principal conserved regions: one near the N-terminus and another at the concave face of the solenoid (monkemeyer2019structuralandfunctional pages 110-111). Systematic mutagenesis of these conserved regions (designated MutN, MutM, and MutC in three different regions of the protein) demonstrated that mutations at both the N-terminal and concave-face sites abolished the interaction between Hgh1 and eEF2/Eft, and prevented complementation of growth defects in <em>eft2 hgh1</em> double-deletion strains (monkemeyer2019structuralandfunctional pages 110-111). These data indicate that the conserved surface areas mediate the essential protein-protein interactions required for Hgh1's co-chaperone function.</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>Although explicit localization studies for the <em>S. pombe</em> Hgh1 protein were not identified in the retrieved literature, all functional evidence places Hgh1 firmly in the cytoplasm. Hgh1 acts co-translationally, engaging nascent eEF2 polypeptides during ribosomal synthesis (monkemeyer2019structuralandfunctional pages 110-111, monkemeyer2019structuralandfunctional pages 133-135). Its binding partners — TRiC/CCT, Hsp90, and Cns1 — are all cytoplasmic chaperone systems (yang2026emw1ttc27isa pages 1-2, engler2025theevolutionand pages 3-5). eEF2 itself is a cytoplasmic translation factor that functions on cytoplasmic ribosomes. Therefore, Hgh1 is expected to function in the cytoplasm, likely in association with translating ribosomes.</p>
+<h2 id="5-biological-pathway-context">5. Biological Pathway Context</h2>
+<h3 id="51-proteostasis-and-translation-elongation">5.1 Proteostasis and Translation Elongation</h3>
+<p>Hgh1 operates at the nexus of protein folding and translation elongation. By ensuring proper eEF2 biogenesis, Hgh1 maintains the functional pool of eEF2 required for efficient ribosomal translocation during translation. Deletion of <em>HGH1</em> alone does not impair growth but triggers a mild heat shock response, indicative of increased protein-folding stress in the cell (monkemeyer2019structuralandfunctional pages 36-38). When combined with additional perturbations — reduced eEF2 gene dosage (e.g., <em>eft2Δ</em>), Hsp90 mutations, or impaired Emw1 function — loss of Hgh1 results in severe growth defects, consistent with reduced eEF2 levels becoming limiting for cell viability (monkemeyer2019structuralandfunctional pages 110-111, fulton2024hsp90andcochaperones pages 7-9, yang2026emw1ttc27isa pages 4-8).</p>
+<h3 id="52-phenotypic-consequences-of-hgh1-deletion">5.2 Phenotypic Consequences of HGH1 Deletion</h3>
+<p>In <em>S. cerevisiae</em>, <em>hgh1Δ</em> causes an approximately 30–35% reduction in total eEF2 protein levels, with concomitant accumulation of insoluble, misfolded eEF2 (monkemeyer2019structuralandfunctional pages 110-111, fulton2024hsp90andcochaperones pages 4-5). The <em>hgh1Δ eft2Δ</em> double mutant reduces eEF2 to only ~25% of wild-type levels, which is limiting for growth, particularly at low temperatures (20°C) (monkemeyer2019structuralandfunctional pages 110-111). Combined <em>hgh1Δ</em> with Hsp90 reopening mutants (S25P, K102E, L379S, Q380K, E377A) results in very poor growth, indicating a critical role for Hgh1 in eEF2 maturation when the Hsp90 conformational cycle is perturbed (fulton2024hsp90andcochaperones pages 7-9).</p>
+<h3 id="53-relevance-to-human-disease">5.3 Relevance to Human Disease</h3>
+<p>Mutations in human eEF2 that are associated with neurodevelopmental disorders (including non-specific craniofacial dysmorphisms, abnormal brain morphology, and autosomal dominant spinocerebellar ataxia) were modeled in yeast, and loss of Hgh1 negatively impacted the growth of strains expressing these disease-mimicking eEF2 variants (fulton2024hsp90andcochaperones pages 1-2, fulton2024hsp90andcochaperones pages 9-10). Notably, overexpression of Hgh1 partially rescued the growth defect associated with the eEF2 C372Y mutation, suggesting that enhancing co-chaperone capacity could mitigate eEF2 misfolding defects relevant to human disease (fulton2024hsp90andcochaperones pages 9-10, fulton2024hsp90andcochaperones pages 14-15). Additionally, human HGH1/FAM203 has been identified as a potential oncogenic factor in breast cancer, where it interacts with eEF2 and is regulated through NSUN2-mediated m5C RNA methylation, influencing mRNA stability and translation efficiency (que2024theroleof pages 5-6).</p>
+<h2 id="6-evolutionary-conservation">6. Evolutionary Conservation</h2>
+<p>Hgh1 and its homologs (FAM203 in humans) are conserved throughout the eukaryotic tree of life (monkemeyer2019structuralandfunctional pages 36-38). The human homolog FAM203/HGH1 was originally identified as a TRiC interactor through genome-wide interaction screening in HeLa cells (monkemeyer2019structuralandfunctional pages 36-38). The conservation of Hgh1 across eukaryotes reflects the fundamental importance of eEF2 biogenesis — eEF2 is an essential and highly abundant protein in all eukaryotic cells, and its complex multi-domain structure necessitates dedicated chaperone assistance for proper folding (yang2026emw1ttc27isa pages 1-2). Within the broader Hsp90 co-chaperone system, Hgh1 represents one of the more client-specific co-chaperones, having evolved to service a single essential client protein (eEF2) rather than acting as a general-purpose co-chaperone (engler2025theevolutionand pages 3-5).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>The <em>S. pombe</em> hgh1 gene product (Q10498) is a conserved co-chaperone protein with an armadillo-repeat-like helical solenoid structure. Its primary molecular function is to facilitate the co-translational folding of eEF2, the essential GTP-dependent translation elongation factor, by binding to the dynamic domain III of nascent eEF2 polypeptides and recruiting the TRiC/CCT chaperonin for encapsulation-mediated folding of eEF2 domains III–V. Hgh1 also participates in a quaternary complex with Hsp90, the co-chaperone Cns1, and eEF2, linking it to the Hsp90 proteostasis machinery. The protein functions in the cytoplasm and is critical for maintaining cellular eEF2 levels and translation fidelity. Loss of Hgh1 results in eEF2 misfolding and reduced protein levels, with significant synthetic interactions with other chaperone and translation factor genes. The HGH1/FAM203 family is conserved across eukaryotes, underscoring the fundamental importance of dedicated chaperone systems for the biogenesis of essential translation factors.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(monkemeyer2019structuralandfunctional pages 36-38): Leonie Mönkemeyer. Structural and functional studies on the eukaryotic chaperonin tric/cct and its cooperating chaperone hgh1. Dissertation, Jan 2019. URL: https://doi.org/10.5282/edoc.23750, doi:10.5282/edoc.23750. This article has 0 citations.</p>
+</li>
+<li>
+<p>(monkemeyer2019structuralandfunctional pages 110-111): Leonie Mönkemeyer. Structural and functional studies on the eukaryotic chaperonin tric/cct and its cooperating chaperone hgh1. Dissertation, Jan 2019. URL: https://doi.org/10.5282/edoc.23750, doi:10.5282/edoc.23750. This article has 0 citations.</p>
+</li>
+<li>
+<p>(yang2026emw1ttc27isa pages 1-2): Mengqi Yang, Ruixin Li, Anna I. Mikolajczak, Vanessa A. Wright, Mahnoor Hassan, Cara K. Vaughan, Thomas A. K. Prescott, Jennifer A. Heritz, Mehdi Mollapour, and Barry Panaretou. Emw1/ttc27 is a chaperone required for folding of the eukaryotic elongation factor 2. Cellular and Molecular Life Sciences, Mar 2026. URL: https://doi.org/10.1007/s00018-026-06154-9, doi:10.1007/s00018-026-06154-9. This article has 0 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 1-2): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(engler2025theevolutionand pages 3-5): Sonja Engler and Johannes Buchner. The evolution and diversification of the hsp90 co-chaperone system. Biological Chemistry, Apr 2025. URL: https://doi.org/10.1515/hsz-2025-0112, doi:10.1515/hsz-2025-0112. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(que2024theroleof pages 5-6): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 14 citations.</p>
+</li>
+<li>
+<p>(monkemeyer2019structuralandfunctional pages 133-135): Leonie Mönkemeyer. Structural and functional studies on the eukaryotic chaperonin tric/cct and its cooperating chaperone hgh1. Dissertation, Jan 2019. URL: https://doi.org/10.5282/edoc.23750, doi:10.5282/edoc.23750. This article has 0 citations.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 13-14): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 7-9): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2026emw1ttc27isa pages 4-8): Mengqi Yang, Ruixin Li, Anna I. Mikolajczak, Vanessa A. Wright, Mahnoor Hassan, Cara K. Vaughan, Thomas A. K. Prescott, Jennifer A. Heritz, Mehdi Mollapour, and Barry Panaretou. Emw1/ttc27 is a chaperone required for folding of the eukaryotic elongation factor 2. Cellular and Molecular Life Sciences, Mar 2026. URL: https://doi.org/10.1007/s00018-026-06154-9, doi:10.1007/s00018-026-06154-9. This article has 0 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 4-5): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sabbarini2023zincfingerproteinzpr1 pages 25-26): Ibrahim M. Sabbarini, Dvir Reif, Alexander J. McQuown, Anjali R. Nelliat, Jeffrey Prince, Britnie Santiago Membreno, Colin Chih-Chien Wu, Andrew W. Murray, and Vladimir Denic. Zinc-finger protein zpr1 is a bespoke chaperone essential for eef1a biogenesis. Molecular cell, 83:252-265.e13, Jan 2023. URL: https://doi.org/10.1016/j.molcel.2022.12.012, doi:10.1016/j.molcel.2022.12.012. This article has 28 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 5-7): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 9-10): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 14-15): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="hgh1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="hgh1-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a><br />
+<img alt="Image artifact created (ID artifact-01): 'Hgh1-Centered eEF2 Chaperone Network' ![Hgh1-Centered eEF2 Chaperone Network](artifact:artifact-01) Artifact IDs that " src="hgh1-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>monkemeyer2019structuralandfunctional pages 36-38</li>
+<li>que2024theroleof pages 5-6</li>
+<li>monkemeyer2019structuralandfunctional pages 133-135</li>
+<li>monkemeyer2019structuralandfunctional pages 110-111</li>
+<li>engler2025theevolutionand pages 3-5</li>
+<li>Hgh1-Centered eEF2 Chaperone Network</li>
+<li>https://doi.org/10.5282/edoc.23750,</li>
+<li>https://doi.org/10.1007/s00018-026-06154-9,</li>
+<li>https://doi.org/10.1371/journal.pgen.1011508,</li>
+<li>https://doi.org/10.1515/hsz-2025-0112,</li>
+<li>https://doi.org/10.1016/j.heliyon.2024.e29029,</li>
+<li>https://doi.org/10.1016/j.molcel.2022.12.012,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hgh1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q10498" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hgh1-spac26f112c-s-pombe-review-notes">hgh1 (SPAC26F1.12c) — S. pombe review notes</h1>
+<p>UniProt: Q10498 (HGH1_SCHPO), 356 aa, 41.3 kDa. PomBase: SPAC26F1.12c, standard name <code>hgh1</code>.<br />
+PomBase product: "eEF2 folding chaperone Hgh1". Characterisation status: <strong>"biological role inferred"</strong><br />
+(i.e. the eEF2-chaperone role is inferred from the S. cerevisiae ortholog, not directly demonstrated in S. pombe).</p>
+<h2 id="identity-family-from-uniprot-interpro-pombase">Identity / family (from UniProt + InterPro + PomBase)</h2>
+<ul>
+<li>UniProt RecName (by similarity to S. cerevisiae P48362): "Co-chaperone protein HGH1 homolog".</li>
+<li>Belongs to the <strong>HGH1 family</strong> (UniProt SIMILARITY, ECO:0000305).</li>
+<li>InterPro architecture: IPR039717 (Hgh1), IPR007205 (Protein_HGH1_N / Pfam PF04063 DUF383),<br />
+  IPR007206 (Protein_HGH1_C / Pfam PF04064 DUF384), on an <strong>ARM-type fold / ARM-like</strong> scaffold<br />
+  (IPR011989 ARM-like, IPR016024 ARM-type_fold; Gene3D 1.25.10.10 "Leucine-rich Repeat Variant";<br />
+  SUPFAM SSF48371 "ARM repeat"). PANTHER PTHR13387 "PROTEIN HGH1 HOMOLOG".</li>
+<li>Orthologs (PomBase): human HGNC:24161 (<strong>HGH1 / FAM203 / C21orf25</strong>), S. cerevisiae <strong>YGR187C (HGH1)</strong>,<br />
+  S. japonicus SJAG_02014. eggNOG KOG2973 (Eukaryota).</li>
+<li>No signal peptide, no TM segment → soluble cytoplasmic protein (consistent with the family).</li>
+</ul>
+<h2 id="what-is-known-about-the-hgh1-family-chiefly-from-s-cerevisiae-hgh1">What is KNOWN about the HGH1 family (chiefly from S. cerevisiae Hgh1)</h2>
+<p>Primary experimental characterization is in <strong>budding yeast</strong> Hgh1 (P48362):<br />
+[PMID:30876804 "Chaperone Function of Hgh1 in the Biogenesis of Eukaryotic Elongation Factor 2",<br />
+Mönkemeyer/Klaips/Balchin/Körner/Hartl/Bracher, Mol Cell 2019].<br />
+Abstract-only cache; key verbatim facts:<br />
+- "the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with TRiC in<br />
+  eEF2 folding."<br />
+- "In the absence of Hgh1, a substantial fraction of newly synthesized eEF2 is degraded or aggregates."<br />
+- "Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III of eEF2 via a<br />
+  bipartite interface."<br />
+- "Hgh1 binding recruits TRiC to the C-terminal eEF2 module and prevents unproductive interactions of<br />
+  domain III, allowing efficient folding of the N-terminal GTPase module."<br />
+- "eEF2 folding is completed upon dissociation of TRiC and Hgh1."</p>
+<p>So the S. cerevisiae protein is a <strong>dedicated co-chaperone/adaptor for eEF2 biogenesis</strong>: it is not an<br />
+ATP-driven foldase itself, but an armadillo-repeat scaffold that (i) shields the dynamic domain III of<br />
+the nascent eEF2, and (ii) recruits the chaperonin TRiC/CCT (and, per UniProt SUBUNIT, potentially<br />
+Hsp90 via Cns1) to the client. It forms a ternary Hgh1–eEF2–TRiC complex. eEF2 (but not Hgh1) is<br />
+essential; Hgh1 loss reduces mature-eEF2 yield rather than abolishing translation.</p>
+<h2 id="what-is-known-specifically-about-s-pombe-hgh1">What is known SPECIFICALLY about S. pombe hgh1</h2>
+<ul>
+<li><strong>No S. pombe-specific molecular study of hgh1.</strong> All GO molecular-function/biological-process<br />
+  annotations in GOA are electronic ISO transfers from S. cerevisiae HGH1 (GO_REF:0000024,<br />
+  with/from SGD:S000003419), plus one IEA subcellular-location mapping and an ISS location.</li>
+<li><strong>Deletion phenotype (S. pombe): viable, normal cell morphology</strong> (PomBase deletion_viability = viable;<br />
+  FYPO:0002060 "viable vegetative cell population", FYPO:0002177 "viable vegetative cell with normal cell<br />
+  morphology"). This is consistent with the non-essential co-chaperone role seen in budding yeast.</li>
+<li>A broad set of high-throughput <strong>stress phenotypes</strong> are recorded from genome-wide screens (e.g.<br />
+  sensitivity to hydroxyurea, lithium, several antifungals; resistance to caffeine, brefeldin A, diamide,<br />
+  bleomycin, etc.). These are pleiotropic HT-screen signals and are not, on their own, evidence of a<br />
+  specific molecular function; I do not build core_functions on them.</li>
+</ul>
+<h2 id="domain-reasoning-inline-no-external-bioinformatics-agent">Domain reasoning (inline, no external bioinformatics agent)</h2>
+<ul>
+<li>The Q10498 sequence is 356 aa with the two-part HGH1 Pfam signature (PF04063 N + PF04064 C) mapped by<br />
+  InterPro, sitting on an all-α ARM/HEAT-like solenoid (SUPFAM ARM repeat; Gene3D 1.25.10.10). Armadillo<br />
+  solenoids are classic <strong>protein–protein interaction scaffolds</strong>, which fits the "adaptor that clamps a<br />
+  client and recruits chaperonins" mechanism established for the ortholog.</li>
+<li>No nucleotide-binding (Walker/P-loop) or catalytic motifs are annotated → consistent with a<br />
+<strong>non-catalytic, non-ATP-dependent co-chaperone</strong> (hence MF GO:0044183 "protein folding chaperone",<br />
+  NOT GO:0140662 "ATP-dependent protein folding chaperone").</li>
+<li>Length and family membership match the S. cerevisiae ortholog (Sc Hgh1 ~394 aa); orthology is<br />
+  unambiguous (single-copy KOG2973; reciprocal PomBase ortholog calls), so ISO transfer of the eEF2<br />
+  co-chaperone role is biologically well-motivated even though not directly tested in S. pombe.</li>
+</ul>
+<h2 id="annotation-by-annotation-plan-goa-has-6-rows-several-are-duplicatesoverlaps">Annotation-by-annotation plan (GOA has 6 rows; several are duplicates/overlaps)</h2>
+<ol>
+<li>GO:0005737 cytoplasm, IEA, GO_REF:0000044 (SubCell mapping). Cytoplasmic localization is expected for<br />
+   this soluble family; ACCEPT (location, non-core).</li>
+<li>GO:0044183 protein folding chaperone, ISO, GO_REF:0000024 (from SGD). This is the correct MF for the<br />
+   ortholog's mechanism (co-chaperone/adaptor, non-ATP). KEEP — core molecular function (transferred).<br />
+   (Appears twice in GOA — duplicate ISO row.)</li>
+<li>GO:0051083 'de novo' cotranslational protein folding, ISO, GO_REF:0000024. Matches the co-translational<br />
+   eEF2-folding role. KEEP — core biological process (transferred).</li>
+<li>GO:0005737 cytoplasm, ISS, GO_REF:0000024 (from UniProt P48362). Redundant with #1 but well-supported;<br />
+   ACCEPT (location).</li>
+<li>GO:0005634 nucleus, ISO, GO_REF:0000024 (is_active_in). <strong>Questionable.</strong> eEF2 folding is a<br />
+   cytoplasmic/co-translational process; the ortholog is described as cytosolic. A nuclear "is_active_in"<br />
+   for a cytoplasmic co-chaperone is not supported by the mechanism and looks like an over-broad ISO<br />
+   transfer (SGD high-throughput localization). MARK_AS_OVER_ANNOTATED (or KEEP_AS_NON_CORE at most).</li>
+<li>GO:0005737 cytoplasm, ISO, is_active_in, GO_REF:0000024. Consistent with the site of action; ACCEPT<br />
+   (location, non-core; cytoplasm is where the eEF2/TRiC folding happens).</li>
+</ol>
+<h2 id="knowledge-gaps-the-honest-core-deliverable">Knowledge gaps (the honest core deliverable)</h2>
+<ul>
+<li><strong>Molecular activity in S. pombe is inferred, not measured.</strong> No study has shown fission-yeast Hgh1<br />
+  binds eEF2 (ef2 = tef1/tef2 products in S. pombe) or TRiC, or affects eEF2 folding/levels.</li>
+<li><strong>Biological role / phenotype:</strong> deletion is viable with normal morphology; the physiological<br />
+  consequence of losing hgh1 in S. pombe (e.g. eEF2 abundance, translation elongation fidelity, stress<br />
+  fitness) has not been dissected. The HT stress phenotypes are unexplained mechanistically.</li>
+<li><strong>Nuclear pool:</strong> whether hgh1 has any genuine nuclear function (vs. an ISO artifact) is unknown.</li>
+<li>Family-level: whether HGH1 proteins have clients beyond eEF2 is not established.</li>
+</ul>
+<h2 id="deep-research-falcon-edison-scientific">Deep research (falcon / Edison Scientific)</h2>
+<p>Falcon deep research completed (~21 min; <code>hgh1-deep-research-falcon.md</code>, 12 citations). It<br />
+independently corroborates the review: HGH1 as a dedicated eEF2 co-chaperone that binds eEF2<br />
+domain III co-translationally, recruits TRiC/CCT (incl. Cct6) and links to a Cns1–Hsp90 network;<br />
+hgh1Δ reduces total eEF2 by ~30–35% with increased insoluble eEF2; localization is cytoplasmic<br />
+by inference, "explicit localization experiments were not identified in the retrieved evidence".<br />
+The report is centered on the S. cerevisiae ortholog and explicitly notes S. pombe hgh1 function<br />
+is inferred. Some falcon citations use Edison-internal keys (e.g. yang2026, fulton2024, engler2025)<br />
+that are not verified PMIDs; the review therefore anchors all <code>supporting_text</code> only to the<br />
+independently verified PMID:30876804. The perplexity-lite fallback failed (API 401/quota).</p>
+<h2 id="references-to-cite">References to cite</h2>
+<ul>
+<li>PMID:30876804 — primary S. cerevisiae Hgh1/eEF2 mechanism (HIGH relevance; the basis for the ISO transfer).</li>
+<li>GO_REF:0000024 — ISO transfer method (already present).</li>
+<li>GO_REF:0000044 — SubCell location mapping (already present).</li>
+<li>file: bioinformatics not needed; UniProt/InterPro domain evidence cited inline.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q10498
+gene_symbol: hgh1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  hgh1 is the Schizosaccharomyces pombe member of the conserved HGH1 protein family
+  (orthologous to Saccharomyces cerevisiae Hgh1 and human HGH1/FAM203). It is a small
+  (~356 aa, ~41 kDa) soluble, non-catalytic protein built on an armadillo/HEAT-like
+  all-alpha repeat scaffold with the family-diagnostic HGH1 N- and C-terminal domains
+  (Pfam DUF383/DUF384). In budding yeast the ortholog is a dedicated co-chaperone for
+  the biogenesis of eukaryotic elongation factor 2 (eEF2): it binds the structurally
+  dynamic central domain III of nascent eEF2 and recruits the chaperonin TRiC/CCT (and
+  potentially Hsp90 via a Cns1 co-chaperone), shielding domain III and promoting
+  productive folding of the essential eEF2 GTPase, before dissociating once folding is
+  complete. On this basis hgh1 is annotated as a cytoplasmic protein-folding chaperone
+  acting in co-translational protein folding. The eEF2-chaperone function has not been
+  directly demonstrated in fission yeast; the fission-yeast gene is dispensable for
+  viability, and its S. pombe-specific molecular activity, client range, and biological
+  role remain to be experimentally established.
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:30876804
+  title: Chaperone Function of Hgh1 in the Biogenesis of Eukaryotic Elongation Factor
+    2.
+  findings:
+  - statement: &gt;-
+      The conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates with
+      the chaperonin TRiC/CCT in the folding of eukaryotic elongation factor 2 (eEF2);
+      in its absence a substantial fraction of newly synthesized eEF2 is degraded or
+      aggregates.
+    supporting_text: &gt;-
+      the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates
+      with TRiC in eEF2 folding. In the absence of Hgh1, a substantial fraction of
+      newly synthesized eEF2 is degraded or aggregates.
+    reference_section_type: ABSTRACT
+  - statement: &gt;-
+      Hgh1 is an armadillo-repeat protein that binds the dynamic central domain III of
+      eEF2 via a bipartite interface, recruits TRiC to the C-terminal eEF2 module, and
+      prevents unproductive interactions of domain III, enabling folding of the
+      N-terminal GTPase module.
+    supporting_text: &gt;-
+      Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III
+      of eEF2 via a bipartite interface. Hgh1 binding recruits TRiC to the C-terminal
+      eEF2 module and prevents unproductive interactions of domain III, allowing
+      efficient folding of the N-terminal GTPase module.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMID verified via NCBI esearch/esummary (Mönkemeyer et al., Mol Cell 74:88-100,
+      2019; DOI 10.1016/j.molcel.2019.01.034). This is the primary experimental
+      characterization of the S. cerevisiae Hgh1 ortholog and is the biological basis
+      for the ISO transfers to S. pombe hgh1. The work is on budding-yeast Hgh1, not
+      fission-yeast hgh1 directly; abstract-only cache.
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization inferred by UniProt SubCell mapping. Consistent with a
+      soluble co-chaperone lacking signal/transmembrane features and with the cytosolic
+      site of eEF2/TRiC-assisted folding.
+    action: ACCEPT
+    reason: &gt;-
+      hgh1 has no signal peptide or transmembrane segment (UniProt Q10498) and belongs
+      to a soluble ARM-repeat family; the cytoplasm is where the eEF2/TRiC co-translational
+      folding it participates in occurs. Location is well supported but not itself a
+      core function.
+    supported_by:
+    - reference_id: PMID:30876804
+      supporting_text: &gt;-
+        the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates
+        with TRiC in eEF2 folding.
+- term:
+    id: GO:0044183
+    label: protein folding chaperone
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Molecular function transferred by orthology from S. cerevisiae Hgh1, which acts as
+      a (non-ATP-dependent) co-chaperone/adaptor that binds nascent eEF2 and recruits the
+      chaperonin TRiC. &#34;protein folding chaperone&#34; (GO:0044183, not the ATP-dependent
+      child GO:0140662) is the appropriate molecular function for this adaptor-type role.
+    action: ACCEPT
+    reason: &gt;-
+      The ortholog&#39;s chaperone activity toward eEF2 is experimentally established
+      (PMID:30876804) and the orthology (single-copy KOG2973; reciprocal PomBase ortholog
+      calls to S. cerevisiae YGR187C and human HGH1/FAM203) is unambiguous. Hgh1 is not an
+      ATP-driven foldase; the general MF term is correct. This is the core molecular
+      function, though it is inferred rather than measured in S. pombe.
+    supported_by:
+    - reference_id: PMID:30876804
+      supporting_text: &gt;-
+        Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III
+        of eEF2 via a bipartite interface.
+- term:
+    id: GO:0051083
+    label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Biological process transferred by orthology. The ortholog assists folding of nascent,
+      ribosome-associated eEF2 co-translationally, recruiting TRiC and shielding domain III
+      until the GTPase module folds. This is consistent with the co-translational,
+      de-novo-folding scope of GO:0051083.
+    action: ACCEPT
+    reason: &gt;-
+      Matches the experimentally described mechanism of the ortholog (assists folding of
+      newly synthesized eEF2, cooperating with the chaperonin). Retained as the core
+      biological process, inferred by orthology.
+    supported_by:
+    - reference_id: PMID:30876804
+      supporting_text: &gt;-
+        In the absence of Hgh1, a substantial fraction of newly synthesized eEF2 is
+        degraded or aggregates.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization transferred by sequence similarity from UniProt P48362
+      (S. cerevisiae Hgh1). Redundant with the IEA SubCell annotation but concordant and
+      well motivated by the family&#39;s soluble, cytosolic character.
+    action: ACCEPT
+    reason: &gt;-
+      Same well-supported cytoplasmic location as the IEA row, from an orthology-based
+      (ISS) source; concordant with the site of eEF2 folding. Location, non-core.
+    supported_by:
+    - reference_id: PMID:30876804
+      supporting_text: &gt;-
+        the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates
+        with TRiC in eEF2 folding.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Nuclear &#34;is_active_in&#34; transferred by orthology. eEF2 biogenesis is a cytoplasmic,
+      co-translational process, and both the fission-yeast protein and the characterized
+      S. cerevisiae ortholog are described as cytosolic (UniProt Q10498/P48362 SUBCELLULAR
+      LOCATION: Cytoplasm). No molecular role for HGH1 proteins in the nucleus has been
+      demonstrated; a nuclear site of action is not supported by the established mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The known function of the HGH1 family (recruiting TRiC/Hsp90 to fold nascent
+      cytoplasmic eEF2) is incompatible with a nuclear site of action. The nuclear
+      &#34;is_active_in&#34; appears to be an over-broad ISO transfer from a high-throughput
+      localization dataset rather than a functionally meaningful nuclear activity. There
+      is no evidence for a nuclear function in S. pombe; flagging as over-annotation rather
+      than removing, since a minor nucleocytoplasmic pool cannot be excluded and the
+      curator&#39;s source evidence has not been read.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: SGD:S000003419
+        source_label: HGH1 (S. cerevisiae, YGR187C)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          The eEF2 co-chaperone activity of the S. cerevisiae ortholog is a cytoplasmic,
+          co-translational process; an is_active_in nucleus qualifier does not reflect the
+          site where this molecular function is executed and should not propagate as a
+          functional (is_active_in) annotation to hgh1.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cytoplasmic site of action transferred by orthology. This is where the eEF2/TRiC
+      co-translational folding cycle occurs, so &#34;is_active_in cytoplasm&#34; correctly captures
+      the compartment in which hgh1&#39;s inferred molecular function is executed.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the established cytosolic mechanism of the ortholog and with the
+      located_in cytoplasm annotations. Non-core location/site-of-action term.
+    supported_by:
+    - reference_id: PMID:30876804
+      supporting_text: &gt;-
+        Hgh1 binding recruits TRiC to the C-terminal eEF2 module and prevents unproductive
+        interactions of domain III, allowing efficient folding of the N-terminal GTPase
+        module.
+core_functions:
+- description: &gt;-
+    Co-chaperone / chaperonin-recruiting adaptor for the folding of nascent eukaryotic
+    elongation factor 2 (eEF2). Built on an armadillo-repeat scaffold, hgh1 binds the
+    dynamic central domain III of newly synthesized eEF2 and recruits the chaperonin
+    TRiC/CCT (and potentially Hsp90) to the client, shielding domain III and promoting
+    productive folding of the eEF2 GTPase module. It is a non-catalytic, non-ATP-dependent
+    protein-folding chaperone. This molecular role is inferred from the diagnostic HGH1
+    family/ARM-repeat architecture and the experimentally established function of the
+    S. cerevisiae and human orthologs; it has not been directly demonstrated for the
+    fission-yeast protein.
+  molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0051083
+    label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:30876804
+    supporting_text: &gt;-
+      Hgh1 is an armadillo repeat protein that binds to the dynamic central domain III of
+      eEF2 via a bipartite interface. Hgh1 binding recruits TRiC to the C-terminal eEF2
+      module and prevents unproductive interactions of domain III, allowing efficient
+      folding of the N-terminal GTPase module.
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether S. pombe hgh1 actually performs the eEF2 co-chaperone function is unmeasured:
+    no fission-yeast experiment has shown hgh1 binds eEF2 (or its domain III), recruits
+    TRiC/CCT or Hsp90, or is required for eEF2 folding, abundance, or stability. Every
+    molecular-function and biological-process annotation for hgh1 is an electronic
+    orthology transfer (ISO from S. cerevisiae; GO_REF:0000024), not a direct observation.
+  boundary: &gt;-
+    The mechanism is firmly established for the S. cerevisiae ortholog: Hgh1 is an
+    armadillo-repeat chaperone that binds nascent eEF2 domain III and recruits TRiC to
+    fold the eEF2 GTPase module (PMID:30876804). Orthology of hgh1 to S. cerevisiae
+    YGR187C and human HGH1/FAM203 is unambiguous (single-copy KOG2973; reciprocal ortholog
+    calls), and hgh1 carries the diagnostic HGH1 domains on an ARM-type fold. What is
+    missing is any S. pombe-specific functional assay.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    eEF2 is essential and highly abundant; a dedicated biogenesis factor for it is a node
+    where translation capacity and proteostasis intersect. Confirming (or refuting) the
+    conserved role in fission yeast would validate the orthology-based annotation and
+    clarify whether the pathway is universally conserved across yeasts.
+  resolution: &gt;-
+    Test physical interaction of hgh1 with eEF2 (ef2/tef products) and with the CCT/TRiC
+    subunits in S. pombe (co-IP, crosslinking); quantify mature eEF2 levels and aggregation
+    in an hgh1-delta strain; assess translation-elongation and eEF2-folding phenotypes.
+  provenance:
+  - reference_id: PMID:30876804
+    supporting_text: &gt;-
+      the highly conserved protein Hgh1 (FAM203 in humans) is a chaperone that cooperates
+      with TRiC in eEF2 folding.
+- gap_statement: &gt;-
+    The biological role and loss-of-function consequences of hgh1 in fission yeast are
+    largely undefined. Deletion is viable with normal morphology, so any requirement is
+    conditional/quantitative; the mechanistic basis for the pleiotropic stress phenotypes
+    reported in high-throughput screens (e.g. hydroxyurea/lithium sensitivity, caffeine
+    resistance) is unknown and not obviously connected to eEF2 folding.
+  boundary: &gt;-
+    PomBase records hgh1 deletion as viable (FYPO &#34;viable vegetative cell population&#34;,
+    &#34;viable vegetative cell with normal cell morphology&#34;) with a broad set of
+    condition-specific stress phenotypes from genome-wide screens; characterisation status
+    is &#34;biological role inferred&#34;. The client protein eEF2 is itself essential.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Understanding why an eEF2 biogenesis factor is dispensable, and what the stress
+    phenotypes reflect, would reveal how much eEF2 folding depends on this dedicated
+    co-chaperone versus general chaperone redundancy.
+  resolution: &gt;-
+    Targeted phenotyping of an hgh1-delta strain under the flagged stresses with eEF2
+    readouts; epistasis with cct/TRiC and hsp90 co-chaperone mutants; measurement of
+    translation elongation rate/fidelity.
+- gap_statement: &gt;-
+    Whether HGH1-family proteins act on clients other than eEF2, and whether hgh1 has any
+    genuine nuclear function (as an &#34;is_active_in nucleus&#34; annotation suggests) rather than
+    being exclusively a cytoplasmic eEF2 co-chaperone, is unknown.
+  boundary: &gt;-
+    All experimentally defined function of the family concerns cytoplasmic eEF2 folding;
+    both hgh1 and its ortholog are annotated as cytoplasmic (UniProt SUBCELLULAR LOCATION).
+    No non-eEF2 client and no nuclear molecular activity have been demonstrated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Establishing the client range would determine whether HGH1 is a dedicated eEF2 factor
+    or a more general folding adaptor, informing how conserved this proteostasis module is.
+  resolution: &gt;-
+    Unbiased interactome (proximity labeling / affinity-MS) of hgh1 in S. pombe; test for
+    any functional nuclear pool by localization and nuclear-anchoring/depletion assays.
+suggested_questions:
+- question: &gt;-
+    Does S. pombe hgh1 physically bind eEF2 and the CCT/TRiC chaperonin, and is it required
+    for efficient eEF2 folding and steady-state abundance in fission yeast, as its
+    S. cerevisiae ortholog is?
+  experts:
+  - Molecular chaperone / eEF2 biogenesis biochemists (e.g. authors of PMID:30876804)
+  - Fission-yeast proteostasis researchers
+- question: &gt;-
+    What accounts for the pleiotropic stress-response phenotypes of hgh1 deletion, and are
+    they downstream of altered eEF2 biogenesis/translation elongation?
+  experts:
+  - Fission-yeast functional-genomics / phenomics groups
+suggested_experiments:
+- hypothesis: &gt;-
+    hgh1 is a conserved co-chaperone that binds nascent eEF2 domain III and recruits TRiC,
+    required for efficient eEF2 folding in S. pombe.
+  description: &gt;-
+    Affinity-purify tagged hgh1 from S. pombe and identify interactors by mass spectrometry;
+    specifically test for eEF2 (ef2) and CCT/TRiC subunits and Hsp90. Complement with in vitro
+    binding to recombinant eEF2 and eEF2 domain-III fragments.
+  experiment_type: co-immunoprecipitation / affinity-MS and in vitro binding
+- hypothesis: &gt;-
+    Loss of hgh1 reduces mature eEF2 and impairs translation elongation under stress.
+  description: &gt;-
+    Construct an hgh1-delta strain; quantify soluble vs aggregated eEF2 and total eEF2 levels,
+    measure translation-elongation rate/fidelity (e.g. ribosome profiling, readthrough
+    reporters), and phenotype under the stresses flagged in high-throughput screens.
+  experiment_type: genetics + proteomics + ribosome profiling
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/iwr1/iwr1-ai-review.html
+++ b/genes/SCHPO/iwr1/iwr1-ai-review.html
@@ -1,0 +1,2653 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>iwr1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>iwr1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O13951" target="_blank" class="term-link">
+                        O13951
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "iwr1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O13951" data-a="DESCRIPTION: iwr1 is the fission-yeast member of the conserved ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>iwr1 is the fission-yeast member of the conserved eukaryotic Iwr1/SLC7A6OS family (Pfam PF08574; InterPro IPR040150/IPR013883, &#34;Interactor of Rpb1&#34;), represented by a single copy per genome. In the well-characterized budding-yeast and metazoan orthologs the protein is a dedicated RNA polymerase II biogenesis factor: it binds the fully assembled 12-subunit Pol II in the active-center cleft between the two largest subunits in the cytoplasm, and presents its own N-terminal bipartite nuclear localization signal to karyopherin-alpha to drive nuclear import of the polymerase. Inside the nucleus it is displaced from Pol II by transcription initiation factors and nucleic acids, allowing its re-export and recycling, so it acts as a cyclic, Pol II-specific, transcription-independent import adaptor rather than a stable subunit. Consistent with this shuttling behaviour the protein distributes between cytoplasm and nucleus. The S. pombe protein (277 aa) carries the family fold plus a long, acidic, intrinsically disordered C-terminus. Its function in S. pombe has not been assayed directly and is inferred from orthology and family conservation.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization is consistent with the conserved function of the Iwr1 family: the import adaptor accompanies RNA polymerase II into the nucleus and is displaced there before recycling. IBA (phylogenetic) is the strongest of the several redundant evidence lines supporting nuclear localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Phylogenetic inference over the Iwr1 family (PTHR28063) supports nuclear localization; consistent with UniProt SUBCELLULAR LOCATION (nucleus) and the nucleocytoplasmic shuttling described for the S. cerevisiae ortholog (PMID:21504834). Represents a core site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                        PMID:21504834
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Iwr1 then uses an N-terminal bipartite nuclear localization signal that is recognized by karyopherin alpha to direct Pol II nuclear import.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytoplasmic localization is consistent with the family function: Iwr1 binds the newly assembled Pol II in the cytoplasm before escorting it into the nucleus, and the protein shuttles between the two compartments.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Phylogenetic inference plus UniProt SUBCELLULAR LOCATION (cytoplasm; &#34;shuttles between the nucleus and cytoplasm&#34;). The cytoplasm is where the ortholog binds and senses assembled Pol II (PMID:21504834), so it is a core site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                        PMID:21504834
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Iwr1 binds Pol II in the active center cleft between the two largest subunits, maybe facilitating or sensing complete Pol II assembly in the cytoplasm.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006606" target="_blank" class="term-link">
+                                    GO:0006606
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0006606" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the core biological role assigned by orthology: the Iwr1 family directs nuclear import of RNA polymerase II. The IBA annotation is the best-evidence (phylogenetically inferred) representative of this function for S. pombe iwr1, whose own role has not been assayed directly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by the defining S. cerevisiae study (PMID:21504834) and by the Iwr1 Pfam/InterPro family signature (PF08574 / IPR040150), which InterPro maps to this same term. Represents the core function; note the substrate is specifically Pol II, which GO:0006606 does not itself express (see knowledge gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                        PMID:21504834
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we show that Pol II nuclear import requires the protein Iwr1 and provide evidence for cyclic Iwr1 function.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProt Subcellular Location vocabulary mapping, mirroring the nucleus localization already captured by the stronger IBA evidence above. Correct but redundant with the phylogenetic annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the IBA nuclear annotation and UniProt SUBCELLULAR LOCATION. Derived from a subcellular-location mapping (GO_REF:0000044) and duplicates the phylogenetically inferred nucleus term, but the localization is correct and corroborated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProt Subcellular Location vocabulary mapping, mirroring the cytoplasm localization already captured by the stronger IBA evidence above. Correct but redundant with the phylogenetic annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the IBA cytoplasm annotation and UniProt SUBCELLULAR LOCATION. Derived from a subcellular-location mapping (GO_REF:0000044) and duplicates the phylogenetically inferred cytoplasm term, but the localization is correct and corroborated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006606" target="_blank" class="term-link">
+                                    GO:0006606
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0006606" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic InterPro2GO annotation mapping the Iwr1 family signature (IPR040150) to protein import into nucleus. Correct in essence and consistent with the orthology-based function; redundant with the IBA/ISO annotations to the same core term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro2GO (GO_REF:0000002) transfer of the Iwr1-family-to-GO:0006606 mapping; biologically defensible from the family signature and consistent with the better-evidenced IBA and ISO annotations for the same core process.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PomBase records the molecular_function root with No Data, correctly reflecting that no molecular activity has been experimentally determined for S. pombe iwr1 and that no specific MF term has been curated. This gene is MF-dark at the level of direct evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Standard ND placeholder indicating the absence of an experimentally supported molecular-function annotation; appropriate given that all functional inference for pombe iwr1 is by orthology. A specific, informative MF (RNA polymerase II complex binding, GO:0000993) is proposed in core_functions on the basis of the conserved family function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006606" target="_blank" class="term-link">
+                                    GO:0006606
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0006606" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Manual orthology transfer (ISO) from the experimentally characterized S. cerevisiae ortholog IWR1 (SGD:S000002273), which was directly shown to be required for RNA polymerase II nuclear import. This is the annotation that most directly reflects the curatorial basis for iwr1&#39;s assigned function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Curator-judged sequence-similarity transfer from S. cerevisiae IWR1, whose Pol II nuclear-import role is experimentally established (PMID:21504834). A defensible, high-confidence orthology assignment for a single-copy conserved family; do not remove.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                        PMID:21504834
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Iwr1 function is Pol II specific, transcription</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0005634" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Manual orthology transfer (ISO) of nuclear localization from S. cerevisiae IWR1. Consistent with the IBA nucleus annotation and with the shuttling behaviour of the ortholog; corroborating the core nuclear-localization call.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Orthology transfer duplicating the nucleus localization already accepted from IBA; correct and consistent with UniProt SUBCELLULAR LOCATION.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000993" target="_blank" class="term-link">
+                                    GO:0000993
+                                </a>
+                            </span>
+                            <span class="term-label">RNA polymerase II complex binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21504834
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Iwr1 directs RNA polymerase II nuclear import.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O13951" data-a="GO:0000993" data-r="PMID:21504834" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed informative molecular-function annotation replacing the uninformative MF-root ND: the conserved Iwr1 activity is direct binding of the assembled RNA polymerase II complex (in the active-center cleft), which is the physical basis of its import-adaptor role. Assigned by orthology/family signature, not yet demonstrated in S. pombe.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0000993 (RNA polymerase II complex binding) is a specific, informative MF that captures the defining Pol II interaction of the Iwr1 family (PMID:21504834), consistent with the Pfam Iwr1 / InterPro &#34;Interactor of Rpb1&#34; signature; far more informative than a generic protein-binding term and appropriate given the MF-dark ND status.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                        PMID:21504834
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Iwr1 binds Pol II in the active center cleft between the two largest subunits, maybe facilitating or sensing complete Pol II assembly in the cytoplasm.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>RNA polymerase II nuclear import adaptor: binds the fully assembled Pol II complex in the cytoplasm (in the active-center cleft, via the conserved Iwr1 fold) and directs its karyopherin-alpha-dependent import into the nucleus, cycling on and off the polymerase. Assigned to S. pombe iwr1 by orthology to experimentally characterized eukaryotic orthologs and by the Iwr1 family signature; not directly demonstrated in S. pombe.</h3>
+                <span class="vote-buttons" data-g="O13951" data-a="FUNCTION: RNA polymerase II nuclear import adaptor: binds th..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000993" target="_blank" class="term-link">
+                            RNA polymerase II complex binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006606" target="_blank" class="term-link">
+                                protein import into nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                PMID:21504834
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Iwr1 binds Pol II in the active center cleft between the two largest subunits, maybe facilitating or sensing complete Pol II assembly in the cytoplasm.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                                PMID:21504834
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Here we show that Pol II nuclear import requires the protein Iwr1 and provide evidence for cyclic Iwr1 function.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" target="_blank" class="term-link">
+                            PMID:21504834
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Iwr1 directs RNA polymerase II nuclear import.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">In S. cerevisiae, RNA polymerase II nuclear import requires Iwr1, which binds Pol II in the active-center cleft between the two largest subunits, then uses an N-terminal bipartite NLS recognized by karyopherin-alpha to direct import; Iwr1 is subsequently displaced by initiation factors and recycled. The function is Pol II specific, transcription independent, and conserved from yeast to human.</div>
+
+                        <div class="finding-text">"Here we show that Pol II nuclear import requires the protein Iwr1 and provide evidence for cyclic Iwr1 function. Iwr1 binds Pol II in the active center cleft between the two largest subunits, maybe facilitating or sensing complete Pol II assembly in the cytoplasm. Iwr1 then uses an N-terminal bipartite nuclear localization signal that is recognized by karyopherin alpha to direct Pol II nuclear import."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21695216" target="_blank" class="term-link">
+                            PMID:21695216
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Iwr1 protein is important for preinitiation complex formation by all three nuclear RNA polymerases in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Iwr1 was originally identified through its physical interaction with RNA polymerase II and is conserved throughout eukaryotes; in S. cerevisiae it is additionally important for preinitiation complex formation by all three nuclear RNA polymerases.</div>
+
+                        <div class="finding-text">"Iwr1, a protein conserved throughout eukaryotes, was originally identified by its physical interaction with RNA polymerase (Pol) II."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe iwr1 physically associate with fission-yeast RNA polymerase II, and is it required for the polymerase&#39;s nuclear localization as in S. cerevisiae?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O13951" data-a="Q: Does S. pombe iwr1 physically associate with fissi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is iwr1 non-essential in S. pombe (as in budding yeast), and what growth or transcriptional phenotypes accompany its deletion?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O13951" data-a="Q: Is iwr1 non-essential in S. pombe (as in budding y..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged iwr1 and test for co-purification of Rpb1/Rpb2; assess Rpb1 nuclear/cytoplasmic distribution by microscopy in wild-type vs iwr1-deletion cells; test genetic interaction with karyopherin-alpha (imp1/cut15).</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: iwr1 binds assembled S. pombe Pol II and mediates its karyopherin-alpha-dependent nuclear import.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O13951" data-a="EXPERIMENT: Affinity-purify tagged iwr1 and test for co-purifi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct an iwr1 deletion and score viability and growth rate, and quantify global Pol II occupancy or nascent transcription relative to wild type.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: iwr1 is non-essential but confers a growth/transcription fitness advantage under normal or stress conditions.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O13951" data-a="EXPERIMENT: Construct an iwr1 deletion and score viability and..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(iwr1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O13951" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="iwr1-spac23h408-o13951-s-pombe-curation-notes">iwr1 (SPAC23H4.08 / O13951) — S. pombe — curation notes</h1>
+<h2 id="identity-verified-from-uniprot-record-iwr1-uniprottxt">Identity (verified from UniProt record <code>iwr1-uniprot.txt</code>)</h2>
+<ul>
+<li>UniProt: <strong>O13951</strong>, <code>IWR1_SCHPO</code>, 277 aa, reviewed. PE level <strong>3 (Inferred from homology)</strong>.</li>
+<li>Gene: <code>iwr1</code>; systematic/ORF name <code>SPAC23H4.08</code>; Chromosome I.</li>
+<li>Taxon: <em>Schizosaccharomyces pombe</em> 972 / ATCC 24843, NCBITaxon:284812.</li>
+<li>RecName: "RNA polymerase II nuclear localization protein iwr1".</li>
+<li>Family: <strong>IWR1/SLC7A6OS family</strong> (UniProt SIMILARITY, ECO:0000305).</li>
+<li>Domains/family signatures (DR lines):</li>
+<li>Pfam <strong>PF08574</strong> (Iwr1)</li>
+<li>InterPro <strong>IPR040150</strong> (Iwr1), <strong>IPR013883</strong> (TF_Iwr1_dom / "Interactor of Rpb1")</li>
+<li>PANTHER <strong>PTHR28063</strong> = "RNA POLYMERASE II NUCLEAR LOCALIZATION PROTEIN IWR1" (SF1 same name)</li>
+<li>Feature table: C-terminal <strong>disordered region 222–277</strong>; MobiDB-lite compositional bias — basic+acidic (225–234), strongly <strong>acidic</strong> (251–277). No annotated structured/globular domain outside the family fold.</li>
+<li>UniProt curated statements (all <strong>by similarity, ECO:0000250</strong> — i.e. NOT direct pombe experiment):</li>
+<li>FUNCTION: "Directs RNA polymerase II nuclear import."</li>
+<li>SUBUNIT: "Associates with RNA polymerase II."</li>
+<li>SUBCELLULAR LOCATION: Cytoplasm + Nucleus; "shuttles between the nucleus and cytoplasm."</li>
+</ul>
+<h2 id="goa-annotation-landscape-iwr1-goatsv-9-annotations-all-inferred">GOA annotation landscape (<code>iwr1-goa.tsv</code>) — 9 annotations, ALL inferred</h2>
+<p>No experimental (IDA/IMP/IGI/IPI/IEP) annotation exists for <strong>pombe</strong> iwr1. Evidence is entirely:<br />
+- <strong>IBA</strong> (GO_REF:0000033, PANTHER PTN002821512 | SGD:S000002273): nucleus (is_active_in), cytoplasm (is_active_in), protein import into nucleus (involved_in).<br />
+- <strong>ISO</strong> (GO_REF:0000024, from <strong>SGD:S000002273</strong> = <em>S. cerevisiae</em> IWR1/YDL115C): nucleus (is_active_in), protein import into nucleus (involved_in).<br />
+- <strong>IEA</strong> (GO_REF:0000044, UniProt-SubCell): nucleus, cytoplasm (located_in).<br />
+- <strong>IEA</strong> (GO_REF:0000002, InterPro IPR040150): protein import into nucleus (involved_in).<br />
+- <strong>ND</strong> (GO_REF:0000015, PomBase): molecular_function root GO:0003674 — i.e. PomBase records <strong>no experimentally-supported MF</strong>.</p>
+<p>=&gt; This is a genuinely <strong>dark / understudied</strong> gene in pombe: all functional inference is by orthology to the well-characterized budding-yeast IWR1, plus family signatures.</p>
+<h2 id="ortholog-literature-s-cerevisiae-iwr1-sgds000002273-the-source-of-the-iso-transfers">Ortholog literature (S. cerevisiae IWR1 = SGD:S000002273; the source of the ISO transfers)</h2>
+<p>The pombe annotations transfer from experimentally characterized S. cerevisiae IWR1.</p>
+<ul>
+<li><strong>Czeko et al. 2011, Mol Cell</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/21504834">PMID:21504834</a> — <em>S. cerevisiae</em> (abstract-only in cache; full_text_available: false):</li>
+<li>"Pol II nuclear import requires the protein Iwr1" <a href="https://pubmed.ncbi.nlm.nih.gov/21504834" title="Here we show that Pol II nuclear import requires the protein Iwr1 and provide evidence for cyclic Iwr1 function.">PMID:21504834</a></li>
+<li>Mechanism: "Iwr1 binds Pol II in the active center cleft between the two largest subunits, maybe facilitating or sensing complete Pol II assembly in the cytoplasm." <a href="https://pubmed.ncbi.nlm.nih.gov/21504834">PMID:21504834</a></li>
+<li>"Iwr1 then uses an N-terminal bipartite nuclear localization signal that is recognized by karyopherin α to direct Pol II nuclear import." <a href="https://pubmed.ncbi.nlm.nih.gov/21504834">PMID:21504834</a></li>
+<li>Recycling: "In the nucleus, Iwr1 is displaced from Pol II by transcription initiation factors and nucleic acids, enabling its export and recycling." <a href="https://pubmed.ncbi.nlm.nih.gov/21504834">PMID:21504834</a></li>
+<li>
+<p>Specificity/conservation: "Iwr1 function is Pol II specific, transcription independent, and apparently conserved from yeast to human." <a href="https://pubmed.ncbi.nlm.nih.gov/21504834">PMID:21504834</a></p>
+</li>
+<li>
+<p><strong>Esberg et al. 2011, PLoS ONE</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/21695216">PMID:21695216</a> — <em>S. cerevisiae</em> (full text in cache):</p>
+</li>
+<li>Originally identified via physical interaction with Pol II: "Iwr1, a protein conserved throughout eukaryotes, was originally identified by its physical interaction with RNA polymerase (Pol) II." <a href="https://pubmed.ncbi.nlm.nih.gov/21695216" title="Iwr1, a protein conserved throughout eukaryotes, was originally identified by its physical interaction with RNA polymerase (Pol) II.">PMID:21695216</a></li>
+<li>Broader PIC role: "Iwr1 plays an important role in preinitiation complex formation by all three nuclear RNA polymerases." <a href="https://pubmed.ncbi.nlm.nih.gov/21695216" title="Thus, Iwr1 plays an important role in preinitiation complex formation by all three nuclear RNA polymerases.">PMID:21695216</a></li>
+<li>iwr1 mutant defects: "an iwr1 mutant strain shows reduced association of TBP and Pol III at Pol III promoters, a decreased rate of Pol III transcription, and lower steady-state levels of Pol III transcripts." <a href="https://pubmed.ncbi.nlm.nih.gov/21695216">PMID:21695216</a></li>
+<li>Note: the Pol I/III effects are interpreted (in the field / Cramer lab) as downstream/indirect consequences of impaired Pol II import; the <em>direct, Pol II-specific</em> import function is the defining molecular role (Czeko 2011).</li>
+</ul>
+<h2 id="known-by-orthology-family-signature-not-pombe-experiment">KNOWN (by orthology + family signature, not pombe experiment)</h2>
+<ul>
+<li>Molecular role: dedicated <strong>RNA polymerase II assembly/import chaperone</strong> — binds the assembled 12-subunit Pol II in its active-center cleft; not a general karyopherin but an adaptor that presents its own bipartite NLS to karyopherin-α.</li>
+<li>Biological role: <strong>protein import into nucleus</strong> (of Pol II specifically), enabling nuclear transcription; cyclic loading/unloading and recycling.</li>
+<li>Localization: nucleocytoplasmic shuttling (cytoplasm + nucleus).</li>
+</ul>
+<h2 id="not-known-for-pombe-iwr1-knowledge-gaps-primary-deliverable">NOT known for pombe iwr1 (knowledge gaps — primary deliverable)</h2>
+<ul>
+<li>No direct S. pombe experimental evidence for ANY molecular function (PomBase MF = ND).</li>
+<li>Whether the Pol II import role is conserved and essential/non-essential in pombe (S. cerevisiae iwr1Δ is viable but growth-impaired; not tested here for pombe).</li>
+<li>Whether pombe iwr1 physically binds pombe Pol II (Rpb1/Rpb2 cleft) — no pombe IPI.</li>
+<li>Deletion/mutant phenotype in pombe (no pombe phenotype annotation captured in GOA).</li>
+<li>Whether it has any Pol I/Pol III-related or transcription-elongation roles in pombe.</li>
+<li>Precise molecular-function GO term: there is no dedicated "Pol II import chaperone" MF term; role is currently captured only at the BP level (protein import into nucleus) — genuine MF gap.</li>
+</ul>
+<h2 id="curation-reasoning-for-actions">Curation reasoning for actions</h2>
+<ul>
+<li>BP <code>GO:0006606 protein import into nucleus</code>: well-supported by orthology + family; the IBA (best phylogenetic evidence) is the core representative; ISO and InterPro-IEA are corroborating duplicates — KEEP core one, mark the duplicate lower-evidence ones as non-core/over-annotated as appropriate (do not REMOVE, all consistent).</li>
+<li>CC <code>GO:0005634 nucleus</code> + <code>GO:0005737 cytoplasm</code>: consistent with shuttling; IBA is_active_in reflects site of action. Keep; SubCell IEA duplicates are redundant but not wrong.</li>
+<li>MF <code>GO:0003674</code> root with ND: this is a placeholder meaning "no MF determined"; keep as-is (standard), acknowledge the MF gap.</li>
+<li>Never REMOVE the ISO/IBA import annotation: it is a defensible orthology transfer from an experimentally solid budding-yeast function; the family signature (Pfam Iwr1) directly supports it.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O13951
+gene_symbol: iwr1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  iwr1 is the fission-yeast member of the conserved eukaryotic Iwr1/SLC7A6OS
+  family (Pfam PF08574; InterPro IPR040150/IPR013883, &#34;Interactor of Rpb1&#34;),
+  represented by a single copy per genome. In the well-characterized budding-yeast
+  and metazoan orthologs the protein is a dedicated RNA polymerase II biogenesis
+  factor: it binds the fully assembled 12-subunit Pol II in the active-center
+  cleft between the two largest subunits in the cytoplasm, and presents its own
+  N-terminal bipartite nuclear localization signal to karyopherin-alpha to drive
+  nuclear import of the polymerase. Inside the nucleus it is displaced from Pol II
+  by transcription initiation factors and nucleic acids, allowing its re-export
+  and recycling, so it acts as a cyclic, Pol II-specific, transcription-independent
+  import adaptor rather than a stable subunit. Consistent with this shuttling
+  behaviour the protein distributes between cytoplasm and nucleus. The S. pombe
+  protein (277 aa) carries the family fold plus a long, acidic, intrinsically
+  disordered C-terminus. Its function in S. pombe has not been assayed directly and
+  is inferred from orthology and family conservation.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:21504834
+  title: Iwr1 directs RNA polymerase II nuclear import.
+  findings:
+  - statement: &gt;-
+      In S. cerevisiae, RNA polymerase II nuclear import requires Iwr1, which binds
+      Pol II in the active-center cleft between the two largest subunits, then uses
+      an N-terminal bipartite NLS recognized by karyopherin-alpha to direct import;
+      Iwr1 is subsequently displaced by initiation factors and recycled. The
+      function is Pol II specific, transcription independent, and conserved from
+      yeast to human.
+    supporting_text: &gt;-
+      Here we show that Pol II nuclear import requires the protein Iwr1 and provide
+      evidence for cyclic Iwr1 function. Iwr1 binds Pol II in the active center cleft
+      between the two largest subunits, maybe facilitating or sensing complete Pol II
+      assembly in the cytoplasm. Iwr1 then uses an N-terminal bipartite nuclear
+      localization signal that is recognized by karyopherin alpha to direct Pol II
+      nuclear import.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Czeko et al. 2011, Mol Cell 42:261-266). Abstract-only in
+      cache. This is the defining functional study for the Iwr1 family; it
+      establishes the Pol II-specific nuclear-import-adaptor role that is transferred
+      to S. pombe iwr1 by orthology (the ISO annotation cites the S. cerevisiae
+      ortholog SGD:S000002273). The paper concerns S. cerevisiae, not S. pombe.
+- id: PMID:21695216
+  title: Iwr1 protein is important for preinitiation complex formation by all three
+    nuclear RNA polymerases in Saccharomyces cerevisiae.
+  findings:
+  - statement: &gt;-
+      Iwr1 was originally identified through its physical interaction with RNA
+      polymerase II and is conserved throughout eukaryotes; in S. cerevisiae it is
+      additionally important for preinitiation complex formation by all three
+      nuclear RNA polymerases.
+    supporting_text: &gt;-
+      Iwr1, a protein conserved throughout eukaryotes, was originally identified by
+      its physical interaction with RNA polymerase (Pol) II.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Esberg et al. 2011, PLoS ONE 6:e20829); full text in cache.
+      S. cerevisiae study. Corroborates the conserved Pol II physical interaction and
+      the family&#39;s broad relevance to transcription-machinery assembly. The reported
+      Pol I/III preinitiation-complex effects are generally interpreted as downstream
+      consequences of impaired Pol II import rather than a direct pombe function, so
+      relevance to the specific molecular role transferred to S. pombe iwr1 is
+      supporting rather than defining.
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Nuclear localization is consistent with the conserved function of the Iwr1
+      family: the import adaptor accompanies RNA polymerase II into the nucleus and
+      is displaced there before recycling. IBA (phylogenetic) is the strongest of the
+      several redundant evidence lines supporting nuclear localization.
+    action: ACCEPT
+    reason: &gt;-
+      Phylogenetic inference over the Iwr1 family (PTHR28063) supports nuclear
+      localization; consistent with UniProt SUBCELLULAR LOCATION (nucleus) and the
+      nucleocytoplasmic shuttling described for the S. cerevisiae ortholog
+      (PMID:21504834). Represents a core site of action.
+    supported_by:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        Iwr1 then uses an N-terminal bipartite nuclear localization signal that is
+        recognized by karyopherin alpha to direct Pol II nuclear import.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cytoplasmic localization is consistent with the family function: Iwr1 binds the
+      newly assembled Pol II in the cytoplasm before escorting it into the nucleus,
+      and the protein shuttles between the two compartments.
+    action: ACCEPT
+    reason: &gt;-
+      Phylogenetic inference plus UniProt SUBCELLULAR LOCATION (cytoplasm; &#34;shuttles
+      between the nucleus and cytoplasm&#34;). The cytoplasm is where the ortholog binds
+      and senses assembled Pol II (PMID:21504834), so it is a core site of action.
+    supported_by:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        Iwr1 binds Pol II in the active center cleft between the two largest subunits,
+        maybe facilitating or sensing complete Pol II assembly in the cytoplasm.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006606
+    label: protein import into nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This is the core biological role assigned by orthology: the Iwr1 family directs
+      nuclear import of RNA polymerase II. The IBA annotation is the best-evidence
+      (phylogenetically inferred) representative of this function for S. pombe iwr1,
+      whose own role has not been assayed directly.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by the defining S. cerevisiae study (PMID:21504834) and by the
+      Iwr1 Pfam/InterPro family signature (PF08574 / IPR040150), which InterPro maps
+      to this same term. Represents the core function; note the substrate is
+      specifically Pol II, which GO:0006606 does not itself express (see knowledge
+      gaps).
+    supported_by:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        Here we show that Pol II nuclear import requires the protein Iwr1 and provide
+        evidence for cyclic Iwr1 function.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation from the UniProt Subcellular Location vocabulary mapping,
+      mirroring the nucleus localization already captured by the stronger IBA
+      evidence above. Correct but redundant with the phylogenetic annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the IBA nuclear annotation and UniProt SUBCELLULAR LOCATION.
+      Derived from a subcellular-location mapping (GO_REF:0000044) and duplicates the
+      phylogenetically inferred nucleus term, but the localization is correct and
+      corroborated.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation from the UniProt Subcellular Location vocabulary mapping,
+      mirroring the cytoplasm localization already captured by the stronger IBA
+      evidence above. Correct but redundant with the phylogenetic annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the IBA cytoplasm annotation and UniProt SUBCELLULAR LOCATION.
+      Derived from a subcellular-location mapping (GO_REF:0000044) and duplicates the
+      phylogenetically inferred cytoplasm term, but the localization is correct and
+      corroborated.
+- term:
+    id: GO:0006606
+    label: protein import into nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic InterPro2GO annotation mapping the Iwr1 family signature
+      (IPR040150) to protein import into nucleus. Correct in essence and consistent
+      with the orthology-based function; redundant with the IBA/ISO annotations to the
+      same core term.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro2GO (GO_REF:0000002) transfer of the Iwr1-family-to-GO:0006606 mapping;
+      biologically defensible from the family signature and consistent with the
+      better-evidenced IBA and ISO annotations for the same core process.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      PomBase records the molecular_function root with No Data, correctly reflecting
+      that no molecular activity has been experimentally determined for S. pombe iwr1
+      and that no specific MF term has been curated. This gene is MF-dark at the level
+      of direct evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Standard ND placeholder indicating the absence of an experimentally supported
+      molecular-function annotation; appropriate given that all functional inference
+      for pombe iwr1 is by orthology. A specific, informative MF (RNA polymerase II
+      complex binding, GO:0000993) is proposed in core_functions on the basis of the
+      conserved family function.
+- term:
+    id: GO:0006606
+    label: protein import into nucleus
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Manual orthology transfer (ISO) from the experimentally characterized
+      S. cerevisiae ortholog IWR1 (SGD:S000002273), which was directly shown to be
+      required for RNA polymerase II nuclear import. This is the annotation that most
+      directly reflects the curatorial basis for iwr1&#39;s assigned function.
+    action: ACCEPT
+    reason: &gt;-
+      Curator-judged sequence-similarity transfer from S. cerevisiae IWR1, whose Pol
+      II nuclear-import role is experimentally established (PMID:21504834). A
+      defensible, high-confidence orthology assignment for a single-copy conserved
+      family; do not remove.
+    supported_by:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        Iwr1 function is Pol II specific, transcription
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Manual orthology transfer (ISO) of nuclear localization from S. cerevisiae
+      IWR1. Consistent with the IBA nucleus annotation and with the shuttling
+      behaviour of the ortholog; corroborating the core nuclear-localization call.
+    action: ACCEPT
+    reason: &gt;-
+      Orthology transfer duplicating the nucleus localization already accepted from
+      IBA; correct and consistent with UniProt SUBCELLULAR LOCATION.
+- term:
+    id: GO:0000993
+    label: RNA polymerase II complex binding
+  evidence_type: ISS
+  original_reference_id: PMID:21504834
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed informative molecular-function annotation replacing the uninformative
+      MF-root ND: the conserved Iwr1 activity is direct binding of the assembled RNA
+      polymerase II complex (in the active-center cleft), which is the physical basis
+      of its import-adaptor role. Assigned by orthology/family signature, not yet
+      demonstrated in S. pombe.
+    action: NEW
+    reason: &gt;-
+      GO:0000993 (RNA polymerase II complex binding) is a specific, informative MF
+      that captures the defining Pol II interaction of the Iwr1 family
+      (PMID:21504834), consistent with the Pfam Iwr1 / InterPro &#34;Interactor of Rpb1&#34;
+      signature; far more informative than a generic protein-binding term and
+      appropriate given the MF-dark ND status.
+    supported_by:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        Iwr1 binds Pol II in the active center cleft between the two largest subunits,
+        maybe facilitating or sensing complete Pol II assembly in the cytoplasm.
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    RNA polymerase II nuclear import adaptor: binds the fully assembled Pol II
+    complex in the cytoplasm (in the active-center cleft, via the conserved Iwr1
+    fold) and directs its karyopherin-alpha-dependent import into the nucleus,
+    cycling on and off the polymerase. Assigned to S. pombe iwr1 by orthology to
+    experimentally characterized eukaryotic orthologs and by the Iwr1 family
+    signature; not directly demonstrated in S. pombe.
+  molecular_function:
+    id: GO:0000993
+    label: RNA polymerase II complex binding
+  directly_involved_in:
+  - id: GO:0006606
+    label: protein import into nucleus
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: PMID:21504834
+    supporting_text: &gt;-
+      Iwr1 binds Pol II in the active center cleft between the two largest subunits,
+      maybe facilitating or sensing complete Pol II assembly in the cytoplasm.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:21504834
+    supporting_text: &gt;-
+      Here we show that Pol II nuclear import requires the protein Iwr1 and provide
+      evidence for cyclic Iwr1 function.
+    reference_section_type: ABSTRACT
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      No molecular function, physical Pol II interaction, subcellular localization,
+      or loss-of-function phenotype has been experimentally determined for S. pombe
+      iwr1; the entire functional assignment is transferred from the S. cerevisiae
+      ortholog and the Iwr1 family signature.
+    boundary: &gt;-
+      Firmly established for the family/ortholog: S. cerevisiae Iwr1 binds assembled
+      Pol II in the active-center cleft and directs karyopherin-alpha-dependent
+      nuclear import in a cyclic, Pol II-specific, transcription-independent manner
+      (PMID:21504834); the family is conserved yeast-to-human and defined by Pfam
+      PF08574 / InterPro IPR040150. For S. pombe iwr1 specifically, GOA/PomBase carry
+      only IBA/ISO/IEA inferences and a molecular_function ND, i.e. no direct
+      experimental evidence.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Iwr1 is the only known dedicated import factor for RNA polymerase II, the
+      enzyme that transcribes all protein-coding genes; whether and how this pathway
+      operates in fission yeast (an evolutionarily distant model with its own import
+      machinery) is a fundamental, untested question for a single-copy conserved gene.
+    resolution: &gt;-
+      Assay a tagged iwr1 for physical association with S. pombe Pol II (Rpb1/Rpb2)
+      and for nucleocytoplasmic shuttling; phenotype an iwr1 deletion for Pol II
+      nuclear-localization defects and growth; test genetic/physical interaction with
+      karyopherin-alpha (cut15/imp1).
+    provenance:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        It is unknown how Pol II is imported into the nucleus.
+      reference_section_type: ABSTRACT
+  - gap_statement: &gt;-
+      There is no molecular-function GO term expressing the specific role &#34;RNA
+      polymerase II nuclear-import adaptor/carrier&#34;; the function is captured only at
+      the biological-process level (protein import into nucleus) plus the physical
+      MF (RNA polymerase II complex binding), which under-specify the adaptor
+      activity.
+    boundary: &gt;-
+      GO:0006606 (protein import into nucleus, BP) and GO:0000993 (RNA polymerase II
+      complex binding, MF) are available and used here, but neither encodes the
+      cargo-specific NLS-presenting import-adaptor activity that Czeko et al. define.
+    gap_kind:
+    - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      An adaptor that presents its own NLS to import a specific macromolecular cargo
+      is a distinct molecular activity worth capturing; its absence forces the role
+      to be described only obliquely.
+    resolution: &gt;-
+      Propose a molecular-function term for &#34;RNA polymerase II import adaptor
+      activity&#34; (or a more general &#34;protein-complex nuclear-import adaptor activity&#34;)
+      under protein-transporter/cargo-receptor activity.
+    provenance:
+    - reference_id: PMID:21504834
+      supporting_text: &gt;-
+        Iwr1 then uses an N-terminal bipartite nuclear localization signal that is
+        recognized by karyopherin alpha to direct Pol II nuclear import.
+      reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Does S. pombe iwr1 physically associate with fission-yeast RNA polymerase II,
+    and is it required for the polymerase&#39;s nuclear localization as in S. cerevisiae?
+- question: &gt;-
+    Is iwr1 non-essential in S. pombe (as in budding yeast), and what growth or
+    transcriptional phenotypes accompany its deletion?
+suggested_experiments:
+- hypothesis: &gt;-
+    iwr1 binds assembled S. pombe Pol II and mediates its karyopherin-alpha-dependent
+    nuclear import.
+  description: &gt;-
+    Affinity-purify tagged iwr1 and test for co-purification of Rpb1/Rpb2; assess
+    Rpb1 nuclear/cytoplasmic distribution by microscopy in wild-type vs iwr1-deletion
+    cells; test genetic interaction with karyopherin-alpha (imp1/cut15).
+- hypothesis: &gt;-
+    iwr1 is non-essential but confers a growth/transcription fitness advantage under
+    normal or stress conditions.
+  description: &gt;-
+    Construct an iwr1 deletion and score viability and growth rate, and quantify
+    global Pol II occupancy or nascent transcription relative to wild type.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/knh4/knh4-ai-review.html
+++ b/genes/SCHPO/knh4/knh4-ai-review.html
@@ -1,0 +1,2269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>knh4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>knh4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O42970" target="_blank" class="term-link">
+                        O42970
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">SPBC1E8.05</span>
+
+                    <span class="badge">gaz2</span>
+
+                    <span class="badge">Knh4</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "knh4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O42970" data-a="DESCRIPTION: knh4 (SPBC1E8.05; synonym gaz2) is a fission-yeast..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>knh4 (SPBC1E8.05; synonym gaz2) is a fission-yeast member of the Kre9/Knh1 family of fungal cell-surface glycoproteins (Pfam PF10342 Kre9_KNH; InterPro IPR018466 Kre9/Knh1-like_N; PANTHER PTHR40633). The protein has an N-terminal signal peptide, a single N-terminal Kre9/Knh1 fold, a long serine/threonine-rich low-complexity disordered stalk, predicted N- and O-glycosylation, and a hydrophobic C-terminus consistent with a GPI-anchor signal; it was identified in a genome-wide screen for predicted GPI-anchored proteins and localizes to the cell surface. In S. pombe, deletion of knh4 is viable but confers sensitivity to cell-wall-degrading (beta-glucanase) enzymes, and high-copy expression of knh4 suppresses the growth defect of N-glycosylation-defective och1 cells; these data indicate that Knh4 non-enzymatically supports cell-surface beta-glucan as part of the fungal cell wall. Kre9/Knh1-family proteins are non-catalytic and, in the budding yeast homologs Kre9p/Knh1p, function in cell-wall (1-&gt;6)-beta-glucan assembly. The specific molecular activity of Knh4, and its individual contribution relative to the essential Kre9 ortholog and other paralogs, have not been experimentally established.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O42970" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function annotation with the ND (no biological data) evidence code, indicating that no specific molecular function has been curated for knh4. This accurately reflects the current state of knowledge: Kre9/Knh1 family proteins are non-catalytic and knh4 has no experimentally defined molecular activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND on the root term is the correct GO representation when no informative molecular function is known. knh4 is a &#34;conserved unknown&#34; cell-surface protein with no demonstrated catalytic or binding activity; the family is non-enzymatic. Retain as-is; the genuine molecular-function gap is recorded in knowledge_gaps rather than by asserting a speculative activity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O42970" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process annotation with the ND evidence code. This ND annotation predates (and does not incorporate) the later functional data showing a cell-wall beta-glucan-support role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND root-process annotation is now superseded by knh4-specific evidence: knh4-delta is beta-glucanase-sensitive and the protein non-enzymatically supports cell-surface beta-glucan (PMID:34738170). A specific biological process can therefore be assigned. Propose replacing the ND root with a cell-wall organization / (1-&gt;6)-beta-D-glucan metabolic-process term reflecting this role.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031505" target="_blank" class="term-link">
+                                    fungal-type cell wall organization
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006077" target="_blank" class="term-link">
+                                    (1-&gt;6)-beta-D-glucan metabolic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34738170" target="_blank" class="term-link">
+                                        PMID:34738170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">non-enzymatically support β-glucan on the cell-surface of S. pombe</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
+                                    GO:0009986
+                                </a>
+                            </span>
+                            <span class="term-label">cell surface</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12845604
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genome-wide identification of fungal GPI proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O42970" data-a="GO:0009986" data-r="PMID:12845604" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cell-surface localization, curated (TAS) from the genome-wide GPI-protein prediction and consistent with the signal peptide, GPI-anchor-like C-terminus, and demonstrated GPI-anchored status of knh4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cell surface (GO:0009986) is the correct and well-supported cellular location for this GPI-anchored, signal-peptide-bearing cell-surface glycoprotein. The localization is corroborated by the functional study (PMID:34738170), which treats SPBC1E8.05 as a GPI-anchored cell-surface protein. Retain as a core location. Note the GPI &#34;anchored component of membrane&#34; GO terms are obsolete, so cell surface is the appropriate CC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                                        PMID:12845604
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">only 33 GPI candidates were identified</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34738170" target="_blank" class="term-link">
+                                        PMID:34738170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">non-enzymatically support β-glucan on the cell-surface of S. pombe</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Non-catalytic cell-surface glycoprotein of the Kre9/Knh1 family that supports cell-wall (1-&gt;6)-beta-glucan. Knh4 is GPI-anchored at the S. pombe cell surface; loss of knh4 does not affect viability but renders cells sensitive to cell-wall-degrading beta-glucanase, and high-copy knh4 rescues the cell-wall/ growth defect of N-glycosylation-deficient och1 cells, together indicating a role in maintaining/organizing cell-surface beta-glucan of the fungal cell wall. No molecular activity is asserted: the Kre9/Knh1 family is non-enzymatic and knh4 has no experimentally defined molecular function (see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="O42970" data-a="FUNCTION: Non-catalytic cell-surface glycoprotein of the Kre..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031505" target="_blank" class="term-link">
+                                fungal-type cell wall organization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
+                                cell surface
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34738170" target="_blank" class="term-link">
+                                PMID:34738170
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">non-enzymatically support β-glucan on the cell-surface of S. pombe</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:O42970
+
+                        </span>
+
+                        <div class="finding-text">Pfam; PF10342; Kre9_KNH; 1.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                            PMID:12845604
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide identification of fungal GPI proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A genome-wide search using a GPI-attachment consensus sequence identified 33 putative GPI-anchored proteins in S. pombe; SPBC1E8.05 (knh4) is among the predicted cell-surface GPI proteins.</div>
+
+                        <div class="finding-text">"only 33 GPI candidates were identified"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34738170" target="_blank" class="term-link">
+                            PMID:34738170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Overexpression of cell-wall GPI-anchored proteins restores cell growth of N-glycosylation-defective och1 mutants in Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SPBC1E8.05 (knh4) and pwp1 were identified as high-copy suppressors of the growth defect of N-glycosylation-defective och1-delta cells; both encode GPI-anchored proteins. Deletion of either gene is viable but confers sensitivity to beta-glucanase, indicating that Knh4 non-enzymatically supports beta-glucan on the S. pombe cell surface.</div>
+
+                        <div class="finding-text">"non-enzymatically support β-glucan on the cell-surface of S. pombe"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20473289" target="_blank" class="term-link">
+                            PMID:20473289
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of a genome-wide set of gene deletions in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21511999" target="_blank" class="term-link">
+                            PMID:21511999
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comparative functional genomics of the fission yeasts.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:O42970
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Uncharacterized serine-rich protein C1E8.05 (YB95_SCHPO)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt assigns O42970 to the Kre9/Knh1 family (Pfam PF10342 Kre9_KNH; InterPro IPR018466 Kre9/Knh1-like_N) with an N-terminal signal peptide, a serine-rich low-complexity/disordered region, predicted glycosylation, and a hydrophobic C-terminus; function is not experimentally determined (PE 2, evidence at transcript level).</div>
+
+                        <div class="finding-text">"Pfam; PF10342; Kre9_KNH; 1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the molecular activity of Knh4 at the cell surface — does it bind or cross-link (1-&gt;6)-beta-glucan, and which cell-wall components are its partners?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O42970" data-a="Q: What is the molecular activity of Knh4 at the cell..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is knh4 functionally redundant with the essential S. pombe Kre9 ortholog and the other Kre9/Knh1 paralogs, and does a higher-order deletion phenocopy the essential family member?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O42970" data-a="Q: Is knh4 functionally redundant with the essential ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How does high-copy knh4 suppress the growth defect of N-glycosylation-defective och1 cells — by restoring cell-wall integrity, and is the GPI anchor required?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O42970" data-a="Q: How does high-copy knh4 suppress the growth defect..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express and purify recombinant Knh4 (with and without the Ser/Thr-rich stalk) and assay binding to and cross-linking of defined beta-1,6- and beta-1,3-glucan substrates in vitro; test whether the isolated Kre9/Knh1 domain is sufficient.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Knh4 directly binds/cross-links cell-wall (1-&gt;6)-beta-glucan.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical binding/activity assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O42970" data-a="EXPERIMENT: Express and purify recombinant Knh4 (with and with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct single and combinatorial deletions of knh4 and its paralogs (and conditional alleles of the essential Kre9 ortholog) and quantify cell-wall beta-glucan content/structure and beta-glucanase/stress sensitivity to test for redundancy versus specialization.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Knh4 is functionally redundant with other S. pombe Kre9/Knh1-family members.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis / cell-wall analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O42970" data-a="EXPERIMENT: Construct single and combinatorial deletions of kn..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare wild-type, GPI-anchor-deleted, and mislocalized Knh4 constructs for rescue of knh4-delta beta-glucanase sensitivity and suppression of the och1 growth defect.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The GPI anchor and cell-surface localization of Knh4 are required for its cell-wall beta-glucan support function.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function complementation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O42970" data-a="EXPERIMENT: Compare wild-type, GPI-anchor-deleted, and misloca..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of Knh4 is unknown. It is undetermined whether Knh4 binds, cross-links, transports, or otherwise scaffolds cell-wall beta-glucan; no catalytic activity, ligand, or biochemical partner has been demonstrated, and the &#34;support&#34; of cell-surface beta-glucan is explicitly non-enzymatic.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Knh4 is firmly established as a GPI-anchored, Kre9/Knh1-family cell-surface glycoprotein whose deletion causes beta-glucanase sensitivity, and whose overexpression rescues N-glycosylation-defective och1 cells (PMID:34738170); the budding-yeast homologs Kre9p/Knh1p act in cell-wall (1-&gt;6)-beta-glucan assembly. What Knh4 does at the molecular level to support beta-glucan is not known.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Defining the molecular activity would convert a &#34;conserved unknown&#34; cell-surface protein into a mechanistic component of fungal cell-wall beta-glucan organization, informing antifungal cell-wall biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of purified Knh4 for beta-glucan binding/ cross-linking activity; interactomics to identify cell-wall partners; and structural/genetic dissection of the Kre9/Knh1 domain versus the Ser/Thr-rich stalk.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"non-enzymatically support β-glucan on the cell-surface of S. pombe"</em> — PMID:34738170</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Knh4&#39;s specific biological role and its contribution relative to the essential Kre9 ortholog and the other non-essential Kre9/Knh1 paralogs in S. pombe are undetermined. Whether knh4 acts redundantly, in a specialized condition, or in a particular cell-wall layer is not resolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> knh4-delta is viable with only cell-wall-stress (beta-glucanase) sensitivity (PMID:34738170; PMID:20473289), implying substantial functional redundancy; the S. pombe genome encodes an essential Kre9 ortholog that carries the core beta-1,6-glucan-formation function, plus additional Kre9/Knh1-family paralogs. The individual and combined contributions of these genes have not been mapped.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing redundancy from specialization would clarify how the Kre9/Knh1 family divides labor in fission-yeast cell-wall assembly.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic single- and combinatorial-deletion analysis of the S. pombe Kre9/Knh1 family (knh4 with its paralogs and the essential Kre9 ortholog), with cell-wall beta-glucan quantification/structural analysis and stress profiling.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"neither gene was essential for cell viability"</em> — PMID:34738170</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(knh4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O42970" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="knh4-spbc1e805-s-pombe-review-notes">knh4 (SPBC1E8.05) — S. pombe — review notes</h1>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li><strong>Standard name:</strong> knh4 (PomBase); <strong>systematic name:</strong> SPBC1E8.05; <strong>synonym:</strong> gaz2.</li>
+<li><strong>UniProt:</strong> O42970 (entry name YB95_SCHPO), "Uncharacterized serine-rich protein C1E8.05", 317 aa, Precursor (has signal peptide).</li>
+<li><strong>PomBase product:</strong> "conserved fungal cell surface protein, Kre9/Knh1 family, Knh4"<br />
+  (queried via PomBase JSON API 2026-07-06). <code>name_descriptions: ['Kre9(Nine) Homolog']</code><br />
+  → <strong>KNH = Kre-Nine Homolog</strong> (homolog of <em>S. cerevisiae</em> Kre9), NOT Knr4/Smi1.</li>
+<li><strong>Characterisation status:</strong> "conserved unknown" (dark gene).</li>
+<li><strong>Taxonomic distribution:</strong> fungi only. Ortholog: <em>S. japonicus</em> SJAG_03521 (PMID:21511999).</li>
+<li><strong>Deletion viability:</strong> viable (knh4Δ is non-essential).</li>
+</ul>
+<h3 id="important-correction-to-task-framing">IMPORTANT correction to task framing</h3>
+<p>The dispatch brief described knh4 as a "Knr4/Smi1-homology (KNH)" family protein. This is<br />
+<strong>incorrect</strong>. The Pfam domain <code>PF10342 Kre9_KNH</code> and InterPro <code>IPR018466 Kre9/Knh1-like_N</code><br />
+refer to the <strong>Kre9/Knh1</strong> family (β-1,6-glucan cell-wall assembly), and PomBase's<br />
+<code>name_descriptions</code> explicitly reads "Kre9(Nine) Homolog". Knr4/Smi1 is an entirely<br />
+different (cytoplasmic, cell-wall-synthesis-regulating) family. This review treats knh4 as a<br />
+<strong>Kre9/Knh1-family cell-surface glycoprotein</strong>. Paralogs are therefore the <em>S. pombe</em> Kre9/Knh1<br />
+family members (the essential Kre9 ortholog + other non-essential Knh/gaz paralogs), NOT knr4.</p>
+<h2 id="domain-sequence-features-from-knh4-uniprottxt-inline">Domain / sequence features (from knh4-uniprot.txt, inline)</h2>
+<ul>
+<li>SIGNAL 1..16 (ECO:0000255) → secreted/cell-surface.</li>
+<li>CHAIN 17..317 mature protein.</li>
+<li>InterPro IPR018466 "Kre9/Knh1-like_N"; Pfam PF10342 "Kre9_KNH" (one copy, N-terminal).</li>
+<li>PANTHER PTHR40633 "SRP1/TIP1-like Cell Wall Component"; subfamily SF1<br />
+  "GPI ANCHORED SERINE-THREONINE RICH PROTEIN".</li>
+<li>REGION 150..259 Disordered; COMPBIAS 150..238 + 247..259 Low complexity — long<br />
+  Ser/Thr-rich low-complexity tract (classic cell-wall O-glycoprotein architecture).</li>
+<li>CARBOHYD 42 N-linked (predicted). KW: Glycoprotein; Signal.</li>
+<li>C-terminus (…LKTGINALVAVGVVSAIALFL) is hydrophobic — consistent with a GPI-anchor<br />
+  signal (the protein is experimentally treated as GPI-anchored, see PMID:34738170).</li>
+</ul>
+<p>Interpretation: a secreted, heavily O-/N-glycosylated, GPI-anchored cell-surface protein with<br />
+a single N-terminal Kre9/Knh1 fold and a long Ser-rich disordered stalk. This is a<br />
+<strong>non-catalytic scaffold</strong> architecture (the Kre9/Knh1 family has no known enzymatic activity).</p>
+<h2 id="known-knh4-specific-evidence">KNOWN (knh4-specific evidence)</h2>
+<ol>
+<li><strong>GPI-anchored cell-surface protein.</strong> Identified as one of 33 predicted <em>S. pombe</em> GPI<br />
+   proteins by a genome-wide GPI-consensus screen <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" title="only 33 GPI candidates were    identified">PMID:12845604</a>. UniProt: signal peptide + hydrophobic C-terminus + Glycoprotein keyword.<br />
+   PomBase CC: GO:0009986 cell surface (TAS, PMID:12845604).</li>
+<li><strong>Non-enzymatic support of cell-surface β-glucan.</strong> In a genome-wide screen for suppressors<br />
+   of the growth defect of N-glycosylation-defective <em>och1Δ</em> cells, SPBC1E8.05 (with pwp1+) was<br />
+   identified as a high-copy suppressor; both encode GPI-anchored proteins. Deletion analysis:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34738170" title="neither gene was essential for cell viability; however, both mutants were    sensitive β-glucanase, suggesting that Pwp1p and the protein encoded by SPBC1E8.05    non-enzymatically support β-glucan on the cell-surface of S. pombe">PMID:34738170</a>. This is the single<br />
+   most direct functional statement about knh4. → FYPO:0001190 "sensitive to cell wall-degrading<br />
+   enzymes" for knh4Δ (cell growth assay, PMID:34738170).</li>
+<li><strong>Non-essential.</strong> knh4Δ is viable (Bioneer genome-wide deletion set, PMID:20473289; and<br />
+   PMID:34738170). Many other large-scale phenotypes exist (salt/detergent/oxidant<br />
+   sensitivities, nitrogen-source growth) but these are pleiotropic high-throughput screen hits,<br />
+   not mechanistic.</li>
+</ol>
+<h2 id="not-known-knowledge-gaps-honest">NOT known / knowledge gaps (honest)</h2>
+<ul>
+<li><strong>Molecular activity is unknown.</strong> Kre9/Knh1-family proteins are non-catalytic; whether knh4<br />
+  binds, cross-links, or scaffolds β-1,6-glucan (the proposed S. cerevisiae Kre9/Knh1 role) has<br />
+  not been shown biochemically for knh4. UniProt MF = ND.</li>
+<li><strong>Specific pathway role vs the essential family member.</strong> The essential <em>S. pombe</em> Kre9<br />
+  ortholog carries the core β-1,6-glucan-formation function; knh4 is one of several apparently<br />
+  redundant non-essential paralogs. knh4's individual contribution is not resolved.</li>
+<li><strong>Redundancy.</strong> knh4Δ single mutant is viable with only mild cell-wall phenotypes → strong<br />
+  functional redundancy among the Kre9/Knh1 paralogs is likely but not directly tested for knh4.</li>
+<li><strong>In-vivo β-glucan role.</strong> The β-glucanase sensitivity implies a cell-wall β-glucan support<br />
+  role, but direct biochemical demonstration (β-glucan quantity/structure in knh4Δ) is lacking.</li>
+</ul>
+<h2 id="family-biology-context-s-cerevisiae-general-not-knh4-specific">Family biology (context, S. cerevisiae / general — NOT knh4-specific)</h2>
+<ul>
+<li>S. cerevisiae Kre9p and its homolog Knh1p are cell-surface O-glycoproteins required for<br />
+  β-1,6-glucan synthesis/assembly (cross-linking β-1,6-glucan into the wall); kre9Δ knh1Δ is<br />
+  synthetically lethal (WebSearch, PubMed:8810042 KNH1 paper; general reviews). KRE9 is the major<br />
+  gene, KNH1 redundant. Used here only as family context, not as knh4 evidence.</li>
+</ul>
+<h2 id="go-annotations-to-review-from-goatsv">GO annotations to review (from goa.tsv)</h2>
+<ol>
+<li>GO:0003674 molecular_function (ND, GO_REF:0000015) — root, no data.</li>
+<li>GO:0008150 biological_process (ND, GO_REF:0000015) — root, no data.</li>
+<li>GO:0009986 cell surface (TAS, PMID:12845604) — GPI-protein prediction; defensible.</li>
+</ol>
+<h2 id="candidate-go-terms-ols4-verified">Candidate GO terms (OLS4-verified)</h2>
+<ul>
+<li>BP: GO:0006077 (1-&gt;6)-beta-D-glucan metabolic process; GO:0006078 biosynthetic process;<br />
+  GO:0031505 fungal-type cell wall organization; GO:0071554 cell wall organization.</li>
+<li>CC: GO:0009986 cell surface (existing); GO:0009277 fungal-type cell wall.</li>
+<li>Note: GPI "anchored component of membrane" GO terms (GO:0031225/GO:0046658) are OBSOLETE<br />
+  (topology, not a component) — do not use.</li>
+</ul>
+<h2 id="deep-research-status">Deep research status</h2>
+<p>Automated deep research FAILED: <code>deep-research-falcon</code> hits the python3.9 <code>dict | None</code> bug;<br />
+the <code>deep_research_wrapper.py</code> uv path errored on template variables (<code>Missing template
+variables: gene_info, ...</code>) and the perplexity-lite fallback returned HTTP 401 (quota<br />
+exhausted). Per project policy I did NOT fabricate a <code>-deep-research-&lt;provider&gt;.md</code> file.<br />
+This review is grounded in UniProt (O42970), PomBase (SPBC1E8.05 JSON API), GOA, OLS4, and the<br />
+cached primary literature (PMID:34738170, 12845604, 20473289, 21511999) plus web/PubMed family<br />
+context.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O42970
+gene_symbol: knh4
+aliases:
+  - SPBC1E8.05
+  - gaz2
+  - Knh4
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  knh4 (SPBC1E8.05; synonym gaz2) is a fission-yeast member of the Kre9/Knh1
+  family of fungal cell-surface glycoproteins (Pfam PF10342 Kre9_KNH; InterPro
+  IPR018466 Kre9/Knh1-like_N; PANTHER PTHR40633). The protein has an N-terminal
+  signal peptide, a single N-terminal Kre9/Knh1 fold, a long serine/threonine-rich
+  low-complexity disordered stalk, predicted N- and O-glycosylation, and a
+  hydrophobic C-terminus consistent with a GPI-anchor signal; it was identified in
+  a genome-wide screen for predicted GPI-anchored proteins and localizes to the
+  cell surface. In S. pombe, deletion of knh4 is viable but confers sensitivity to
+  cell-wall-degrading (beta-glucanase) enzymes, and high-copy expression of knh4
+  suppresses the growth defect of N-glycosylation-defective och1 cells; these data
+  indicate that Knh4 non-enzymatically supports cell-surface beta-glucan as part of
+  the fungal cell wall. Kre9/Knh1-family proteins are non-catalytic and, in the
+  budding yeast homologs Kre9p/Knh1p, function in cell-wall (1-&gt;6)-beta-glucan
+  assembly. The specific molecular activity of Knh4, and its individual contribution
+  relative to the essential Kre9 ortholog and other paralogs, have not been
+  experimentally established.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: PMID:12845604
+    title: Genome-wide identification of fungal GPI proteins.
+    findings:
+      - statement: &gt;-
+          A genome-wide search using a GPI-attachment consensus sequence identified
+          33 putative GPI-anchored proteins in S. pombe; SPBC1E8.05 (knh4) is among
+          the predicted cell-surface GPI proteins.
+        reference_section_type: ABSTRACT
+        supporting_text: &gt;-
+          only 33 GPI candidates were identified
+        full_text_unavailable: true
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Genome-wide bioinformatic identification of fungal GPI
+        proteins; the S. pombe subset (33 candidates) includes SPBC1E8.05. This is
+        the source cited by PomBase for the cell surface (GO:0009986) annotation.
+        It is a prediction paper (consensus-sequence screen), not an experimental
+        localization of knh4, hence MEDIUM relevance for the cell-surface claim.
+  - id: PMID:34738170
+    title: &gt;-
+      Overexpression of cell-wall GPI-anchored proteins restores cell growth of
+      N-glycosylation-defective och1 mutants in Schizosaccharomyces pombe.
+    findings:
+      - statement: &gt;-
+          SPBC1E8.05 (knh4) and pwp1 were identified as high-copy suppressors of the
+          growth defect of N-glycosylation-defective och1-delta cells; both encode
+          GPI-anchored proteins. Deletion of either gene is viable but confers
+          sensitivity to beta-glucanase, indicating that Knh4 non-enzymatically
+          supports beta-glucan on the S. pombe cell surface.
+        reference_section_type: ABSTRACT
+        supporting_text: &gt;-
+          non-enzymatically support β-glucan on the cell-surface of S. pombe
+        full_text_unavailable: true
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified; the abstract explicitly names SPBC1E8.05 (knh4). This is the
+        single most direct functional study of knh4: it establishes that knh4-delta
+        is viable but beta-glucanase-sensitive and that the encoded protein
+        non-enzymatically supports cell-surface beta-glucan. Cached record is
+        abstract-only, but the abstract itself states the key knh4-specific claims.
+  - id: PMID:20473289
+    title: &gt;-
+      Analysis of a genome-wide set of gene deletions in the fission yeast
+      Schizosaccharomyces pombe.
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. The Bioneer genome-wide deletion resource; source of the
+        &#34;viable&#34; (non-essential) status for knh4-delta. Large-scale resource, not a
+        knh4-specific functional study, hence LOW relevance beyond viability.
+  - id: PMID:21511999
+    title: Comparative functional genomics of the fission yeasts.
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Comparative genomics of the Schizosaccharomyces clade;
+        source of the knh4 ortholog assignment (S. japonicus SJAG_03521). No
+        knh4-specific functional data.
+  - id: UniProt:O42970
+    title: Uncharacterized serine-rich protein C1E8.05 (YB95_SCHPO)
+    findings:
+      - statement: &gt;-
+          UniProt assigns O42970 to the Kre9/Knh1 family (Pfam PF10342 Kre9_KNH;
+          InterPro IPR018466 Kre9/Knh1-like_N) with an N-terminal signal peptide, a
+          serine-rich low-complexity/disordered region, predicted glycosylation, and
+          a hydrophobic C-terminus; function is not experimentally determined (PE 2,
+          evidence at transcript level).
+        reference_section_type: OTHER
+        supporting_text: &gt;-
+          Pfam; PF10342; Kre9_KNH; 1.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        UniProt record for the reviewed gene. Domain (Kre9/Knh1), signal-peptide,
+        low-complexity/disordered, and glycoprotein features are the primary
+        structural evidence for the cell-surface, non-catalytic scaffold
+        interpretation used in this review.
+existing_annotations:
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root molecular_function annotation with the ND (no biological data) evidence
+        code, indicating that no specific molecular function has been curated for
+        knh4. This accurately reflects the current state of knowledge: Kre9/Knh1
+        family proteins are non-catalytic and knh4 has no experimentally defined
+        molecular activity.
+      action: ACCEPT
+      reason: &gt;-
+        ND on the root term is the correct GO representation when no informative
+        molecular function is known. knh4 is a &#34;conserved unknown&#34; cell-surface
+        protein with no demonstrated catalytic or binding activity; the family is
+        non-enzymatic. Retain as-is; the genuine molecular-function gap is recorded
+        in knowledge_gaps rather than by asserting a speculative activity.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Root biological_process annotation with the ND evidence code. This ND
+        annotation predates (and does not incorporate) the later functional data
+        showing a cell-wall beta-glucan-support role.
+      action: MODIFY
+      reason: &gt;-
+        The ND root-process annotation is now superseded by knh4-specific evidence:
+        knh4-delta is beta-glucanase-sensitive and the protein non-enzymatically
+        supports cell-surface beta-glucan (PMID:34738170). A specific biological
+        process can therefore be assigned. Propose replacing the ND root with a
+        cell-wall organization / (1-&gt;6)-beta-D-glucan metabolic-process term
+        reflecting this role.
+      proposed_replacement_terms:
+        - id: GO:0031505
+          label: fungal-type cell wall organization
+        - id: GO:0006077
+          label: (1-&gt;6)-beta-D-glucan metabolic process
+      supported_by:
+        - reference_id: PMID:34738170
+          supporting_text: &gt;-
+            non-enzymatically support β-glucan on the cell-surface of S. pombe
+  - term:
+      id: GO:0009986
+      label: cell surface
+    evidence_type: TAS
+    original_reference_id: PMID:12845604
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Cell-surface localization, curated (TAS) from the genome-wide GPI-protein
+        prediction and consistent with the signal peptide, GPI-anchor-like
+        C-terminus, and demonstrated GPI-anchored status of knh4.
+      action: ACCEPT
+      reason: &gt;-
+        Cell surface (GO:0009986) is the correct and well-supported cellular
+        location for this GPI-anchored, signal-peptide-bearing cell-surface
+        glycoprotein. The localization is corroborated by the functional study
+        (PMID:34738170), which treats SPBC1E8.05 as a GPI-anchored cell-surface
+        protein. Retain as a core location. Note the GPI &#34;anchored component of
+        membrane&#34; GO terms are obsolete, so cell surface is the appropriate CC.
+      supported_by:
+        - reference_id: PMID:12845604
+          supporting_text: &gt;-
+            only 33 GPI candidates were identified
+        - reference_id: PMID:34738170
+          supporting_text: &gt;-
+            non-enzymatically support β-glucan on the cell-surface of S. pombe
+core_functions:
+  - description: &gt;-
+      Non-catalytic cell-surface glycoprotein of the Kre9/Knh1 family that supports
+      cell-wall (1-&gt;6)-beta-glucan. Knh4 is GPI-anchored at the S. pombe cell
+      surface; loss of knh4 does not affect viability but renders cells sensitive to
+      cell-wall-degrading beta-glucanase, and high-copy knh4 rescues the cell-wall/
+      growth defect of N-glycosylation-deficient och1 cells, together indicating a
+      role in maintaining/organizing cell-surface beta-glucan of the fungal cell
+      wall. No molecular activity is asserted: the Kre9/Knh1 family is non-enzymatic
+      and knh4 has no experimentally defined molecular function (see knowledge_gaps).
+    directly_involved_in:
+      - id: GO:0031505
+        label: fungal-type cell wall organization
+    locations:
+      - id: GO:0009986
+        label: cell surface
+    supported_by:
+      - reference_id: PMID:34738170
+        supporting_text: &gt;-
+          non-enzymatically support β-glucan on the cell-surface of S. pombe
+      - reference_id: UniProt:O42970
+        supporting_text: &gt;-
+          Pfam; PF10342; Kre9_KNH; 1.
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular activity of Knh4 is unknown. It is undetermined whether Knh4
+      binds, cross-links, transports, or otherwise scaffolds cell-wall beta-glucan;
+      no catalytic activity, ligand, or biochemical partner has been demonstrated,
+      and the &#34;support&#34; of cell-surface beta-glucan is explicitly non-enzymatic.
+    boundary: &gt;-
+      Knh4 is firmly established as a GPI-anchored, Kre9/Knh1-family cell-surface
+      glycoprotein whose deletion causes beta-glucanase sensitivity, and whose
+      overexpression rescues N-glycosylation-defective och1 cells (PMID:34738170);
+      the budding-yeast homologs Kre9p/Knh1p act in cell-wall (1-&gt;6)-beta-glucan
+      assembly. What Knh4 does at the molecular level to support beta-glucan is not
+      known.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Defining the molecular activity would convert a &#34;conserved unknown&#34;
+      cell-surface protein into a mechanistic component of fungal cell-wall
+      beta-glucan organization, informing antifungal cell-wall biology.
+    resolution: &gt;-
+      Biochemical characterization of purified Knh4 for beta-glucan binding/
+      cross-linking activity; interactomics to identify cell-wall partners; and
+      structural/genetic dissection of the Kre9/Knh1 domain versus the Ser/Thr-rich
+      stalk.
+    provenance:
+      - reference_id: PMID:34738170
+        supporting_text: &gt;-
+          non-enzymatically support β-glucan on the cell-surface of S. pombe
+  - gap_statement: &gt;-
+      Knh4&#39;s specific biological role and its contribution relative to the essential
+      Kre9 ortholog and the other non-essential Kre9/Knh1 paralogs in S. pombe are
+      undetermined. Whether knh4 acts redundantly, in a specialized condition, or in
+      a particular cell-wall layer is not resolved.
+    boundary: &gt;-
+      knh4-delta is viable with only cell-wall-stress (beta-glucanase) sensitivity
+      (PMID:34738170; PMID:20473289), implying substantial functional redundancy;
+      the S. pombe genome encodes an essential Kre9 ortholog that carries the core
+      beta-1,6-glucan-formation function, plus additional Kre9/Knh1-family paralogs.
+      The individual and combined contributions of these genes have not been mapped.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Distinguishing redundancy from specialization would clarify how the Kre9/Knh1
+      family divides labor in fission-yeast cell-wall assembly.
+    resolution: &gt;-
+      Systematic single- and combinatorial-deletion analysis of the S. pombe
+      Kre9/Knh1 family (knh4 with its paralogs and the essential Kre9 ortholog), with
+      cell-wall beta-glucan quantification/structural analysis and stress profiling.
+    provenance:
+      - reference_id: PMID:34738170
+        supporting_text: &gt;-
+          neither gene was essential for cell viability
+suggested_questions:
+  - question: &gt;-
+      What is the molecular activity of Knh4 at the cell surface — does it bind or
+      cross-link (1-&gt;6)-beta-glucan, and which cell-wall components are its partners?
+    experts: []
+  - question: &gt;-
+      Is knh4 functionally redundant with the essential S. pombe Kre9 ortholog and
+      the other Kre9/Knh1 paralogs, and does a higher-order deletion phenocopy the
+      essential family member?
+    experts: []
+  - question: &gt;-
+      How does high-copy knh4 suppress the growth defect of N-glycosylation-defective
+      och1 cells — by restoring cell-wall integrity, and is the GPI anchor required?
+    experts: []
+suggested_experiments:
+  - hypothesis: &gt;-
+      Knh4 directly binds/cross-links cell-wall (1-&gt;6)-beta-glucan.
+    description: &gt;-
+      Express and purify recombinant Knh4 (with and without the Ser/Thr-rich stalk)
+      and assay binding to and cross-linking of defined beta-1,6- and beta-1,3-glucan
+      substrates in vitro; test whether the isolated Kre9/Knh1 domain is sufficient.
+    experiment_type: biochemical binding/activity assay
+  - hypothesis: &gt;-
+      Knh4 is functionally redundant with other S. pombe Kre9/Knh1-family members.
+    description: &gt;-
+      Construct single and combinatorial deletions of knh4 and its paralogs (and
+      conditional alleles of the essential Kre9 ortholog) and quantify cell-wall
+      beta-glucan content/structure and beta-glucanase/stress sensitivity to test for
+      redundancy versus specialization.
+    experiment_type: genetic epistasis / cell-wall analysis
+  - hypothesis: &gt;-
+      The GPI anchor and cell-surface localization of Knh4 are required for its
+      cell-wall beta-glucan support function.
+    description: &gt;-
+      Compare wild-type, GPI-anchor-deleted, and mislocalized Knh4 constructs for
+      rescue of knh4-delta beta-glucanase sensitivity and suppression of the och1
+      growth defect.
+    experiment_type: structure-function complementation
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/mmf2/mmf2-ai-review.html
+++ b/genes/SCHPO/mmf2/mmf2-ai-review.html
@@ -1,0 +1,2753 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mmf2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mmf2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9UR06" target="_blank" class="term-link">
+                        Q9UR06
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mmf2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9UR06" data-a="DESCRIPTION: mmf2 is a fission-yeast member of the RidA/YjgF/YE..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>mmf2 is a fission-yeast member of the RidA/YjgF/YER057c/UK114 (Rid) family of reactive enamine/imine deaminases (&#34;metabolite-damage pre-emption&#34; enzymes). Proteins of this family form homotrimers and use a single conserved active-site arginine to hydrolyze reactive enamine/imine intermediates - most characteristically 2-aminoacrylate and the corresponding imines 2-iminopropanoate and 2-iminobutanoate, produced by pyridoxal-5&#39;-phosphate-dependent serine/threonine dehydratases - to the stable 2-oxo (keto) acids, thereby protecting PLP-dependent enzymes from covalent damage. mmf2 carries an N-terminal mitochondrial targeting sequence and is assigned to the mitochondrial matrix, with a portion also detected in the cytoplasm. Its characterized orthologs (Saccharomyces cerevisiae Mmf1p and human UK114/HRSP12) act in the mitochondrion, where deaminase activity indirectly supports mitochondrial genome integrity by preventing 2-aminoacrylate stress arising from mitochondrial amino-acid catabolism. The specific in-vivo substrate and physiological role of the fission-yeast protein itself have not been experimentally defined.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019239" target="_blank" class="term-link">
+                                    GO:0019239
+                                </a>
+                            </span>
+                            <span class="term-label">deaminase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0019239" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RidA/Rid-family molecular function. Deaminase activity is domain-defensible: mmf2 belongs to PANTHER PTHR11803 (2-iminobutanoate/2-iminopropanoate deaminase RidA) and retains the single conserved catalytic arginine essential for imine/enamine hydrolysis. The term is correct but very general; a more specific RidA term (GO:0120241) better captures the activity and is proposed in core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA-supported family activity is real, but &#34;deaminase activity&#34; is uninformatively broad for a RidA protein. The specific RidA reaction is 2-iminobutanoate/2-iminopropanoate (and 2-aminoacrylate) deamination.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000211014</span>
+
+                                    &middot; RidA/Rid family ancestral node (PTHR11803)
+
+
+
+                                    <div class="propagation-comment">IBA seed node annotated with the generic ancestral term &#34;deaminase activity&#34; rather than the specific RidA reaction, so the transfer to mmf2 is imprecise.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P0AF93</span>
+
+                                    &middot; E. coli RutC (RidA-family)
+
+
+
+                                    <div class="propagation-comment">Family co-member used in the IBA with/from set.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120241" target="_blank" class="term-link">
+                                    2-iminobutanoate/2-iminopropanoate deaminase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25975565" target="_blank" class="term-link">
+                                        PMID:25975565
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial localization is well supported: mmf2 has a predicted N-terminal mitochondrial transit peptide and its characterized orthologs act in the mitochondrion. This is the general (organelle-level) term; mitochondrial matrix (GO:0005759) is the more precise location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the transit peptide and with ISO-supported mitochondrial-matrix localization; correct but less precise than the matrix term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytosolic localization is plausible for a Rid-family protein (the S. cerevisiae paralog Hmf1p is cytosolic), and IBA propagates cytosolic membership across the family. For mmf2, whose transit peptide targets it to the mitochondrion, this likely reflects a pre-import pool or family-level tree noise rather than its core site of action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not the core (mitochondrial-matrix) location; retained as a plausible secondary pool consistent with the dual mitochondrion/cytoplasm UniProt subcellular assignment.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt Cytoplasm subcellular-location keyword (SL-0086). Broad parent of cytosol; consistent with a non-mitochondrial pool but not the core site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> General cytoplasmic term derived from the UniProt SubCell keyword; retained as non-core, subsumed by the more specific cytosol annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt Mitochondrion subcellular-location keyword (SL-0173), consistent with the predicted transit peptide and the ISO matrix annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization is well supported by the transit peptide and orthology; the term is correct though less precise than mitochondrial matrix.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process placeholder with ND evidence, indicating no experimentally or phylogenetically curated BP is assigned in fission yeast. This reflects the genuine BP knowledge gap for this &#34;conserved unknown&#34; gene (see knowledge_gaps).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND root placeholder; retained as-is. It correctly signals that no specific biological process has been established for the fission-yeast protein.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UR06" data-a="GO:0005759" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Best-supported subcellular location: transferred by orthology (ISO) from S. cerevisiae Mmf1p, a characterized mitochondrial-matrix factor, and consistent with mmf2&#39;s predicted mitochondrial transit peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Precise, orthology-supported localization consistent with the transit-peptide prediction; the primary/core location for this protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11003673" target="_blank" class="term-link">
+                                        PMID:11003673
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mmf1p is a mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Reactive enamine/imine deaminase of the RidA/Rid family. mmf2 retains the single conserved catalytic arginine (Arg101, in the C-terminal PAR motif aligning to S. enterica RidA Arg105) and the conserved active-site GPY/KIEIE motifs, indicating an intact RidA active site. It most plausibly hydrolyzes the reactive enamine 2-aminoacrylate and the corresponding imines (2-iminopropanoate/2-iminobutanoate) produced by PLP-dependent serine/threonine dehydratases to the stable 2-oxo acids, acting in the mitochondrial matrix. The specific in-vivo substrate for the fission-yeast protein is inferred from family membership and orthology, not directly demonstrated.</h3>
+                <span class="vote-buttons" data-g="Q9UR06" data-a="FUNCTION: Reactive enamine/imine deaminase of the RidA/Rid f..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120241" target="_blank" class="term-link">
+                            2-iminobutanoate/2-iminopropanoate deaminase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29487232" target="_blank" class="term-link">
+                                PMID:29487232
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">preempting metabolic stress and loss of the mitochondrial</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25975565" target="_blank" class="term-link">
+                                PMID:25975565
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29487232" target="_blank" class="term-link">
+                            PMID:29487232
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mmf1p Couples Amino Acid Metabolism to Mitochondrial DNA Maintenance in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The RidA-family protein Mmf1p (the S. cerevisiae ortholog of mmf2) is an enamine/imine deaminase that deaminates 2-aminoacrylate, preempting metabolic stress and indirectly maintaining the mitochondrial genome.</div>
+
+                        <div class="finding-text">"preempting metabolic stress and loss of the mitochondrial"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11003673" target="_blank" class="term-link">
+                            PMID:11003673
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mmf1p, a novel yeast mitochondrial protein conserved throughout evolution and involved in maintenance of the mitochondrial genome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Mmf1p is a mitochondrial matrix factor whose deletion causes loss of mitochondrial DNA; the source of the &#34;maintenance of mitochondrial function&#34; (Mmf) name applied to mmf2.</div>
+
+                        <div class="finding-text">"Mmf1p is a mitochondrial matrix"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25975565" target="_blank" class="term-link">
+                            PMID:25975565
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genomic and experimental evidence for multiple metabolic functions in the RidA/YjgF/YER057c/UK114 (Rid) protein family.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Rid family comprises multiple subfamilies; RidA and the Rid1/Rid2/Rid3 subfamilies retain the conserved active-site arginine essential for imine/enamine deaminase activity.</div>
+
+                        <div class="finding-text">"The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does fission-yeast mmf2 hydrolyze 2-aminoacrylate / 2-iminopropanoate in vitro, and is Arg101 the essential catalytic residue?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UR06" data-a="Q: Does fission-yeast mmf2 hydrolyze 2-aminoacrylate ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does deletion of mmf2 in S. pombe cause mitochondrial DNA loss / a respiratory (petite) phenotype or serine/2-aminoacrylate sensitivity, as seen for S. cerevisiae Mmf1p?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UR06" data-a="Q: Does deletion of mmf2 in S. pombe cause mitochondr..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Purify recombinant mmf2 (mature form) and an Arg101-&gt;Ala variant; assay deamination of 2-aminoacrylate and 2-iminobutanoate using coupled serine/threonine-dehydratase pyruvate/2-oxobutanoate production assays, comparing rates to S. enterica RidA and S. cerevisiae Mmf1p.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: mmf2 is a mitochondrial RidA deaminase that hydrolyzes 2-aminoacrylate/2-iminopropanoate via its conserved catalytic arginine.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro enzyme assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UR06" data-a="EXPERIMENT: Purify recombinant mmf2 (mature form) and an Arg10..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct an mmf2 deletion, quantify mitochondrial DNA content and respiratory competence, test sensitivity to serine and to conditions that elevate mitochondrial serine/threonine dehydratase flux, and test complementation by S. cerevisiae MMF1 or human HRSP12/UK114.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: mmf2 protects the fission-yeast mitochondrial genome against 2-aminoacrylate stress.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / mitochondrial phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UR06" data-a="EXPERIMENT: Construct an mmf2 deletion, quantify mitochondrial..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mmf2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UR06" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">18 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T16:48:14.661909</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="mmf2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-mmf2-q9ur06-in-schizosaccharomyces-pombe">Comprehensive Research Report: mmf2 (Q9UR06) in <em>Schizosaccharomyces pombe</em></h2>
+<h3 id="1-geneprotein-identification-and-verification">1. Gene/Protein Identification and Verification</h3>
+<p>The target protein is <strong>mmf2</strong> (UniProt accession Q9UR06), also known as <strong>hpm1</strong>, encoded by systematic ORF names <strong>SPAC1039.10</strong> and <strong>SPAC922.01</strong> in <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843). According to its UniProt annotation, mmf2 is described as "Protein mmf2, mitochondrial" with the full name "Maintenance of mitochondrial function 2," and it is synthesized as a precursor, consistent with mitochondrial targeting. The protein is classified as belonging to the <strong>RutC family</strong> within the broader <strong>Rid (YjgF/YER057c/UK114) protein superfamily</strong>, and it contains the <strong>RidA domain</strong> (IPR006056), the <strong>RutC-like superfold</strong> (IPR035959), and the <strong>Ribonuclease L-PSP/YjgF</strong> domain (PF01042).</p>
+<p><strong>Important note on literature availability:</strong> Direct primary literature specifically characterizing <em>S. pombe</em> mmf2 was not identified in the literature searches conducted. The functional annotation of mmf2 therefore relies primarily on (i) its domain and family assignments, (ii) the well-characterized biochemistry of the Rid/RidA/RutC protein superfamily, and (iii) functional inference from the closely related <em>Saccharomyces cerevisiae</em> ortholog <strong>Mmf1p</strong> (mitochondrial matrix factor 1), which has been experimentally characterized in detail. The following report integrates these lines of evidence.</p>
+<h3 id="2-protein-family-the-rid-yjgfyer057cuk114-superfamily">2. Protein Family: The Rid (YjgF/YER057c/UK114) Superfamily</h3>
+<p>The Rid protein superfamily was first defined by sequence homology and is found across all domains of life, from bacteria and archaea to eukaryotes (irons2020ridaproteinsprotect pages 1-1). The superfamily encompasses nine recognized subfamilies: the archetypal <strong>RidA</strong> subfamily, <strong>Rid1 through Rid7</strong>, and <strong>RutC</strong> (irons2020ridaproteinsprotect pages 1-1, irons2020ridaproteinsprotect pages 15-17). RidA is the only subfamily present in eukaryotes; however, UniProt classifies mmf2 within the RutC family based on sequence features, suggesting it may have closer similarity to the RutC lineage than to canonical RidA members (irons2020ridaproteinsprotect pages 15-17).</p>
+<p>Structurally, Rid-family proteins are <strong>homotrimers</strong> with intersubunit active sites defined by seven highly conserved residues (irons2020ridaproteinsprotect pages 3-4, borchert2019reactiveenaminesand pages 2-3). The most conserved residue across the superfamily is <strong>glutamate 120</strong> (E120, using <em>S. enterica</em> RidA numbering), while <strong>Ser30</strong> and <strong>Gly31</strong> are also common across all subfamilies (borchert2019reactiveenaminesand pages 2-3). Numerous crystal structures have been solved for Rid-family members, including those from <em>S. cerevisiae</em>: the mitochondrial homolog <strong>Mmf1p</strong> (PDB: 3QUW) and the cytoplasmic homolog <strong>Hmf1p</strong> (PDB: 1JD1) (irons2020ridaproteinsprotect pages 3-4).</p>
+<h3 id="3-predicted-enzymatic-function-enamineimine-deaminase-activity">3. Predicted Enzymatic Function: Enamine/Imine Deaminase Activity</h3>
+<h4 id="31-the-rida-paradigm">3.1 The RidA Paradigm</h4>
+<p>The definitive biochemical activity established for RidA-subfamily proteins is <strong>enamine/imine deaminase</strong> activity. RidA proteins catalyze the hydrolysis of reactive enamine and imine intermediates—most notably <strong>2-aminoacrylate (2AA)</strong>—that are generated as obligatory intermediates by <strong>pyridoxal 5′-phosphate (PLP)-dependent α,β-eliminases</strong> such as serine/threonine dehydratases (IlvA, EC 4.3.1.19) and cysteine desulfhydrases (hodgehanson2017membersofthe pages 1-3, irons2020ridaproteinsprotect pages 7-8, borchert2019reactiveenaminesand pages 2-3). In the absence of RidA, 2AA can escape the active site of the generating enzyme, diffuse through the cell, and <strong>covalently modify and inactivate other PLP-dependent enzymes</strong>, leading to broad metabolic disruption (irons2020ridaproteinsprotect pages 8-9, irons2020ridaproteinsprotect pages 7-8, borchert2019reactiveenaminesand pages 4-6). RidA deaminates 2AA to <strong>pyruvate</strong>, effectively quenching this reactive intermediate before it can cause damage (hodgehanson2017membersofthe pages 1-3, irons2020ridaproteinsprotect pages 5-7).</p>
+<p>The catalytic mechanism involves the substrate's carboxyl group forming a salt bridge with the conserved <strong>Arg105</strong> residue at the intersubunit active site, while other conserved residues stabilize the substrate and facilitate hydrolysis (irons2020ridaproteinsprotect pages 7-8, borchert2019reactiveenaminesand pages 4-6). This deaminase activity is the <strong>only biochemical function conserved across all tested RidA homologs</strong> from organisms spanning all domains of life (irons2020ridaproteinsprotect pages 22-23, irons2020ridaproteinsprotect pages 11-12).</p>
+<h4 id="32-rutc-subfamily-specificity">3.2 RutC Subfamily Specificity</h4>
+<p>Since UniProt classifies mmf2 as belonging to the <strong>RutC family</strong> rather than the canonical RidA subfamily, it is important to note the functional distinction. In <em>E. coli</em>, RutC functions specifically within the <strong>rut operon</strong> for pyrimidine (uracil) utilization, where it catalyzes the deamination of <strong>3-aminoacrylate to malonic semialdehyde and ammonia</strong> (irons2020ridaproteinsprotect pages 20-22, irons2020ridaproteinsprotect pages 22-23). While RutC shares the overall Rid-family fold and deaminase mechanism, it has a distinct substrate preference: notably, RutC did <strong>not</strong> show significant deaminase activity on 2AA in vitro, unlike canonical RidA members (irons2020ridaproteinsprotect pages 19-20). This suggests that if mmf2 is indeed a RutC-type protein, its preferred substrate in the mitochondria may differ from canonical 2AA, potentially involving aminoacrylate intermediates from other metabolic pathways.</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>Based on its UniProt annotation as a mitochondrial precursor protein and its name ("Maintenance of mitochondrial function 2"), mmf2 is predicted to localize to the <strong>mitochondria</strong> of <em>S. pombe</em>. This is strongly supported by analogy to the <em>S. cerevisiae</em> ortholog Mmf1p, which is specifically targeted to the <strong>mitochondrial matrix</strong> (irons2020ridaproteinsprotect pages 11-12). In <em>S. cerevisiae</em>, the two RidA homologs partition between compartments: <strong>Mmf1p</strong> resides in the mitochondria, while <strong>Hmf1p</strong> is cytoplasmic (irons2020ridaproteinsprotect pages 11-12).</p>
+<h3 id="5-functional-inference-from-the-s-cerevisiae-ortholog-mmf1p">5. Functional Inference from the <em>S. cerevisiae</em> Ortholog Mmf1p</h3>
+<p>The best-characterized functional comparator for <em>S. pombe</em> mmf2 is <em>S. cerevisiae</em> <strong>Mmf1p</strong> (mitochondrial matrix factor 1). The following phenotypic and biochemical data from Mmf1p provide the strongest basis for inferring the function of mmf2:</p>
+<ul>
+<li><strong>Loss of Mmf1p</strong> causes accumulation of <strong>2-aminoacrylate (2AA)</strong> in the mitochondria, generated by the mitochondrial serine dehydratases <strong>Ilv1p</strong> and <strong>Cha1p</strong> (irons2020ridaproteinsprotect pages 11-12).</li>
+<li>This 2AA accumulation leads to <strong>metabolic stress</strong> and, critically, to <strong>irreversible loss of mitochondrial DNA (mtDNA)</strong>, resulting in petite phenotypes and loss of respiratory competence (irons2020ridaproteinsprotect pages 11-12).</li>
+<li><em>mmf1</em> mutants show <strong>reduced growth on dextrose</strong>, which can be partially restored by supplementation with <strong>isoleucine or threonine</strong> (an isoleucine precursor) (irons2020ridaproteinsprotect pages 11-12). Isoleucine acts as an allosteric inhibitor of IlvA-type serine/threonine dehydratases, thereby reducing 2AA generation at its source.</li>
+<li>In the absence of Mmf1p, <strong>glycerol respiration is eliminated</strong> due to loss of mitochondrial DNA and, ultimately, mitochondrial function (irons2020ridaproteinsprotect pages 11-12).</li>
+<li>Notably, addition of an <strong>iron chelator</strong> to the growth medium of <em>mmf1</em> mutants <strong>prevents mitochondrial loss</strong>, suggesting that RidA influences <strong>iron homeostasis</strong> within the mitochondrial context and that iron-dependent processes contribute to mitochondrial damage when 2AA accumulates (irons2020ridaproteinsprotect pages 11-12).</li>
+<li>More recently, absence of <em>MMF1</em> has been shown to <strong>disrupt heme biosynthesis</strong> by targeting the PLP-dependent enzyme <strong>Hem1p</strong> (5-aminolevulinate synthase), which is a mitochondrial PLP-dependent enzyme vulnerable to 2AA-mediated inactivation (Whitaker et al., 2021 — cited as unobtainable paper).</li>
+</ul>
+<h3 id="6-biochemical-pathways-and-metabolic-context">6. Biochemical Pathways and Metabolic Context</h3>
+<p>The primary metabolic context for mmf2 function, inferred from the RidA paradigm and the Mmf1p ortholog, centers on:</p>
+<ol>
+<li>
+<p><strong>Branched-chain amino acid biosynthesis:</strong> The serine/threonine dehydratase (IlvA/Ilv1p) that generates 2AA as a by-product is a key enzyme in the isoleucine biosynthetic pathway. RidA/Mmf1-type proteins protect this pathway by clearing toxic 2AA intermediates (irons2020ridaproteinsprotect pages 11-12, irons2020ridaproteinsprotect pages 5-7).</p>
+</li>
+<li>
+<p><strong>Protection of PLP-dependent enzymes:</strong> The broader role of RidA-type proteins is to prevent <strong>2AA stress</strong>—a condition where accumulated 2AA covalently damages multiple PLP-dependent enzymes, causing pleiotropic metabolic imbalances across amino acid biosynthesis, one-carbon metabolism, and other pathways (irons2020ridaproteinsprotect pages 8-9, irons2020ridaproteinsprotect pages 7-8, irons2020ridaproteinsprotect pages 13-14).</p>
+</li>
+<li>
+<p><strong>Heme biosynthesis:</strong> In the mitochondrial context, the PLP-dependent enzyme Hem1p (5-aminolevulinate synthase) is a target of 2AA damage, linking RidA function to heme production and, by extension, to respiratory chain integrity.</p>
+</li>
+<li>
+<p><strong>Potential pyrimidine catabolism role:</strong> If the RutC family assignment is accurate, mmf2 could also participate in deamination of 3-aminoacrylate intermediates arising from pyrimidine degradation within the mitochondrial compartment, converting them to malonic semialdehyde (irons2020ridaproteinsprotect pages 20-22, irons2020ridaproteinsprotect pages 22-23).</p>
+</li>
+</ol>
+<h3 id="7-summary-and-confidence-assessment">7. Summary and Confidence Assessment</h3>
+<p>The following table summarizes the key features of mmf2:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>mmf2 in <em>Schizosaccharomyces pombe</em> (Q9UR06)</th>
+<th>Evidence / interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Verified target identity</td>
+<td>UniProt Q9UR06; protein name: Protein mmf2, mitochondrial; synonyms: <strong>hpm1</strong>, <strong>SPAC1039.10</strong>, <strong>SPAC922.01</strong>; organism: <em>Schizosaccharomyces pombe</em> strain 972 / ATCC 24843</td>
+<td>Provided target specification; literature search found no conflicting <em>S. pombe</em> gene with this accession in the retrieved sources</td>
+</tr>
+<tr>
+<td>Gene symbol ambiguity status</td>
+<td><strong>Literature is limited for this specific protein</strong>; direct primary papers on <em>S. pombe</em> <strong>mmf2</strong> were not retrieved, so annotation must rely mainly on UniProt/domain assignment and homolog-based inference</td>
+<td>The RidA/RutC family literature and yeast homolog literature are available, but not direct <em>S. pombe mmf2</em> studies in the retrieved corpus (irons2020ridaproteinsprotect pages 1-1, irons2020ridaproteinsprotect pages 11-12)</td>
+</tr>
+<tr>
+<td>Protein family / domains</td>
+<td>Member of the <strong>Rid/YjgF/YER057c/UK114 superfamily</strong>; UniProt assigns <strong>RutC family</strong>; domains include <strong>RidA / YjgF-like</strong> fold</td>
+<td>Rid proteins comprise RidA plus Rid1–7 and RutC subfamilies; RutC is a Rid-family deaminase lineage distinct from canonical RidA (irons2020ridaproteinsprotect pages 1-1, irons2020ridaproteinsprotect pages 15-17, irons2020ridaproteinsprotect pages 20-22, irons2020ridaproteinsprotect pages 22-23)</td>
+</tr>
+<tr>
+<td>Conserved structural class</td>
+<td>Rid-family proteins are typically <strong>homotrimers</strong> with an intersubunit active site built around conserved residues</td>
+<td>Review of solved Rid structures shows trimeric architecture and conserved active-site residues across the family (irons2020ridaproteinsprotect pages 4-5, irons2020ridaproteinsprotect pages 3-4, borchert2019reactiveenaminesand pages 2-3)</td>
+</tr>
+<tr>
+<td>Predicted primary biochemical function</td>
+<td>Most likely a <strong>reactive enamine/imine detoxification enzyme</strong>; by family analogy, predicted to accelerate deamination/hydrolysis of reactive aminoacrylate/imino intermediates rather than serve as a transporter or structural scaffold</td>
+<td>RidA proteins catalyze deamination of reactive enamines/imines, especially 2-aminoacrylate (2AA), protecting metabolism from damage (hodgehanson2017membersofthe pages 1-3, irons2020ridaproteinsprotect pages 7-8, borchert2019reactiveenaminesand pages 2-3, irons2020ridaproteinsprotect pages 5-7)</td>
+</tr>
+<tr>
+<td>Likely substrate class</td>
+<td>Reactive <strong>enamine/imines</strong> generated during amino acid metabolism; canonical RidA substrates include <strong>2-aminoacrylate (2AA)</strong> and <strong>2-aminocrotonate</strong>; if the UniProt RutC assignment is correct, a more RutC-like substrate possibility would be <strong>3-aminoacrylate</strong></td>
+<td>Canonical RidA acts on 2AA/related intermediates, whereas RutC specifically deaminates 3-aminoacrylate in uracil degradation; no <em>S. pombe mmf2</em>-specific substrate has been directly shown in retrieved sources (irons2020ridaproteinsprotect pages 20-22, irons2020ridaproteinsprotect pages 22-23, irons2020ridaproteinsprotect pages 19-20, irons2020ridaproteinsprotect pages 5-7)</td>
+</tr>
+<tr>
+<td>Likely reaction outcome</td>
+<td>Deamination/hydrolysis of reactive aminoacrylate/imino intermediates to less reactive keto-acid products; for 2AA this yields <strong>pyruvate</strong>, and for RutC-like 3-aminoacrylate this yields <strong>malonic semialdehyde + ammonia</strong></td>
+<td>Reaction chemistry is established for RidA and RutC family members in vitro and in pathway models (hodgehanson2017membersofthe pages 1-3, irons2020ridaproteinsprotect pages 20-22, irons2020ridaproteinsprotect pages 5-7)</td>
+</tr>
+<tr>
+<td>Predicted subcellular localization</td>
+<td><strong>Mitochondrial</strong>, likely matrix-facing, based on UniProt “mitochondrial; precursor” annotation and analogy to budding-yeast mitochondrial RidA</td>
+<td>In <em>S. cerevisiae</em>, the mitochondrial RidA homolog is Mmf1p, whereas Hmf1p is cytoplasmic (irons2020ridaproteinsprotect pages 11-12)</td>
+</tr>
+<tr>
+<td>Predicted biological role</td>
+<td>Maintenance of mitochondrial metabolic integrity by preventing accumulation of reactive PLP-derived intermediates that can damage PLP-dependent enzymes and destabilize mitochondrial function</td>
+<td>Loss of mitochondrial RidA in budding yeast causes mitochondrial metabolic stress and mtDNA loss, supporting this interpretation for a mitochondrial homolog (irons2020ridaproteinsprotect pages 11-12)</td>
+</tr>
+<tr>
+<td>Ortholog / closest functional comparator</td>
+<td>Best functional comparator is <strong>Mmf1p</strong> of <em>Saccharomyces cerevisiae</em>; yeast also encodes a cytoplasmic paralog <strong>Hmf1p</strong></td>
+<td>The review explicitly identifies <em>S. cerevisiae</em> Mmf1p as mitochondrial RidA and Hmf1p as cytoplasmic RidA (irons2020ridaproteinsprotect pages 11-12)</td>
+</tr>
+<tr>
+<td>What is known from the <em>S. cerevisiae</em> mitochondrial homolog</td>
+<td><strong>Mmf1p</strong> loss causes mitochondrial <strong>2AA accumulation</strong> from serine dehydratases (<strong>Ilv1p/Cha1p</strong>), <strong>metabolic stress</strong>, <strong>irreversible mitochondrial DNA loss</strong>, defective glycerol respiration, and reduced dextrose growth rescued by <strong>isoleucine or threonine</strong>; iron chelation suppresses mitochondrial loss</td>
+<td>Strongest available orthology-based functional evidence for the likely role of <em>S. pombe</em> mmf2 (irons2020ridaproteinsprotect pages 11-12)</td>
+</tr>
+<tr>
+<td>Pathway context</td>
+<td>Connected to <strong>PLP-dependent amino acid metabolism</strong>, especially serine/threonine dehydratase chemistry and prevention of <strong>2AA stress</strong>; broader Rid-family members can also participate in other imine-handling pathways</td>
+<td>RidA proteins intercept reactive intermediates released by PLP-dependent enzymes; RutC is a specialized example in pyrimidine utilization (irons2020ridaproteinsprotect pages 1-1, irons2020ridaproteinsprotect pages 7-8, borchert2019reactiveenaminesand pages 2-3, irons2020ridaproteinsprotect pages 20-22, irons2020ridaproteinsprotect pages 5-7)</td>
+</tr>
+<tr>
+<td>Confidence assessment</td>
+<td><strong>Moderate for mitochondrial localization and general deaminase role; low for exact substrate specificity in <em>S. pombe</em></strong> because direct experiments on Q9UR06 were not retrieved</td>
+<td>Direct organism-specific evidence is lacking in the retrieved literature; conclusions are family- and ortholog-based (irons2020ridaproteinsprotect pages 1-1, irons2020ridaproteinsprotect pages 15-17, irons2020ridaproteinsprotect pages 11-12)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, family assignment, predicted function, localization, and inferred orthology of </em>S. pombe<em> mmf2 (Q9UR06). It is useful because direct literature on mmf2 is sparse, so the most reliable interpretation comes from Rid-family biochemistry and the better-characterized </em>S. cerevisiae<em> mitochondrial homolog Mmf1p.</em></p>
+<p>In summary, <em>S. pombe</em> mmf2 (Q9UR06) is a <strong>mitochondrial member of the Rid/RutC protein superfamily</strong> predicted to function as a <strong>reactive enamine/imine deaminase</strong>. Its primary role is inferred to be the detoxification of reactive aminoacrylate intermediates (most likely 2-aminoacrylate or 3-aminoacrylate) within the mitochondrial matrix, thereby protecting PLP-dependent metabolic enzymes from covalent inactivation and maintaining mitochondrial metabolic integrity. This functional assignment is supported by (i) conserved domain architecture, (ii) the well-established biochemistry of the Rid protein superfamily across all domains of life (irons2020ridaproteinsprotect pages 1-1, irons2020ridaproteinsprotect pages 7-8, borchert2019reactiveenaminesand pages 2-3), and (iii) detailed characterization of the <em>S. cerevisiae</em> mitochondrial ortholog Mmf1p, which demonstrates that loss of this enzyme leads to 2AA accumulation, PLP-enzyme damage, mitochondrial DNA loss, and respiratory deficiency (irons2020ridaproteinsprotect pages 11-12). Direct experimental validation of mmf2's enzymatic activity, substrate specificity, and precise physiological role in <em>S. pombe</em> remains an open area for future investigation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(irons2020ridaproteinsprotect pages 1-1): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 15-17): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 3-4): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(borchert2019reactiveenaminesand pages 2-3): Andrew J. Borchert, Dustin C. Ernst, and Diana M. Downs. Reactive enamines and imines in vivo: lessons from the rida paradigm. Trends in biochemical sciences, 44:849-860, Oct 2019. URL: https://doi.org/10.1016/j.tibs.2019.04.011, doi:10.1016/j.tibs.2019.04.011. This article has 43 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hodgehanson2017membersofthe pages 1-3): Kelsey M. Hodge-Hanson and Diana M. Downs. Members of the rid protein family have broad imine deaminase activity and can accelerate the pseudomonas aeruginosa d-arginine dehydrogenase (daua) reaction in vitro. PLOS ONE, 12:e0185544, Sep 2017. URL: https://doi.org/10.1371/journal.pone.0185544, doi:10.1371/journal.pone.0185544. This article has 30 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 7-8): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 8-9): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(borchert2019reactiveenaminesand pages 4-6): Andrew J. Borchert, Dustin C. Ernst, and Diana M. Downs. Reactive enamines and imines in vivo: lessons from the rida paradigm. Trends in biochemical sciences, 44:849-860, Oct 2019. URL: https://doi.org/10.1016/j.tibs.2019.04.011, doi:10.1016/j.tibs.2019.04.011. This article has 43 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 5-7): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 22-23): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 11-12): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 20-22): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 19-20): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 13-14): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(irons2020ridaproteinsprotect pages 4-5): Jessica L. Irons, Kelsey Hodge-Hanson, and Diana M. Downs. Rida proteins protect against metabolic damage by reactive intermediates. Aug 2020. URL: https://doi.org/10.1128/mmbr.00024-20, doi:10.1128/mmbr.00024-20. This article has 52 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="mmf2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>irons2020ridaproteinsprotect pages 1-1</li>
+<li>irons2020ridaproteinsprotect pages 15-17</li>
+<li>borchert2019reactiveenaminesand pages 2-3</li>
+<li>irons2020ridaproteinsprotect pages 3-4</li>
+<li>irons2020ridaproteinsprotect pages 19-20</li>
+<li>irons2020ridaproteinsprotect pages 11-12</li>
+<li>hodgehanson2017membersofthe pages 1-3</li>
+<li>irons2020ridaproteinsprotect pages 7-8</li>
+<li>irons2020ridaproteinsprotect pages 8-9</li>
+<li>borchert2019reactiveenaminesand pages 4-6</li>
+<li>irons2020ridaproteinsprotect pages 5-7</li>
+<li>irons2020ridaproteinsprotect pages 22-23</li>
+<li>irons2020ridaproteinsprotect pages 20-22</li>
+<li>irons2020ridaproteinsprotect pages 13-14</li>
+<li>irons2020ridaproteinsprotect pages 4-5</li>
+<li>https://doi.org/10.1128/mmbr.00024-20,</li>
+<li>https://doi.org/10.1016/j.tibs.2019.04.011,</li>
+<li>https://doi.org/10.1371/journal.pone.0185544,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mmf2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UR06" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mmf2-spac103910-s-pombe-curation-notes">mmf2 (SPAC1039.10) — S. pombe — curation notes</h1>
+<h2 id="identity-provenance">Identity / provenance</h2>
+<ul>
+<li>UniProt: <strong>Q9UR06</strong> (MMF2_SCHPO), 126 aa precursor, "Protein mmf2, mitochondrial";<br />
+  AltName "Maintenance of mitochondrial function 2". PomBase standard name <strong>mmf2</strong>,<br />
+  systematic name <strong>SPAC1039.10</strong> (synonym hpm1; obsolete ORF SPAC922.01).<br />
+  [genes/SCHPO/mmf2/mmf2-uniprot.txt]</li>
+<li>PomBase product line: "mitochondrial matrix protein, YjgF family protein Mmf2,<br />
+  reactive intermediate imine deaminase A homolog, NNf2, implicated in detoxification<br />
+  and branched amino acid biosynthesis"; <strong>characterisation status = "conserved unknown"</strong><br />
+  (queried PomBase JSON API 2026-07-06). So there is <em>no direct experimental<br />
+  characterisation of the pombe protein's biochemical activity</em>; the annotations are<br />
+  homology/phylogeny-based.</li>
+</ul>
+<h2 id="domain-family-inline-domain-reasoning">Domain / family (inline domain reasoning)</h2>
+<ul>
+<li>Family: <strong>RidA / YjgF / YER057c / UK114</strong> (a.k.a. RutC family). UniProt SIMILARITY:<br />
+  "Belongs to the RutC family." InterPro IPR006056 (RidA), IPR006175<br />
+  (YjgF/YER057c/UK114), IPR035959 (RutC-like_sf); Pfam PF01042 (Ribonuc_L-PSP);<br />
+  CDD cd00448 (YjgF_YER057c_UK114_family); NCBIfam TIGR00004 "Rid family detoxifying<br />
+  hydrolase"; PANTHER PTHR11803 "2-IMINOBUTANOATE/2-IMINOPROPANOATE DEAMINASE RIDA",<br />
+  subfamily PTHR11803:SF58 "PROTEIN HMF1-RELATED". [mmf2-uniprot.txt]</li>
+<li>These proteins form homotrimers with three active-site clefts at the subunit<br />
+  interfaces (canonical RidA fold; Gene3D 3.30.1330.40 RutC-like).</li>
+<li><strong>Catalytic-residue check (done inline).</strong> RidA imine/enamine deaminase activity<br />
+  requires a single conserved active-site <strong>arginine</strong> (Arg105 in <em>S. enterica</em> RidA;<br />
+  Arg107 in human hp14.5) that makes a bidentate salt bridge to the substrate<br />
+  carboxylate. I aligned mmf2 (Q9UR06) to <em>S. enterica</em> RidA by pairwise global<br />
+  alignment (script run under uv/python 3.12). mmf2 retains:</li>
+<li>the catalytic Arg in the conserved C-terminal <strong>P-A-R</strong> motif: mmf2 <code>...DPMPAR...</code><br />
+    R at <strong>position 101</strong> aligns to RidA <code>...NATFPAR...</code> R105.</li>
+<li>the conserved N-terminal <strong>G-P-Y</strong> substrate-pocket motif (mmf2 pos 15 <code>GGPY</code>,<br />
+    RidA pos 15 <code>GPY</code>).</li>
+<li>the conserved C-terminal <strong>KIEIE</strong> motif (mmf2 pos 117, RidA pos 118).<br />
+  =&gt; The catalytic machinery for imine/enamine (2-iminopropanoate / 2-iminobutanoate /<br />
+  2-aminoacrylate) deamination is intact. A RidA-type deaminase MF is therefore<br />
+<strong>domain-defensible</strong> for mmf2.</li>
+</ul>
+<h2 id="what-is-known-well-supported">What is KNOWN (well-supported)</h2>
+<ol>
+<li><strong>RidA-family enamine/imine deaminase activity (by orthology + conserved catalytic Arg).</strong><br />
+   RidA proteins hydrolyze the reactive enamine 2-aminoacrylate (2AA) and related<br />
+   enamines/imines (e.g. 2-iminopropanoate/2-iminobutanoate) to the corresponding<br />
+   2-oxo (keto) acids, pre-empting metabolite damage.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29487232" title="RidA family proteins are deaminases that hydrolyze the reactive enamine 2-aminoacrylate (2AA), and other enamine/imine substrates, to ketoacids">PMID:29487232</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25975565" title="The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA">PMID:25975565</a></li>
+<li><strong>Mitochondrial (matrix) localization</strong> — UniProt has a predicted N-terminal<br />
+   mitochondrial transit peptide (Flags: Precursor; KW Transit peptide) and<br />
+   SUBCELLULAR LOCATION Mitochondrion + Cytoplasm. PomBase/GOA: mitochondrial matrix<br />
+   (ISO from <em>S. cerevisiae</em> Mmf1p, SGD:S000001313) and cytosol/mitochondrion (IBA).<br />
+   [mmf2-uniprot.txt]</li>
+<li><strong>Ortholog function (S. cerevisiae Mmf1p / YIL051C) — the source of the "Mmf" name.</strong><br />
+   Mmf1p is a mitochondrial-matrix RidA protein; deletion causes loss of mtDNA and a<br />
+   growth defect (Δmmf1 → rho0 petite). The paralog Hmf1p (cytoplasmic) has no visible<br />
+   deletion phenotype but can functionally replace Mmf1p when routed to mitochondria.<br />
+   [PMID:11003673 "Mmf1p is a mitochondrial matrix factor" ... "Deltammf1 cells lose mitochondrial DNA (mtDNA) and have a decreased growth rate, while Deltahmf1 cells do not display any visible phenotype"]<br />
+   Mechanistically, Mmf1p maintains mtDNA <strong>indirectly</strong> by deaminating 2AA generated<br />
+   by mitochondrial PLP-dependent serine/threonine dehydratases (Ilv1p, Cha1p); without<br />
+   Mmf1p, 2AA accumulates and damages PLP enzymes (incl. iron-metabolism enzymes),<br />
+   destabilizing the mitochondrial genome. Human UK114 can substitute for Mmf1p.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29487232" title="The RidA family protein Mmf1p deaminates 2-aminoacrylate, preempting metabolic stress and loss of the mitochondrial genome">PMID:29487232</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29487232" title="Mmf1p indirectly contributes to mitochondrial DNA maintenance by preventing 2-aminoacrylate stress derived from mitochondrial amino acid metabolism">PMID:29487232</a></li>
+</ol>
+<h2 id="what-is-not-known-gaps-specific-to-pombe-mmf2">What is NOT known (gaps specific to pombe mmf2)</h2>
+<ul>
+<li><strong>No direct biochemistry on the pombe protein</strong>: the specific in-vivo enamine/imine<br />
+  substrate for mmf2 (2-aminoacrylate vs 2-iminobutanoate vs a broader set) has not<br />
+  been demonstrated experimentally. Family assignment (PANTHER SF58 "HMF1-RELATED")<br />
+  and the intact catalytic Arg make 2AA/2-iminopropanoate the most likely substrate,<br />
+  but this is inference.</li>
+<li><strong>No characterized mmf2Δ phenotype in pombe tied to mtDNA/2AA.</strong> PomBase records<br />
+  only high-throughput screen phenotypes (deletion is <strong>viable, normal morphology</strong>;<br />
+  scattered stress sensitivities: diamide, lithium/LiCl, tunicamycin, terbinafine,<br />
+  itraconazole, KCl/MgCl2/LiCl+SDS; resistance to EGTA; decreased centromeric outer-repeat<br />
+  silencing). None of these was individually followed up, and none directly demonstrates<br />
+  a 2AA / mtDNA-maintenance role in pombe. (PomBase single-locus phenotype list,<br />
+  queried 2026-07-06.)</li>
+<li><strong>Mitochondrial-matrix localization is inferred, not directly shown in pombe</strong><br />
+  (ISO from cerevisiae + transit-peptide prediction). The dual mito/cytoplasm<br />
+  annotation may reflect a fraction in the cytosol (as for the cerevisiae paralog Hmf1p)<br />
+  or simply pre-import protein; not experimentally resolved for pombe.</li>
+<li>The pombe genome may encode more than one RidA paralog; whether mmf2 is the sole<br />
+  mitochondrial RidA and which serine/threonine dehydratases generate its substrate<br />
+  in pombe are open questions.</li>
+</ul>
+<h2 id="annotation-by-annotation-reasoning-goa">Annotation-by-annotation reasoning (GOA)</h2>
+<table>
+<thead>
+<tr>
+<th>term</th>
+<th>ev</th>
+<th>ref</th>
+<th>decision</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0019239 deaminase activity (MF, enables)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MODIFY → GO:0016838 carbon-nitrogen lyase, or keep general; family MF is the core. Actually deaminase activity is defensible but non-specific; propose more specific RidA activity via core_functions. Decision: ACCEPT (domain-defensible, catalytic Arg present) but note it is general.</td>
+</tr>
+<tr>
+<td>GO:0005739 mitochondrion (CC, is_active_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT (redundant with matrix)</td>
+</tr>
+<tr>
+<td>GO:0005829 cytosol (CC, is_active_in)</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE — RidA paralogs are partly cytosolic; but for a matrix-targeted protein this is likely IBA tree noise / pre-import pool. Keep, non-core.</td>
+</tr>
+<tr>
+<td>GO:0005737 cytoplasm (CC, located_in)</td>
+<td>IEA</td>
+<td>GO_REF:0000044</td>
+<td>KEEP_AS_NON_CORE (SubCell mapping; parent of cytosol)</td>
+</tr>
+<tr>
+<td>GO:0005739 mitochondrion (CC, located_in)</td>
+<td>IEA</td>
+<td>GO_REF:0000044</td>
+<td>ACCEPT (SubCell mapping consistent with transit peptide)</td>
+</tr>
+<tr>
+<td>GO:0008150 biological_process (ND)</td>
+<td>ND</td>
+<td>GO_REF:0000015</td>
+<td>KEEP_AS_NON_CORE (root ND placeholder; leave)</td>
+</tr>
+<tr>
+<td>GO:0005759 mitochondrial matrix (CC, is_active_in)</td>
+<td>ISO</td>
+<td>GO_REF:0000024</td>
+<td>ACCEPT — best-supported localization (ISO from cerevisiae Mmf1p matrix).</td>
+</tr>
+</tbody>
+</table>
+<p>Note: existing-annotation term ids are trusted (from GOA) — do not rewrite.</p>
+<h2 id="core-function-summary-for-core_functions">Core function summary (for core_functions)</h2>
+<p>mmf2 is, by family assignment and retention of the catalytic active-site arginine,<br />
+a <strong>RidA/Rid-family reactive enamine/imine deaminase</strong> (a "metabolite-damage<br />
+pre-emption" / hydrolase-type enzyme) that most plausibly hydrolyzes the reactive<br />
+enamine 2-aminoacrylate (and/or 2-iminopropanoate/2-iminobutanoate) to the stable<br />
+2-oxo acid, acting in the <strong>mitochondrial matrix</strong>. By analogy to the <em>S. cerevisiae</em><br />
+ortholog Mmf1p and human UK114, its likely physiological role is protecting<br />
+mitochondrial PLP-dependent enzymes (and thereby indirectly mitochondrial genome<br />
+integrity) from enamine/imine damage arising from serine/threonine catabolism. The<br />
+specific in-vivo substrate and phenotype in pombe are not experimentally established.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9UR06
+gene_symbol: mmf2
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  mmf2 is a fission-yeast member of the RidA/YjgF/YER057c/UK114 (Rid) family of
+  reactive enamine/imine deaminases (&#34;metabolite-damage pre-emption&#34; enzymes).
+  Proteins of this family form homotrimers and use a single conserved active-site
+  arginine to hydrolyze reactive enamine/imine intermediates - most characteristically
+  2-aminoacrylate and the corresponding imines 2-iminopropanoate and 2-iminobutanoate,
+  produced by pyridoxal-5&#39;-phosphate-dependent serine/threonine dehydratases - to the
+  stable 2-oxo (keto) acids, thereby protecting PLP-dependent enzymes from covalent
+  damage. mmf2 carries an N-terminal mitochondrial targeting sequence and is assigned
+  to the mitochondrial matrix, with a portion also detected in the cytoplasm. Its
+  characterized orthologs (Saccharomyces cerevisiae Mmf1p and human UK114/HRSP12)
+  act in the mitochondrion, where deaminase activity indirectly supports mitochondrial
+  genome integrity by preventing 2-aminoacrylate stress arising from mitochondrial
+  amino-acid catabolism. The specific in-vivo substrate and physiological role of the
+  fission-yeast protein itself have not been experimentally defined.
+references:
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:29487232
+  title: Mmf1p Couples Amino Acid Metabolism to Mitochondrial DNA Maintenance in Saccharomyces
+    cerevisiae.
+  findings:
+  - statement: &gt;-
+      The RidA-family protein Mmf1p (the S. cerevisiae ortholog of mmf2) is an
+      enamine/imine deaminase that deaminates 2-aminoacrylate, preempting metabolic
+      stress and indirectly maintaining the mitochondrial genome.
+    supporting_text: &gt;-
+      preempting metabolic stress and loss of the mitochondrial
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified full text (mBio 2018). Directly establishes the biochemical
+      activity and physiological role of the S. cerevisiae ortholog Mmf1p; used here as
+      orthology-based support for mmf2, not as direct evidence for the fission-yeast protein.
+- id: PMID:11003673
+  title: Mmf1p, a novel yeast mitochondrial protein conserved throughout evolution and
+    involved in maintenance of the mitochondrial genome.
+  findings:
+  - statement: &gt;-
+      Mmf1p is a mitochondrial matrix factor whose deletion causes loss of mitochondrial
+      DNA; the source of the &#34;maintenance of mitochondrial function&#34; (Mmf) name applied to mmf2.
+    supporting_text: &gt;-
+      Mmf1p is a mitochondrial matrix
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Mol Cell Biol 2000; abstract-only in cache). Original description
+      of the S. cerevisiae ortholog Mmf1p and its mitochondrial-matrix localization / mtDNA
+      maintenance role; establishes the naming basis for mmf2.
+- id: PMID:25975565
+  title: Genomic and experimental evidence for multiple metabolic functions in the RidA/YjgF/YER057c/UK114
+    (Rid) protein family.
+  findings:
+  - statement: &gt;-
+      The Rid family comprises multiple subfamilies; RidA and the Rid1/Rid2/Rid3 subfamilies
+      retain the conserved active-site arginine essential for imine/enamine deaminase activity.
+    supporting_text: &gt;-
+      The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed/PMC-verified full text (mBio 2015). Defines Rid subfamily structure and the
+      catalytic residues; supports the family/catalytic-residue reasoning for mmf2.
+existing_annotations:
+- term:
+    id: GO:0019239
+    label: deaminase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      RidA/Rid-family molecular function. Deaminase activity is domain-defensible: mmf2
+      belongs to PANTHER PTHR11803 (2-iminobutanoate/2-iminopropanoate deaminase RidA) and
+      retains the single conserved catalytic arginine essential for imine/enamine hydrolysis.
+      The term is correct but very general; a more specific RidA term (GO:0120241) better
+      captures the activity and is proposed in core_functions.
+    action: MODIFY
+    reason: &gt;-
+      The IBA-supported family activity is real, but &#34;deaminase activity&#34; is uninformatively
+      broad for a RidA protein. The specific RidA reaction is 2-iminobutanoate/2-iminopropanoate
+      (and 2-aminoacrylate) deamination.
+    proposed_replacement_terms:
+    - id: GO:0120241
+      label: 2-iminobutanoate/2-iminopropanoate deaminase activity
+    supported_by:
+    - reference_id: PMID:25975565
+      supporting_text: &gt;-
+        The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000211014
+        source_label: RidA/Rid family ancestral node (PTHR11803)
+        comment: &gt;-
+          IBA seed node annotated with the generic ancestral term &#34;deaminase activity&#34;
+          rather than the specific RidA reaction, so the transfer to mmf2 is imprecise.
+      - source_id: UniProtKB:P0AF93
+        source_label: E. coli RutC (RidA-family)
+        comment: Family co-member used in the IBA with/from set.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Mitochondrial localization is well supported: mmf2 has a predicted N-terminal
+      mitochondrial transit peptide and its characterized orthologs act in the mitochondrion.
+      This is the general (organelle-level) term; mitochondrial matrix (GO:0005759) is the
+      more precise location.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the transit peptide and with ISO-supported mitochondrial-matrix
+      localization; correct but less precise than the matrix term.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cytosolic localization is plausible for a Rid-family protein (the S. cerevisiae paralog
+      Hmf1p is cytosolic), and IBA propagates cytosolic membership across the family. For
+      mmf2, whose transit peptide targets it to the mitochondrion, this likely reflects a
+      pre-import pool or family-level tree noise rather than its core site of action.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Not the core (mitochondrial-matrix) location; retained as a plausible secondary pool
+      consistent with the dual mitochondrion/cytoplasm UniProt subcellular assignment.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping from the UniProt Cytoplasm subcellular-location keyword (SL-0086).
+      Broad parent of cytosol; consistent with a non-mitochondrial pool but not the core site.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      General cytoplasmic term derived from the UniProt SubCell keyword; retained as non-core,
+      subsumed by the more specific cytosol annotation.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping from the UniProt Mitochondrion subcellular-location keyword (SL-0173),
+      consistent with the predicted transit peptide and the ISO matrix annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Localization is well supported by the transit peptide and orthology; the term is correct
+      though less precise than mitochondrial matrix.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process placeholder with ND evidence, indicating no experimentally or
+      phylogenetically curated BP is assigned in fission yeast. This reflects the genuine BP
+      knowledge gap for this &#34;conserved unknown&#34; gene (see knowledge_gaps).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ND root placeholder; retained as-is. It correctly signals that no specific biological
+      process has been established for the fission-yeast protein.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Best-supported subcellular location: transferred by orthology (ISO) from S. cerevisiae
+      Mmf1p, a characterized mitochondrial-matrix factor, and consistent with mmf2&#39;s predicted
+      mitochondrial transit peptide.
+    action: ACCEPT
+    reason: &gt;-
+      Precise, orthology-supported localization consistent with the transit-peptide prediction;
+      the primary/core location for this protein.
+    supported_by:
+    - reference_id: PMID:11003673
+      supporting_text: &gt;-
+        Mmf1p is a mitochondrial matrix
+core_functions:
+- description: &gt;-
+    Reactive enamine/imine deaminase of the RidA/Rid family. mmf2 retains the single
+    conserved catalytic arginine (Arg101, in the C-terminal PAR motif aligning to
+    S. enterica RidA Arg105) and the conserved active-site GPY/KIEIE motifs, indicating
+    an intact RidA active site. It most plausibly hydrolyzes the reactive enamine
+    2-aminoacrylate and the corresponding imines (2-iminopropanoate/2-iminobutanoate)
+    produced by PLP-dependent serine/threonine dehydratases to the stable 2-oxo acids,
+    acting in the mitochondrial matrix. The specific in-vivo substrate for the
+    fission-yeast protein is inferred from family membership and orthology, not directly demonstrated.
+  molecular_function:
+    id: GO:0120241
+    label: 2-iminobutanoate/2-iminopropanoate deaminase activity
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:29487232
+    supporting_text: &gt;-
+      preempting metabolic stress and loss of the mitochondrial
+  - reference_id: PMID:25975565
+    supporting_text: &gt;-
+      The Rid1, Rid2, and Rid3 subfamilies retain the conserved arginine and glutamate residues found in RidA
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      The specific in-vivo enamine/imine substrate deaminated by fission-yeast mmf2 (e.g.
+      2-aminoacrylate vs 2-iminobutanoate vs a broader set) has not been experimentally
+      determined; the activity is inferred from RidA-family membership and the conserved
+      catalytic arginine.
+    boundary: &gt;-
+      Firmly established: mmf2 belongs to the RidA/YjgF/UK114 family (PANTHER PTHR11803,
+      InterPro RidA/IPR006056) and retains the conserved catalytic arginine and active-site
+      motifs, so it is a bona fide member of an imine/enamine-deaminase family. The generic
+      &#34;deaminase activity&#34; is thus safe; the exact preferred substrate is not.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Different Rid subfamilies prefer different enamine/imine substrates; pinning the
+      preferred substrate is needed to state mmf2&#39;s precise molecular function rather than a
+      family-level inference.
+    resolution: &gt;-
+      In-vitro deaminase assays on recombinant mmf2 with 2-aminoacrylate/2-iminopropanoate and
+      2-iminobutanoate (e.g. coupled serine/threonine-dehydratase assays), and an Arg101-&gt;Ala
+      catalytic-null control.
+    provenance:
+    - reference_id: PMID:29487232
+      supporting_text: &gt;-
+        The biochemical activity of RidA from yeast (e.g., Mmf1p) was not addressed by those previous studies
+  - gap_statement: &gt;-
+      No physiological role or loss-of-function phenotype has been characterized for mmf2 in
+      S. pombe; whether it maintains mitochondrial DNA / protects mitochondrial PLP enzymes
+      (as its S. cerevisiae ortholog Mmf1p does) is unknown. PomBase records only high-throughput
+      screen phenotypes (viable deletion; scattered stress sensitivities) with no follow-up.
+    boundary: &gt;-
+      Firmly established: the ortholog Mmf1p acts in the mitochondrion and its loss causes
+      2-aminoacrylate stress and mtDNA loss in S. cerevisiae, and human UK114 can complement it.
+      For fission yeast mmf2 itself there is no dedicated functional study - PomBase lists it as
+      &#34;conserved unknown&#34;.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Establishing the biological process (e.g. mitochondrial 2-aminoacrylate detoxification /
+      mtDNA maintenance) would let the ND biological_process placeholder be replaced with a
+      curated BP term.
+    resolution: &gt;-
+      Targeted mmf2 deletion in S. pombe with assays for mtDNA content / respiratory (petite)
+      phenotype, serine/2-aminoacrylate sensitivity, and cross-species complementation.
+    provenance:
+    - reference_id: PMID:29487232
+      supporting_text: &gt;-
+        The biochemical activity of RidA from yeast (e.g., Mmf1p) was not addressed by those previous studies
+  - gap_statement: &gt;-
+      The mitochondrial-matrix localization of mmf2 has not been directly demonstrated in
+      S. pombe; it rests on an ISO transfer from S. cerevisiae Mmf1p and a predicted transit
+      peptide, and the significance of the concurrent cytoplasm/cytosol annotations is unresolved.
+    boundary: &gt;-
+      Firmly established: mmf2 carries a predicted N-terminal mitochondrial transit peptide and
+      the ortholog Mmf1p is a matrix protein. Not established: direct experimental localization
+      of mmf2 in fission yeast, or whether the cytosolic signal is a genuine second pool.
+    gap_kind:
+    - BIOLOGY
+    - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Confirming the matrix location (vs a genuine dual mitochondrial/cytosolic distribution)
+      would resolve whether the IBA cytosol annotation reflects a real functional pool.
+    resolution: &gt;-
+      Fluorescent-tag or subcellular-fractionation localization of mmf2 in S. pombe;
+      transit-peptide cleavage-site mapping.
+    provenance:
+    - reference_id: PMID:11003673
+      supporting_text: &gt;-
+        Mmf1p is a mitochondrial matrix
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does fission-yeast mmf2 hydrolyze 2-aminoacrylate / 2-iminopropanoate in vitro, and is
+    Arg101 the essential catalytic residue?
+  experts: []
+- question: &gt;-
+    Does deletion of mmf2 in S. pombe cause mitochondrial DNA loss / a respiratory (petite)
+    phenotype or serine/2-aminoacrylate sensitivity, as seen for S. cerevisiae Mmf1p?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    mmf2 is a mitochondrial RidA deaminase that hydrolyzes 2-aminoacrylate/2-iminopropanoate
+    via its conserved catalytic arginine.
+  description: &gt;-
+    Purify recombinant mmf2 (mature form) and an Arg101-&gt;Ala variant; assay deamination of
+    2-aminoacrylate and 2-iminobutanoate using coupled serine/threonine-dehydratase pyruvate/2-oxobutanoate
+    production assays, comparing rates to S. enterica RidA and S. cerevisiae Mmf1p.
+  experiment_type: in vitro enzyme assay
+- hypothesis: &gt;-
+    mmf2 protects the fission-yeast mitochondrial genome against 2-aminoacrylate stress.
+  description: &gt;-
+    Construct an mmf2 deletion, quantify mitochondrial DNA content and respiratory competence,
+    test sensitivity to serine and to conditions that elevate mitochondrial serine/threonine
+    dehydratase flux, and test complementation by S. cerevisiae MMF1 or human HRSP12/UK114.
+  experiment_type: genetics / mitochondrial phenotyping
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/mtl3/mtl3-ai-review.html
+++ b/genes/SCHPO/mtl3/mtl3-ai-review.html
@@ -1,0 +1,2597 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mtl3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mtl3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O94317" target="_blank" class="term-link">
+                        O94317
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">SPBC215.13</span>
+
+                    <span class="badge">mtl1</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mtl3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O94317" data-a="DESCRIPTION: mtl3 (systematic name SPBC215.13; UniProt O94317) ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>mtl3 (systematic name SPBC215.13; UniProt O94317) is a Schizosaccharomyces-specific, GPI-anchored, serine/threonine-rich plasma-membrane glycoprotein of the fungal Mid2-like cell-wall stress-sensor family (the name Mtl denotes &#34;Mid Two-Like&#34;; it is distinct from and unrelated to the Mtr4-like nuclear RNA helicase, which in S. pombe is the separately named mtl1/SPAC17H9.02). The 534-residue precursor has the canonical architecture of a single-pass fungal cell-surface sensor: an N-terminal secretion signal peptide and a single transmembrane segment, a long serine/threonine-rich, O-mannosylation-prone extracellular ectodomain that is intrinsically disordered/low-complexity, N-linked glycosylation, and a C-terminal GPI-anchor addition signal that tethers the mature protein to the outer face of the plasma membrane. It carries no enzymatic domain of any kind (no helicase, ATPase/P-loop, or other catalytic module). Genome-wide deletion phenotyping shows mtl3 loss alters sensitivity and resistance to cell-wall-perturbing and ionic stresses (e.g. altered responses to SDS combined with salts, ethanol, lithium, and oxidants) and reduces viability in stationary phase, consistent with a role at the cell surface in sensing envelope/membrane stress. By family membership its inferred role is to transmit cell-wall/membrane stress to intracellular signaling (as for the related fission-yeast sensors Wsc1 and Mtl2, which activate the Rho1 GTPase), but a direct molecular activity, ligand, signaling partner, or pathway output has not been experimentally established for mtl3 itself.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94317" data-a="GO:0005783" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER localization is supported by the systematic GFP-localization dataset cited by UniProt (ECO:0000269|PubMed:16823372) and is plausible as a secretory-pathway transit compartment for a signal-peptide-bearing, GPI-anchored membrane protein en route to the cell surface. It is not the primary functional site of the protein, which is the plasma membrane.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                                        PMID:16823372
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ORFeome cloning and global analysis of protein localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94317" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plasma-membrane localization is consistent with the protein&#39;s architecture (signal peptide, single transmembrane segment, and C-terminal GPI-anchor addition signal) and with its predicted GPI-anchored cell-surface status. This is a core localization, although the more specific term GO:0009897 (external side of plasma membrane) better captures where the GPI-anchored ectodomain resides.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94317" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> No molecular function has been experimentally determined for mtl3, so the ND (No Data) root annotation is an honest and appropriate reflection of the current state of knowledge. Although family membership (a Mid2-like cell-wall sensor) suggests a stress-sensing/signal-transducing role, there is no direct assay of ligand binding, signaling output, or any catalytic activity for this protein, and its sequence lacks any enzymatic domain. The unknown molecular function is recorded as a knowledge gap rather than filled by an unsupported specific term.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94317" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> No biological process has been directly demonstrated for mtl3, so the ND root annotation is appropriate. Deletion phenotypes (altered sensitivity/resistance to cell-wall/membrane and ionic stressors; reduced stationary-phase viability) and membership in the Mid2-like sensor family point toward a role in cell-wall-integrity / stress signaling, but this is inferred, not established. A specific BP term should not be asserted from the current evidence; the gap is recorded below.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009897" target="_blank" class="term-link">
+                                    GO:0009897
+                                </a>
+                            </span>
+                            <span class="term-label">external side of plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12845604
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genome-wide identification of fungal GPI proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94317" data-a="GO:0009897" data-r="PMID:12845604" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the most specific and best-supported localization: a GPI-anchored, serine/threonine-rich ectodomain displayed on the outer (external) face of the plasma membrane, exactly as expected for a fungal cell-wall stress sensor. Supported by the genome-wide GPI-protein prediction study and consistent with the UniProt GPI-anchor and topology features.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                                        PMID:12845604
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">only 33 GPI candidates were identified</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Displays a serine/threonine-rich, GPI-anchored ectodomain on the external face of the plasma membrane. mtl3 belongs to the fungal Mid2-like cell-wall stress-sensor family and is inferred to participate in sensing cell-wall/membrane stress at the cell surface, but its molecular activity and downstream signaling partners are undetermined; only its cell-surface localization is directly supported.</h3>
+                <span class="vote-buttons" data-g="O94317" data-a="FUNCTION: Displays a serine/threonine-rich, GPI-anchored ect..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009897" target="_blank" class="term-link">
+                                external side of plasma membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                                PMID:12845604
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">only 33 GPI candidates were identified</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12845604" target="_blank" class="term-link">
+                            PMID:12845604
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide identification of fungal GPI proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide computational screen predicting GPI-anchored proteins across fungi; the S. pombe GPI proteome is small, and mtl3/SPBC215.13 was identified as a predicted GPI-anchored cell-surface protein, supporting its localization to the outer face of the plasma membrane.</div>
+
+                        <div class="finding-text">"only 33 GPI candidates were identified"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                            PMID:16823372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Systematic GFP-fusion localization study; the source of the UniProt endoplasmic reticulum subcellular-location assignment for mtl3 (a secretory-pathway compartment consistent with a GPI-anchored membrane protein en route to the cell surface).</div>
+
+                        <div class="finding-text">"ORFeome cloning and global analysis of protein localization"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37787768" target="_blank" class="term-link">
+                            PMID:37787768
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Broad functional profiling of fission yeast proteins using phenomics and machine learning.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide phenomics/machine-learning profiling of S. pombe deletion mutants; the source of the curated mtl3-delta stress-response phenotypes (altered sensitivity and resistance to cell-wall/membrane and ionic stressors; reduced stationary-phase viability). mtl3 appears in the supplementary phenotype matrix rather than being discussed by name in the text.</div>
+
+                        <div class="finding-text">"Broad functional profiling of fission yeast proteins using phenomics and machine learning"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25375137" target="_blank" class="term-link">
+                            PMID:25375137
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Systematic analysis of the role of RNA-binding proteins in the regulation of RNA stability.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Systematic RNA-stability / RNA-binding-protein study; the basis for PomBase&#39;s record of mtl3 mRNA as a regulatory target (of the zinc-finger RNA-binding protein zfs1), indicating post-transcriptional control of mtl3 expression.</div>
+
+                        <div class="finding-text">"Systematic analysis of the role of RNA-binding proteins in the regulation of RNA stability"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23907979" target="_blank" class="term-link">
+                            PMID:23907979
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The fission yeast cell wall stress sensor-like proteins Mtl2 and Wsc1 act by turning on the GTPase Rho1p but act independently of the cell wall integrity pathway.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes the related fission-yeast plasma-membrane cell-wall stress sensors Mtl2 and Wsc1, which signal by activating the Rho1 GTPase. Provides family/architecture context for mtl3 (a Mid2-like sensor of the same class); it does not study mtl3 itself, so its findings are contextual rather than direct evidence for mtl3.</div>
+
+                        <div class="finding-text">"The fission yeast cell wall stress sensor-like proteins Mtl2 and Wsc1 act by turning on the GTPase Rho1p but act independently of the cell wall integrity pathway"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does mtl3 function as a cell-wall/membrane stress sensor that activates Rho1 and/or the Pmk1 cell-wall-integrity MAP kinase pathway, and is this activity redundant with wsc1 and mtl2?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94317" data-a="Q: Does mtl3 function as a cell-wall/membrane stress ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What cue does the serine/threonine-rich, O-mannosylated ectodomain of mtl3 sense, and does the cytoplasmic/juxtamembrane region recruit any GEF or signaling partner?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94317" data-a="Q: What cue does the serine/threonine-rich, O-mannosy..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Why is mtl3 mRNA a target of the RNA-binding protein zfs1, and does this post-transcriptional control couple mtl3 levels to a specific stress condition?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94317" data-a="Q: Why is mtl3 mRNA a target of the RNA-binding prote..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Construct single and combinatorial deletions (mtl3-delta alone and with wsc1-delta, mtl2-delta, mid2-delta) and assay growth and morphology under cell-wall/membrane stress (SDS, caspofungin/echinocandins, calcofluor, sorbitol osmotic support), scoring for synthetic phenotypes that reveal redundancy within the sensor family.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94317" data-a="EXPERIMENT: Construct single and combinatorial deletions (mtl3..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure Rho1-GTP loading and Pmk1 MAPK phosphorylation in mtl3-delta versus wild type under cell-wall stress to test whether mtl3 feeds the Rho1/CWI signaling axis.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94317" data-a="EXPERIMENT: Measure Rho1-GTP loading and Pmk1 MAPK phosphoryla..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform proximity-labeling or affinity-purification mass spectrometry on tagged mtl3 to identify cell-surface and cytoplasmic interaction partners, and biochemically confirm the predicted GPI anchor and O-mannosylated ectodomain.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94317" data-a="EXPERIMENT: Perform proximity-labeling or affinity-purificatio..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> mtl3 has no experimentally established molecular function, no identified binding partner or ligand, and no directly demonstrated biological process. Its assignment to the Mid2-like cell-wall stress-sensor family and its inferred role in transmitting cell-wall/membrane stress to intracellular signaling (e.g. via Rho1, as shown for the related sensors Wsc1 and Mtl2) are extrapolations from family membership, sequence architecture, and deletion phenotypes, not from direct study of the mtl3 protein.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: subcellular localization (GPI-anchored, external face of the plasma membrane; ER in transit); protein architecture (signal peptide, single N-terminal transmembrane segment, long serine/threonine-rich disordered/low-complexity ectodomain, N-glycosylation, C-terminal GPI-anchor signal; no enzymatic domain); genome-wide deletion phenotypes (altered sensitivity/resistance to cell-wall/membrane and ionic stressors, reduced stationary-phase viability); post-transcriptional regulation of its mRNA (a zfs1 target); and a single S. japonicus ortholog (SJAG_00415). The gene is Schizosaccharomyces- specific.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Fission yeast maintains cell-wall integrity through a set of cell-surface sensors, but the specific contribution, redundancy, and signaling wiring of mtl3 within this system are unknown. mtl3 is a genuinely understudied (&#34;dark&#34;) gene whose only high-confidence GO statement is its cell-surface localization; both its molecular function and biological process remain at the ND root.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Direct functional study of mtl3: epistasis/redundancy analysis with wsc1, mtl2, mid2 and the Rho1/Pmk1 CWI machinery; sensor-activation assays under defined cell-wall/membrane stress; identification of interacting proteins; and structural/biochemical confirmation of the ectodomain modifications. Any positive result would move both the MF and BP aspects off the ND root.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Use of the ND evidence code for Gene Ontology (GO) terms"</em> — GO_REF:0000015</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mtl3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O94317" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">20 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T16:50:46.719743</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="mtl3-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-mtl3-spbc21513-uniprot-o94317-in-schizosaccharomyces-pombe">Research Report: mtl3 / SPBC215.13 (UniProt O94317) in <em>Schizosaccharomyces pombe</em></h2>
+<h3 id="1-gene-identity-and-nomenclature">1. Gene Identity and Nomenclature</h3>
+<p>The gene <strong>mtl3</strong> corresponds to the systematic open reading frame <strong>SPBC215.13</strong> in <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843), encoding a protein annotated in UniProt (accession O94317) as an <strong>"Uncharacterized serine-rich protein C215.13"</strong> flagged as a <strong>precursor</strong>. Extensive literature searching revealed that the gene symbol "mtl3" does not appear directly in any of the retrieved primary research papers. The naming convention "mtl" in <em>S. pombe</em> follows the pattern established by the well-characterized gene <strong>mtl2</strong> (Mid two-like 2), which encodes a cell wall stress sensor protein structurally related to <em>Saccharomyces cerevisiae</em> Mid2 (cruz2013thefissionyeast pages 1-2). The "mtl3" designation thus likely denotes "<strong>Mid two-like 3</strong>," implying membership in the same family of serine/threonine-rich cell surface proteins, although this relationship has not been experimentally validated for SPBC215.13.</p>
+<p><strong>Important caveat:</strong> This protein is largely <strong>uncharacterized</strong> in the published literature. No primary study was identified that directly investigates the biochemical function, localization, or phenotypic consequences of mtl3/SPBC215.13 deletion or mutation. The information below is therefore predominantly <strong>inference-based</strong>, drawn from computational predictions, genome-wide surveys, and analogy with better-characterized family members.</p>
+<h3 id="2-protein-features-and-predicted-structure">2. Protein Features and Predicted Structure</h3>
+<p>SPBC215.13 was identified as a <strong>putative GPI (glycosylphosphatidylinositol)-anchored protein</strong> in a genome-wide computational survey of fungal GPI proteins by de Groot et al. (2003). In that study, the <em>S. pombe</em> genome was screened using a C-terminal GPI-signal algorithm, and SPBC215.13 was among 33 GPI protein candidates identified from 4,950 ORFs (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12). The protein was reported as approximately <strong>226 amino acids</strong> in length with a <strong>serine/threonine (S/T) content of 22%</strong> (groot2003genome‐wideidentificationof pages 10-10). The unannotated ORFs identified in that study had an average S/T content of 41%, and the authors noted that high S/T content strengthened the likelihood that these were indeed GPI proteins (groot2003genome‐wideidentificationof pages 10-12).</p>
+<p>The UniProt "precursor" flag indicates the presence of an <strong>N-terminal signal peptide</strong> directing the protein into the secretory pathway, consistent with its predicted cell-surface localization. GPI-anchored proteins in fungi typically possess both an N-terminal signal peptide and a C-terminal GPI-anchor addition signal that is cleaved and replaced with a GPI moiety in the endoplasmic reticulum.</p>
+<p>The following table summarizes key features and contextual information for mtl3/SPBC215.13:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>Description/Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Target identity</td>
+<td><strong>mtl3 / SPBC215.13 / UniProt O94317</strong> in <em>Schizosaccharomyces pombe</em> strain 972. UniProt describes the product as an <strong>uncharacterized serine-rich precursor protein</strong>. Direct primary literature using the name <strong>mtl3</strong> was not found in the retrieved corpus, so identity must be anchored to the systematic ID <strong>SPBC215.13</strong> and UniProt accession <strong>O94317</strong>.</td>
+</tr>
+<tr>
+<td>Evidence status</td>
+<td>Literature for this specific protein is <strong>very limited</strong>. No direct biochemical, genetic, or localization study for SPBC215.13/mtl3 was retrieved. Most conclusions are therefore <strong>inference-based</strong>, drawn from prediction studies and comparison with related fungal cell-surface proteins (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12).</td>
+</tr>
+<tr>
+<td>Predicted protein class</td>
+<td>A genome-wide survey of fungal GPI proteins identified <strong>SPBC215.13</strong> among <em>S. pombe</em> <strong>putative GPI-anchored proteins</strong>, supporting classification as a likely <strong>cell-surface/cell-wall-associated glycoprotein</strong> rather than a soluble intracellular factor (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12).</td>
+</tr>
+<tr>
+<td>Size and composition</td>
+<td>In the de Groot et al. table, <strong>SPBC215.13</strong> is listed as <strong>226 aa</strong> with <strong>22% serine/threonine content</strong>, consistent with a <strong>serine-rich</strong> extracellular protein subject to extensive glycosylation, a common feature of fungal surface proteins (groot2003genome‐wideidentificationof pages 10-10).</td>
+</tr>
+<tr>
+<td>Precursor/signal features</td>
+<td>UniProt flags the protein as a <strong>precursor</strong>, consistent with entry into the secretory pathway. In fungal GPI proteins, this generally implies an <strong>N-terminal signal peptide</strong> plus a <strong>C-terminal GPI-anchor addition signal</strong>, although these exact features were not experimentally validated here for SPBC215.13 (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12).</td>
+</tr>
+<tr>
+<td>Predicted localization</td>
+<td>Best current inference: <strong>cell surface</strong>, likely <strong>plasma membrane outer leaflet and/or covalently associated cell wall space</strong> after GPI anchoring/remodeling. This inference follows from the GPI-protein prediction and general fungal GPI biology (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12, yoshimi2022cellwallintegrity pages 7-8).</td>
+</tr>
+<tr>
+<td>Likely molecular role</td>
+<td>No catalytic activity is known. The most plausible current interpretation is that SPBC215.13 is a <strong>structural or sensor-like cell-envelope protein</strong>, potentially contributing to <strong>cell wall organization, stress sensing, or wall–membrane coupling</strong> rather than acting as an enzyme with defined substrate specificity (cansado2021thefissionyeast pages 2-3, yoshimi2022cellwallintegrity pages 7-8).</td>
+</tr>
+<tr>
+<td>Relationship to the name “mtl3”</td>
+<td>The symbol <strong>mtl3</strong> appears consistent with a <strong>Mid2-like naming convention</strong>, but this specific protein was <strong>not directly discussed</strong> in the retrieved papers. Thus, the name suggests possible membership in a broader family of cell-surface proteins related by architecture/function, but this remains <strong>unproven</strong> from current evidence.</td>
+</tr>
+<tr>
+<td>Comparison to S. pombe Mtl2</td>
+<td><strong>Mtl2</strong> is a <strong>characterized cell wall stress sensor</strong> in <em>S. pombe</em> that localizes to the <strong>cell periphery</strong> and promotes survival under cell wall stress by activating <strong>Rho1</strong> signaling (cruz2013thefissionyeast pages 1-2). SPBC215.13/mtl3 has <strong>no comparable direct evidence</strong> yet; similarity is currently only conceptual/name-based, not experimentally demonstrated.</td>
+</tr>
+<tr>
+<td>Comparison to S. pombe Wsc1</td>
+<td><strong>Wsc1</strong> is another characterized <em>S. pombe</em> cell wall sensor that acts in a distinct <strong>Rho1-dependent</strong> network and localizes to growth zones/tips; it is <strong>not</strong> the same protein as mtl3/SPBC215.13 (cruz2013thefissionyeast pages 1-2, cansado2021thefissionyeast pages 2-3).</td>
+</tr>
+<tr>
+<td>Comparison to S. cerevisiae Mid2/Mtl1</td>
+<td>In budding yeast, <strong>Mid2/Mtl1</strong> proteins are <strong>cell wall integrity sensors</strong> with <strong>single-pass membrane anchoring</strong>, small cytosolic tails, and <strong>serine/threonine-rich, highly O-mannosylated extracellular domains</strong> that function as mechanosensors (levin2005cellwallintegrity pages 8-9, levin2005cellwallintegrity pages 9-10, cruz2013thefissionyeast pages 1-2). SPBC215.13 shares the <strong>serine-rich surface-protein logic</strong>, but unlike those classical sensors it is currently only predicted to be <strong>GPI-anchored</strong>, not experimentally shown to be a transmembrane signaling receptor.</td>
+</tr>
+<tr>
+<td>Structural features of related sensors</td>
+<td>Related fungal wall sensors typically contain <strong>STR (Ser/Thr-rich) regions</strong> that become heavily <strong>O-mannosylated</strong>, stiffening the ectodomain and enabling <strong>mechanosensory</strong> behavior at the wall–membrane interface (cansado2021thefissionyeast pages 2-3, levin2005cellwallintegrity pages 9-10, yoshimi2022cellwallintegrity pages 2-4, cruz2013thefissionyeast pages 1-2). This provides a plausible framework for interpreting a serine-rich protein such as mtl3/SPBC215.13.</td>
+</tr>
+<tr>
+<td>Pathway involvement</td>
+<td><strong>No direct pathway assignment</strong> is currently supported for SPBC215.13. By analogy only, it could participate in <strong>cell wall integrity/homeostasis</strong> or extracellular stress-response processes, but there is <strong>no direct evidence</strong> connecting it to <strong>Rho1</strong>, <strong>Pmk1/CIP</strong>, or other defined signaling modules.</td>
+</tr>
+<tr>
+<td>Biochemical activity / substrate specificity</td>
+<td><strong>Unknown.</strong> No enzymatic function, transported substrate, or binding partner has been experimentally established for SPBC215.13 in the retrieved literature.</td>
+</tr>
+<tr>
+<td>Practical interpretation</td>
+<td>The safest current annotation is: <strong>uncharacterized serine-rich predicted GPI-anchored cell-surface protein of S. pombe, probably associated with the cell wall/plasma membrane interface</strong>. Any stronger claim—such as calling it a bona fide mechanosensor or assigning a defined signaling role—would presently be <strong>speculative</strong>.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes what can currently be said about the S. pombe gene mtl3/SPBC215.13 from the available literature and database-linked evidence. It distinguishes direct evidence from inference and clarifies how mtl3 relates to the better-characterized cell wall sensor proteins Mtl2, Wsc1, and budding-yeast Mid2/Mtl1.</em></p>
+<h3 id="3-predicted-subcellular-localization">3. Predicted Subcellular Localization</h3>
+<p>No direct experimental localization data exists for mtl3/SPBC215.13. However, several lines of evidence support a <strong>cell surface</strong> localization:</p>
+<ul>
+<li><strong>GPI-anchor prediction:</strong> The protein was computationally identified as a GPI protein candidate, which in fungi are typically anchored to the outer leaflet of the plasma membrane or covalently transferred to cell wall glucans (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12).</li>
+<li><strong>Signal peptide:</strong> The precursor designation indicates entry into the secretory pathway.</li>
+<li><strong>Analogy to Mtl2:</strong> The related <em>S. pombe</em> protein Mtl2 localizes to the <strong>cell periphery</strong> as demonstrated by Mtl2-GFP imaging (cruz2013thefissionyeast pages 1-2). In <em>S. cerevisiae</em>, the analogous sensors Mid2 and Mtl1 are <strong>plasma membrane-associated</strong> with their ectodomains extending into the cell wall space (levin2005cellwallintegrity pages 8-9, levin2005cellwallintegrity pages 9-10).</li>
+</ul>
+<p>The most parsimonious prediction is that mtl3/SPBC215.13 localizes to the <strong>plasma membrane and/or cell wall interface</strong>, with its serine-rich domain facing the extracellular/periplasmic space.</p>
+<h3 id="4-inferred-function-and-pathway-context">4. Inferred Function and Pathway Context</h3>
+<h4 id="41-no-known-enzymatic-activity-or-substrate">4.1 No Known Enzymatic Activity or Substrate</h4>
+<p>No catalytic activity, transported substrate, or direct binding partner has been experimentally established for mtl3/SPBC215.13. The protein lacks recognized enzymatic domains based on its UniProt annotation.</p>
+<h4 id="42-relationship-to-the-mid2-like-cell-wall-sensor-family">4.2 Relationship to the Mid2-Like Cell Wall Sensor Family</h4>
+<p>The naming convention and structural features of mtl3 suggest it may belong to the broader family of <strong>cell wall sensor-like proteins</strong>. In <em>S. pombe</em>, two such sensors have been functionally characterized:</p>
+<ul>
+<li>
+<p><strong>Mtl2 (Mid two-like 2):</strong> A cell wall stress sensor that localizes to the cell periphery and is essential for survival under various cell wall stresses. Mtl2 activates the <strong>Rho1 GTPase</strong> and signals through <strong>Pck1</strong> kinase. Deletion of <em>mtl2</em> causes sensitivity to caspofungin, caffeine, vanadate, NaCl, H₂O₂, and SDS, and is associated with decreased β-1,3-glucan content (cruz2013thefissionyeast pages 1-2, yoshimi2022cellwallintegrity pages 4-5, cruz2013thefissionyeast pages 11-13).</p>
+</li>
+<li>
+<p><strong>Wsc1:</strong> A WSC-type sensor concentrated at cell tips that interacts with the Rho-GEF <strong>Rgf2</strong> and activates <strong>glucan synthase</strong> through Rho1. Wsc1 and Mtl2 have complementary essential functions—simultaneous deletion of both is lethal, rescuable by overexpression of Rho1 or its GEFs (cruz2013thefissionyeast pages 1-2, cansado2021thefissionyeast pages 2-3).</p>
+</li>
+</ul>
+<p>These sensors share common structural features: small C-terminal cytoplasmic domains, a single transmembrane domain (or GPI anchor), and a <strong>periplasmic domain rich in serine/threonine residues</strong> that is extensively O-mannosylated (cansado2021thefissionyeast pages 2-3, levin2005cellwallintegrity pages 8-9, levin2005cellwallintegrity pages 9-10, cruz2013thefissionyeast pages 1-2). The O-mannosylation extends and stiffens the polypeptide, and these proteins have been proposed to function as <strong>mechanosensors</strong> whose ectodomains act as rigid probes of the extracellular matrix (levin2005cellwallintegrity pages 9-10, yoshimi2022cellwallintegrity pages 2-4).</p>
+<p>In <em>S. cerevisiae</em>, the analogous family includes <strong>Wsc1-3, Mid2, and Mtl1</strong>, all of which are plasma membrane sensors for cell wall integrity that signal through <strong>Rom2</strong> (a Rho1 GEF) to activate the <strong>cell wall integrity (CWI) MAPK pathway</strong> (levin2005cellwallintegrity pages 8-9, levin2005cellwallintegrity pages 9-10).</p>
+<h4 id="43-possible-role-in-cell-wall-organization">4.3 Possible Role in Cell Wall Organization</h4>
+<p>Given its predicted GPI-anchored, serine-rich surface protein nature, mtl3/SPBC215.13 likely participates in <strong>cell wall organization or homeostasis</strong> at the cell surface. However, whether it functions as a bona fide stress sensor (like Mtl2), a structural cell wall component, or has another role remains entirely speculative without experimental data.</p>
+<h3 id="5-relationship-to-the-mtrec-complex-and-mtl1-helicase">5. Relationship to the MTREC Complex and Mtl1 Helicase</h3>
+<p>It is important to distinguish mtl3/SPBC215.13 from the unrelated <em>S. pombe</em> protein <strong>Mtl1</strong> (Mtr4-like 1), which is an <strong>ATP-dependent RNA helicase</strong> and a core component of the <strong>MTREC (Mtl1-Red1 core) complex</strong>. The MTREC complex is an 11-subunit nuclear RNA surveillance complex that targets cryptic unstable transcripts (CUTs), meiotic mRNAs, and unspliced pre-mRNAs for degradation by the nuclear exosome (zhou2015thefissionyeast pages 2-3, zhou2015thefissionyeast pages 8-8, dobrev2021thezincfingerprotein pages 1-2, zhou2015thefissionyeast pages 1-2). Mtl1 is an Mtr4 paralogue with 52% identity and 73% similarity to Mtr4 (dobrev2021thezincfingerprotein pages 1-2). Despite the superficial similarity in naming ("Mtl"), the MTREC helicase Mtl1 and the cell wall-associated protein mtl3/SPBC215.13 are <strong>functionally and structurally unrelated</strong>.</p>
+<h3 id="6-conclusions-and-limitations">6. Conclusions and Limitations</h3>
+<p>The gene <strong>mtl3</strong> (SPBC215.13, UniProt O94317) in <em>S. pombe</em> encodes an <strong>uncharacterized serine-rich protein</strong> that is computationally predicted to be <strong>GPI-anchored</strong> and localized at the <strong>cell surface/cell wall interface</strong> (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12). Its naming suggests it belongs to the <strong>Mid2-like family</strong> of cell wall-associated proteins, alongside the well-characterized sensor Mtl2 (cruz2013thefissionyeast pages 1-2, cansado2021thefissionyeast pages 2-3). However, no direct experimental evidence exists for its biochemical function, subcellular localization, protein interactions, or deletion phenotype. The protein has no known enzymatic activity, and no signaling pathway has been definitively linked to it.</p>
+<p>The safest current annotation is: <strong>an uncharacterized serine-rich predicted GPI-anchored cell-surface protein</strong>, likely associated with the cell wall/plasma membrane interface, with possible involvement in cell wall organization or integrity based solely on structural analogy to related proteins. Any stronger functional claim would be speculative pending direct experimental characterization.</p>
+<h3 id="key-references">Key References</h3>
+<ul>
+<li>De Groot, P. W. J., Hellingwerf, K. J., &amp; Klis, F. M. (2003). Genome-wide identification of fungal GPI proteins. <em>Yeast</em>, 20, 781–796 (groot2003genome‐wideidentificationof pages 10-10, groot2003genome‐wideidentificationof pages 10-12).</li>
+<li>Cruz, S., et al. (2013). The fission yeast cell wall stress sensor-like proteins Mtl2 and Wsc1 act by turning on the GTPase Rho1p. <em>MicrobiologyOpen</em>, 2, 778–794 (cruz2013thefissionyeast pages 1-2, cruz2013thefissionyeast pages 11-13).</li>
+<li>Cansado, J., et al. (2021). The fission yeast cell integrity pathway. <em>Journal of Fungi</em>, 8, 32 (cansado2021thefissionyeast pages 2-3).</li>
+<li>Levin, D. E. (2005). Cell wall integrity signaling in <em>Saccharomyces cerevisiae</em>. <em>Microbiol. Mol. Biol. Rev.</em>, 69, 262–291 (levin2005cellwallintegrity pages 8-9, levin2005cellwallintegrity pages 9-10).</li>
+<li>Yoshimi, A., et al. (2022). Cell wall integrity and its industrial applications in filamentous fungi. <em>Journal of Fungi</em>, 8, 435 (yoshimi2022cellwallintegrity pages 4-5, yoshimi2022cellwallintegrity pages 2-4).</li>
+<li>Zhou, Y., et al. (2015). The fission yeast MTREC complex targets CUTs and unspliced pre-mRNAs to the nuclear exosome. <em>Nature Communications</em>, 6, 7050 (zhou2015thefissionyeast pages 2-3, zhou2015thefissionyeast pages 8-8).</li>
+<li>Dobrev, N., et al. (2021). The zinc-finger protein Red1 orchestrates MTREC submodules. <em>Nature Communications</em>, 12 (dobrev2021thezincfingerprotein pages 1-2, dobrev2021thezincfingerprotein pages 3-4).</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(cruz2013thefissionyeast pages 1-2): Sandra Cruz, Sofía Muñoz, Elvira Manjón, Patricia García, and Yolanda Sanchez. The fission yeast cell wall stress sensor-like proteins mtl2 and wsc1 act by turning on the gtpase rho1p but act independently of the cell wall integrity pathway. MicrobiologyOpen, 2:778-794, Jul 2013. URL: https://doi.org/10.1002/mbo3.113, doi:10.1002/mbo3.113. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(groot2003genome‐wideidentificationof pages 10-10): Piet W. J. de Groot, Klaas J. Hellingwerf, and Frans M. Klis. Genome‐wide identification of fungal gpi proteins. Yeast, 20:781-796, Jul 2003. URL: https://doi.org/10.1002/yea.1007, doi:10.1002/yea.1007. This article has 388 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(groot2003genome‐wideidentificationof pages 10-12): Piet W. J. de Groot, Klaas J. Hellingwerf, and Frans M. Klis. Genome‐wide identification of fungal gpi proteins. Yeast, 20:781-796, Jul 2003. URL: https://doi.org/10.1002/yea.1007, doi:10.1002/yea.1007. This article has 388 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yoshimi2022cellwallintegrity pages 7-8): Akira Yoshimi, Ken Miyazawa, Moriyuki Kawauchi, and Keietsu Abe. Cell wall integrity and its industrial applications in filamentous fungi. Journal of Fungi, 8:435, Apr 2022. URL: https://doi.org/10.3390/jof8050435, doi:10.3390/jof8050435. This article has 50 citations.</p>
+</li>
+<li>
+<p>(cansado2021thefissionyeast pages 2-3): José Cansado, Teresa Soto, Alejandro Franco, Jero Vicente-Soler, and Marisa Madrid. The fission yeast cell integrity pathway: a functional hub for cell survival upon stress and beyond. Journal of Fungi, 8:32, Dec 2021. URL: https://doi.org/10.3390/jof8010032, doi:10.3390/jof8010032. This article has 42 citations.</p>
+</li>
+<li>
+<p>(levin2005cellwallintegrity pages 8-9): David E. Levin. Cell wall integrity signaling in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, 69:262-291, Jun 2005. URL: https://doi.org/10.1128/mmbr.69.2.262-291.2005, doi:10.1128/mmbr.69.2.262-291.2005. This article has 1478 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(levin2005cellwallintegrity pages 9-10): David E. Levin. Cell wall integrity signaling in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, 69:262-291, Jun 2005. URL: https://doi.org/10.1128/mmbr.69.2.262-291.2005, doi:10.1128/mmbr.69.2.262-291.2005. This article has 1478 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yoshimi2022cellwallintegrity pages 2-4): Akira Yoshimi, Ken Miyazawa, Moriyuki Kawauchi, and Keietsu Abe. Cell wall integrity and its industrial applications in filamentous fungi. Journal of Fungi, 8:435, Apr 2022. URL: https://doi.org/10.3390/jof8050435, doi:10.3390/jof8050435. This article has 50 citations.</p>
+</li>
+<li>
+<p>(yoshimi2022cellwallintegrity pages 4-5): Akira Yoshimi, Ken Miyazawa, Moriyuki Kawauchi, and Keietsu Abe. Cell wall integrity and its industrial applications in filamentous fungi. Journal of Fungi, 8:435, Apr 2022. URL: https://doi.org/10.3390/jof8050435, doi:10.3390/jof8050435. This article has 50 citations.</p>
+</li>
+<li>
+<p>(cruz2013thefissionyeast pages 11-13): Sandra Cruz, Sofía Muñoz, Elvira Manjón, Patricia García, and Yolanda Sanchez. The fission yeast cell wall stress sensor-like proteins mtl2 and wsc1 act by turning on the gtpase rho1p but act independently of the cell wall integrity pathway. MicrobiologyOpen, 2:778-794, Jul 2013. URL: https://doi.org/10.1002/mbo3.113, doi:10.1002/mbo3.113. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2015thefissionyeast pages 2-3): Yang Zhou, Jianguo Zhu, Géza Schermann, Corina Ohle, Katja Bendrin, Rie Sugioka-Sugiyama, Tomoyasu Sugiyama, and Tamás Fischer. The fission yeast mtrec complex targets cuts and unspliced pre-mrnas to the nuclear exosome. Nature Communications, May 2015. URL: https://doi.org/10.1038/ncomms8050, doi:10.1038/ncomms8050. This article has 139 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2015thefissionyeast pages 8-8): Yang Zhou, Jianguo Zhu, Géza Schermann, Corina Ohle, Katja Bendrin, Rie Sugioka-Sugiyama, Tomoyasu Sugiyama, and Tamás Fischer. The fission yeast mtrec complex targets cuts and unspliced pre-mrnas to the nuclear exosome. Nature Communications, May 2015. URL: https://doi.org/10.1038/ncomms8050, doi:10.1038/ncomms8050. This article has 139 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dobrev2021thezincfingerprotein pages 1-2): Nikolay Dobrev, Yasar Luqman Ahmed, Anusree Sivadas, Komal Soni, Tamás Fischer, and Irmgard Sinning. The zinc-finger protein red1 orchestrates mtrec submodules and binds the mtl1 helicase arch domain. Nature Communications, Jun 2021. URL: https://doi.org/10.1038/s41467-021-23565-3, doi:10.1038/s41467-021-23565-3. This article has 30 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2015thefissionyeast pages 1-2): Yang Zhou, Jianguo Zhu, Géza Schermann, Corina Ohle, Katja Bendrin, Rie Sugioka-Sugiyama, Tomoyasu Sugiyama, and Tamás Fischer. The fission yeast mtrec complex targets cuts and unspliced pre-mrnas to the nuclear exosome. Nature Communications, May 2015. URL: https://doi.org/10.1038/ncomms8050, doi:10.1038/ncomms8050. This article has 139 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dobrev2021thezincfingerprotein pages 3-4): Nikolay Dobrev, Yasar Luqman Ahmed, Anusree Sivadas, Komal Soni, Tamás Fischer, and Irmgard Sinning. The zinc-finger protein red1 orchestrates mtrec submodules and binds the mtl1 helicase arch domain. Nature Communications, Jun 2021. URL: https://doi.org/10.1038/s41467-021-23565-3, doi:10.1038/s41467-021-23565-3. This article has 30 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="mtl3-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>cruz2013thefissionyeast pages 1-2</li>
+<li>dobrev2021thezincfingerprotein pages 1-2</li>
+<li>cansado2021thefissionyeast pages 2-3</li>
+<li>yoshimi2022cellwallintegrity pages 7-8</li>
+<li>levin2005cellwallintegrity pages 8-9</li>
+<li>levin2005cellwallintegrity pages 9-10</li>
+<li>yoshimi2022cellwallintegrity pages 2-4</li>
+<li>yoshimi2022cellwallintegrity pages 4-5</li>
+<li>cruz2013thefissionyeast pages 11-13</li>
+<li>zhou2015thefissionyeast pages 2-3</li>
+<li>zhou2015thefissionyeast pages 8-8</li>
+<li>zhou2015thefissionyeast pages 1-2</li>
+<li>dobrev2021thezincfingerprotein pages 3-4</li>
+<li>https://doi.org/10.1002/mbo3.113,</li>
+<li>https://doi.org/10.1002/yea.1007,</li>
+<li>https://doi.org/10.3390/jof8050435,</li>
+<li>https://doi.org/10.3390/jof8010032,</li>
+<li>https://doi.org/10.1128/mmbr.69.2.262-291.2005,</li>
+<li>https://doi.org/10.1038/ncomms8050,</li>
+<li>https://doi.org/10.1038/s41467-021-23565-3,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mtl3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O94317" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mtl3-spbc21513-uniprot-o94317-curation-notes">mtl3 (SPBC215.13, UniProt O94317) — curation notes</h1>
+<h2 id="identity-and-a-critical-name-disambiguation">Identity and a critical name disambiguation</h2>
+<p><strong>mtl3</strong> is the PomBase standard name for <em>S. pombe</em> systematic-name <strong>SPBC215.13</strong>,<br />
+UniProt <strong>O94317</strong> (entry name <code>YH5D_SCHPO</code>, 534 aa). PomBase product description<br />
+(verbatim): <strong>"plasma membrane-associated serine-rich cell wall sensor Mtl1/Mtl3"</strong>;<br />
+PomBase name description: <strong>"S. cerevisiae Mid Two-Like"</strong>; PomBase exact synonym: <strong>mtl1</strong>.<br />
+So the gene symbol string "mtl1"/"mtl3" here means <strong>"Mid Two-Like"</strong> (Mtl = <em>Mid Two-Like</em>),<br />
+i.e. this is a <strong>Mid2-like cell-wall-integrity (CWI) stress sensor</strong>.</p>
+<p><strong>IMPORTANT — this is NOT the Mtr4-like RNA helicase.</strong> The curation task described mtl3 as<br />
+"a Mtr4-like DExH RNA-helicase-family member related to the nuclear RNA-surveillance/MTREC<br />
+machinery." That description is a <strong>name collision</strong>: in <em>S. pombe</em> the <strong>Mtr4-like helicase</strong><br />
+is a <em>different</em> gene, PomBase standard name <strong>mtl1 = SPAC17H9.02</strong> (an MTREC/NURS-complex<br />
+DExH-box RNA helicase; UniProt O60058), reviewed e.g. in<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24210919" title="Mtr4-like protein coordinates nuclear RNA processing...">PMID:24210919</a> and<br />
+[PMID:26089201 (MTREC targets CUTs), Nat Commun 6:7050]. The two share the abbreviation<br />
+"Mtl" but stand for entirely different things (Mid-Two-Like vs Mtr4-Like). The UniProt<br />
+record for O94317 is decisive: it is a <strong>serine-rich GPI-anchored plasma-membrane/ER<br />
+precursor with a signal peptide and a single N-terminal transmembrane segment — there is<br />
+NO helicase domain, NO DExH/DEAD box, NO Walker A/B (P-loop) NTPase motif, and NO<br />
+arch/KOW domain</strong>. All downstream reasoning below treats mtl3/SPBC215.13 strictly as the<br />
+Mid2-like cell-wall sensor.</p>
+<h2 id="domain-sequence-analysis-inline-from-the-uniprot-record-o94317">Domain / sequence analysis (inline, from the UniProt record O94317)</h2>
+<ul>
+<li>534 aa; MW 53.4 kDa. <code>PE 1: Evidence at protein level</code>.</li>
+<li><strong>Signal peptide</strong> 1–22 (ECO:0000255) → secretory-pathway entry.</li>
+<li><strong>Single transmembrane segment</strong> ~7–29 (TMHMM, PomBase) near the N-terminus.</li>
+<li><strong>GPI-anchor</strong> predicted (KW GPI-anchor, Lipoprotein; PROPEP <code>?..534</code> "Removed in mature form",<br />
+  ECO:0000255) — C-terminal signal for GPI attachment; MOD:00818 (PomBase).</li>
+<li><strong>Two large disordered / low-complexity regions</strong> (MobiDB-lite: 70–145 and 176–418;<br />
+  PomBase low-complexity: 62–89, 92–420, 426–445, 449–492, 501–517). The sequence is<br />
+  strikingly <strong>serine-rich</strong> (long runs of S/T/P), the hallmark of the O-mannosylated,<br />
+  cell-wall-facing ectodomain of fungal CWI mechanosensors.</li>
+<li><strong>N-glycosylation</strong> at N31 and N426 (ECO:0000255; PMID:36408920 for the PSI-MOD sites).</li>
+<li>Subcellular location (UniProt): <strong>Endoplasmic reticulum</strong> (ECO:0000269|PubMed:16823372,<br />
+  ORFeome GFP localization) and <strong>Cell membrane; Lipid-anchor, GPI-anchor</strong> (ECO:0000305).</li>
+<li><strong>Catalytic competence:</strong> none inferred — no enzymatic domain of any kind. This is a<br />
+  structural/signaling single-pass membrane glycoprotein, consistent with a cell-surface sensor.</li>
+</ul>
+<p>Architecture summary: N-terminal signal peptide + single TM anchor → long serine/threonine-rich<br />
+(O-mannosylation-prone) extracellular ectodomain → C-terminal GPI-anchor addition. This is the<br />
+canonical architecture of fungal plasma-membrane cell-wall stress sensors (Wsc/Mid2/Mtl family).</p>
+<h2 id="what-is-known-with-provenance">What is KNOWN (with provenance)</h2>
+<ul>
+<li><strong>Localization:</strong> external side of the plasma membrane / cell surface; GPI-anchored.<br />
+  [GOA GO:0009897 external side of plasma membrane, TAS PMID:12845604]; ER + cell membrane<br />
+  [UniProt, PubMed:16823372 ORFeome localization; PubMed:12845604 GPI prediction].<br />
+  PMID:12845604 is the genome-wide fungal-GPI-protein prediction study<br />
+  ["only 33 GPI candidates were identified" in Sz. pombe] — supports GPI/cell-surface class,<br />
+  abstract-only (full_text_available: false).</li>
+<li><strong>It is a member of the Mid2-like cell-wall sensor family</strong> (PomBase name "Mid Two-Like";<br />
+  product "cell wall sensor Mtl1/Mtl3"). The <em>S. pombe</em> CWI sensor family (Wsc1, Mtl2, Mid2-like<br />
+  proteins) are single-pass, Ser/Thr-rich, O-mannosylated membrane sensors that signal to the<br />
+  Rho1 GTPase [PMID:23907979 Cruz et al. 2013 MicrobiologyOpen; Mtl2 and Wsc1 turn on Rho1p;<br />
+  family context, not mtl3-specific evidence].</li>
+<li><strong>Deletion phenotypes (mtl3Δ), curated in PomBase from a genome-wide phenomics screen</strong><br />
+  [PMID:37787768 Rodríguez-López et al. 2023 eLife, phenomics/ML dataset]:<br />
+  altered sensitivity/resistance to cell-wall/membrane and ionic stressors — sensitive to<br />
+  SDS + MgCl2, ethanol, lithium, cycloheximide; resistant to EGTA, KCl+SDS, MgCl2+SDS,<br />
+  tert-butyl hydroperoxide; loss of viability in stationary phase; increased vegetative<br />
+  growth; otherwise viable with normal morphology (FYPO terms listed in PomBase). These are<br />
+  the classic phenotypic signatures of a CWI/membrane stress sensor. NOTE: this is a<br />
+  large-scale dataset paper; it does not discuss mtl3 by name in the text, so no verbatim<br />
+  mtl3-specific quote is available — the annotations derive from the supplementary phenotype matrix.</li>
+<li><strong>Post-transcriptional regulation:</strong> mtl3 mRNA is a target in a systematic RNA-stability /<br />
+  RNA-binding-protein study [PMID:25375137 Hasan et al. 2014 PLoS Genet]; PomBase records mtl3<br />
+  as a target-of (zfs1) mRNA-binding annotation. Again a systematic dataset (no in-text mtl3 prose).</li>
+<li><strong>Ortholog:</strong> <em>S. japonicus</em> SJAG_00415 (also named mtl3) [PMID:21511999, PomBase ortholog annotation].<br />
+  Taxonomic distribution "Schizosaccharomyces specific" per PomBase.</li>
+<li>PomBase characterization status: <strong>"biological role published"</strong> (i.e. a biological role has<br />
+  been assigned, chiefly via the phenomics phenotype profile and family membership).</li>
+</ul>
+<h2 id="what-is-not-known-knowledge-gaps">What is NOT known (knowledge gaps)</h2>
+<ul>
+<li><strong>No experimentally demonstrated molecular function.</strong> GOA MF is GO:0003674 (ND). No ligand,<br />
+  no direct binding partner, no signaling-output assay published <em>for mtl3 specifically</em>. Its<br />
+  proposed role as a Rho1/CWI-pathway sensor is inferred from family membership and phenotypes,<br />
+  not shown directly for this protein.</li>
+<li><strong>No direct evidence of the signaling pathway it feeds</strong> (Rho1 GEFs? Pmk1 MAPK? Mkh1–Pek1–Pmk1<br />
+  cascade?). Note the related sensors Mtl2/Wsc1 signal to Rho1 but were reported to act<br />
+<em>independently of</em> Pmk1 MAPK <a href="https://pubmed.ncbi.nlm.nih.gov/23907979">PMID:23907979</a>; whether mtl3 uses the MAPK-independent Rho1 route is unknown.</li>
+<li><strong>Redundancy / genetic relationships</strong> with the other S. pombe cell-wall sensors (wsc1, mtl2,<br />
+  and any mid2-like paralog) are not established for mtl3.</li>
+<li><strong>No structure</strong> (only AlphaFold model). No biochemistry (glycosylation confirmed only by<br />
+  prediction + one PSI-MOD dataset). The Ser/Thr-rich ectodomain O-mannosylation is inferred.</li>
+<li>Whether the ER localization (ORFeome GFP) is the mature steady-state site or an<br />
+  overexpression/trafficking artifact vs. the functional plasma-membrane pool is unresolved.</li>
+</ul>
+<h2 id="curation-plan-for-the-5-goa-annotations">Curation plan for the 5 GOA annotations</h2>
+<ol>
+<li>GO:0005783 endoplasmic reticulum (IEA, GO_REF:0000044, located_in) — KEEP_AS_NON_CORE.<br />
+   Supported by UniProt SubCell (ORFeome GFP, PubMed:16823372); plausible as secretory-pathway<br />
+   transit; not the primary functional site.</li>
+<li>GO:0005886 plasma membrane (IEA, GO_REF:0000044, located_in) — ACCEPT (core location; but the<br />
+   more specific external-side term below is preferable). Keep; MF/location core is the cell surface.</li>
+<li>GO:0003674 molecular_function (ND, GO_REF:0000015) — KEEP_AS_NON_CORE / accept the ND: honestly<br />
+   reflects that no MF has been experimentally determined. (ND root — cannot MODIFY to a specific<br />
+   MF without evidence; flag as knowledge gap rather than invent an MF.)</li>
+<li>GO:0008150 biological_process (ND, GO_REF:0000015) — same: ND root reflects no assigned BP.<br />
+   A cell-wall-integrity/stress-response BP is <em>inferred</em> from phenotypes but not directly shown;<br />
+   do not over-annotate. Keep ND; note gap.</li>
+<li>GO:0009897 external side of plasma membrane (TAS, PMID:12845604, is_active_in) — ACCEPT.<br />
+   Most specific, best-supported localization (GPI-anchored ectodomain on the outer PM face).</li>
+</ol>
+<h2 id="falcon-deep-research-corroboration-independent">Falcon deep-research corroboration (independent)</h2>
+<p>The falcon deep-research report (<code>mtl3-deep-research-falcon.md</code>, generated 2026-07-06 with the<br />
+correct O94317/SPBC215.13 context) independently reached the SAME identity and disambiguation:<br />
+it classifies mtl3/SPBC215.13 as a putative GPI-anchored, serine/threonine-rich cell-surface<br />
+glycoprotein of the "Mid two-like" family, and includes a dedicated section explicitly stating<br />
+that mtl3 is "functionally and structurally unrelated" to the Mtr4-like MTREC helicase Mtl1<br />
+"despite the superficial similarity in naming". It likewise notes that the symbol "mtl3" does<br />
+not appear in the retrieved primary literature (dark gene), so identity is anchored to the<br />
+systematic ID + UniProt accession. This is independent confirmation of the review's central<br />
+finding; no fabricated function was introduced.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O94317
+gene_symbol: mtl3
+aliases:
+  - SPBC215.13
+  - mtl1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  mtl3 (systematic name SPBC215.13; UniProt O94317) is a Schizosaccharomyces-specific,
+  GPI-anchored, serine/threonine-rich plasma-membrane glycoprotein of the fungal Mid2-like
+  cell-wall stress-sensor family (the name Mtl denotes &#34;Mid Two-Like&#34;; it is distinct from
+  and unrelated to the Mtr4-like nuclear RNA helicase, which in S. pombe is the separately
+  named mtl1/SPAC17H9.02). The 534-residue precursor has the canonical architecture of a
+  single-pass fungal cell-surface sensor: an N-terminal secretion signal peptide and a single
+  transmembrane segment, a long serine/threonine-rich, O-mannosylation-prone extracellular
+  ectodomain that is intrinsically disordered/low-complexity, N-linked glycosylation, and a
+  C-terminal GPI-anchor addition signal that tethers the mature protein to the outer face of
+  the plasma membrane. It carries no enzymatic domain of any kind (no helicase, ATPase/P-loop,
+  or other catalytic module). Genome-wide deletion phenotyping shows mtl3 loss alters
+  sensitivity and resistance to cell-wall-perturbing and ionic stresses (e.g. altered
+  responses to SDS combined with salts, ethanol, lithium, and oxidants) and reduces viability
+  in stationary phase, consistent with a role at the cell surface in sensing envelope/membrane
+  stress. By family membership its inferred role is to transmit cell-wall/membrane stress to
+  intracellular signaling (as for the related fission-yeast sensors Wsc1 and Mtl2, which
+  activate the Rho1 GTPase), but a direct molecular activity, ligand, signaling partner, or
+  pathway output has not been experimentally established for mtl3 itself.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000044
+    title: &gt;-
+      Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+      mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: PMID:12845604
+    title: Genome-wide identification of fungal GPI proteins.
+    findings:
+      - statement: &gt;-
+          Genome-wide computational screen predicting GPI-anchored proteins across fungi; the
+          S. pombe GPI proteome is small, and mtl3/SPBC215.13 was identified as a predicted
+          GPI-anchored cell-surface protein, supporting its localization to the outer face of
+          the plasma membrane.
+        supporting_text: &#34;only 33 GPI candidates were identified&#34;
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified genome-wide fungal GPI-protein prediction study (De Groot et al. 2003,
+        Yeast). Abstract-only in cache (full_text_available: false). It establishes mtl3 as a
+        predicted GPI-anchored cell-surface protein (basis of the TAS GO:0009897 annotation),
+        but says nothing about its molecular function or signaling role.
+  - id: PMID:16823372
+    title: &gt;-
+      ORFeome cloning and global analysis of protein localization in the fission yeast
+      Schizosaccharomyces pombe.
+    findings:
+      - statement: &gt;-
+          Systematic GFP-fusion localization study; the source of the UniProt endoplasmic
+          reticulum subcellular-location assignment for mtl3 (a secretory-pathway compartment
+          consistent with a GPI-anchored membrane protein en route to the cell surface).
+        supporting_text: &#34;ORFeome cloning and global analysis of protein localization&#34;
+        reference_section_type: TITLE
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified large-scale GFP-localization dataset (Matsuyama et al. 2006, Nat
+        Biotechnol); cited by UniProt (ECO:0000269|PubMed:16823372) as the source of the ER
+        localization. A systematic dataset, not an mtl3-focused study.
+  - id: PMID:37787768
+    title: Broad functional profiling of fission yeast proteins using phenomics and machine learning.
+    findings:
+      - statement: &gt;-
+          Genome-wide phenomics/machine-learning profiling of S. pombe deletion mutants; the
+          source of the curated mtl3-delta stress-response phenotypes (altered sensitivity and
+          resistance to cell-wall/membrane and ionic stressors; reduced stationary-phase
+          viability). mtl3 appears in the supplementary phenotype matrix rather than being
+          discussed by name in the text.
+        supporting_text: &#34;Broad functional profiling of fission yeast proteins using phenomics and machine learning&#34;
+        reference_section_type: TITLE
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed/PMC-verified (Rodriguez-Lopez et al. 2023, eLife; PMC10547477). Full text
+        available but mtl3-specific data live in the genome-wide phenotype dataset, so no
+        mtl3-specific prose quote is available; supports the deletion phenotypes at the
+        dataset level, consistent with a cell-surface stress-sensor role.
+  - id: PMID:25375137
+    title: Systematic analysis of the role of RNA-binding proteins in the regulation of RNA stability.
+    findings:
+      - statement: &gt;-
+          Systematic RNA-stability / RNA-binding-protein study; the basis for PomBase&#39;s record
+          of mtl3 mRNA as a regulatory target (of the zinc-finger RNA-binding protein zfs1),
+          indicating post-transcriptional control of mtl3 expression.
+        supporting_text: &#34;Systematic analysis of the role of RNA-binding proteins in the regulation of RNA stability&#34;
+        reference_section_type: TITLE
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed/PMC-verified (Hasan et al. 2014, PLoS Genet; PMC4222612). Systematic dataset;
+        mtl3 is a target in the supplementary data, not discussed by name. Relevant to mtl3
+        regulation, not to its molecular function.
+  - id: PMID:23907979
+    title: &gt;-
+      The fission yeast cell wall stress sensor-like proteins Mtl2 and Wsc1 act by turning on
+      the GTPase Rho1p but act independently of the cell wall integrity pathway.
+    findings:
+      - statement: &gt;-
+          Characterizes the related fission-yeast plasma-membrane cell-wall stress sensors Mtl2
+          and Wsc1, which signal by activating the Rho1 GTPase. Provides family/architecture
+          context for mtl3 (a Mid2-like sensor of the same class); it does not study mtl3
+          itself, so its findings are contextual rather than direct evidence for mtl3.
+        supporting_text: &gt;-
+          The fission yeast cell wall stress sensor-like proteins Mtl2 and Wsc1 act by turning
+          on the GTPase Rho1p but act independently of the cell wall integrity pathway
+        reference_section_type: TITLE
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Cruz et al. 2013, MicrobiologyOpen; PMC3831639). Family/pathway context
+        for the S. pombe cell-wall sensor class; explicitly about paralogous sensors (Mtl2,
+        Wsc1), NOT about mtl3. Included to frame the inferred sensor role and to keep the
+        mtl3 (Mid-Two-Like) vs mtl1 (Mtr4-Like helicase) distinction clear.
+existing_annotations:
+  - term:
+      id: GO:0005783
+      label: endoplasmic reticulum
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        ER localization is supported by the systematic GFP-localization dataset cited by
+        UniProt (ECO:0000269|PubMed:16823372) and is plausible as a secretory-pathway transit
+        compartment for a signal-peptide-bearing, GPI-anchored membrane protein en route to
+        the cell surface. It is not the primary functional site of the protein, which is the
+        plasma membrane.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:16823372
+          supporting_text: &#34;ORFeome cloning and global analysis of protein localization&#34;
+          reference_section_type: TITLE
+  - term:
+      id: GO:0005886
+      label: plasma membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Plasma-membrane localization is consistent with the protein&#39;s architecture (signal
+        peptide, single transmembrane segment, and C-terminal GPI-anchor addition signal) and
+        with its predicted GPI-anchored cell-surface status. This is a core localization,
+        although the more specific term GO:0009897 (external side of plasma membrane) better
+        captures where the GPI-anchored ectodomain resides.
+      action: ACCEPT
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        No molecular function has been experimentally determined for mtl3, so the ND (No
+        Data) root annotation is an honest and appropriate reflection of the current state of
+        knowledge. Although family membership (a Mid2-like cell-wall sensor) suggests a
+        stress-sensing/signal-transducing role, there is no direct assay of ligand binding,
+        signaling output, or any catalytic activity for this protein, and its sequence lacks
+        any enzymatic domain. The unknown molecular function is recorded as a knowledge gap
+        rather than filled by an unsupported specific term.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        No biological process has been directly demonstrated for mtl3, so the ND root
+        annotation is appropriate. Deletion phenotypes (altered sensitivity/resistance to
+        cell-wall/membrane and ionic stressors; reduced stationary-phase viability) and
+        membership in the Mid2-like sensor family point toward a role in cell-wall-integrity /
+        stress signaling, but this is inferred, not established. A specific BP term should not
+        be asserted from the current evidence; the gap is recorded below.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0009897
+      label: external side of plasma membrane
+    evidence_type: TAS
+    original_reference_id: PMID:12845604
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        This is the most specific and best-supported localization: a GPI-anchored,
+        serine/threonine-rich ectodomain displayed on the outer (external) face of the plasma
+        membrane, exactly as expected for a fungal cell-wall stress sensor. Supported by the
+        genome-wide GPI-protein prediction study and consistent with the UniProt GPI-anchor
+        and topology features.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:12845604
+          supporting_text: &#34;only 33 GPI candidates were identified&#34;
+          reference_section_type: ABSTRACT
+core_functions:
+  - description: &gt;-
+      Displays a serine/threonine-rich, GPI-anchored ectodomain on the external face of the
+      plasma membrane. mtl3 belongs to the fungal Mid2-like cell-wall stress-sensor family and
+      is inferred to participate in sensing cell-wall/membrane stress at the cell surface, but
+      its molecular activity and downstream signaling partners are undetermined; only its
+      cell-surface localization is directly supported.
+    supported_by:
+      - reference_id: PMID:12845604
+        supporting_text: &#34;only 33 GPI candidates were identified&#34;
+        reference_section_type: ABSTRACT
+    locations:
+      - id: GO:0009897
+        label: external side of plasma membrane
+      - id: GO:0005886
+        label: plasma membrane
+    knowledge_gaps:
+      - gap_statement: &gt;-
+          The molecular function of mtl3 is undetermined: it is unknown what (if any) cell-wall
+          or membrane cue it senses, what its direct binding partner or signaling output is, and
+          whether it acts as a bona fide stress sensor/receptor, a purely structural cell-surface
+          glycoprotein, or an adhesion/mannoprotein-like component. No molecular-function GO term
+          is currently justified beyond the ND root.
+        boundary: &gt;-
+          Firmly established: mtl3 is a Schizosaccharomyces-specific, GPI-anchored,
+          serine/threonine-rich, N-glycosylated single-pass glycoprotein displayed on the
+          external face of the plasma membrane, with the canonical architecture of the fungal
+          Mid2-like cell-wall sensor family and stress-related deletion phenotypes. It has no
+          catalytic/enzymatic domain.
+        gap_kind:
+          - BIOLOGY
+        dark_aspect: MF_DARK
+        status: OPEN
+        significance: &gt;-
+          mtl3 is a candidate component of the fission-yeast cell-surface stress-sensing system
+          (alongside Wsc1 and Mtl2, which activate Rho1); establishing whether and how it
+          transduces cell-wall/membrane stress would clarify redundancy within this sensor family
+          and how fission yeast couples envelope integrity to intracellular signaling.
+        resolution: &gt;-
+          Test genetic interactions and redundancy with wsc1, mtl2 and other cell-wall sensors;
+          assay activation of Rho1/CWI signaling (e.g. Pmk1 MAPK phosphorylation, Rho1-GTP
+          levels) in mtl3-delta under cell-wall stress; identify interacting partners of the
+          cytoplasmic region by proximity/affinity proteomics; and confirm the O-mannosylated
+          ectodomain and GPI anchor biochemically.
+        provenance:
+          - reference_id: GO_REF:0000015
+            supporting_text: Use of the ND evidence code for Gene Ontology (GO) terms
+            reference_section_type: OTHER
+knowledge_gaps:
+  - gap_statement: &gt;-
+      mtl3 has no experimentally established molecular function, no identified binding partner
+      or ligand, and no directly demonstrated biological process. Its assignment to the Mid2-like
+      cell-wall stress-sensor family and its inferred role in transmitting cell-wall/membrane
+      stress to intracellular signaling (e.g. via Rho1, as shown for the related sensors Wsc1
+      and Mtl2) are extrapolations from family membership, sequence architecture, and deletion
+      phenotypes, not from direct study of the mtl3 protein.
+    boundary: &gt;-
+      Firmly established: subcellular localization (GPI-anchored, external face of the plasma
+      membrane; ER in transit); protein architecture (signal peptide, single N-terminal
+      transmembrane segment, long serine/threonine-rich disordered/low-complexity ectodomain,
+      N-glycosylation, C-terminal GPI-anchor signal; no enzymatic domain); genome-wide deletion
+      phenotypes (altered sensitivity/resistance to cell-wall/membrane and ionic stressors,
+      reduced stationary-phase viability); post-transcriptional regulation of its mRNA (a zfs1
+      target); and a single S. japonicus ortholog (SJAG_00415). The gene is Schizosaccharomyces-
+      specific.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: WHOLLY_DARK
+    status: OPEN
+    significance: &gt;-
+      Fission yeast maintains cell-wall integrity through a set of cell-surface sensors, but the
+      specific contribution, redundancy, and signaling wiring of mtl3 within this system are
+      unknown. mtl3 is a genuinely understudied (&#34;dark&#34;) gene whose only high-confidence GO
+      statement is its cell-surface localization; both its molecular function and biological
+      process remain at the ND root.
+    resolution: &gt;-
+      Direct functional study of mtl3: epistasis/redundancy analysis with wsc1, mtl2, mid2 and
+      the Rho1/Pmk1 CWI machinery; sensor-activation assays under defined cell-wall/membrane
+      stress; identification of interacting proteins; and structural/biochemical confirmation of
+      the ectodomain modifications. Any positive result would move both the MF and BP aspects off
+      the ND root.
+    provenance:
+      - reference_id: GO_REF:0000015
+        supporting_text: Use of the ND evidence code for Gene Ontology (GO) terms
+        reference_section_type: OTHER
+suggested_questions:
+  - question: &gt;-
+      Does mtl3 function as a cell-wall/membrane stress sensor that activates Rho1 and/or the
+      Pmk1 cell-wall-integrity MAP kinase pathway, and is this activity redundant with wsc1 and
+      mtl2?
+  - question: &gt;-
+      What cue does the serine/threonine-rich, O-mannosylated ectodomain of mtl3 sense, and does
+      the cytoplasmic/juxtamembrane region recruit any GEF or signaling partner?
+  - question: &gt;-
+      Why is mtl3 mRNA a target of the RNA-binding protein zfs1, and does this post-transcriptional
+      control couple mtl3 levels to a specific stress condition?
+suggested_experiments:
+  - description: &gt;-
+      Construct single and combinatorial deletions (mtl3-delta alone and with wsc1-delta,
+      mtl2-delta, mid2-delta) and assay growth and morphology under cell-wall/membrane stress
+      (SDS, caspofungin/echinocandins, calcofluor, sorbitol osmotic support), scoring for
+      synthetic phenotypes that reveal redundancy within the sensor family.
+  - description: &gt;-
+      Measure Rho1-GTP loading and Pmk1 MAPK phosphorylation in mtl3-delta versus wild type
+      under cell-wall stress to test whether mtl3 feeds the Rho1/CWI signaling axis.
+  - description: &gt;-
+      Perform proximity-labeling or affinity-purification mass spectrometry on tagged mtl3 to
+      identify cell-surface and cytoplasmic interaction partners, and biochemically confirm the
+      predicted GPI anchor and O-mannosylated ectodomain.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/mug151/mug151-ai-review.html
+++ b/genes/SCHPO/mug151/mug151-ai-review.html
@@ -1,0 +1,2168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mug151 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mug151</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q10069" target="_blank" class="term-link">
+                        Q10069
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mug151";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q10069" data-a="DESCRIPTION: mug151 (systematic name SPAC3H1.03) is a small (14..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>mug151 (systematic name SPAC3H1.03) is a small (146-residue) nuclear protein of the fission yeast Schizosaccharomyces pombe. It is the fission-yeast member of the SAP30BP/HCNGP family (Pfam PF07818, HCNGP; InterPro IPR012479, SAP30BP; PANTHER PTHR13464:SF0, SAP30-binding protein), whose best-studied member is the human SAP30 binding protein SAP30BP. The protein has a charged, disordered N-terminal region followed by the conserved HCNGP region, an architecture typical of small nuclear adaptor/regulator proteins rather than of an enzyme (no catalytic, nucleotide-binding, or metal-binding motif is present). In animals, proteins of this family act in the nucleus in two documented ways: as transcriptional co-regulators linked to the SAP30/Sin3 histone-deacetylase co-repressor apparatus, and as splicing cofactors for RBM17/SPF45 that promote removal of a subset of short introns. The direct molecular activity of the S. pombe protein has not been experimentally determined; its assignment to this family is by sequence and domain conservation. The transcript is up-regulated during meiosis (the basis of its &#34;meiotically up-regulated gene&#34; name), and deletion mutants are viable with normal vegetative morphology.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q10069" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization inferred from the UniProtKB/Swiss-Prot subcellular-location mapping (UniProt records &#34;SUBCELLULAR LOCATION: Nucleus&#34; by similarity, ECO:0000250). This is consistent with the SAP30BP/HCNGP family, whose members are nuclear transcription/splicing regulators, and the protein has no transmembrane or signal features. It is a reasonable localization inference, though not experimentally verified for the S. pombe protein, and describes where the protein is rather than what it does.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported localization inference (family + UniProt by-similarity), but it is a cellular-component annotation and not a direct statement of molecular function; retained as non-core context.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
+                                    GO:0006355
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of DNA-templated transcription</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q10069" data-a="GO:0006355" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Domain-based (InterPro IPR012479, SAP30BP; PANTHER PTHR13464 &#34;transcriptional regulator protein HCNGP&#34;) inference of a transcriptional-regulation role. This is the best-supported functional hypothesis from the family assignment, and is broadly consistent with the SAP30/Sin3-HDAC association reported for the animal ortholog. However, it is unproven for the S. pombe protein, and the same family also has a documented pre-mRNA splicing role (via RBM17/SPF45), so transcription regulation is a plausible but not exclusive or established function here.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable domain-family inference, retained as a plausible (non-core) role. Meiotic up-regulation and family membership do not establish that mug151 actually regulates transcription in S. pombe; there is no experimental support, and the family has an alternative splicing function. Not promoted to a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10069" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PomBase &#34;no data&#34; (ND) placeholder recording that no molecular function has been experimentally determined for mug151. This accurately reflects the current state of knowledge for this dark gene: the direct molecular activity has never been assayed in S. pombe.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Honest reflection of the knowledge state. No experimental molecular-function data exist; the family-based transcription/splicing hypotheses are captured in knowledge_gaps and suggested_questions rather than asserted as function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10069" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PomBase &#34;no data&#34; (ND) placeholder for the cellular component where the gene product is active. A by-similarity nuclear localization is separately captured by the UniProt/SubCell IEA annotation (GO:0005634).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate ND placeholder; the specific active site/component in S. pombe has not been experimentally established. The nuclear localization is retained via the GO:0005634 IEA annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10069" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PomBase &#34;no data&#34; (ND) placeholder for biological process. No specific biological process has been experimentally assigned to mug151. It is meiotically up-regulated, but a large-scale deletion screen did not identify it among the genes critical for meiotic events, so a specific meiotic (or other) process function remains undetermined.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Honest reflection of the knowledge state for a dark gene. Meiotic up-regulation of the transcript is not evidence of a meiotic function; the unresolved process/role is documented in knowledge_gaps.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16303567" target="_blank" class="term-link">
+                            PMID:16303567
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A large-scale screen in S. pombe identifies seven novel genes required for critical meiotic events.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion screen of 175 meiotically up-regulated S. pombe genes; mug151 was among the deleted genes but was not one of the seven identified as critical for meiotic events, so this reference documents meiotic transcriptional up-regulation rather than a demonstrated specific meiotic function for mug151.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11859360" target="_blank" class="term-link">
+                            PMID:11859360
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The genome sequence of Schizosaccharomyces pombe.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38065098" target="_blank" class="term-link">
+                            PMID:38065098
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SAP30BP interacts with RBM17/SPF45 to promote splicing in a subset of human short introns.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human SAP30BP (a factor previously implicated in transcriptional control) is an essential splicing cofactor for RBM17/SPF45; this documents a splicing role for the SAP30BP/HCNGP family that mug151 belongs to, in human rather than S. pombe.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe mug151 function as a transcriptional co-regulator associated with a Sin3/HDAC (Clr6-type) co-repressor complex, as suggested by its SAP30BP/HCNGP family assignment and the InterPro/PomBase transcription-regulation annotations?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10069" data-a="Q: Does S. pombe mug151 function as a transcriptional..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Alternatively (or additionally), does mug151 act as a pre-mRNA splicing cofactor for a fission-yeast RBM17/SPF45-type factor, mirroring the characterized human SAP30BP splicing role on short introns?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10069" data-a="Q: Alternatively (or additionally), does mug151 act a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does mug151 have a genuine meiosis-specific function, or does its meiotic up-regulation simply reflect meiotic induction of a broadly-acting nuclear regulator that was not scored as critical in the 2005 deletion screen?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10069" data-a="Q: Does mug151 have a genuine meiosis-specific functi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged mug151 from S. pombe extracts followed by mass spectrometry to identify stable interaction partners; specifically test for co-purification with Sin3/HDAC (e.g. Clr6 complex) subunits and with any RBM17/SPF45-type splicing factor.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: mug151 physically associates with the SAP30/Sin3-HDAC co-repressor machinery in fission yeast.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10069" data-a="EXPERIMENT: Affinity-purify tagged mug151 from S. pombe extrac..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform RNA-seq (with intron-retention/splicing analysis) comparing wild-type and mug151-deletion strains during vegetative growth and during meiosis, to distinguish a transcriptional-regulation phenotype from a splicing phenotype and to identify any target transcripts.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: mug151 influences transcription and/or splicing of a defined set of transcripts.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: comparative transcriptomics / splicing analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10069" data-a="EXPERIMENT: Perform RNA-seq (with intron-retention/splicing an..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantify meiotic progression, recombination, spore viability, and chromosome segregation fidelity in mug151-deletion crosses, using assays comparable to those that scored the seven critical genes in the 2005 meiotic screen.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: mug151 has a meiosis-specific role not detectable in standard viability screens.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: meiotic phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10069" data-a="EXPERIMENT: Quantify meiotic progression, recombination, spore..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct molecular function of S. pombe mug151 is undetermined: no catalytic, binding, or other biochemical activity has been experimentally assayed for the protein, and its assignment to the SAP30BP/HCNGP family is purely by sequence and domain conservation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is firmly established is that mug151 is a small nuclear protein carrying the conserved HCNGP domain (Pfam PF07818) of the SAP30BP family, and that the animal ortholog SAP30BP has two documented molecular activities (SAP30/Sin3-associated transcriptional co-regulation and splicing-cofactor activity for RBM17/SPF45). The gap is which, if either, of these activities mug151 actually performs in fission yeast.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> mug151 is a conserved, HCNGP-domain nuclear protein whose family sits at the intersection of chromatin-linked transcriptional repression and pre-mRNA splicing; determining which activity operates in a genetically tractable single-celled eukaryote would clarify the ancestral function of the family and whether the human transcription and splicing roles are separable, related activities.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical and interaction studies (affinity purification-mass spectrometry, directed binding assays) to identify partners, combined with structure-guided separation-of-function assays, would define the molecular activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"we demonstrate that SAP30BP, a factor previously implicated in transcriptional control, is an essential splicing cofactor for RBM17."</em> — PMID:38065098</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unknown whether mug151 has a genuine, specific meiotic function or whether its classification as a &#34;meiotically up-regulated gene&#34; reflects only transcriptional induction of a broadly-acting nuclear protein.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> What is established is that the mug151 transcript is up-regulated during meiosis and that mug151 was among 175 meiotically-upregulated genes deleted in a systematic screen. That screen positively identified seven other genes as critical for meiotic events and did not report mug151 among them; deletion mutants are viable with normal vegetative morphology. The gap is whether mug151 nonetheless contributes to a meiotic process below the sensitivity of that screen.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing induced-expression from actual meiotic requirement is essential to avoid over-interpreting the &#34;mug&#34; designation as evidence of a meiotic role, and would either add mug151 to the catalog of meiotic factors or reassign it to a non-meiotic nuclear process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Detailed meiotic phenotyping of the deletion mutant (recombination, spore viability, chromosome segregation, meiotic progression), and identification of the pathway in which mug151 acts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"we have deleted 175 meiotically upregulated genes and found seven genes not previously reported to be critical for meiotic events."</em> — PMID:16303567</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mug151-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q10069" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mug151-spac3h103-q10069-curation-notes">mug151 (SPAC3H1.03 / Q10069) — curation notes</h1>
+<p>Fission yeast (<em>Schizosaccharomyces pombe</em>) protein. UniProt name: "Meiotically up-regulated<br />
+gene 151 protein". 146 aa. Classified as an UNDERSTUDIED / dark gene.</p>
+<h2 id="identity-provenance-verified-from-fetched-records">Identity / provenance (verified from fetched records)</h2>
+<ul>
+<li>UniProt Q10069, <code>mug151-uniprot.txt</code>: RecName "Meiotically up-regulated gene 151 protein";<br />
+  GN Name=mug151; ORFNames=SPAC3H1.03; taxon 284812 (S. pombe 972).</li>
+<li>PomBase (API <code>www.pombase.org/api/v1/dataset/latest/data/gene/SPAC3H1.03</code>, fetched<br />
+  2026-07-06): <code>name: mug151</code>, <code>product: "SAP30 binding protein ortholog"</code>,<br />
+<code>characterisation_status: "biological role inferred"</code>, <code>feature_type: mRNA gene</code>.<br />
+  This is the key framing: the <em>only</em> functional label PomBase assigns is inferred from the<br />
+  ortholog/domain, NOT from direct experimental characterization of the S. pombe protein.</li>
+</ul>
+<h2 id="domain-family-inline-analysis-of-mug151-uniprottxt">Domain / family (inline analysis of <code>mug151-uniprot.txt</code>)</h2>
+<ul>
+<li><strong>Pfam PF07818 (HCNGP)</strong> — the single defining domain of the protein.</li>
+<li><strong>InterPro IPR012479 "SAP30BP"</strong>.</li>
+<li><strong>PANTHER PTHR13464:SF0 = "SAP30-BINDING PROTEIN"</strong> (family PTHR13464 = "TRANSCRIPTIONAL<br />
+  REGULATOR PROTEIN HCNGP").</li>
+<li>eggNOG <strong>KOG2959</strong> (conserved across Eukaryota).</li>
+<li>Feature table: N-terminal REGION 1..40 "Disordered" (MobiDB-lite); COMPBIAS 21..32<br />
+  "Basic and acidic residues". So the protein is a small (146 aa) protein with a<br />
+  disordered, charged N-terminus followed by the HCNGP globular region — architecture<br />
+  typical of small nuclear adaptor/regulator proteins, NOT of an enzyme (no catalytic<br />
+  domain, no nucleotide/metal-binding motif).</li>
+<li>Sequence has no transmembrane segment and no signal peptide → consistent with the<br />
+  UniProt <code>SUBCELLULAR LOCATION: Nucleus {ECO:0000250}</code> (by similarity).</li>
+</ul>
+<h2 id="ortholog-function-what-the-sap30bphcngp-family-does-metazoan-evidence">Ortholog function — what the SAP30BP/HCNGP family does (metazoan evidence)</h2>
+<p>The human ortholog is <strong>SAP30BP</strong> (SAP30 binding protein; HCNGP family). Two documented,<br />
+non-mutually-exclusive functional threads in the family:</p>
+<ol>
+<li><strong>Transcriptional corepression via SAP30 / Sin3–HDAC.</strong> SAP30BP was identified as a SAP30<br />
+   (Sin3-associated protein 30) binding partner; the family is annotated as an HCNGP<br />
+   transcriptional regulator that promotes histone-deacetylase-mediated repression<br />
+   (NCBI Gene 29115 for SAP30BP; OMIM 610218; the broader SAP30/Sin3 corepressor literature).<br />
+   This is consistent with the PomBase IC annotation GO:0045814 "negative regulation of gene<br />
+   expression, epigenetic" and the InterPro2GO annotation GO:0006355 "regulation of<br />
+   DNA-templated transcription".</li>
+<li><strong>Splicing cofactor for RBM17/SPF45 on short introns.</strong> SAP30BP interacts with RBM17/SPF45<br />
+   and is essential for splicing of a subset of human short introns with truncated<br />
+   polypyrimidine tracts; a UHM in RBM17 binds a UHM-ligand motif in SAP30BP, recruiting<br />
+   RBM17 to phosphorylated SF3B1 [Fukumura et al., Cell Reports 2023, PMID:38065098; the<br />
+   fly homologs of SAP30BP and RBM17 were detected on a short (62 nt) but not long (147 nt)<br />
+   intron, and yeast two-hybrid showed RBM17–SAP30BP interaction — i.e. the interaction is<br />
+   conserved beyond mammals]. This is a MORE RECENTLY characterized function of the family<br />
+   and is arguably the better-supported biochemical role for the domain.</li>
+</ol>
+<p>IMPORTANT CAVEAT: both threads are established for the <em>human/animal</em> ortholog. For S. pombe<br />
+mug151 there is NO published biochemical demonstration of either a SAP30/Sin3 interaction or<br />
+a spliceosomal role; the family assignment is by sequence/domain only. So these inform a<br />
+plausible molecular hypothesis but must NOT be asserted as established S. pombe functions.</p>
+<h2 id="what-is-actually-known-about-mug151-in-s-pombe">What is actually KNOWN about mug151 in S. pombe</h2>
+<ul>
+<li><strong>Meiotically up-regulated</strong>: transcript is induced in meiosis (basis of the "mug" name and<br />
+  the UniProt <code>KW Meiosis</code> / GO:0051321 keyword). Up-regulation of expression during meiosis<br />
+  does NOT by itself establish a meiotic <em>function</em>.</li>
+<li><strong>PMID:16303567</strong> (Martín-Castellanos et al., Curr Biol 2005): a screen deleting 175<br />
+  meiotically-upregulated genes. It reports <strong>seven</strong> genes as critical for meiotic events<br />
+  (rec24, rec25, rec27, tht2, bqt1, bqt2, moa1). <strong>mug151 is NOT among the seven.</strong> mug151 was<br />
+  one of the 175 deletions assayed but showed no reported critical meiotic phenotype in that<br />
+  screen. The UniProt <code>FUNCTION: Has a role in meiosis {ECO:0000269|PubMed:16303567}</code> and the<br />
+<code>mug</code> name therefore rest on membership in the meiotically-upregulated set + the deletion<br />
+  screen, not on a demonstrated specific meiotic mechanism. (Abstract-only in cache;<br />
+  full_text_available: false. Do not overrule the curator — but the annotation is<br />
+  expression-driven, and the screen positively excluded mug151 from its "critical" list.)</li>
+<li><strong>Deletion viable / non-essential</strong>: PomBase phenotype FYPO:0002060 "viable vegetative cell<br />
+  population" and FYPO:0002177 "viable vegetative cell with normal cell morphology" (fetched<br />
+  via PomBase API 2026-07-06). Mild growth phenotypes reported: FYPO:0009007 "decreased<br />
+  vegetative cell population viability", FYPO:0001355 "decreased vegetative cell population<br />
+  growth".</li>
+<li><strong>High-throughput stress-screen phenotypes</strong> (deletion library screens): resistance to<br />
+  cadmium (FYPO:0000763), cycloheximide (FYPO:0000764), diamide (FYPO:0002693), ethanol<br />
+  (FYPO:0001453), tunicamycin (FYPO:0001034), lithium (FYPO:0001583), tert-butyl hydroperoxide<br />
+  (FYPO:0003383), amorolfine (FYPO:0009066); sensitivity to vanadate (FYPO:0003656) and EGTA<br />
+  (FYPO:0007931). These are pleiotropic HT-screen hits, not a specific characterized pathway.</li>
+</ul>
+<h2 id="known-vs-not-known-summary">KNOWN vs NOT-KNOWN summary</h2>
+<p>KNOWN:<br />
+- Small nuclear protein of the SAP30BP/HCNGP (Pfam PF07818) family; human ortholog SAP30BP.<br />
+- Transcript is meiotically up-regulated.<br />
+- Deletion is viable (non-essential), normal cell morphology; only mild/HT-screen phenotypes.<br />
+- Predicted nuclear localization (by similarity).</p>
+<p>NOT KNOWN (genuine gaps):<br />
+- The <strong>molecular function of the S. pombe protein has never been assayed</strong> (GOA carries<br />
+  GO:0003674 ND). No demonstrated catalytic or binding activity in S. pombe.<br />
+- Whether mug151 actually participates in transcriptional corepression (Sin3/HDAC) OR in<br />
+  pre-mRNA splicing (RBM17-type) in S. pombe — the two candidate family functions — is<br />
+  undetermined. The domain is compatible with either, but neither is experimentally<br />
+  demonstrated in fission yeast.<br />
+- Whether mug151 has a genuine, specific meiotic role, or whether its "mug" status simply<br />
+  reflects meiotic transcriptional induction of a broadly-acting nuclear regulator, is<br />
+  unresolved. The 2005 screen did NOT place it among the meiotically-critical genes.<br />
+- No characterized phenotype tying loss of mug151 to a defined biological process.</p>
+<h2 id="annotation-decisions-rationale">Annotation decisions (rationale)</h2>
+<ul>
+<li>GO:0005634 nucleus (IEA, GO_REF:0000044, SubCell): ACCEPT/KEEP_AS_NON_CORE — consistent with<br />
+  UniProt ECO:0000250 nuclear location and family (nuclear transcriptional/splicing regulator).<br />
+  Localization, not the core "function".</li>
+<li>GO:0006355 regulation of DNA-templated transcription (IEA, InterPro IPR012479): the<br />
+  best-supported <em>functional</em> inference from the domain family (transcriptional-regulator<br />
+  family). KEEP_AS_NON_CORE — reasonable domain-based inference but unproven in S. pombe, and<br />
+  the family also has a splicing role, so it is not exclusively transcriptional.</li>
+<li>GO:0045814 negative regulation of gene expression, epigenetic (IC:PomBase): in the UniProt DR<br />
+  block but NOT in the GOA TSV snapshot — noted; consistent with the SAP30/Sin3-HDAC family<br />
+  hypothesis. (Not present as a row in <code>mug151-goa.tsv</code>, so not added as an existing_annotation<br />
+  row; discussed in notes only.)</li>
+<li>GO:0003674 ND / GO:0005575 ND / GO:0008150 ND (PomBase GO_REF:0000015): these are the honest<br />
+  "not yet annotated" placeholders — ACCEPT as accurate reflections of the current knowledge<br />
+  state for a dark gene (do not invent MF/BP/CC to replace them).</li>
+<li>Meiosis: no separate GOA row for GO:0051321 in the TSV (it is the UniProt KW→GO). Treat the<br />
+  meiotic role as expression-driven and unproven; capture in knowledge_gaps.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q10069
+gene_symbol: mug151
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  mug151 (systematic name SPAC3H1.03) is a small (146-residue) nuclear protein of
+  the fission yeast Schizosaccharomyces pombe. It is the fission-yeast member of the
+  SAP30BP/HCNGP family (Pfam PF07818, HCNGP; InterPro IPR012479, SAP30BP; PANTHER
+  PTHR13464:SF0, SAP30-binding protein), whose best-studied member is the human
+  SAP30 binding protein SAP30BP. The protein has a charged, disordered N-terminal
+  region followed by the conserved HCNGP region, an architecture typical of small
+  nuclear adaptor/regulator proteins rather than of an enzyme (no catalytic,
+  nucleotide-binding, or metal-binding motif is present). In animals, proteins of
+  this family act in the nucleus in two documented ways: as transcriptional
+  co-regulators linked to the SAP30/Sin3 histone-deacetylase co-repressor apparatus,
+  and as splicing cofactors for RBM17/SPF45 that promote removal of a subset of short
+  introns. The direct molecular activity of the S. pombe protein has not been
+  experimentally determined; its assignment to this family is by sequence and domain
+  conservation. The transcript is up-regulated during meiosis (the basis of its
+  &#34;meiotically up-regulated gene&#34; name), and deletion mutants are viable with normal
+  vegetative morphology.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: PMID:16303567
+    title: A large-scale screen in S. pombe identifies seven novel genes required for critical meiotic events.
+    findings:
+      - statement: &gt;-
+          Deletion screen of 175 meiotically up-regulated S. pombe genes; mug151 was
+          among the deleted genes but was not one of the seven identified as critical
+          for meiotic events, so this reference documents meiotic transcriptional
+          up-regulation rather than a demonstrated specific meiotic function for mug151.
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified; abstract-only in cache (full_text_available: false). The paper
+        deleted 175 meiotically-upregulated genes and reported seven (rec24, rec25,
+        rec27, tht2, bqt1, bqt2, moa1) as critical for meiosis; mug151 is not among
+        them. It is the basis for the UniProt &#34;role in meiosis&#34; statement, which reflects
+        meiotic up-regulation plus inclusion in the deletion set, not a characterized
+        meiotic mechanism.
+  - id: PMID:11859360
+    title: The genome sequence of Schizosaccharomyces pombe.
+    findings: []
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Genome-sequence reference establishing the SPAC3H1.03 locus; background/contextual,
+        does not address mug151 function.
+  - id: PMID:38065098
+    title: SAP30BP interacts with RBM17/SPF45 to promote splicing in a subset of human short introns.
+    findings:
+      - statement: &gt;-
+          Human SAP30BP (a factor previously implicated in transcriptional control) is an
+          essential splicing cofactor for RBM17/SPF45; this documents a splicing role for
+          the SAP30BP/HCNGP family that mug151 belongs to, in human rather than S. pombe.
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified; abstract-only. Characterizes the human ortholog SAP30BP as a
+        splicing cofactor for RBM17/SPF45 on short introns, and notes it was previously
+        implicated in transcriptional control. Informs the plausible molecular hypotheses
+        for the family but does not assay the S. pombe protein mug151.
+existing_annotations:
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Nuclear localization inferred from the UniProtKB/Swiss-Prot subcellular-location
+        mapping (UniProt records &#34;SUBCELLULAR LOCATION: Nucleus&#34; by similarity,
+        ECO:0000250). This is consistent with the SAP30BP/HCNGP family, whose members are
+        nuclear transcription/splicing regulators, and the protein has no transmembrane or
+        signal features. It is a reasonable localization inference, though not
+        experimentally verified for the S. pombe protein, and describes where the protein
+        is rather than what it does.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Well-supported localization inference (family + UniProt by-similarity), but it is
+        a cellular-component annotation and not a direct statement of molecular function;
+        retained as non-core context.
+  - term:
+      id: GO:0006355
+      label: regulation of DNA-templated transcription
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Domain-based (InterPro IPR012479, SAP30BP; PANTHER PTHR13464 &#34;transcriptional
+        regulator protein HCNGP&#34;) inference of a transcriptional-regulation role. This is
+        the best-supported functional hypothesis from the family assignment, and is
+        broadly consistent with the SAP30/Sin3-HDAC association reported for the animal
+        ortholog. However, it is unproven for the S. pombe protein, and the same family
+        also has a documented pre-mRNA splicing role (via RBM17/SPF45), so transcription
+        regulation is a plausible but not exclusive or established function here.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Reasonable domain-family inference, retained as a plausible (non-core) role.
+        Meiotic up-regulation and family membership do not establish that mug151 actually
+        regulates transcription in S. pombe; there is no experimental support, and the
+        family has an alternative splicing function. Not promoted to a core function.
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        PomBase &#34;no data&#34; (ND) placeholder recording that no molecular function has been
+        experimentally determined for mug151. This accurately reflects the current state
+        of knowledge for this dark gene: the direct molecular activity has never been
+        assayed in S. pombe.
+      action: ACCEPT
+      reason: &gt;-
+        Honest reflection of the knowledge state. No experimental molecular-function data
+        exist; the family-based transcription/splicing hypotheses are captured in
+        knowledge_gaps and suggested_questions rather than asserted as function.
+  - term:
+      id: GO:0005575
+      label: cellular_component
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        PomBase &#34;no data&#34; (ND) placeholder for the cellular component where the gene
+        product is active. A by-similarity nuclear localization is separately captured by
+        the UniProt/SubCell IEA annotation (GO:0005634).
+      action: ACCEPT
+      reason: &gt;-
+        Accurate ND placeholder; the specific active site/component in S. pombe has not
+        been experimentally established. The nuclear localization is retained via the
+        GO:0005634 IEA annotation.
+  - term:
+      id: GO:0008150
+      label: biological_process
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        PomBase &#34;no data&#34; (ND) placeholder for biological process. No specific biological
+        process has been experimentally assigned to mug151. It is meiotically
+        up-regulated, but a large-scale deletion screen did not identify it among the
+        genes critical for meiotic events, so a specific meiotic (or other) process
+        function remains undetermined.
+      action: ACCEPT
+      reason: &gt;-
+        Honest reflection of the knowledge state for a dark gene. Meiotic up-regulation of
+        the transcript is not evidence of a meiotic function; the unresolved
+        process/role is documented in knowledge_gaps.
+core_functions: []
+suggested_questions:
+  - question: &gt;-
+      Does S. pombe mug151 function as a transcriptional co-regulator associated with a
+      Sin3/HDAC (Clr6-type) co-repressor complex, as suggested by its SAP30BP/HCNGP family
+      assignment and the InterPro/PomBase transcription-regulation annotations?
+    experts: []
+  - question: &gt;-
+      Alternatively (or additionally), does mug151 act as a pre-mRNA splicing cofactor for
+      a fission-yeast RBM17/SPF45-type factor, mirroring the characterized human SAP30BP
+      splicing role on short introns?
+    experts: []
+  - question: &gt;-
+      Does mug151 have a genuine meiosis-specific function, or does its meiotic
+      up-regulation simply reflect meiotic induction of a broadly-acting nuclear regulator
+      that was not scored as critical in the 2005 deletion screen?
+    experts: []
+suggested_experiments:
+  - hypothesis: &gt;-
+      mug151 physically associates with the SAP30/Sin3-HDAC co-repressor machinery in
+      fission yeast.
+    description: &gt;-
+      Affinity-purify tagged mug151 from S. pombe extracts followed by mass spectrometry to
+      identify stable interaction partners; specifically test for co-purification with
+      Sin3/HDAC (e.g. Clr6 complex) subunits and with any RBM17/SPF45-type splicing factor.
+    experiment_type: affinity purification-mass spectrometry
+  - hypothesis: &gt;-
+      mug151 influences transcription and/or splicing of a defined set of transcripts.
+    description: &gt;-
+      Perform RNA-seq (with intron-retention/splicing analysis) comparing wild-type and
+      mug151-deletion strains during vegetative growth and during meiosis, to distinguish a
+      transcriptional-regulation phenotype from a splicing phenotype and to identify any
+      target transcripts.
+    experiment_type: comparative transcriptomics / splicing analysis
+  - hypothesis: &gt;-
+      mug151 has a meiosis-specific role not detectable in standard viability screens.
+    description: &gt;-
+      Quantify meiotic progression, recombination, spore viability, and chromosome
+      segregation fidelity in mug151-deletion crosses, using assays comparable to those
+      that scored the seven critical genes in the 2005 meiotic screen.
+    experiment_type: meiotic phenotyping
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The direct molecular function of S. pombe mug151 is undetermined: no catalytic,
+      binding, or other biochemical activity has been experimentally assayed for the
+      protein, and its assignment to the SAP30BP/HCNGP family is purely by sequence and
+      domain conservation.
+    boundary: &gt;-
+      What is firmly established is that mug151 is a small nuclear protein carrying the
+      conserved HCNGP domain (Pfam PF07818) of the SAP30BP family, and that the animal
+      ortholog SAP30BP has two documented molecular activities (SAP30/Sin3-associated
+      transcriptional co-regulation and splicing-cofactor activity for RBM17/SPF45). The
+      gap is which, if either, of these activities mug151 actually performs in fission
+      yeast.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      mug151 is a conserved, HCNGP-domain nuclear protein whose family sits at the
+      intersection of chromatin-linked transcriptional repression and pre-mRNA splicing;
+      determining which activity operates in a genetically tractable single-celled
+      eukaryote would clarify the ancestral function of the family and whether the human
+      transcription and splicing roles are separable, related activities.
+    resolution: &gt;-
+      Biochemical and interaction studies (affinity purification-mass spectrometry,
+      directed binding assays) to identify partners, combined with structure-guided
+      separation-of-function assays, would define the molecular activity.
+    provenance:
+      - reference_id: PMID:38065098
+        supporting_text: &gt;-
+          we demonstrate that SAP30BP, a factor previously implicated in transcriptional
+          control, is an essential splicing cofactor for RBM17.
+  - gap_statement: &gt;-
+      It is unknown whether mug151 has a genuine, specific meiotic function or whether its
+      classification as a &#34;meiotically up-regulated gene&#34; reflects only transcriptional
+      induction of a broadly-acting nuclear protein.
+    boundary: &gt;-
+      What is established is that the mug151 transcript is up-regulated during meiosis and
+      that mug151 was among 175 meiotically-upregulated genes deleted in a systematic
+      screen. That screen positively identified seven other genes as critical for meiotic
+      events and did not report mug151 among them; deletion mutants are viable with normal
+      vegetative morphology. The gap is whether mug151 nonetheless contributes to a meiotic
+      process below the sensitivity of that screen.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Distinguishing induced-expression from actual meiotic requirement is essential to
+      avoid over-interpreting the &#34;mug&#34; designation as evidence of a meiotic role, and
+      would either add mug151 to the catalog of meiotic factors or reassign it to a
+      non-meiotic nuclear process.
+    resolution: &gt;-
+      Detailed meiotic phenotyping of the deletion mutant (recombination, spore viability,
+      chromosome segregation, meiotic progression), and identification of the pathway in
+      which mug151 acts.
+    provenance:
+      - reference_id: PMID:16303567
+        supporting_text: &gt;-
+          we have deleted 175 meiotically upregulated genes and found seven genes not
+          previously reported to be critical for meiotic events.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/nce101/nce101-ai-review.html
+++ b/genes/SCHPO/nce101/nce101-ai-review.html
@@ -1,0 +1,2659 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>nce101 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>nce101</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/C6Y4B6" target="_blank" class="term-link">
+                        C6Y4B6
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "nce101";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="C6Y4B6" data-a="DESCRIPTION: nce101 (SPAC12G12.17) is a small (58 amino acid) m..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>nce101 (SPAC12G12.17) is a small (58 amino acid) membrane-associated microprotein of fission yeast and the sole S. pombe member of the NCE101 family (InterPro IPR024242, Pfam PF11654, PANTHER PTHR28011), orthologous to Saccharomyces cerevisiae NCE101 (NCE1). The protein carries a single predicted transmembrane helix (residues 10-27) and a short, basic-residue-enriched C-terminal tail, features consistent with a single-pass membrane protein, though its topology and precise subcellular localization have not been experimentally determined. The founding member of the family, budding yeast NCE1, was recovered in a genetic screen for factors affecting a signal-sequence-independent (&#34;non-classical&#34;) protein export pathway, and the family is therefore annotated to protein secretion/transport; the original study could not distinguish whether the small protein is part of the export machinery or is itself a non-classically secreted substrate. No molecular activity, interaction partner, or catalytic motif has been identified for the S. pombe protein, and it is classified as a conserved protein of unknown biological role. Genome-wide deletion profiling of the nce101 deletion reports only broad, pleiotropic chemical-stress sensitivity and resistance phenotypes, none of which isolate a specific molecular function.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009306" target="_blank" class="term-link">
+                                    GO:0009306
+                                </a>
+                            </span>
+                            <span class="term-label">protein secretion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="C6Y4B6" data-a="GO:0009306" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of protein secretion across the NCE101 family (PANTHER PTN001997334), seeded by S. cerevisiae NCE101 whose own annotation derives from the Cleves et al. 1996 non-classical export screen (IGI:SGD, PMID:8655575). This is a defensible family-level inference and there is no positive evidence against it, so it is retained; however it is an indirect inference for a gene with no direct functional data, and even in the founding study the protein&#39;s role (machinery versus substrate) was ambiguous, so it should not be treated as an experimentally established core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable phylogenetic inference for an uncharacterized family member, but not demonstrated for the S. pombe protein and interpretively ambiguous at source; keep as a non-core, low-confidence functional context rather than a core function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">SOURCE EVIDENCE WEAK</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q02820</span>
+
+                                    &middot; S. cerevisiae NCE101 (NCE1)
+
+
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
+
+
+                                    <div class="propagation-comment">Seed annotation is IGI from a single overexpression screen (PMID:8655575) in which the small NCE1 protein&#39;s role was ambiguous (machinery versus exported substrate).</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009306" target="_blank" class="term-link">
+                                    GO:0009306
+                                </a>
+                            </span>
+                            <span class="term-label">protein secretion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="C6Y4B6" data-a="GO:0009306" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping of the NCE101 family signature (IPR024242) to protein secretion. This is the same family-level inference as the IBA annotation, mapped from the domain model rather than the phylogenetic tree, and is redundant with it. Accurate at the family level but uninformative about the specific molecular function of the S. pombe protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct family-signature-to-GO mapping but redundant with the IBA and not evidence of a demonstrated function; retain as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="C6Y4B6" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Membrane localization mapped from the UniProtKB subcellular-location keyword, which itself rests on a single predicted transmembrane helix (residues 10-27, ECO:0000255) and the curator-inferred single-pass membrane assignment (ECO:0000305). Consistent with the sequence but not experimentally verified; note the S. cerevisiae ortholog also carries a cytosol (HDA) annotation, so the localization is not firmly established. This is an accurate but low-information cellular-component term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization is only predicted (single TM helix) and not experimentally confirmed; the term is not wrong but is uninformative and non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C6Y4B6" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with the ND (no biological data) evidence code, correctly recording that no molecular function has been experimentally determined for nce101. There is no biochemical activity, ligand, substrate, or catalytic motif described for this protein or its family, so ND is the honest and appropriate annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND correctly captures a genuine molecular-function knowledge gap; retaining it is the accurate curatorial choice for a dark gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005575" target="_blank" class="term-link">
+                                    GO:0005575
+                                </a>
+                            </span>
+                            <span class="term-label">cellular_component</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C6Y4B6" data-a="GO:0005575" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root cellular_component term with ND evidence, from PomBase. The only localization signal is the predicted transmembrane helix (captured separately by the UniProt SubCell membrane IEA); no experimental localization has been reported, so PomBase&#39;s ND annotation reflects the absence of curated CC evidence. Retained as an honest record of the gap.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurately records that no experimentally supported cellular component is curated; consistent with a conserved-unknown-function gene.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008150" target="_blank" class="term-link">
+                                    GO:0008150
+                                </a>
+                            </span>
+                            <span class="term-label">biological_process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="C6Y4B6" data-a="GO:0008150" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root biological_process term with ND evidence. No biological process has been experimentally established for the S. pombe gene; deletion phenotypes are limited to broad, pleiotropic chemical-stress sensitivities and resistances that do not define a specific pathway, and the family-level protein secretion inference is captured by the IBA/IEA annotations. ND appropriately marks the absence of a curated process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ND honestly records an unknown biological process; the pleiotropic drug phenotypes do not support a specific BP annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>No molecular function can be assigned with confidence. nce101 is a small single-pass membrane microprotein of the NCE101 family whose only functional association, protein secretion / non-classical protein export, is a family-level phylogenetic inference (IBA/InterPro) transferred from budding yeast NCE101 and is interpretively ambiguous at its experimental source (the founding study could not distinguish an export-machinery role from an export-substrate role). No molecular_function term is asserted here because none is supported by direct evidence; the molecular function is an open question (see knowledge_gaps).</h3>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="FUNCTION: No molecular function can be assigned with confide..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8655575" target="_blank" class="term-link">
+                                PMID:8655575
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">A screen for components of the export machinery has identified genes that are involved in nonclassical export. These findings demonstrate a new pathway for protein export that is distinct from the classical secretory pathway in yeast.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11859360" target="_blank" class="term-link">
+                            PMID:11859360
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The genome sequence of Schizosaccharomyces pombe.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18488015" target="_blank" class="term-link">
+                            PMID:18488015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynamic repertoire of a eukaryotic transcriptome surveyed at single-nucleotide resolution.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8655575" target="_blank" class="term-link">
+                            PMID:8655575
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A new pathway for protein export in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Defines the non-classical (signal-sequence-independent) protein export pathway in budding yeast and, through a genetic screen, identified the founding NCE genes including NCE1/NCE101, the ortholog of S. pombe nce101. Establishes the family-level basis for the protein secretion / protein transport annotations, but the paper&#39;s molecular characterization is performed on NCE2, not on the small NCE1 gene product, whose role (machinery versus exported substrate) was left unresolved.</div>
+
+                        <div class="finding-text">"A screen for components of the export machinery has identified genes that are involved in nonclassical export. These findings demonstrate a new pathway for protein export that is distinct from the classical secretory pathway in yeast."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe possess a non-classical (signal-sequence-independent) protein export pathway, and if so does nce101 contribute to it?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="Q: Does S. pombe possess a non-classical (signal-sequ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is nce101 a component of a transport/export machinery or is it itself a secreted or membrane-cargo substrate, as the ambiguity in the founding budding-yeast study implies?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="Q: Is nce101 a component of a transport/export machin..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the true subcellular localization and membrane topology of the Nce101 protein?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="Q: What is the true subcellular localization and memb..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the endogenous subcellular localization and membrane topology of Nce101 by tagging (avoiding tag-induced mislocalization of a 58-aa protein), fluorescence microscopy, and protease-protection / carbonate-extraction membrane fractionation.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Fluorescence microscopy and membrane fractionation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="EXPERIMENT: Determine the endogenous subcellular localization ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Identify physical interaction partners by co-immunoprecipitation/mass spectrometry or proximity labeling to test the export-machinery hypothesis, and perform secretome analysis of nce101-delta versus wild type to test whether it affects non-classical protein secretion.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Affinity purification / mass spectrometry and secretome analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="EXPERIMENT: Identify physical interaction partners by co-immun..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Characterize nce101-delta (and combinations with related small membrane proteins, to control for redundancy) under the stress conditions flagged by chemical-genomics screens to connect the pleiotropic phenotypes to a defined cellular process.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Genetic / phenotypic characterization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="C6Y4B6" data-a="EXPERIMENT: Characterize nce101-delta (and combinations with r..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of nce101 is undetermined: no biochemical activity, ligand, substrate, catalytic residue, or diagnostic sequence motif has been identified for the protein or the NCE101 family.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The protein is a defined 58-aa NCE101-family member with a single predicted transmembrane helix; its only functional association (protein secretion / non-classical export) is an indirect inference from an overexpression/genetic screen of the S. cerevisiae ortholog, in which the founding authors could not determine whether the small protein acts as part of the export machinery or is itself a non-classically secreted substrate.</p>
+
+
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process in which nce101 participates in S. pombe is unknown, and it has not been shown that fission yeast operates a non-classical protein export pathway through nce101.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Genome-wide deletion profiling of nce101-delta reports only broad, pleiotropic chemical-stress phenotypes (sensitivity to cadmium, diamide, valproate and vanadate; resistance to lithium, MMS, tert-butyl hydroperoxide, EGTA, amorolfine, and various salt/SDS combinations) that do not point to a single pathway.</p>
+
+
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization and membrane topology of Nce101 are experimentally undetermined: it is unclear whether the protein is stably membrane-integral, which membrane it occupies, and in what orientation (N-in versus N-out, signal-anchored versus tail-anchored).</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Membrane association is inferred solely from a single predicted transmembrane helix (residues 10-27) and a curator-assigned single-pass membrane annotation; the S. cerevisiae ortholog additionally carries a high-throughput cytosol annotation.</p>
+
+
+
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No loss-of-function phenotype isolates a specific molecular or cellular role, and no interacting partners, complex membership, or regulatory context are known; it is also unresolved whether nce101 is functionally redundant with other small membrane microproteins, which would mask deletion phenotypes.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">WHOLLY_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> A viable deletion strain exists and has been chemically profiled, but the resulting phenotypes are pleiotropic and non-diagnostic.</p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(nce101-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="C6Y4B6" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *nce101* (SPAC12G12.17) in *Schizosaccharomyces pombe*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">27 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T16:47:59.912326</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="nce101-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-nce101-spac12g1217-in-schizosaccharomyces-pombe">Comprehensive Research Report: <em>nce101</em> (SPAC12G12.17) in <em>Schizosaccharomyces pombe</em></h1>
+<h2 id="1-geneprotein-identity-and-nomenclature">1. Gene/Protein Identity and Nomenclature</h2>
+<p>The <em>nce101</em> gene (systematic name SPAC12G12.17) in <em>Schizosaccharomyces pombe</em> (strain 972/ATCC 24843) encodes a protein designated "Non-classical export protein 1" (UniProt accession C6Y4B6). The protein belongs to the NCE101 family, characterized by the NCE101 domain (InterPro: IPR024242; Pfam: PF11654). It is critical to distinguish this protein from the much more extensively studied Nce102 protein, as the two are frequently confused due to their similar names but represent fundamentally different protein families with distinct sizes, domain architectures, and levels of functional characterization.</p>
+<h2 id="2-historical-context-discovery-of-the-nce-gene-family">2. Historical Context: Discovery of the NCE Gene Family</h2>
+<p>The NCE (Non-Classical Export) gene nomenclature originates from a landmark study by Cleves et al. (1996), who investigated non-classical protein secretion in <em>Saccharomyces cerevisiae</em>. In this study, the mammalian protein galectin-1—which lacks a classical secretory signal sequence yet is exported from cells—was expressed in yeast. Galectin-1 was shown to be exported across the yeast plasma membrane by a novel mechanism that does not require the classical secretory pathway (Sec18p-dependent) nor the multidrug resistance-like transporter Ste6p (cleves1996anewpathway pages 1-2, cleves1996anewpathway pages 4-6). A genetic screen for components of this non-classical export machinery identified three genes: <em>NCE1</em>, <em>NCE2</em>, and <em>NCE3</em> (cleves1996anewpathway pages 4-6, cleves1996anewpathway pages 8-9).</p>
+<p><strong>NCE1</strong> (the <em>S. cerevisiae</em> ortholog of <em>S. pombe</em> nce101) encodes a small 53-amino acid protein. It was one of four novel proteins smaller than 100 amino acids identified in the screen. The NCE1 genomic sequence contains a 143-bp intron between nucleotides 32 and 33 of the cDNA (between the second and third nucleotide of the Lys11 codon), and its sequence was confirmed by homology to genomic sequence SCPRP21 on chromosome X (cleves1996anewpathway pages 6-6). The small size of the open reading frame and the presence of the intron likely explain why NCE1 was not originally annotated in the database sequence (cleves1996anewpathway pages 6-6).</p>
+<p>Regarding NCE1's precise role, the original investigators suggested that "the small NCE1 gene product may be part of the export machinery, or, along with the other low molecular weight proteins identified in the screen, may also be a substrate for nonclassical export" (cleves1996anewpathway pages 8-9). The exact mechanism by which NCE1 participates in non-classical export has not been definitively resolved.</p>
+<h2 id="3-critical-distinction-nce101-vs-nce102">3. Critical Distinction: NCE101 vs. NCE102</h2>
+<p>A key finding from this research is that NCE101 (Nce1) and NCE102 (Nce102/Nce2) are entirely distinct proteins that should not be conflated:</p>
+<ul>
+<li>
+<p><strong>NCE1/NCE101</strong> encodes a small ~53-amino acid protein belonging to the NCE101 family (PF11654). It was identified in the non-classical export screen but remains poorly characterized (cleves1996anewpathway pages 6-6).</p>
+</li>
+<li>
+<p><strong>NCE2/NCE102</strong> encodes a much larger 173-amino acid protein with four predicted transmembrane domains, belonging to the MARVEL-domain tetraspan protein family. It is extensively studied as a critical component of MCC (Membrane Compartment of Can1)/eisosome domains (cleves1996anewpathway pages 6-6, cleves1996anewpathway pages 6-8, athanasopoulos2019fungalplasmamembrane pages 6-7).</p>
+</li>
+</ul>
+<p>The following table summarizes the key differences between these two protein families:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>NCE101/Nce1</th>
+<th>NCE102/Nce102</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name (<em>S. cerevisiae</em>)</td>
+<td><strong>NCE1</strong>; small ORF first identified in a non-classical export screen (cleves1996anewpathway pages 4-6, cleves1996anewpathway pages 6-6)</td>
+<td><strong>NCE2 / NCE102</strong>; the better-characterized MCC/eisosome tetraspan protein (cleves1996anewpathway pages 6-8, grossmann2008plasmamembranemicrodomains pages 4-5, lanze2020plasmamembranemcceisosome pages 5-6)</td>
+</tr>
+<tr>
+<td>Gene name (<em>S. pombe</em>)</td>
+<td><strong>nce101</strong>; ORF <strong>SPAC12G12.17</strong> (UniProt annotation from prompt; family context supported by NCE1 literature) (cleves1996anewpathway pages 6-6)</td>
+<td><strong>fhn1</strong>; the fission-yeast Nce102 homolog (<strong>SpFhn1</strong>) (athanasopoulos2019fungalplasmamembrane pages 6-7)</td>
+</tr>
+<tr>
+<td>Protein size (amino acids)</td>
+<td><strong>53 aa</strong> in <em>S. cerevisiae</em> Nce1 (cleves1996anewpathway pages 6-6)</td>
+<td><strong>173 aa</strong> in <em>S. cerevisiae</em> Nce102/Nce2 (cleves1996anewpathway pages 6-6, cleves1996anewpathway pages 6-8)</td>
+</tr>
+<tr>
+<td>Domain/family</td>
+<td><strong>NCE101 family</strong>; fungal-specific family including PF11654 / IPR024242; poorly characterized experimentally (family assignment from prompt; primary literature establishes the NCE1 small-protein class) (cleves1996anewpathway pages 6-6)</td>
+<td><strong>MARVEL-domain / Nce102-family tetraspan membrane protein</strong> associated with MCC/eisosomes (athanasopoulos2019fungalplasmamembrane pages 6-7, lanze2020plasmamembranemcceisosome pages 5-6)</td>
+</tr>
+<tr>
+<td>Transmembrane domains</td>
+<td><strong>Not established directly in the cited primary literature</strong> for <em>S. cerevisiae</em> Nce1; small protein with limited structural characterization (cleves1996anewpathway pages 6-6)</td>
+<td><strong>4 transmembrane domains</strong> predicted for <em>S. cerevisiae</em> Nce102/Nce2 (cleves1996anewpathway pages 6-8, athanasopoulos2019fungalplasmamembrane pages 6-7)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Unclear / poorly characterized</strong> for Nce1; original work did not define a precise localization (cleves1996anewpathway pages 8-9, cleves1996anewpathway pages 6-6)</td>
+<td><strong>Plasma membrane MCC/eisosome domain</strong>; localizes to plasma-membrane invaginations/furrows (kim2016theplasmamembrane pages 1-2, grossmann2008plasmamembranemicrodomains pages 2-4, lanze2020plasmamembranemcceisosome pages 5-6)</td>
+</tr>
+<tr>
+<td>Known function</td>
+<td>Implicated in <strong>non-classical protein export</strong>; may be part of export machinery or itself a non-classical export substrate, but remains poorly defined (cleves1996anewpathway pages 4-6, cleves1996anewpathway pages 8-9, cleves1996anewpathway pages 6-6)</td>
+<td><strong>Sphingolipid-responsive MCC/eisosome organizer and sensor</strong>; regulates transporter partitioning, endocytosis protection, and signaling linked to lipid homeostasis (frohlich2010analysisofsphingolipidsignaling pages 81-82, zahumensky2019roleofmcceisosome pages 7-9, athanasopoulos2019fungalplasmamembrane pages 8-9, grossmann2008plasmamembranemicrodomains pages 4-5)</td>
+</tr>
+<tr>
+<td>Role in eisosomes</td>
+<td><strong>No direct evidence for a defined eisosome role</strong>; should not be conflated with Nce102 (cleves1996anewpathway pages 8-9, cleves1996anewpathway pages 6-6)</td>
+<td><strong>Core functional MCC/eisosome protein</strong>; required for proper eisosome assembly and stability in budding yeast, and its homolog is required in fission yeast (athanasopoulos2019fungalplasmamembrane pages 6-7)</td>
+</tr>
+<tr>
+<td><em>S. pombe</em> ortholog name</td>
+<td><strong>nce101</strong> (same family/gene designation in fission yeast)</td>
+<td><strong>SpFhn1</strong> (the Nce102 homolog in fission yeast) (athanasopoulos2019fungalplasmamembrane pages 6-7)</td>
+</tr>
+<tr>
+<td>UniProt accession (<em>S. pombe</em>)</td>
+<td><strong>C6Y4B6</strong> (from prompt)</td>
+<td><strong>Not established in the cited contexts</strong></td>
+</tr>
+<tr>
+<td>Characterization status</td>
+<td><strong>Poorly characterized</strong>; literature is sparse and largely inferential beyond the original export screen (cleves1996anewpathway pages 8-9, cleves1996anewpathway pages 6-6)</td>
+<td><strong>Well characterized</strong> relative to Nce1; extensively studied in plasma-membrane domain and eisosome biology (frohlich2010analysisofsphingolipidsignaling pages 81-82, athanasopoulos2019fungalplasmamembrane pages 6-7, athanasopoulos2019fungalplasmamembrane pages 8-9, lanze2020plasmamembranemcceisosome pages 5-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table contrasts the poorly characterized NCE101/Nce1 family with the well-studied NCE102/Nce102 family in budding and fission yeast. It is useful for avoiding a common annotation error: Nce101 and Nce102 are distinct proteins with different sizes, families, and biological roles.</em></p>
+<h2 id="4-functional-annotation-by-inference-from-the-s-cerevisiae-ortholog">4. Functional Annotation by Inference from the S. cerevisiae Ortholog</h2>
+<h3 id="41-non-classical-protein-export">4.1 Non-Classical Protein Export</h3>
+<p>The primary function attributed to NCE101 family proteins derives from the Cleves et al. (1996) genetic screen. Overexpression of the <em>NCE1</em> cDNA (along with <em>NCE2</em>) caused a ~10-fold increase in galectin-1 export from a Δ<em>ste6</em> background, increasing high-pH-extractable galectin-1 from 0.5% to approximately 6.8% (cleves1996anewpathway pages 4-6). This indicates that NCE1 gene products affect the non-classical protein secretion machinery. The NCE1 gene was described as "involved in protein secretion" in subsequent transcriptomic studies (miura2006alargescalefulllength pages 4-5). However, it remains unclear whether NCE1 is a component of the export machinery itself or an indirect modulator.</p>
+<p>Non-classical protein export in yeast appears to involve redundant pathways. Deletion of individual components (such as NCE2 or STE6) does not eliminate all non-classical export, and the profile of exported proteins in <em>sec18</em>ts/<em>nce2</em>Δ double mutants was not significantly different from <em>sec18</em>ts alone (cleves1996anewpathway pages 8-9, cleves1996anewpathway pages 9-10). This redundancy makes it difficult to assign a precise mechanistic role to NCE1 alone.</p>
+<h3 id="42-possible-relationship-to-membrane-organization">4.2 Possible Relationship to Membrane Organization</h3>
+<p>While NCE102 (Nce102) is well-established as a critical MCC/eisosome protein in <em>S. cerevisiae</em>—functioning as a sphingolipid sensor that regulates eisosome assembly through inhibition of Pkh1/2 kinases (frohlich2010analysisofsphingolipidsignaling pages 81-82, athanasopoulos2019fungalplasmamembrane pages 6-7, athanasopoulos2019fungalplasmamembrane pages 8-9)—there is no direct evidence placing NCE101 in the eisosome complex. The MCC/eisosome literature consistently lists Nce102 (not Nce101) among the integral membrane proteins of the MCC domain, alongside Sur7 family tetraspans and nutrient transporters (grossmann2008plasmamembranemicrodomains pages 2-4, lanze2020plasmamembranemcceisosome pages 5-6).</p>
+<h2 id="5-context-in-s-pombe-eisosome-biology-and-membrane-organization">5. Context in <em>S. pombe</em>: Eisosome Biology and Membrane Organization</h2>
+<p>Although direct literature on <em>S. pombe</em> nce101 is essentially absent, the broader context of eisosome biology in fission yeast is relevant for understanding the cellular environment in which this protein may function.</p>
+<p>In <em>S. pombe</em>, eisosomes are multiprotein structures that generate linear invaginations at the plasma membrane (cansado2021thefissionyeast pages 6-8). The scaffold proteins Pil1 and Pil2 (Lsp1 homologs) are the core structural components, containing BAR domains that promote membrane curvature (athanasopoulos2019fungalplasmamembrane pages 5-6). The Nce102 homolog in <em>S. pombe</em> is called <strong>SpFhn1</strong>, and it is required for proper eisosome assembly—deletion of SpFhn1 reduces Pil1 foci to approximately 15% (athanasopoulos2019fungalplasmamembrane pages 6-7). SpFhn1, like <em>S. cerevisiae</em> Nce102, contains a conserved MARVEL transmembrane domain and is the only transmembrane protein known to be required for eisosome assembly (athanasopoulos2019fungalplasmamembrane pages 6-7).</p>
+<p>Eisosomes in <em>S. pombe</em> have been implicated in several cellular processes:</p>
+<ul>
+<li><strong>Membrane reservoir function</strong>: Eisosomes provide membrane reservoirs for rapid expansion of the plasma membrane.</li>
+<li><strong>Lipid homeostasis</strong>: MCC/eisosome domains form contact sites between the cortical endoplasmic reticulum and the plasma membrane, likely important for lipid homeostasis (lanze2020plasmamembranemcceisosome pages 16-17).</li>
+<li><strong>Cell integrity signaling</strong>: Eisosomes modulate the cell integrity pathway (CIP) through regulation of Rho2 localization and phosphoinositide turnover, affecting Pmk1 MAPK activation during osmotic stress (cansado2021thefissionyeast pages 6-8).</li>
+<li><strong>PI(4,5)P₂ regulation</strong>: MCC/eisosomes regulate PI(4,5)P₂ levels, which play a central role in recruiting plasma membrane components that regulate cell wall synthesis and morphogenesis (lanze2020plasmamembranemcceisosome pages 16-17).</li>
+</ul>
+<h2 id="6-domain-and-structural-considerations">6. Domain and Structural Considerations</h2>
+<p>The <em>S. pombe</em> Nce101 protein belongs to the NCE101 family (PF11654/IPR024242), a fungal-specific protein family. Based on the <em>S. cerevisiae</em> ortholog, the protein is small (~53 amino acids) and contains at least one predicted hydrophobic region, though the original study by Cleves et al. did not report transmembrane domain predictions for NCE1 (the four-transmembrane domain model was reported only for NCE2) (cleves1996anewpathway pages 6-6, cleves1996anewpathway pages 6-8). The small size of the protein and its association with a non-classical export pathway suggest it may function as either a small membrane-associated accessory factor or as a substrate for non-classical secretion.</p>
+<h2 id="7-subcellular-localization">7. Subcellular Localization</h2>
+<p>No direct experimental localization data for <em>S. pombe</em> Nce101 were identified in the literature surveyed. Based on its implication in non-classical export and its annotation as a membrane-associated protein, the protein likely localizes to the plasma membrane or is exported through non-classical mechanisms. However, this inference should be treated with caution in the absence of direct experimental evidence such as fluorescence microscopy or subcellular fractionation studies.</p>
+<h2 id="8-summary-and-limitations">8. Summary and Limitations</h2>
+<p>The <em>S. pombe</em> nce101 gene (SPAC12G12.17, UniProt C6Y4B6) encodes a small protein of the NCE101 family that is implicated in non-classical protein export based on studies of its <em>S. cerevisiae</em> ortholog. The gene was originally identified in a genetic screen for components of a novel protein secretion pathway that operates independently of the classical ER-Golgi secretory pathway and the Ste6p ABC transporter (cleves1996anewpathway pages 1-2, cleves1996anewpathway pages 8-9). The protein is <strong>distinct from Nce102</strong>, which is a well-characterized MARVEL-domain tetraspan protein critical for eisosome/MCC assembly and sphingolipid sensing. In <em>S. pombe</em>, the Nce102 homolog is SpFhn1, not Nce101.</p>
+<p><strong>Key limitations of this report</strong>: Direct experimental studies on <em>S. pombe</em> nce101 are essentially absent from the literature. The functional annotation is primarily inferred from the <em>S. cerevisiae</em> ortholog NCE1, which itself remains poorly characterized beyond its identification in the non-classical export screen. The precise biochemical function, subcellular localization, interaction partners, and pathway context of Nce101 in <em>S. pombe</em> remain open questions requiring targeted experimental investigation.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(cleves1996anewpathway pages 1-2): A E Cleves, D N Cooper, S H Barondes, and R B Kelly. A new pathway for protein export in saccharomyces cerevisiae. The Journal of Cell Biology, 133:1017-1026, Jun 1996. URL: https://doi.org/10.1083/jcb.133.5.1017, doi:10.1083/jcb.133.5.1017. This article has 269 citations.</p>
+</li>
+<li>
+<p>(cleves1996anewpathway pages 4-6): A E Cleves, D N Cooper, S H Barondes, and R B Kelly. A new pathway for protein export in saccharomyces cerevisiae. The Journal of Cell Biology, 133:1017-1026, Jun 1996. URL: https://doi.org/10.1083/jcb.133.5.1017, doi:10.1083/jcb.133.5.1017. This article has 269 citations.</p>
+</li>
+<li>
+<p>(cleves1996anewpathway pages 8-9): A E Cleves, D N Cooper, S H Barondes, and R B Kelly. A new pathway for protein export in saccharomyces cerevisiae. The Journal of Cell Biology, 133:1017-1026, Jun 1996. URL: https://doi.org/10.1083/jcb.133.5.1017, doi:10.1083/jcb.133.5.1017. This article has 269 citations.</p>
+</li>
+<li>
+<p>(cleves1996anewpathway pages 6-6): A E Cleves, D N Cooper, S H Barondes, and R B Kelly. A new pathway for protein export in saccharomyces cerevisiae. The Journal of Cell Biology, 133:1017-1026, Jun 1996. URL: https://doi.org/10.1083/jcb.133.5.1017, doi:10.1083/jcb.133.5.1017. This article has 269 citations.</p>
+</li>
+<li>
+<p>(cleves1996anewpathway pages 6-8): A E Cleves, D N Cooper, S H Barondes, and R B Kelly. A new pathway for protein export in saccharomyces cerevisiae. The Journal of Cell Biology, 133:1017-1026, Jun 1996. URL: https://doi.org/10.1083/jcb.133.5.1017, doi:10.1083/jcb.133.5.1017. This article has 269 citations.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 6-7): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(grossmann2008plasmamembranemicrodomains pages 4-5): Guido Grossmann, Jan Malinsky, Wiebke Stahlschmidt, Martin Loibl, Ina Weig-Meckl, Wolf B. Frommer, Miroslava Opekarová, and Widmar Tanner. Plasma membrane microdomains regulate turnover of transport proteins in yeast. The Journal of Cell Biology, 183:1075-1088, Dec 2008. URL: https://doi.org/10.1083/jcb.200806035, doi:10.1083/jcb.200806035. This article has 284 citations.</p>
+</li>
+<li>
+<p>(lanze2020plasmamembranemcceisosome pages 5-6): Carla E. Lanze, Rafael M. Gandra, Jenna E. Foderaro, Kara A. Swenson, Lois M. Douglas, and James B. Konopka. Plasma membrane mcc/eisosome domains promote stress resistance in fungi. Nov 2020. URL: https://doi.org/10.1128/mmbr.00063-19, doi:10.1128/mmbr.00063-19. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kim2016theplasmamembrane pages 1-2): Hyung J. Kim, Mi-Young Jeong, Timothy J. Parnell, Markus Babst, John D. Phillips, and Dennis R. Winge. The plasma membrane protein nce102 implicated in eisosome formation rescues a heme defect in mitochondria. Journal of Biological Chemistry, 291:17417-17426, Aug 2016. URL: https://doi.org/10.1074/jbc.m116.727743, doi:10.1074/jbc.m116.727743. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(grossmann2008plasmamembranemicrodomains pages 2-4): Guido Grossmann, Jan Malinsky, Wiebke Stahlschmidt, Martin Loibl, Ina Weig-Meckl, Wolf B. Frommer, Miroslava Opekarová, and Widmar Tanner. Plasma membrane microdomains regulate turnover of transport proteins in yeast. The Journal of Cell Biology, 183:1075-1088, Dec 2008. URL: https://doi.org/10.1083/jcb.200806035, doi:10.1083/jcb.200806035. This article has 284 citations.</p>
+</li>
+<li>
+<p>(frohlich2010analysisofsphingolipidsignaling pages 81-82): Florian Fröhlich. Analysis of sphingolipid-signaling at the plasma membrane of saccharomyces cerevisiae. Dissertation, Jan 2010. URL: https://doi.org/10.5282/edoc.12051, doi:10.5282/edoc.12051. This article has 1 citations.</p>
+</li>
+<li>
+<p>(zahumensky2019roleofmcceisosome pages 7-9): Jakub Zahumensky and Jan Malinsky. Role of mcc/eisosome in fungal lipid homeostasis. Biomolecules, 9:305, Jul 2019. URL: https://doi.org/10.3390/biom9080305, doi:10.3390/biom9080305. This article has 51 citations.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 8-9): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(miura2006alargescalefulllength pages 4-5): Fumihito Miura, Noriko Kawaguchi, Jun Sese, Atsushi Toyoda, Masahira Hattori, Shinichi Morishita, and Takashi Ito. A large-scale full-length cdna analysis to explore the budding yeast transcriptome. Proceedings of the National Academy of Sciences, 103:17846-17851, Nov 2006. URL: https://doi.org/10.1073/pnas.0605645103, doi:10.1073/pnas.0605645103. This article has 295 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cleves1996anewpathway pages 9-10): A E Cleves, D N Cooper, S H Barondes, and R B Kelly. A new pathway for protein export in saccharomyces cerevisiae. The Journal of Cell Biology, 133:1017-1026, Jun 1996. URL: https://doi.org/10.1083/jcb.133.5.1017, doi:10.1083/jcb.133.5.1017. This article has 269 citations.</p>
+</li>
+<li>
+<p>(cansado2021thefissionyeast pages 6-8): José Cansado, Teresa Soto, Alejandro Franco, Jero Vicente-Soler, and Marisa Madrid. The fission yeast cell integrity pathway: a functional hub for cell survival upon stress and beyond. Journal of Fungi, 8:32, Dec 2021. URL: https://doi.org/10.3390/jof8010032, doi:10.3390/jof8010032. This article has 42 citations.</p>
+</li>
+<li>
+<p>(athanasopoulos2019fungalplasmamembrane pages 5-6): Alexandros Athanasopoulos, Bruno André, Vicky Sophianopoulou, and Christos Gournas. Fungal plasma membrane domains. FEMS Microbiology Reviews, 43:642-673, Aug 2019. URL: https://doi.org/10.1093/femsre/fuz022, doi:10.1093/femsre/fuz022. This article has 96 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lanze2020plasmamembranemcceisosome pages 16-17): Carla E. Lanze, Rafael M. Gandra, Jenna E. Foderaro, Kara A. Swenson, Lois M. Douglas, and James B. Konopka. Plasma membrane mcc/eisosome domains promote stress resistance in fungi. Nov 2020. URL: https://doi.org/10.1128/mmbr.00063-19, doi:10.1128/mmbr.00063-19. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="nce101-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>cleves1996anewpathway pages 6-6</li>
+<li>cleves1996anewpathway pages 8-9</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 6-7</li>
+<li>cleves1996anewpathway pages 4-6</li>
+<li>miura2006alargescalefulllength pages 4-5</li>
+<li>cansado2021thefissionyeast pages 6-8</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 5-6</li>
+<li>lanze2020plasmamembranemcceisosome pages 16-17</li>
+<li>cleves1996anewpathway pages 1-2</li>
+<li>cleves1996anewpathway pages 6-8</li>
+<li>grossmann2008plasmamembranemicrodomains pages 4-5</li>
+<li>lanze2020plasmamembranemcceisosome pages 5-6</li>
+<li>kim2016theplasmamembrane pages 1-2</li>
+<li>grossmann2008plasmamembranemicrodomains pages 2-4</li>
+<li>frohlich2010analysisofsphingolipidsignaling pages 81-82</li>
+<li>zahumensky2019roleofmcceisosome pages 7-9</li>
+<li>athanasopoulos2019fungalplasmamembrane pages 8-9</li>
+<li>cleves1996anewpathway pages 9-10</li>
+<li>https://doi.org/10.1083/jcb.133.5.1017,</li>
+<li>https://doi.org/10.1093/femsre/fuz022,</li>
+<li>https://doi.org/10.1083/jcb.200806035,</li>
+<li>https://doi.org/10.1128/mmbr.00063-19,</li>
+<li>https://doi.org/10.1074/jbc.m116.727743,</li>
+<li>https://doi.org/10.5282/edoc.12051,</li>
+<li>https://doi.org/10.3390/biom9080305,</li>
+<li>https://doi.org/10.1073/pnas.0605645103,</li>
+<li>https://doi.org/10.3390/jof8010032,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(nce101-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="C6Y4B6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="nce101-spac12g1217-s-pombe-research-notes">nce101 (SPAC12G12.17) — S. pombe — research notes</h1>
+<p>Journal / provenance log for the AI GO-annotation review. This is an<br />
+<strong>understudied ("dark") gene</strong>: the fission yeast protein itself has <strong>no direct<br />
+experimental functional characterization</strong>. All conclusions below are grounded in<br />
+the UniProt record, the GOA annotation set, PomBase curation, family/orthology<br />
+data, and the single foundational budding-yeast paper that defines the family.</p>
+<h2 id="1-identity-and-sequence-facts-from-uniprot-c6y4b6-do-not-edit-that-file">1. Identity and sequence facts (from UniProt C6Y4B6; do not edit that file)</h2>
+<ul>
+<li>UniProt: <strong>C6Y4B6</strong> (NCE1_SCHPO), Reviewed/Swiss-Prot, <strong>58 aa</strong>, MW ~6998 Da.</li>
+<li>Gene: <code>nce101</code>; systematic/ORF name <code>SPAC12G12.17</code>; chromosome I.</li>
+<li><strong>PE 2: Evidence at transcript level</strong> — i.e., the protein's existence is inferred<br />
+  from transcript evidence; there is <strong>no protein-level experimental evidence</strong> for<br />
+  this specific ORF beyond transcript detection.</li>
+<li>Only two primary references on the UniProt entry, and neither characterizes function:</li>
+<li>PMID:11859360 — the S. pombe genome sequence (Wood et al., 2002) [genomic DNA].</li>
+<li>PMID:18488015 — transcriptome at single-nucleotide resolution (Wilhelm et al.,<br />
+    2008) [IDENTIFICATION; confirms the transcript exists].</li>
+<li>Domain / topology (UniProt):</li>
+<li><code>TRANSMEM 10..27 /note="Helical" /evidence=ECO:0000255</code> — a single predicted TM<br />
+    helix (sequence-analysis prediction, not experimentally determined topology).</li>
+<li><code>SUBCELLULAR LOCATION: Membrane {ECO:0000305}; Single-pass membrane protein
+    {ECO:0000305}</code> — inferred (ECO:0000305 = curator inference), not experimentally shown.</li>
+<li>Keywords: Membrane, Protein transport, Transmembrane, Transmembrane helix, Transport.</li>
+<li><code>FUNCTION: Involved in a novel pathway of export of proteins that lack a cleavable
+  signal sequence. May be part of the export machinery or may also be a substrate for
+  non-classical export (By similarity). {ECO:0000250}</code> — <strong>ECO:0000250 = inferred from<br />
+  sequence/structural similarity ("By similarity")</strong>, i.e. transferred from the<br />
+  S. cerevisiae ortholog, NOT measured in S. pombe. Note the explicit hedge:<br />
+  machinery <strong>OR</strong> substrate.</li>
+<li><code>SIMILARITY: Belongs to the NCE101 family {ECO:0000305}.</code></li>
+<li>Family/domain databases: InterPro <strong>IPR024242</strong> (NCE101), Pfam <strong>PF11654</strong> (NCE101),<br />
+  PANTHER <strong>PTHR28011 / PTHR28011:SF1</strong> ("NON-CLASSICAL EXPORT PROTEIN 1").</li>
+<li>No AlphaFold-derived functional annotation beyond a model in AlphaFoldDB; SMR entry.</li>
+</ul>
+<p>Sequence:<br />
+<code>MSQPYLISKW MDPLFGIFVG TYGYYLYEKE HRPRGRSLRE LALRKWNKQA VSQQSMKN</code> (58 aa)<br />
+The TM helix (res 10–27) is the single obvious feature. Because the TM segment is<br />
+N-terminal (not near the C-terminus), the topology is more consistent with a<br />
+signal-anchor / type-II-like single-pass membrane protein than with a tail-anchored<br />
+protein; the ~30-residue post-TM segment is short and enriched in basic/charged residues<br />
+(…RPRGRSLRELALRKWNKQ…). No diagnostic catalytic motif is present. The precise orientation<br />
+(N-in vs N-out) is not experimentally determined.</p>
+<h2 id="2-family-orthology-from-interpro-panther-interpropantherpthr28011">2. Family / orthology (from InterPro + PANTHER; interpro/panther/PTHR28011/)</h2>
+<ul>
+<li><strong>InterPro IPR024242 (NCE101)</strong> description (fetched from InterPro API):<br />
+  "This entry represents the non classical export protein 1 family. Family members<br />
+  are involved in a novel pathway of export of proteins that lack a cleavable signal<br />
+  sequence."</li>
+<li>PANTHER PTHR28011 "NON-CLASSICAL EXPORT PROTEIN 1": 275 proteins, 1 subfamily<br />
+  (PTHR28011:SF1), 729 taxa, 236 AlphaFold models, 0 experimental structures,<br />
+  0 associated pathways. Reviewed members captured: only <strong>2</strong>:</li>
+<li>C6Y4B6 (S. pombe nce101, 58 aa) — this gene.</li>
+<li><strong>Q02820 (S. cerevisiae NCE101, 53 aa)</strong> — the reference ortholog.</li>
+<li>So the family is small microproteins, essentially unstudied outside the founding paper.</li>
+</ul>
+<h2 id="3-the-founding-paper-pmid8655575-cleves-cooper-barondes-kelly-1996">3. The founding paper: PMID:8655575 (Cleves, Cooper, Barondes, Kelly, 1996)</h2>
+<p>"A new pathway for protein export in Saccharomyces cerevisiae", J Cell Biol.<br />
+(Full text read via Europe PMC / PMC2120850.)</p>
+<ul>
+<li>Screen design: a mammalian non-classically-secreted reporter (<strong>galectin-1</strong>) was<br />
+  expressed in yeast; a <strong>multicopy cDNA library</strong> screen looked for clones whose<br />
+  overexpression modulated non-classical export of galectin-1.</li>
+<li>NCE1 = "clone07"; NCE2 = "clone17":<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8655575" title="We have named the clone07 and clone17 genes NCE1 and NCE2 (nonclassical   _export), respectively.">PMID:8655575</a></li>
+<li>NCE1 encodes a small protein: <a href="https://pubmed.ncbi.nlm.nih.gov/8655575" title="The NCE1 cDNA encodes a 53-amino">PMID:8655575</a> (53 aa<br />
+  in S. cerevisiae). It was "one of four novel proteins smaller than 100 amino acids<br />
+  identified in this screen."</li>
+<li><strong>Crucial ambiguity of function</strong> — the paper explicitly does NOT resolve whether NCE1<br />
+  is machinery or cargo: <a href="https://pubmed.ncbi.nlm.nih.gov/8655575" title="The small NCE1 gene product may be part of the   export machinery, or, along with the other low molecular weight proteins identified in   the screen, may also be a substrate for nonclassical export.">PMID:8655575</a><br />
+  This is the exact hedge preserved in the UniProt FUNCTION line.</li>
+<li>The paper's <strong>mechanistic/genetic characterization (transmembrane topology model, null<br />
+  allele, essentiality, suppression of ste6Δ) is done on NCE2, not NCE1.</strong> NCE2 is the<br />
+  4-TM candidate machinery component; NCE1 was left essentially uncharacterized beyond<br />
+  the overexpression phenotype.</li>
+<li>The overall claim: yeast has a signal-sequence-independent ("non-classical") protein<br />
+  export pathway distinct from the classical ER/Golgi secretory route:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8655575" title="These findings demonstrate a new pathway for protein export that is   distinct from the classical secretory pathway in yeast.">PMID:8655575</a></li>
+</ul>
+<p>Nomenclature caution: the yeast "NCE" genes are a tangle. The well-studied<br />
+S. cerevisiae <strong>NCE102</strong> (an MCC/eisosome plasma-membrane microdomain protein) descends<br />
+from the NCE2 story, NOT from NCE1. <strong>NCE101 (Q02820) is the small NCE1 clone</strong>, and<br />
+remains poorly characterized. Do not conflate nce101 with the eisosomal Nce102 literature.</p>
+<h2 id="4-s-cerevisiae-ortholog-q02820-nce101-nce1-yjl205c-source-of-the-iba">4. S. cerevisiae ortholog Q02820 (NCE101 / NCE1 / YJL205C) — source of the IBA</h2>
+<ul>
+<li>FUNCTION identical hedged wording, but attributed <strong>{ECO:0000269|PubMed:8655575}</strong><br />
+  (experimental, from the founding paper).</li>
+<li>GOA-relevant GO on Q02820:</li>
+<li>GO:0009306 protein secretion — <strong>IGI:SGD</strong> (inferred from genetic interaction; the<br />
+    1996 overexpression screen).</li>
+<li>GO:0016020 membrane — IEA (UniProtKB-SubCell).</li>
+<li>GO:0005829 cytosol — HDA:SGD (high-throughput; note this contradicts a strict<br />
+    membrane-only view and reflects that localization is not firmly established).</li>
+<li>So the <strong>entire "protein secretion" evidence chain for fission yeast nce101 is an IBA<br />
+  propagated from a budding-yeast gene whose own support is a single indirect<br />
+  overexpression/genetic screen with explicitly ambiguous interpretation</strong> (machinery vs<br />
+  substrate). It is a legitimate phylogenetic inference but should be treated as<br />
+  low-confidence and non-core.</li>
+</ul>
+<h2 id="5-pombase-curation-pombase-api-dataset-latest">5. PomBase curation (PomBase API, dataset latest)</h2>
+<ul>
+<li>product: "non-classical export protein family Nce101"</li>
+<li><strong>characterisation_status: <code>conserved unknown</code></strong> — PomBase's explicit flag that the<br />
+  biological role is not known (dark gene).</li>
+<li>Manual GO in MF / BP / CC aspects: <strong>none</strong> (empty) — consistent with no experimental<br />
+  functional data.</li>
+<li>12 single-locus phenotype annotations, all on the <strong><code>nce101delta</code> (deletion) genotype</strong>,<br />
+  all from large-scale chemical-genomics/drug-sensitivity profiling (no reference-specific,<br />
+  mechanistically diagnostic phenotype):</li>
+<li>resistance to: amorolfine, egtazic acid (EGTA), lithium / LiCl+SDS,<br />
+    MgCl2+SDS, KCl+SDS, methyl methanesulfonate (MMS), tert-butyl hydroperoxide.</li>
+<li>sensitive to: cadmium, diamide, valproic acid, vanadate.<br />
+  These are pleiotropic stress/drug phenotypes typical of genome-wide screens; they do<br />
+<strong>not</strong> point to a specific molecular function and are not GO-BP annotated by PomBase.</li>
+</ul>
+<h2 id="6-known-vs-not-known-synthesis">6. KNOWN vs NOT-KNOWN (synthesis)</h2>
+<p>KNOWN / defensible:<br />
+- It is a <strong>small (58 aa) membrane-associated microprotein</strong> with <strong>one predicted TM<br />
+  helix</strong> (sequence prediction; ECO:0000255/0000305). Membrane association is a<br />
+  reasonable, if not experimentally proven, localization.<br />
+- It is the S. pombe member of the <strong>NCE101 family</strong> (IPR024242 / PF11654 / PTHR28011),<br />
+  orthologous to S. cerevisiae NCE101.<br />
+- The transcript is expressed (PMID:18488015).<br />
+- Deletion gives only broad, pleiotropic chemical-stress phenotypes; the gene is<br />
+  non-essential-behaving in screens (viable deletion collection member).</p>
+<p>NOT known (genuine knowledge gaps):<br />
+- <strong>Molecular function is unknown.</strong> There is no biochemical activity, no ligand/substrate,<br />
+  no interaction partner, no catalytic motif. "protein transport"/"protein secretion" is a<br />
+  family-level inference from an indirect budding-yeast overexpression screen, and even<br />
+  there the founding authors could not distinguish whether the protein is part of the<br />
+  export <strong>machinery</strong> or is itself an export <strong>substrate/cargo</strong>.<br />
+- <strong>Biological process is unknown</strong> for the fission yeast gene specifically; the<br />
+  non-classical export pathway has not been demonstrated to operate through nce101 in<br />
+  S. pombe.<br />
+- <strong>Precise localization is unknown</strong> (membrane inferred; the S. cerevisiae ortholog is<br />
+  also annotated cytosol by HDA — conflicting).<br />
+- <strong>Topology/orientation</strong> (N-in vs N-out, tail-anchored vs signal-anchored) is not<br />
+  experimentally determined.<br />
+- No loss-of-function phenotype that isolates a specific pathway.</p>
+<h2 id="7-annotation-review-plan-for-nce101-ai-reviewyaml">7. Annotation-review plan (for nce101-ai-review.yaml)</h2>
+<p>Six GOA annotations:<br />
+1. GO:0009306 protein secretion — IBA (GO_REF:0000033; from PANTHER PTN001997334 / SGD<br />
+   S000003742). Defensible as a family-level phylogenetic inference but weak and NOT the<br />
+   demonstrated core function → <strong>KEEP_AS_NON_CORE</strong> (do not elevate to core; it is an<br />
+   inference from an indirect screen). Keep per "don't overrule phylogenetic annotation<br />
+   without positive evidence against it."<br />
+2. GO:0009306 protein secretion — IEA (GO_REF:0000002; InterPro IPR024242). Same term<br />
+   from InterPro2GO mapping of the family signature; redundant with the IBA and equally<br />
+   family-level → <strong>KEEP_AS_NON_CORE</strong>.<br />
+3. GO:0016020 membrane — IEA (GO_REF:0000044; UniProtKB-SubCell). Supported by the single<br />
+   predicted TM helix and Membrane keyword; uninformative-but-not-wrong root-ish CC.<br />
+   → <strong>KEEP_AS_NON_CORE</strong> (accurate but low-information; membrane is only predicted).<br />
+4. GO:0003674 molecular_function (root) — ND (GO_REF:0000015). Correct use of ND: MF is<br />
+   genuinely unknown → <strong>ACCEPT</strong> (this honestly records the knowledge gap).<br />
+5. GO:0005575 cellular_component (root) — ND. → <strong>ACCEPT</strong> (but see #3; PomBase ND may<br />
+   predate/parallel the SubCell membrane call).<br />
+6. GO:0008150 biological_process (root) — ND. → <strong>ACCEPT</strong>.</p>
+<p>core_functions: minimal — at most a single, low-confidence entry, or empty, because no MF<br />
+is established. Lean toward NOT asserting a molecular_function id we cannot support; the<br />
+honest position is that MF is unknown (captured by the ND annotation and knowledge_gaps).</p>
+<p>knowledge_gaps (REQUIRED, primary deliverable): unknown MF, unknown BP role in S. pombe,<br />
+unproven localization/topology, machinery-vs-substrate ambiguity, no LOF phenotype<br />
+isolating a pathway.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: C6Y4B6
+gene_symbol: nce101
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  nce101 (SPAC12G12.17) is a small (58 amino acid) membrane-associated microprotein of
+  fission yeast and the sole S. pombe member of the NCE101 family (InterPro IPR024242,
+  Pfam PF11654, PANTHER PTHR28011), orthologous to Saccharomyces cerevisiae NCE101 (NCE1).
+  The protein carries a single predicted transmembrane helix (residues 10-27) and a short,
+  basic-residue-enriched C-terminal tail, features consistent with a single-pass membrane
+  protein, though its topology and precise subcellular localization have not been
+  experimentally determined. The founding member of the family, budding yeast NCE1, was
+  recovered in a genetic screen for factors affecting a signal-sequence-independent
+  (&#34;non-classical&#34;) protein export pathway, and the family is therefore annotated to protein
+  secretion/transport; the original study could not distinguish whether the small protein
+  is part of the export machinery or is itself a non-classically secreted substrate. No
+  molecular activity, interaction partner, or catalytic motif has been identified for the
+  S. pombe protein, and it is classified as a conserved protein of unknown biological role.
+  Genome-wide deletion profiling of the nce101 deletion reports only broad, pleiotropic
+  chemical-stress sensitivity and resistance phenotypes, none of which isolate a specific
+  molecular function.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000015
+  title: Use of the ND evidence code for Gene Ontology (GO) terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:11859360
+  title: The genome sequence of Schizosaccharomyces pombe.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Background genome reference: the source of the SPAC12G12.17 gene model on chromosome I.
+      Establishes the gene&#39;s existence but says nothing about its function.
+- id: PMID:18488015
+  title: Dynamic repertoire of a eukaryotic transcriptome surveyed at single-nucleotide
+    resolution.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Background transcriptome reference underlying the UniProt &#34;Evidence at transcript level&#34;
+      (PE 2) status; confirms the transcript is expressed but provides no functional evidence.
+- id: PMID:8655575
+  title: A new pathway for protein export in Saccharomyces cerevisiae.
+  findings:
+  - statement: &gt;-
+      Defines the non-classical (signal-sequence-independent) protein export pathway in
+      budding yeast and, through a genetic screen, identified the founding NCE genes
+      including NCE1/NCE101, the ortholog of S. pombe nce101. Establishes the family-level
+      basis for the protein secretion / protein transport annotations, but the paper&#39;s
+      molecular characterization is performed on NCE2, not on the small NCE1 gene product,
+      whose role (machinery versus exported substrate) was left unresolved.
+    supporting_text: &gt;-
+      A screen for components of the export machinery has identified genes that are
+      involved in nonclassical export. These findings demonstrate a new pathway for
+      protein export that is distinct from the classical secretory pathway in yeast.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Cleves et al., J Cell Biol 1996; PMC2120850); correctly the primary
+      source behind the NCE101 family and the IBA/InterPro protein secretion annotations.
+      Relevance is MEDIUM rather than HIGH because the S. pombe protein itself is not studied
+      here: the abstract (the only cached text; full_text_available is false) does not name
+      NCE1 individually, and in the full text NCE1 is one of four small proteins recovered in
+      an overexpression screen whose function (export machinery versus export substrate) is
+      explicitly left ambiguous.
+existing_annotations:
+- term:
+    id: GO:0009306
+    label: protein secretion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation of protein secretion across the NCE101 family (PANTHER
+      PTN001997334), seeded by S. cerevisiae NCE101 whose own annotation derives from the
+      Cleves et al. 1996 non-classical export screen (IGI:SGD, PMID:8655575). This is a
+      defensible family-level inference and there is no positive evidence against it, so it
+      is retained; however it is an indirect inference for a gene with no direct functional
+      data, and even in the founding study the protein&#39;s role (machinery versus substrate)
+      was ambiguous, so it should not be treated as an experimentally established core
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reasonable phylogenetic inference for an uncharacterized family member, but not
+      demonstrated for the S. pombe protein and interpretively ambiguous at source; keep as
+      a non-core, low-confidence functional context rather than a core function.
+    additional_reference_ids:
+    - PMID:8655575
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      failure_modes:
+      - SOURCE_EVIDENCE_WEAK
+      source_entities:
+      - source_id: UniProtKB:Q02820
+        source_label: S. cerevisiae NCE101 (NCE1)
+        source_status: SOURCE_WEAK_OR_INFERRED
+        comment: &gt;-
+          Seed annotation is IGI from a single overexpression screen (PMID:8655575) in which
+          the small NCE1 protein&#39;s role was ambiguous (machinery versus exported substrate).
+- term:
+    id: GO:0009306
+    label: protein secretion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO mapping of the NCE101 family signature (IPR024242) to protein secretion.
+      This is the same family-level inference as the IBA annotation, mapped from the domain
+      model rather than the phylogenetic tree, and is redundant with it. Accurate at the
+      family level but uninformative about the specific molecular function of the S. pombe
+      protein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct family-signature-to-GO mapping but redundant with the IBA and not evidence of
+      a demonstrated function; retain as non-core.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Membrane localization mapped from the UniProtKB subcellular-location keyword, which
+      itself rests on a single predicted transmembrane helix (residues 10-27, ECO:0000255)
+      and the curator-inferred single-pass membrane assignment (ECO:0000305). Consistent with
+      the sequence but not experimentally verified; note the S. cerevisiae ortholog also
+      carries a cytosol (HDA) annotation, so the localization is not firmly established. This
+      is an accurate but low-information cellular-component term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Localization is only predicted (single TM helix) and not experimentally confirmed; the
+      term is not wrong but is uninformative and non-core.
+- term:
+    id: GO:0003674
+    label: molecular_function
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root molecular_function term with the ND (no biological data) evidence code, correctly
+      recording that no molecular function has been experimentally determined for nce101.
+      There is no biochemical activity, ligand, substrate, or catalytic motif described for
+      this protein or its family, so ND is the honest and appropriate annotation.
+    action: ACCEPT
+    reason: &gt;-
+      ND correctly captures a genuine molecular-function knowledge gap; retaining it is the
+      accurate curatorial choice for a dark gene.
+- term:
+    id: GO:0005575
+    label: cellular_component
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Root cellular_component term with ND evidence, from PomBase. The only localization
+      signal is the predicted transmembrane helix (captured separately by the UniProt SubCell
+      membrane IEA); no experimental localization has been reported, so PomBase&#39;s ND
+      annotation reflects the absence of curated CC evidence. Retained as an honest record of
+      the gap.
+    action: ACCEPT
+    reason: &gt;-
+      Accurately records that no experimentally supported cellular component is curated;
+      consistent with a conserved-unknown-function gene.
+- term:
+    id: GO:0008150
+    label: biological_process
+  evidence_type: ND
+  original_reference_id: GO_REF:0000015
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Root biological_process term with ND evidence. No biological process has been
+      experimentally established for the S. pombe gene; deletion phenotypes are limited to
+      broad, pleiotropic chemical-stress sensitivities and resistances that do not define a
+      specific pathway, and the family-level protein secretion inference is captured by the
+      IBA/IEA annotations. ND appropriately marks the absence of a curated process.
+    action: ACCEPT
+    reason: &gt;-
+      ND honestly records an unknown biological process; the pleiotropic drug phenotypes do
+      not support a specific BP annotation.
+core_functions:
+- description: &gt;-
+    No molecular function can be assigned with confidence. nce101 is a small single-pass
+    membrane microprotein of the NCE101 family whose only functional association, protein
+    secretion / non-classical protein export, is a family-level phylogenetic inference
+    (IBA/InterPro) transferred from budding yeast NCE101 and is interpretively ambiguous at
+    its experimental source (the founding study could not distinguish an export-machinery
+    role from an export-substrate role). No molecular_function term is asserted here because
+    none is supported by direct evidence; the molecular function is an open question (see
+    knowledge_gaps).
+  supported_by:
+  - reference_id: PMID:8655575
+    supporting_text: &gt;-
+      A screen for components of the export machinery has identified genes that are
+      involved in nonclassical export. These findings demonstrate a new pathway for
+      protein export that is distinct from the classical secretory pathway in yeast.
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular function of nce101 is undetermined: no biochemical activity, ligand,
+    substrate, catalytic residue, or diagnostic sequence motif has been identified for the
+    protein or the NCE101 family.
+  boundary: &gt;-
+    The protein is a defined 58-aa NCE101-family member with a single predicted transmembrane
+    helix; its only functional association (protein secretion / non-classical export) is an
+    indirect inference from an overexpression/genetic screen of the S. cerevisiae ortholog,
+    in which the founding authors could not determine whether the small protein acts as part
+    of the export machinery or is itself a non-classically secreted substrate.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+- gap_statement: &gt;-
+    The biological process in which nce101 participates in S. pombe is unknown, and it has
+    not been shown that fission yeast operates a non-classical protein export pathway through
+    nce101.
+  boundary: &gt;-
+    Genome-wide deletion profiling of nce101-delta reports only broad, pleiotropic
+    chemical-stress phenotypes (sensitivity to cadmium, diamide, valproate and vanadate;
+    resistance to lithium, MMS, tert-butyl hydroperoxide, EGTA, amorolfine, and various
+    salt/SDS combinations) that do not point to a single pathway.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+- gap_statement: &gt;-
+    The subcellular localization and membrane topology of Nce101 are experimentally
+    undetermined: it is unclear whether the protein is stably membrane-integral, which
+    membrane it occupies, and in what orientation (N-in versus N-out, signal-anchored versus
+    tail-anchored).
+  boundary: &gt;-
+    Membrane association is inferred solely from a single predicted transmembrane helix
+    (residues 10-27) and a curator-assigned single-pass membrane annotation; the
+    S. cerevisiae ortholog additionally carries a high-throughput cytosol annotation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+- gap_statement: &gt;-
+    No loss-of-function phenotype isolates a specific molecular or cellular role, and no
+    interacting partners, complex membership, or regulatory context are known; it is also
+    unresolved whether nce101 is functionally redundant with other small membrane
+    microproteins, which would mask deletion phenotypes.
+  boundary: &gt;-
+    A viable deletion strain exists and has been chemically profiled, but the resulting
+    phenotypes are pleiotropic and non-diagnostic.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: WHOLLY_DARK
+  status: OPEN
+suggested_questions:
+- question: &gt;-
+    Does S. pombe possess a non-classical (signal-sequence-independent) protein export
+    pathway, and if so does nce101 contribute to it?
+- question: &gt;-
+    Is nce101 a component of a transport/export machinery or is it itself a secreted or
+    membrane-cargo substrate, as the ambiguity in the founding budding-yeast study implies?
+- question: &gt;-
+    What is the true subcellular localization and membrane topology of the Nce101 protein?
+suggested_experiments:
+- experiment_type: Fluorescence microscopy and membrane fractionation
+  description: &gt;-
+    Determine the endogenous subcellular localization and membrane topology of Nce101 by
+    tagging (avoiding tag-induced mislocalization of a 58-aa protein), fluorescence
+    microscopy, and protease-protection / carbonate-extraction membrane fractionation.
+- experiment_type: Affinity purification / mass spectrometry and secretome analysis
+  description: &gt;-
+    Identify physical interaction partners by co-immunoprecipitation/mass spectrometry or
+    proximity labeling to test the export-machinery hypothesis, and perform secretome
+    analysis of nce101-delta versus wild type to test whether it affects non-classical
+    protein secretion.
+- experiment_type: Genetic / phenotypic characterization
+  description: &gt;-
+    Characterize nce101-delta (and combinations with related small membrane proteins, to
+    control for redundancy) under the stress conditions flagged by chemical-genomics screens
+    to connect the pleiotropic phenotypes to a defined cellular process.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/rrg8/rrg8-ai-review.html
+++ b/genes/SCHPO/rrg8/rrg8-ai-review.html
@@ -1,0 +1,2591 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>rrg8 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>rrg8</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O14106" target="_blank" class="term-link">
+                        O14106
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">SPAC31G5.06</span>
+
+                    <span class="badge">rgg8</span>
+
+                </div>
+            </div>
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "rrg8";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O14106" data-a="DESCRIPTION: rrg8 (SPAC31G5.06) is a small (234-residue) fungal..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>rrg8 (SPAC31G5.06) is a small (234-residue) fungal mitochondrial protein of unknown molecular function. Its budding-yeast ortholog RRG8/YPR116W (alias MTA1) is one of several accessory factors required for efficient 5&#39;-end processing of mitochondrial tRNAs: it associates with the mitochondrial inner membrane, sediments as a high-molecular-weight complex, and co-purifies with Rpm2p, the protein subunit of mitochondrial RNase P (the endonuclease that cleaves the 5&#39; leader of pre-tRNAs). Loss of the ortholog reduces mitochondrial tRNA levels and causes respiratory deficiency and defects in mitochondrial genome maintenance and mitochondrial protein synthesis. In fission yeast, where loss of mitochondrial DNA is lethal, deletion of rrg8 is inviable. The protein carries no recognizable domain, catalytic motif, or family signature, and no direct biochemical activity has been demonstrated for either the fission-yeast protein or its orthologs; its role in mitochondrial tRNA processing and gene expression is inferred from ortholog genetics rather than measured for the S. pombe protein itself.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14106" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt Subcellular Location keyword-mapping) nuclear annotation, ultimately derived from a high-throughput C-terminal YFP-tagging screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The nucleus call traces to the genome-scale YFP-tagging ORFeome screen (PMID:16823372) via UniProt Subcellular Location and GO_REF:0000044. It conflicts with the orthology-based mitochondrial localization of this protein (the S. cerevisiae ortholog RRG8/MTA1 is on the matrix side of the inner mitochondrial membrane) and is not curated as a cellular component by PomBase, which annotates only mitochondrion. Large-scale C-terminally tagged screens frequently produce spurious cytosolic/nuclear signal for low-abundance organellar proteins, and a C-terminal tag can mask a cleavable mitochondrial targeting signal. Flag as an over-annotation for a mitochondrial protein rather than a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                                        PMID:16823372
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we determined the localization of 4,431 proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14106" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt Subcellular Location keyword-mapping) cytoplasmic annotation from the same high-throughput YFP-tagging screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As with the nucleus annotation, cytoplasm derives from the genome-scale YFP screen (PMID:16823372) mapped through UniProt Subcellular Location (GO_REF:0000044). It is a broad, non-specific term that is inconsistent with the mitochondrial localization inferred from the well-characterized ortholog and with PomBase&#39;s expert decision to annotate only mitochondrion. Mark as over-annotated; the informative location is mitochondrion.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                                        PMID:16823372
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we determined the localization of 4,431 proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14106" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function term with the No-Data (ND) evidence code, correctly recording that no molecular function has been determined for rrg8.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The molecular function of rrg8 is genuinely unknown. The protein has no recognizable domain, catalytic motif, or family signature (no InterPro/Pfam/PANTHER assignment), and even the better-studied budding-yeast ortholog is described as &#34;of unknown function&#34;. The ND annotation to the root term is the honest and correct representation of this gap; retain it.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14106" data-a="GO:0005739" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial localization transferred by orthology (ISO) from the S. cerevisiae ortholog RRG8/MTA1 (SGD:S000006320), which localizes to the matrix side of the mitochondrial inner membrane and is GFP-tagged in mitochondria.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ISO transfer is well supported: the ortholog is experimentally mitochondrial (inner-membrane-associated; GFP in mitochondria, PMID:19751518) and functions there in mitochondrial tRNA processing (PMID:30759361). Mitochondrion is the single cellular component curated by PomBase for rrg8 and represents its core location. Retain as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19751518" target="_blank" class="term-link">
+                                        PMID:19751518
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identified ten previously uncharacterized genes essential for respiratory growth</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" target="_blank" class="term-link">
+                                        PMID:30759361
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mta1p, Mta2p, Pet130p, and Gep5p are associated with the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097745" target="_blank" class="term-link">
+                                    GO:0097745
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial tRNA 5&#39;-end processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14106" data-a="GO:0097745" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Involvement in mitochondrial tRNA 5&#39;-end processing transferred by orthology (ISO) from the S. cerevisiae ortholog RRG8/MTA1, which is required for efficient 5&#39; processing of mitochondrial tRNAs and associates with mitochondrial RNase P (Rpm2p).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The process assignment is well supported by ortholog genetics and biochemistry: mta1 null mutants have severely reduced mitochondrial tRNA levels, ts mutants accumulate pre-tRNA transcripts, and Mta1p co-immunopurifies with Rpm2p, the protein subunit of mitochondrial RNase P (PMID:30759361). This is the best-supported biological process for rrg8 and is consistent with its essentiality in fission yeast, where loss of mtDNA/mitochondrial gene expression is lethal. Note this is a process (BP) annotation, not a claim that rrg8 is the catalytic nuclease. Retain as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" target="_blank" class="term-link">
+                                        PMID:30759361
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify four novel genes MTA1, MTA2, GEP5 and PET130 of</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" target="_blank" class="term-link">
+                                        PMID:30759361
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">co-immunopurification of Rpm2 with Mta1p</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Accessory factor for mitochondrial tRNA 5&#39;-end processing / mitochondrial gene expression. Acting within the mitochondrion (ortholog is on the matrix side of the inner membrane), rrg8 is required for efficient 5&#39; maturation of mitochondrial tRNAs, a step catalyzed by mitochondrial RNase P. Its precise molecular activity is unknown; the ortholog associates with, and co-purifies with, the RNase P protein subunit Rpm2p, consistent with a scaffolding/assembly or accessory role rather than an intrinsic catalytic function. No molecular_function term is asserted because none can be defended from sequence (no domain, motif, or family) or from experiment.</h3>
+                <span class="vote-buttons" data-g="O14106" data-a="FUNCTION: Accessory factor for mitochondrial tRNA 5&#39;-end pro..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097745" target="_blank" class="term-link">
+                                mitochondrial tRNA 5&#39;-end processing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" target="_blank" class="term-link">
+                                PMID:30759361
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we identify four novel genes MTA1, MTA2, GEP5 and PET130 of</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19751518" target="_blank" class="term-link">
+                                PMID:19751518
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">identified ten previously uncharacterized genes essential for respiratory growth</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" target="_blank" class="term-link">
+                            PMID:30759361
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">5&#39; processing of Saccharomyces cerevisiae mitochondrial tRNAs requires expression of multiple genes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The budding-yeast ortholog RRG8/MTA1 is one of four genes (MTA1, MTA2, GEP5, PET130) required for efficient 5&#39; processing of mitochondrial tRNAs; the proteins associate with the mitochondrial inner membrane, form high-molecular-weight complexes, and Mta1p co-immunopurifies with the RNase P protein subunit Rpm2p.</div>
+
+                        <div class="finding-text">"we identify four novel genes MTA1, MTA2, GEP5 and PET130 of"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19751518" target="_blank" class="term-link">
+                            PMID:19751518
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide deletion mutant analysis reveals genes required for respiratory growth, mitochondrial genome maintenance and mitochondrial protein synthesis in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Systematic deletion analysis named RRG8 (YPR116w) as one of ten previously uncharacterized genes essential for respiratory growth; the GFP-tagged protein localizes to mitochondria and its loss compromises mitochondrial protein synthesis and genome maintenance.</div>
+
+                        <div class="finding-text">"identified ten previously uncharacterized genes essential for respiratory growth"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20473289" target="_blank" class="term-link">
+                            PMID:20473289
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of a genome-wide set of gene deletions in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide fission-yeast deletion analysis; provides the essentiality classification underlying the inviable phenotype of rrg8 deletion and notes that loss of mtDNA is lethal in fission yeast (unlike budding yeast petites), explaining why a mitochondrial gene-expression factor is essential in S. pombe.</div>
+
+                        <div class="finding-text">"Loss of mtDNA is lethal in fission yeast but not in budding yeast"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23697806" target="_blank" class="term-link">
+                            PMID:23697806
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A genome-wide resource of cell cycle and cell shape genes of fission yeast.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Microscopy-based screen providing the evidence for the inviable, tapered-cell deletion phenotype of rrg8 recorded in PomBase.</div>
+
+                        <div class="finding-text">"A genome-wide resource of cell cycle and cell shape genes of fission yeast"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
+                            PMID:16823372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-throughput C-terminal YFP-tagging localization screen; the source (via UniProt Subcellular Location) of the electronic cytoplasm and nucleus annotations for rrg8. Such large-scale C-terminally tagged screens can mislocalize low-abundance organellar proteins.</div>
+
+                        <div class="finding-text">"we determined the localization of 4,431 proteins"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39367033" target="_blank" class="term-link">
+                            PMID:39367033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative proteomics and phosphoproteomics profiling of meiotic divisions in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Meiotic proteomics detecting rrg8 at the protein level, with increased abundance during meiotic division; establishes that the gene is expressed as a protein.</div>
+
+                        <div class="finding-text">"Quantitative proteomics and phosphoproteomics profiling of meiotic divisions"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is Rrg8 a stoichiometric subunit of fission-yeast mitochondrial RNase P, or a transient assembly/maturation factor for the enzyme?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14106" data-a="Q: Is Rrg8 a stoichiometric subunit of fission-yeast ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the essential phenotype of rrg8 deletion in S. pombe reflect specifically defective mitochondrial tRNA processing (and consequent loss of mitochondrial translation and mtDNA), or an additional/independent function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14106" data-a="Q: Does the essential phenotype of rrg8 deletion in S..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenously epitope-tag rrg8, purify from isolated mitochondria under native conditions, and test by mass spectrometry / co-immunoprecipitation for association with the RNase P protein subunit (Rpm2 ortholog) and other Mta1/Mta2/Gep5/Pet130-equivalent factors. In parallel, use a conditional rrg8 allele and northern blotting / primer extension to test for accumulation of unprocessed mitochondrial pre-tRNA 5&#39; leaders.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Rrg8 associates with mitochondrial RNase P and is required for 5&#39; processing of mitochondrial pre-tRNAs in S. pombe.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: affinity purification-mass spectrometry and RNA processing assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14106" data-a="EXPERIMENT: Endogenously epitope-tag rrg8, purify from isolate..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine or predict the structure of Rrg8 (cryo-EM within the mitochondrial RNase P complex, or high-confidence structure prediction plus DALI/Foldseek search) to identify structural homologs, a possible RNA-binding surface, or a degenerate catalytic site, and use conservation mapping across fungal orthologs to nominate functionally important residues for mutagenesis.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Rrg8 possesses an assignable fold and candidate functional surface despite lacking recognized sequence signatures.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structural biology / structure-based homology detection</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O14106" data-a="EXPERIMENT: Determine or predict the structure of Rrg8 (cryo-E..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular function of rrg8 is unknown. No biochemical activity, catalytic residue, domain, or family signature has been identified for the fission-yeast protein or for any of its orthologs; whether it is an enzyme, an RNA-binding protein, or a purely structural scaffold is undetermined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The protein is 234 residues, carries a single low-complexity region and no recognizable InterPro/Pfam/PANTHER domain, and UniProt lists no FUNCTION and only &#34;Predicted&#34; protein existence. Even the better-studied S. cerevisiae ortholog RRG8/MTA1 is repeatedly described as a protein &#34;of unknown function&#34;, so the gap is real and field-acknowledged, not merely uncurated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> rrg8 is essential in fission yeast and its ortholog is required for respiratory growth, yet the molecular basis of these phenotypes is completely unexplained. It is a conserved, single-copy, essential &#34;dark&#34; gene of exactly the type the unknome program targets.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Biochemical characterization of purified rrg8 / Rrg8-family protein: test for nuclease, RNA-binding, or protein-scaffolding activity in mitochondrial RNase P reconstitution; structural determination (X-ray/cryo-EM or high-confidence structure prediction) to assign a fold and candidate active site.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"identified ten previously uncharacterized genes essential for respiratory growth"</em> — PMID:19751518</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether rrg8 is a stable subunit of mitochondrial RNase P, a transient assembly/maturation factor for the enzyme, or acts on tRNA processing indirectly is unresolved. The mechanism by which it promotes 5&#39; pre-tRNA cleavage is not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In the ortholog, Mta1p (together with Mta2p, Gep5p, Pet130p) is inner-membrane-associated, sediments as a high-molecular-weight complex, and co-immunopurifies with the RNase P protein subunit Rpm2p (PMID:30759361); null mutants have reduced mitochondrial tRNA levels and ts mutants accumulate pre-tRNA transcripts. This establishes a functional link to RNase P but not the mechanistic role (subunit vs assembly factor vs indirect).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing a bona fide RNase P subunit from an accessory assembly factor would clarify the architecture of fungal mitochondrial RNase P and determine whether an appropriate GO complex/subunit term (currently lacking) is needed to express rrg8&#39;s contribution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Native purification / cryo-EM of fungal mitochondrial RNase P to test for stoichiometric inclusion of Rrg8; in-organello pre-tRNA processing assays in rrg8 conditional mutants; define whether the RNase P activity or its assembly is lost.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"co-immunopurification of Rpm2 with Mta1p"</em> — PMID:30759361</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct role of the S. pombe protein itself has not been measured. All functional annotations (mitochondrion, mitochondrial tRNA 5&#39;-end processing) are transferred by orthology from S. cerevisiae; there is no fission-yeast biochemistry, localization by native methods, or in-organello assay for rrg8.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> rrg8 deletion is inviable in fission yeast (PomBase; microscopy evidence PMID:23697806), and the protein is expressed (detected at RNA and protein level, increased in meiosis, PMID:39367033). The essential phenotype is consistent with a mitochondrial gene-expression role because loss of mtDNA is lethal in fission yeast (PMID:20473289), but the specific molecular defect in rrg8-null cells has not been characterized.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Direct fission-yeast evidence would upgrade the ISO annotations to experimental support and test whether the mitochondrial tRNA-processing role is conserved in S. pombe or whether the essential phenotype reflects a different or additional function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Localize an endogenously tagged Rrg8 by fluorescence and subcellular fractionation; analyze mitochondrial tRNA processing and mtDNA maintenance in a conditional (e.g. tetO/thiamine- repressible) rrg8 allele.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Loss of mtDNA is lethal in fission yeast but not in budding yeast"</em> — PMID:20473289</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(rrg8-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O14106" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="rrg8-spac31g506-uniprot-o14106-curation-notes">rrg8 (SPAC31G5.06, UniProt O14106) — curation notes</h1>
+<p>Journal of research for the AI GO-annotation review of the fission yeast gene <strong>rrg8</strong>.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li><strong>Systematic name:</strong> SPAC31G5.06 (chromosome I, S. pombe strain 972 / ATCC 24843)</li>
+<li><strong>PomBase standard name:</strong> <code>rrg8</code> ("Required for Respiratory Growth 8"). Note: the UniProt entry<br />
+  (O14106, entry <code>RGG8_SCHPO</code>) currently lists the gene name as <code>rgg8</code>; this is a lagging/variant<br />
+  spelling. PomBase (authoritative for S. pombe nomenclature) gives <code>rrg8</code>, product<br />
+  "mitochondrial tRNA 5'-end processing protein Rrg8"<br />
+  (PomBase API <code>dataset/latest/data/gene/SPAC31G5.06</code>, <code>name: "rrg8"</code>). This review uses <code>rrg8</code>.</li>
+<li><strong>UniProt accession:</strong> O14106 (Swiss-Prot, but <code>PE 4: Predicted</code> — protein existence only predicted).</li>
+<li><strong>Length:</strong> 234 aa; MW ~27.5 kDa. One low-complexity region (aa 209–225, per PomBase).</li>
+<li><strong>PomBase characterisation status:</strong> "biological role inferred"; taxonomic distribution "fungi only";<br />
+  "predominantly single copy (one to one)".</li>
+<li><strong>S. cerevisiae ortholog:</strong> YPR116W = <strong>RRG8</strong> (SGD:S000006320, UniProt Q06109), alias <strong>MTA1</strong><br />
+  (PomBase <code>ortholog_annotations</code> → YPR116W, taxon 4932; SGD alias record).</li>
+</ul>
+<h2 id="domain-bioinformatic-analysis-done-inline">Domain / bioinformatic analysis (done inline)</h2>
+<ul>
+<li><strong>No recognized domains or family signatures.</strong> The UniProt record (cached<br />
+<code>rrg8-uniprot.txt</code> and live <code>rest.uniprot.org/uniprotkb/O14106.txt</code>, checked 2026-07-06) has<br />
+<strong>no</strong> InterPro / Pfam / PANTHER / PROSITE / SUPFAM / Gene3D / SMART / CDD cross-references, and<br />
+<code>just fetch-gene</code> reported "No PANTHER family found". InterPro protein API returns no matched entries.</li>
+<li><strong>No FUNCTION comment</strong> in UniProt; feature table lists only a single CHAIN (1..234) — no annotated<br />
+  TRANSIT peptide, signal peptide, transmembrane, or catalytic domain. (Absence of an annotated<br />
+  mitochondrial transit peptide does not exclude one; the record does not carry TargetP/MitoFates<br />
+  predictions and PomBase/orthology place the protein in mitochondria — see below.)</li>
+<li><strong>Conclusion from sequence:</strong> rrg8 is a genuinely "dark" protein — no fold/domain/EC assignable<br />
+  from sequence, no derivable molecular function. This is consistent across S. pombe and its<br />
+  budding-yeast ortholog.</li>
+</ul>
+<h2 id="what-is-known">What is KNOWN</h2>
+<h3 id="mitochondrial-localization-and-role-in-mitochondrial-trna-5-processing-via-ortholog-iso">Mitochondrial localization and role in mitochondrial tRNA 5' processing (via ortholog, ISO)</h3>
+<p>The two functional GO annotations on rrg8 (GO:0005739 mitochondrion; GO:0097745 mitochondrial tRNA<br />
+5'-end processing) are <strong>ISO</strong> (<code>GO_REF:0000024</code>) transferred from the S. cerevisiae ortholog<br />
+RRG8/MTA1 (with/from <code>SGD:S000006320</code>), per PomBase annotation_details (ids 124631, 124632).</p>
+<p>The budding-yeast ortholog is functionally characterised:<br />
+- SGD summary for YPR116W/RRG8/MTA1: "Protein of unknown function; required for efficient 5'<br />
+  processing of mitochondrial tRNAs, for respiratory growth and mitochondrial genome maintenance;<br />
+  ... localizes to the matrix side of the inner mitochondrial membrane" (SGD locus S000006320).<br />
+- [PMID:30759361 "5' processing of Saccharomyces cerevisiae mitochondrial tRNAs requires expression of multiple genes", "we identify four novel genes MTA1, MTA2, GEP5 and PET130 of the Saccharomycetaceae family that are necessary for an efficient processing of mitochondrial tRNAs"] — MTA1 = the RRG8 ortholog. Null mutants have severely reduced mt-tRNA levels; ts mutants accumulate pre-tRNA transcripts. <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" title="Mta1p, Mta2p, Pet130p, and Gep5p are associated with the mitochondrial inner membrane and are all extracted and sediment in sucrose gradients as high molecular weight complexes, where they may be present in a common complex with Rpm2p">PMID:30759361</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/30759361" title="co-immunopurification of Rpm2 with Mta1p">PMID:30759361</a>. Rpm2p is the protein subunit of yeast mitochondrial RNase P — the enzyme that carries out 5' pre-tRNA cleavage. So the ortholog is an <strong>accessory factor associated with mitochondrial RNase P</strong>, not the established catalytic component.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/19751518" title="identified ten previously uncharacterized genes essential for respiratory growth (RRG1 through RRG10)">PMID:19751518</a> — this is the paper that named RRG8. Its Table 5 lists "RRG8 / YPR116w / Unknown function, GFP-tagged protein in mitochondria", with mitochondrial localization "+", and after cytoduction "Translation activity ... Absent" and "Nucleoids ... Altered", i.e. loss of RRG8 damages mitochondrial genome maintenance and mitochondrial protein synthesis.</p>
+<h3 id="essentiality-phenotype-in-s-pombe">Essentiality / phenotype in S. pombe</h3>
+<ul>
+<li>PomBase <code>deletion_viability: inviable</code>; single-locus phenotypes FYPO:0002061 "inviable vegetative<br />
+  cell population" and FYPO:0002111 "inviable tapered vegetative cell" (microscopy evidence,<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23697806">PMID:23697806</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/20473289">PMID:20473289</a>).</li>
+<li>Why essential in S. pombe but only respiratory-deficient (viable) in S. cerevisiae: fission yeast<br />
+  cannot survive loss of mtDNA. <a href="https://pubmed.ncbi.nlm.nih.gov/20473289" title="Loss of mtDNA is lethal in fission yeast but not in budding yeast where “petite” mutants lacking mtDNA are viable and mitochondrial translation is not essential">PMID:20473289</a>. A mitochondrial-gene-expression factor is therefore expected to be essential in S. pombe even though its budding-yeast ortholog is a viable respiratory (pet) mutant — this cross-species pattern strengthens (rather than weakens) the mitochondrial functional assignment.</li>
+</ul>
+<h3 id="expression">Expression</h3>
+<ul>
+<li>Detected at RNA and protein level; protein level increases during meiotic division<br />
+  (<a href="https://pubmed.ncbi.nlm.nih.gov/39367033">PMID:39367033</a>, meiotic proteomics; PomBase gene-expression annotations, ext during GO:0007127<br />
+  meiosis I / GO:0072690). <a href="https://pubmed.ncbi.nlm.nih.gov/23101633">PMID:23101633</a> quantitative transcriptome/proteome, expression during<br />
+  quiescence (GO:0072690).</li>
+</ul>
+<h2 id="what-is-not-known-knowledge-gaps-the-primary-deliverable">What is NOT known (knowledge gaps — the primary deliverable)</h2>
+<ol>
+<li><strong>Molecular function is unknown.</strong> No domain, no catalytic motif, no EC. Even in the<br />
+   better-studied budding-yeast ortholog the protein is "of unknown function". Its association with<br />
+   RNase P (co-IP with Rpm2p) suggests an accessory/scaffolding or assembly role in the mitochondrial<br />
+   RNase P holoenzyme, but no biochemical activity has been demonstrated. rrg8 is NOT shown to be the<br />
+   nuclease; GO:0097745 is a <em>process</em> (BP) annotation, not a molecular-function claim.</li>
+<li><strong>Direct role of the S. pombe protein is inferred, not measured.</strong> The mitochondrion and mt-tRNA<br />
+   5' processing annotations are ISO from S. cerevisiae; there is no direct S. pombe biochemistry or<br />
+   in-organello assay for rrg8 itself.</li>
+<li><strong>Precise submitochondrial location and topology in S. pombe</strong> are not established (ortholog is on<br />
+   the matrix side of the inner membrane).</li>
+<li><strong>Whether rrg8 is a stable subunit of, or a transient assembly factor for, mitochondrial RNase P</strong><br />
+   is unresolved.</li>
+</ol>
+<h2 id="annotation-review-decisions-summary">Annotation review decisions (summary)</h2>
+<table>
+<thead>
+<tr>
+<th>Term</th>
+<th>Evidence</th>
+<th>Decision</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0005739 mitochondrion (is_active_in, ISO from SGD)</td>
+<td>ISO</td>
+<td>ACCEPT (core CC)</td>
+<td>Ortholog mitochondrial (inner membrane); PomBase curated this as the sole CC.</td>
+</tr>
+<tr>
+<td>GO:0097745 mitochondrial tRNA 5'-end processing (involved_in, ISO)</td>
+<td>ISO</td>
+<td>ACCEPT (core BP)</td>
+<td>Well-supported by ortholog genetics/biochemistry (PMID:30759361, 19751518).</td>
+</tr>
+<tr>
+<td>GO:0003674 molecular_function (ND)</td>
+<td>ND</td>
+<td>ACCEPT</td>
+<td>Honest "no data" for MF — matches the true knowledge gap; keep.</td>
+</tr>
+<tr>
+<td>GO:0005737 cytoplasm (located_in, IEA GO_REF:0000044 / SubCell)</td>
+<td>IEA</td>
+<td>MARK_AS_OVER_ANNOTATED</td>
+<td>From a C-terminally YFP-tagged high-throughput screen (PMID:16823372); a mitochondrial matrix-side inner-membrane protein. PomBase does not annotate cytoplasm. Broad/likely-artefactual for this protein.</td>
+</tr>
+<tr>
+<td>GO:0005634 nucleus (located_in, IEA GO_REF:0000044 / SubCell)</td>
+<td>IEA</td>
+<td>MARK_AS_OVER_ANNOTATED</td>
+<td>Same high-throughput dual cyto/nuclear call; inconsistent with orthology-based mitochondrial localization and not curated by PomBase.</td>
+</tr>
+</tbody>
+</table>
+<p>Note on the cytoplasm/nucleus calls: UniProt SubCellular Location cites the Matsuyama YFP ORFeome<br />
+screen (PMID:16823372). C-terminal fluorescent tags can disrupt or mask C-terminal / cleavable<br />
+mitochondrial targeting information, and high-throughput screens frequently produce cytosolic/nuclear<br />
+"leftover" signal for low-abundance organellar proteins. Per CLAUDE.md, IEA electronic inferences may<br />
+be argued against on biological grounds; these are not experimental annotations. I therefore flag them<br />
+as over-annotations rather than REMOVE.</p>
+<h2 id="deep-research-provenance-note">Deep research provenance note</h2>
+<p>The <code>deep_research_wrapper.py</code> (falcon → perplexity-lite fallback) was run twice in the foreground<br />
+(2026-07-06) and <strong>hung with no output</strong> (timed out at 200 s / 590 s, exit 124), producing no file.<br />
+Per project policy I did NOT fabricate a <code>-deep-research-*.md</code>. All assertions above are grounded in<br />
+the cached UniProt record, GOA TSV, PomBase and SGD REST APIs (authoritative ortholog annotation), and<br />
+cached primary publications (PMID:30759361, 19751518, 20473289, 23697806, 16823372, 39367033,<br />
+23101633), with verbatim quotes recorded inline.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O14106
+gene_symbol: rrg8
+aliases:
+  - SPAC31G5.06
+  - rgg8
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  rrg8 (SPAC31G5.06) is a small (234-residue) fungal mitochondrial protein of unknown
+  molecular function. Its budding-yeast ortholog RRG8/YPR116W (alias MTA1) is one of
+  several accessory factors required for efficient 5&#39;-end processing of mitochondrial
+  tRNAs: it associates with the mitochondrial inner membrane, sediments as a
+  high-molecular-weight complex, and co-purifies with Rpm2p, the protein subunit of
+  mitochondrial RNase P (the endonuclease that cleaves the 5&#39; leader of pre-tRNAs).
+  Loss of the ortholog reduces mitochondrial tRNA levels and causes respiratory
+  deficiency and defects in mitochondrial genome maintenance and mitochondrial protein
+  synthesis. In fission yeast, where loss of mitochondrial DNA is lethal, deletion of
+  rrg8 is inviable. The protein carries no recognizable domain, catalytic motif, or
+  family signature, and no direct biochemical activity has been demonstrated for either
+  the fission-yeast protein or its orthologs; its role in mitochondrial tRNA processing
+  and gene expression is inferred from ortholog genetics rather than measured for the
+  S. pombe protein itself.
+references:
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:30759361
+    title: &#34;5&#39; processing of Saccharomyces cerevisiae mitochondrial tRNAs requires expression\
+      \ of multiple genes.&#34;
+    findings:
+      - statement: &gt;-
+          The budding-yeast ortholog RRG8/MTA1 is one of four genes (MTA1, MTA2, GEP5,
+          PET130) required for efficient 5&#39; processing of mitochondrial tRNAs; the proteins
+          associate with the mitochondrial inner membrane, form high-molecular-weight
+          complexes, and Mta1p co-immunopurifies with the RNase P protein subunit Rpm2p.
+        supporting_text: &gt;-
+          we identify four novel genes MTA1, MTA2, GEP5 and PET130 of
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified primary paper (abstract-only in cache). This is the functional
+        source for the mt-tRNA 5&#39;-end processing role transferred by ISO to rrg8. Establishes
+        MTA1 (= YPR116W = the RRG8 ortholog) as an inner-membrane, RNase-P-associated accessory
+        factor, not a demonstrated catalytic nuclease.
+  - id: PMID:19751518
+    title: Genome-wide deletion mutant analysis reveals genes required for respiratory growth,
+      mitochondrial genome maintenance and mitochondrial protein synthesis in Saccharomyces
+      cerevisiae.
+    findings:
+      - statement: &gt;-
+          Systematic deletion analysis named RRG8 (YPR116w) as one of ten previously
+          uncharacterized genes essential for respiratory growth; the GFP-tagged protein
+          localizes to mitochondria and its loss compromises mitochondrial protein synthesis
+          and genome maintenance.
+        supporting_text: &gt;-
+          identified ten previously uncharacterized genes essential for respiratory growth
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed/PMC-verified. Source of the RRG8 gene name (&#34;Required for Respiratory Growth 8&#34;)
+        and of mitochondrial localization/respiratory-deficiency of the ortholog. Table 5 lists
+        RRG8/YPR116w as &#34;Unknown function, GFP-tagged protein in mitochondria&#34;.
+  - id: PMID:20473289
+    title: Analysis of a genome-wide set of gene deletions in the fission yeast Schizosaccharomyces
+      pombe.
+    findings:
+      - statement: &gt;-
+          Genome-wide fission-yeast deletion analysis; provides the essentiality classification
+          underlying the inviable phenotype of rrg8 deletion and notes that loss of mtDNA is
+          lethal in fission yeast (unlike budding yeast petites), explaining why a mitochondrial
+          gene-expression factor is essential in S. pombe.
+        supporting_text: &gt;-
+          Loss of mtDNA is lethal in fission yeast but not in budding yeast
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PMC-verified genome-wide deletion resource. Per-gene call for SPAC31G5.06 is in
+        supplementary data; PomBase records the inviable deletion phenotype. Cited here for
+        essentiality context and the fission-yeast-specific lethality of mtDNA loss.
+  - id: PMID:23697806
+    title: A genome-wide resource of cell cycle and cell shape genes of fission yeast.
+    findings:
+      - statement: &gt;-
+          Microscopy-based screen providing the evidence for the inviable, tapered-cell
+          deletion phenotype of rrg8 recorded in PomBase.
+        supporting_text: &gt;-
+          A genome-wide resource of cell cycle and cell shape genes of fission yeast
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PMC-verified. Bioneer/Sysgro microscopy resource; PomBase attributes the FYPO inviable
+        phenotype (microscopy evidence) of rrg8 deletion to this study.
+  - id: PMID:16823372
+    title: ORFeome cloning and global analysis of protein localization in the fission yeast
+      Schizosaccharomyces pombe.
+    findings:
+      - statement: &gt;-
+          High-throughput C-terminal YFP-tagging localization screen; the source (via UniProt
+          Subcellular Location) of the electronic cytoplasm and nucleus annotations for rrg8.
+          Such large-scale C-terminally tagged screens can mislocalize low-abundance organellar
+          proteins.
+        supporting_text: &gt;-
+          we determined the localization of 4,431 proteins
+    reference_review:
+      relevance: LOW
+      correctness: LOW_QUALITY
+      review_notes: &gt;-
+        PubMed-verified (abstract-only). Genome-scale YFP-tagging screen; the cyto/nuclear call
+        for rrg8 conflicts with orthology-based mitochondrial localization and is not curated as
+        a component by PomBase. Treated as the basis of over-annotated electronic CC terms.
+  - id: PMID:39367033
+    title: Quantitative proteomics and phosphoproteomics profiling of meiotic divisions in the
+      fission yeast Schizosaccharomyces pombe.
+    findings:
+      - statement: &gt;-
+          Meiotic proteomics detecting rrg8 at the protein level, with increased abundance during
+          meiotic division; establishes that the gene is expressed as a protein.
+        supporting_text: &gt;-
+          Quantitative proteomics and phosphoproteomics profiling of meiotic divisions
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PMC-verified. Expression/abundance evidence only (protein detected, increased in meiosis);
+        does not inform molecular function.
+existing_annotations:
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic (UniProt Subcellular Location keyword-mapping) nuclear annotation, ultimately
+        derived from a high-throughput C-terminal YFP-tagging screen.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The nucleus call traces to the genome-scale YFP-tagging ORFeome screen (PMID:16823372)
+        via UniProt Subcellular Location and GO_REF:0000044. It conflicts with the
+        orthology-based mitochondrial localization of this protein (the S. cerevisiae ortholog
+        RRG8/MTA1 is on the matrix side of the inner mitochondrial membrane) and is not curated
+        as a cellular component by PomBase, which annotates only mitochondrion. Large-scale
+        C-terminally tagged screens frequently produce spurious cytosolic/nuclear signal for
+        low-abundance organellar proteins, and a C-terminal tag can mask a cleavable
+        mitochondrial targeting signal. Flag as an over-annotation for a mitochondrial protein
+        rather than a core location.
+      supported_by:
+        - reference_id: PMID:16823372
+          supporting_text: &gt;-
+            we determined the localization of 4,431 proteins
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Electronic (UniProt Subcellular Location keyword-mapping) cytoplasmic annotation from the
+        same high-throughput YFP-tagging screen.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        As with the nucleus annotation, cytoplasm derives from the genome-scale YFP screen
+        (PMID:16823372) mapped through UniProt Subcellular Location (GO_REF:0000044). It is a
+        broad, non-specific term that is inconsistent with the mitochondrial localization inferred
+        from the well-characterized ortholog and with PomBase&#39;s expert decision to annotate only
+        mitochondrion. Mark as over-annotated; the informative location is mitochondrion.
+      supported_by:
+        - reference_id: PMID:16823372
+          supporting_text: &gt;-
+            we determined the localization of 4,431 proteins
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root molecular_function term with the No-Data (ND) evidence code, correctly recording that
+        no molecular function has been determined for rrg8.
+      action: ACCEPT
+      reason: &gt;-
+        The molecular function of rrg8 is genuinely unknown. The protein has no recognizable domain,
+        catalytic motif, or family signature (no InterPro/Pfam/PANTHER assignment), and even the
+        better-studied budding-yeast ortholog is described as &#34;of unknown function&#34;. The ND
+        annotation to the root term is the honest and correct representation of this gap; retain it.
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        Mitochondrial localization transferred by orthology (ISO) from the S. cerevisiae ortholog
+        RRG8/MTA1 (SGD:S000006320), which localizes to the matrix side of the mitochondrial inner
+        membrane and is GFP-tagged in mitochondria.
+      action: ACCEPT
+      reason: &gt;-
+        The ISO transfer is well supported: the ortholog is experimentally mitochondrial
+        (inner-membrane-associated; GFP in mitochondria, PMID:19751518) and functions there in
+        mitochondrial tRNA processing (PMID:30759361). Mitochondrion is the single cellular
+        component curated by PomBase for rrg8 and represents its core location. Retain as core.
+      supported_by:
+        - reference_id: PMID:19751518
+          supporting_text: &gt;-
+            identified ten previously uncharacterized genes essential for respiratory growth
+        - reference_id: PMID:30759361
+          supporting_text: &gt;-
+            Mta1p, Mta2p, Pet130p, and Gep5p are associated with the
+  - term:
+      id: GO:0097745
+      label: mitochondrial tRNA 5&#39;-end processing
+    evidence_type: ISO
+    original_reference_id: GO_REF:0000024
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        Involvement in mitochondrial tRNA 5&#39;-end processing transferred by orthology (ISO) from
+        the S. cerevisiae ortholog RRG8/MTA1, which is required for efficient 5&#39; processing of
+        mitochondrial tRNAs and associates with mitochondrial RNase P (Rpm2p).
+      action: ACCEPT
+      reason: &gt;-
+        The process assignment is well supported by ortholog genetics and biochemistry: mta1 null
+        mutants have severely reduced mitochondrial tRNA levels, ts mutants accumulate pre-tRNA
+        transcripts, and Mta1p co-immunopurifies with Rpm2p, the protein subunit of mitochondrial
+        RNase P (PMID:30759361). This is the best-supported biological process for rrg8 and is
+        consistent with its essentiality in fission yeast, where loss of mtDNA/mitochondrial gene
+        expression is lethal. Note this is a process (BP) annotation, not a claim that rrg8 is the
+        catalytic nuclease. Retain as core.
+      supported_by:
+        - reference_id: PMID:30759361
+          supporting_text: &gt;-
+            we identify four novel genes MTA1, MTA2, GEP5 and PET130 of
+        - reference_id: PMID:30759361
+          supporting_text: &gt;-
+            co-immunopurification of Rpm2 with Mta1p
+core_functions:
+  - description: &gt;-
+      Accessory factor for mitochondrial tRNA 5&#39;-end processing / mitochondrial gene expression.
+      Acting within the mitochondrion (ortholog is on the matrix side of the inner membrane), rrg8
+      is required for efficient 5&#39; maturation of mitochondrial tRNAs, a step catalyzed by
+      mitochondrial RNase P. Its precise molecular activity is unknown; the ortholog associates
+      with, and co-purifies with, the RNase P protein subunit Rpm2p, consistent with a
+      scaffolding/assembly or accessory role rather than an intrinsic catalytic function. No
+      molecular_function term is asserted because none can be defended from sequence (no domain,
+      motif, or family) or from experiment.
+    directly_involved_in:
+      - id: GO:0097745
+        label: mitochondrial tRNA 5&#39;-end processing
+    locations:
+      - id: GO:0005739
+        label: mitochondrion
+    supported_by:
+      - reference_id: PMID:30759361
+        supporting_text: &gt;-
+          we identify four novel genes MTA1, MTA2, GEP5 and PET130 of
+      - reference_id: PMID:19751518
+        supporting_text: &gt;-
+          identified ten previously uncharacterized genes essential for respiratory growth
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular function of rrg8 is unknown. No biochemical activity, catalytic residue,
+      domain, or family signature has been identified for the fission-yeast protein or for any
+      of its orthologs; whether it is an enzyme, an RNA-binding protein, or a purely structural
+      scaffold is undetermined.
+    boundary: &gt;-
+      The protein is 234 residues, carries a single low-complexity region and no recognizable
+      InterPro/Pfam/PANTHER domain, and UniProt lists no FUNCTION and only &#34;Predicted&#34; protein
+      existence. Even the better-studied S. cerevisiae ortholog RRG8/MTA1 is repeatedly described
+      as a protein &#34;of unknown function&#34;, so the gap is real and field-acknowledged, not merely
+      uncurated.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      rrg8 is essential in fission yeast and its ortholog is required for respiratory growth,
+      yet the molecular basis of these phenotypes is completely unexplained. It is a conserved,
+      single-copy, essential &#34;dark&#34; gene of exactly the type the unknome program targets.
+    resolution: &gt;-
+      Biochemical characterization of purified rrg8 / Rrg8-family protein: test for nuclease,
+      RNA-binding, or protein-scaffolding activity in mitochondrial RNase P reconstitution;
+      structural determination (X-ray/cryo-EM or high-confidence structure prediction) to assign
+      a fold and candidate active site.
+    provenance:
+      - reference_id: PMID:19751518
+        supporting_text: &gt;-
+          identified ten previously uncharacterized genes essential for respiratory growth
+  - gap_statement: &gt;-
+      Whether rrg8 is a stable subunit of mitochondrial RNase P, a transient assembly/maturation
+      factor for the enzyme, or acts on tRNA processing indirectly is unresolved. The mechanism by
+      which it promotes 5&#39; pre-tRNA cleavage is not defined.
+    boundary: &gt;-
+      In the ortholog, Mta1p (together with Mta2p, Gep5p, Pet130p) is inner-membrane-associated,
+      sediments as a high-molecular-weight complex, and co-immunopurifies with the RNase P protein
+      subunit Rpm2p (PMID:30759361); null mutants have reduced mitochondrial tRNA levels and ts
+      mutants accumulate pre-tRNA transcripts. This establishes a functional link to RNase P but
+      not the mechanistic role (subunit vs assembly factor vs indirect).
+    gap_kind:
+      - BIOLOGY
+      - ONTOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Distinguishing a bona fide RNase P subunit from an accessory assembly factor would clarify
+      the architecture of fungal mitochondrial RNase P and determine whether an appropriate GO
+      complex/subunit term (currently lacking) is needed to express rrg8&#39;s contribution.
+    resolution: &gt;-
+      Native purification / cryo-EM of fungal mitochondrial RNase P to test for stoichiometric
+      inclusion of Rrg8; in-organello pre-tRNA processing assays in rrg8 conditional mutants;
+      define whether the RNase P activity or its assembly is lost.
+    provenance:
+      - reference_id: PMID:30759361
+        supporting_text: &gt;-
+          co-immunopurification of Rpm2 with Mta1p
+  - gap_statement: &gt;-
+      The direct role of the S. pombe protein itself has not been measured. All functional
+      annotations (mitochondrion, mitochondrial tRNA 5&#39;-end processing) are transferred by
+      orthology from S. cerevisiae; there is no fission-yeast biochemistry, localization by native
+      methods, or in-organello assay for rrg8.
+    boundary: &gt;-
+      rrg8 deletion is inviable in fission yeast (PomBase; microscopy evidence PMID:23697806),
+      and the protein is expressed (detected at RNA and protein level, increased in meiosis,
+      PMID:39367033). The essential phenotype is consistent with a mitochondrial gene-expression
+      role because loss of mtDNA is lethal in fission yeast (PMID:20473289), but the specific
+      molecular defect in rrg8-null cells has not been characterized.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Direct fission-yeast evidence would upgrade the ISO annotations to experimental support and
+      test whether the mitochondrial tRNA-processing role is conserved in S. pombe or whether the
+      essential phenotype reflects a different or additional function.
+    resolution: &gt;-
+      Localize an endogenously tagged Rrg8 by fluorescence and subcellular fractionation; analyze
+      mitochondrial tRNA processing and mtDNA maintenance in a conditional (e.g. tetO/thiamine-
+      repressible) rrg8 allele.
+    provenance:
+      - reference_id: PMID:20473289
+        supporting_text: &gt;-
+          Loss of mtDNA is lethal in fission yeast but not in budding yeast
+suggested_questions:
+  - question: &gt;-
+      Is Rrg8 a stoichiometric subunit of fission-yeast mitochondrial RNase P, or a transient
+      assembly/maturation factor for the enzyme?
+    experts: []
+  - question: &gt;-
+      Does the essential phenotype of rrg8 deletion in S. pombe reflect specifically defective
+      mitochondrial tRNA processing (and consequent loss of mitochondrial translation and mtDNA),
+      or an additional/independent function?
+    experts: []
+suggested_experiments:
+  - hypothesis: &gt;-
+      Rrg8 associates with mitochondrial RNase P and is required for 5&#39; processing of
+      mitochondrial pre-tRNAs in S. pombe.
+    description: &gt;-
+      Endogenously epitope-tag rrg8, purify from isolated mitochondria under native conditions, and
+      test by mass spectrometry / co-immunoprecipitation for association with the RNase P protein
+      subunit (Rpm2 ortholog) and other Mta1/Mta2/Gep5/Pet130-equivalent factors. In parallel, use a
+      conditional rrg8 allele and northern blotting / primer extension to test for accumulation of
+      unprocessed mitochondrial pre-tRNA 5&#39; leaders.
+    experiment_type: affinity purification-mass spectrometry and RNA processing assay
+  - hypothesis: &gt;-
+      Rrg8 possesses an assignable fold and candidate functional surface despite lacking recognized
+      sequence signatures.
+    description: &gt;-
+      Determine or predict the structure of Rrg8 (cryo-EM within the mitochondrial RNase P complex,
+      or high-confidence structure prediction plus DALI/Foldseek search) to identify structural
+      homologs, a possible RNA-binding surface, or a degenerate catalytic site, and use conservation
+      mapping across fungal orthologs to nominate functionally important residues for mutagenesis.
+    experiment_type: structural biology / structure-based homology detection
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/sil1/sil1-ai-review.html
+++ b/genes/SCHPO/sil1/sil1-ai-review.html
@@ -1,0 +1,2530 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>sil1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>sil1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9UTR0" target="_blank" class="term-link">
+                        Q9UTR0
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "sil1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9UTR0" data-a="DESCRIPTION: sil1 (systematic name SPAC1071.03c; UniProt Q9UTR0..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>sil1 (systematic name SPAC1071.03c; UniProt Q9UTR0) is the Schizosaccharomyces pombe member of the SIL1/HspBP1 family of nucleotide-exchange factors (NEFs) for Hsp70 chaperones. It is the one-to-one ortholog of human SIL1 (the gene mutated in Marinesco-Sjogren syndrome) and of Saccharomyces cerevisiae Sil1p/YOL031C. The 338-residue protein is built around an armadillo-repeat (ARM-type) alpha-helical fold, the structural hallmark of this NEF class, and carries an N-terminal hydrophobic segment (residues ~20-42) that is most consistent with an endoplasmic-reticulum signal/anchor sequence. By orthology, Sil1-family proteins act in the endoplasmic reticulum, where they bind the ATPase (nucleotide-binding) domain of the ER Hsp70 chaperone BiP (Kar2p in budding yeast) and accelerate ADP release, thereby driving the BiP chaperone cycle that folds and translocates nascent secretory proteins. In budding yeast BiP is served by two functionally distinct NEFs, Sil1p and the Hsp110/Grp170-type Lhs1p; either single deletion is viable but the double deletion is lethal, indicating that BiP nucleotide exchange is essential and partly redundant. In fission yeast sil1 is non-essential (deletion viable) and has not been characterized biochemically; the molecular NEF activity, ER localization, and biological roles above are inferred from conserved domain architecture and orthology rather than from direct experiments in this species.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UTR0" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Endoplasmic reticulum is the expected site of action for a SIL1-family BiP nucleotide-exchange factor. The IBA (phylogenetic) inference is consistent with the ER-lumenal localization of the S. cerevisiae and human orthologs and with the N-terminal ER signal/anchor sequence of the pombe protein. This is the meaningful, informative compartment for the gene and is retained as the core localization. Direct localization data in fission yeast are not available.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
+                                    GO:0000774
+                                </a>
+                            </span>
+                            <span class="term-label">adenyl-nucleotide exchange factor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UTR0" data-a="GO:0000774" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the defining molecular function of the SIL1/HspBP1 family: binding the ATPase (nucleotide-binding) domain of an ER Hsp70 (BiP/Kar2p) and stimulating ADP release (nucleotide exchange). It is well supported by orthology to experimentally characterized S. cerevisiae Sil1p and human SIL1, and by the diagnostic armadillo-repeat fold. This is a specific, informative MF term (preferable to generic protein binding) and is retained as the core function. The activity has not been demonstrated biochemically in S. pombe itself.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20430899" target="_blank" class="term-link">
+                                        PMID:20430899
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These studies identified a role for the IIB domain of Kar2p in Sil1p binding and Sil1p-stimulated nucleotide exchange</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UTR0" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IEA annotation is an automatic mapping from the UniProt Subcellular Location keyword (SL-0162 Membrane), which itself derives from a single predicted N-terminal transmembrane/hydrophobic segment (residues ~20-42). For a SIL1-family protein this hydrophobic stretch is more consistent with an ER signal/anchor than with a genuine multi-compartment membrane residence, and generic membrane is uninformative relative to the endoplasmic reticulum term already annotated. Retained as a non-core, low-information electronic annotation.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006616" target="_blank" class="term-link">
+                                    GO:0006616
+                                </a>
+                            </span>
+                            <span class="term-label">SRP-dependent cotranslational protein targeting to membrane, translocation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UTR0" data-a="GO:0006616" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This ISO annotation was transferred from a S. cerevisiae ortholog (SGD:S000005391) and reflects the participation of the BiP/Kar2p chaperone system in translocation of nascent secretory polypeptides into the ER. It is a downstream, process-level attribution of the Sil1 NEF role (Sil1 assists BiP, which acts in ER protein import) rather than sil1&#39;s core molecular function, and it is not directly demonstrated in fission yeast. The essence of ER-protein-biogenesis involvement is defensible, so it is kept as non-core rather than removed; the precise process term is broader than what is established for sil1 specifically in pombe.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Nucleotide-exchange factor (NEF) for the endoplasmic-reticulum Hsp70 chaperone BiP. sil1 is a SIL1/HspBP1-family, armadillo-repeat protein that binds the ATPase (nucleotide-binding) domain of ER-lumenal BiP and accelerates ADP release, resetting BiP for the next ATP-bound, substrate-engaging cycle. Through this activity it supports BiP-dependent folding and translocation of nascent secretory proteins in the ER. This molecular role is inferred from the diagnostic ARM fold and from orthology to experimentally characterized S. cerevisiae Sil1p and human SIL1; the activity, the BiP partner, and the in-vivo requirement have not been demonstrated in S. pombe.</h3>
+                <span class="vote-buttons" data-g="Q9UTR0" data-a="FUNCTION: Nucleotide-exchange factor (NEF) for the endoplasm..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
+                            adenyl-nucleotide exchange factor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                endoplasmic reticulum
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20430899" target="_blank" class="term-link">
+                                PMID:20430899
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Two NEFs have been identified for Kar2p in the ER lumen of Saccharomyces cerevisiae, namely Lhs1p and Sil1p</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20430899" target="_blank" class="term-link">
+                            PMID:20430899
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactions between Kar2p and its nucleotide exchange factors Sil1p and Lhs1p are mechanistically distinct.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The ER Hsp70 Kar2p (BiP) is regulated by two nucleotide-exchange factors, Sil1p and Lhs1p; NEFs promote ADP release to drive the next round of ATP binding in the chaperone cycle.</div>
+
+                        <div class="finding-text">"Two NEFs have been identified for Kar2p in the ER lumen of Saccharomyces cerevisiae, namely Lhs1p and Sil1p"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Sil1p binds the IIB subdomain of the Kar2p ATPase domain to stimulate nucleotide exchange, mechanistically distinct from Lhs1p.</div>
+
+                        <div class="finding-text">"These studies identified a role for the IIB domain of Kar2p in Sil1p binding and Sil1p-stimulated nucleotide exchange"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Single deletions of SIL1 or LHS1 are viable but the double deletion is lethal, showing BiP nucleotide exchange is essential and the two NEFs are partly redundant.</div>
+
+                        <div class="finding-text">"Individual deletions of LHS1 (Δlhs1) and SIL1 (Δsil1) in yeast cells are viable (13, 14), but the double deletion (Δlhs1Δsil1) is lethal suggesting that nucleotide exchange is essential for Kar2p activity and cell viability"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37787768" target="_blank" class="term-link">
+                            PMID:37787768
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Broad functional profiling of fission yeast proteins using phenomics and machine learning.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide phenomics/machine-learning profiling of S. pombe deletion mutants; the study explicitly targets poorly characterized proteins, and sil1 phenotypes in PomBase derive from this class of broad screen rather than a dedicated study.</div>
+
+                        <div class="finding-text">"Many proteins remain poorly characterized even in well-studied organisms"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28410370" target="_blank" class="term-link">
+                            PMID:28410370
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A systematic screen for morphological abnormalities during fission yeast sexual reproduction identifies a mechanism of actin aster formation for cell fusion.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Systematic mating-morphology deletion screen in S. pombe; the cell-fusion phenotype recorded for sil1 in PomBase (incomplete cell wall disassembly at the fusion site) originates from this genome-wide screen.</div>
+
+                        <div class="finding-text">"morphological abnormalities of the mating process in fission yeast"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe Sil1 bind fission-yeast BiP and stimulate its nucleotide exchange, as its orthologs do for Kar2p and mammalian BiP?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: ER chaperone / Hsp70 co-chaperone biochemists, Fission-yeast secretory-pathway biologists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UTR0" data-a="Q: Does S. pombe Sil1 bind fission-yeast BiP and stim..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is sil1 functionally redundant with the pombe Hsp110/Grp170-type BiP NEF, such that the double deletion is synthetically lethal as in budding yeast?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Yeast ER-proteostasis geneticists</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UTR0" data-a="Q: Is sil1 functionally redundant with the pombe Hsp1..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute recombinant pombe Sil1 with pombe BiP and measure Sil1-stimulated nucleotide exchange and ATPase activity to test the inferred NEF function directly.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: In-vitro biochemistry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UTR0" data-a="EXPERIMENT: Reconstitute recombinant pombe Sil1 with pombe BiP..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Build sil1 single and sil1 plus Lhs1/Grp170-ortholog double deletions and test for synthetic lethality and ER-stress (tunicamycin, DTT) hypersensitivity to define redundancy among pombe BiP NEFs.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Genetic interaction analysis</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UTR0" data-a="EXPERIMENT: Build sil1 single and sil1 plus Lhs1/Grp170-orthol..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the subcellular localization and membrane topology of tagged pombe Sil1 (ER lumen vs membrane; protease protection) to resolve the single-pass-membrane vs lumenal ambiguity.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: Localization / topology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UTR0" data-a="EXPERIMENT: Determine the subcellular localization and membran..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether Sil1 nucleotide-exchange activity is individually required in S. pombe, or is functionally redundant with the fission-yeast Hsp110/Grp170-type NEF (the Lhs1/Grp170 class), is undetermined; the phenotypic consequence of losing sil1 versus losing both BiP NEFs has not been tested in pombe.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In S. cerevisiae, single sil1 or lhs1 deletions are viable but the sil1 lhs1 double deletion is lethal, showing the two NEFs are partly redundant and that BiP nucleotide exchange is essential. In S. pombe, sil1 deletion is viable, but no analogous single/double NEF-deletion analysis has been reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Determines whether sil1 is a dispensable, redundant NEF in pombe or contributes a non-redundant function, and whether the conserved &#34;BiP has two NEFs, together essential&#34; logic holds in fission yeast.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Construct and phenotype pombe sil1 single and sil1 (Lhs1/Grp170-ortholog) double deletions for synthetic lethality and ER-stress sensitivity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Individual deletions of LHS1 (Δlhs1) and SIL1 (Δsil1) in yeast cells are viable (13, 14), but the double deletion (Δlhs1Δsil1) is lethal suggesting that nucleotide exchange is essential for Kar2p activity and cell viability"</em> — PMID:20430899</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The in-vivo biological roles and physiological clients of sil1 in S. pombe are unknown; the only pombe phenotypes are scattered drug/stress sensitivities and a cell-fusion morphology defect drawn from genome-wide screens, none mechanistically connected to its BiP-NEF activity.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> sil1 deletion is viable with grossly normal morphology; genome-wide phenomics and a mating-morphology screen recorded assorted stress phenotypes and an &#34;incomplete cell wall disassembly at cell fusion site&#34; phenotype, but there is no dedicated study of sil1 in fission yeast.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether sil1 has a specialized secretory/ER-proteostasis role in pombe (e.g. in mating or cell-wall remodeling) beyond generic BiP support is unresolved.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Directed phenotyping of sil1 deletion under ER stress (tunicamycin, DTT) and mating conditions, and identification of Sil1/BiP-dependent secretory cargo by proteomics.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Many proteins remain poorly characterized even in well-studied organisms"</em> — PMID:37787768</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The membrane topology and ER-retention mechanism of pombe Sil1 are unresolved: the protein is annotated as a single-pass membrane protein from one predicted TM helix, yet SIL1-family orthologs are ER-lumenal, and no canonical HDEL/KDEL retention motif is evident in the pombe sequence.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt/TMHMM predict one hydrophobic segment at residues ~20-42 and an ECO:0000305 single-pass membrane call; S. cerevisiae Sil1p and human SIL1 are ER-lumenal with signal and ER-retention signals. The actual topology of the pombe protein has not been determined experimentally.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifies whether the N-terminal hydrophobic segment is a signal/anchor for an ER-lumenal NEF (as in orthologs) and how the protein is retained in the ER.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Determine subcellular localization and topology (protease-protection, lumenal vs membrane fractionation, tagged-protein imaging) of pombe Sil1.</p>
+
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(sil1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UTR0" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Research Report: Functional Annotation of *sil1* (SPAC1071.03c, UniProt Q9UTR0) in *Schizosaccharomyces pombe*</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">26 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T16:37:16.512960</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="sil1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-functional-annotation-of-sil1-spac107103c-uniprot-q9utr0-in-schizosaccharomyces-pombe">Research Report: Functional Annotation of <em>sil1</em> (SPAC1071.03c, UniProt Q9UTR0) in <em>Schizosaccharomyces pombe</em></h1>
+<h2 id="1-gene-identity-and-literature-availability">1. Gene Identity and Literature Availability</h2>
+<p>The <em>S. pombe</em> gene SPAC1071.03c (UniProt Q9UTR0), designated <em>sil1</em>, encodes an uncharacterized protein of 442 amino acids. No primary literature directly investigating this gene in fission yeast was identified. However, the protein's domain architecture—comprising an ARM-like domain (IPR011989), an ARM-type fold (IPR016024), and membership in the SIL1/FES1/HPBP1 family (IPR050693)—unambiguously identifies it as an ortholog of the well-characterized SIL1/SLS1 nucleotide exchange factors described in <em>Saccharomyces cerevisiae</em>, <em>Yarrowia lipolytica</em>, and mammals. Consequently, this report infers the function of the <em>S. pombe</em> sil1 gene product based on extensive ortholog evidence, which is summarized in the table below.</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Evidence Source</th>
+<th>Organism Studied</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene identity / inference scope</td>
+<td><strong>S. pombe</strong> SPAC1071.03c (UniProt Q9UTR0) is uncharacterized directly, but its ARM-like and SIL1/FES1/HPBP1 family annotations strongly support orthology to fungal/mammalian <strong>SIL1/Sls1</strong> proteins; functional assignment is therefore inferred from orthologs rather than direct fission-yeast experiments.</td>
+<td>UniProt/domain context summarized from the research prompt; ortholog-based family/function reviews (ichhaporia2021roleofthe pages 4-5, bracher2015grpehsp110grp170hspbp1sil1 pages 11-14)</td>
+<td><em>S. pombe</em> inferred from orthologs; family evidence from budding yeast and mammals</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Canonical function is a <strong>nucleotide exchange factor (NEF)</strong> for the ER Hsp70 chaperone <strong>BiP/Kar2</strong>, promoting ADP release and ATP rebinding to reset the chaperone cycle and release bound substrates.</td>
+<td>(ichhaporia2021roleofthe pages 4-5, david2019redoxsignalingthrough pages 29-33, ichhaporia2021roleofthe pages 1-3)</td>
+<td><em>S. cerevisiae</em>, mammals</td>
+</tr>
+<tr>
+<td>Structural features</td>
+<td>SIL1-family proteins have an elongated ARM-domain architecture: ~16 α-helices arranged into <strong>4 armadillo repeats</strong> that form a curved superhelical scaffold specialized for BiP binding.</td>
+<td>(ichhaporia2021roleofthe pages 4-5, bracher2015grpehsp110grp170hspbp1sil1 pages 11-14)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>NEF mechanism</td>
+<td>The ARM domain wraps around <strong>lobe IIb</strong> of BiP/Kar2’s nucleotide-binding domain, with additional contacts to lobe Ib; this rotates the lobes apart, destabilizes ADP binding, and drives nucleotide exchange.</td>
+<td>(ichhaporia2021roleofthe pages 4-5, bracher2015grpehsp110grp170hspbp1sil1 pages 11-14)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>N-terminal regulatory region</td>
+<td>Beyond the ARM core, the N-terminal region can contact BiP’s substrate-binding domain as a <strong>pseudo-substrate-like regulatory element</strong>, modulating substrate release and BiP activity.</td>
+<td>(pareja2018arolefor pages 31-36, pareja2018arolefor pages 26-31)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>SIL1 orthologs are <strong>ER-luminal</strong> proteins. They carry an <strong>N-terminal ER signal sequence</strong> and typically a <strong>C-terminal ER-retention motif</strong>; ER retention may also be reinforced by strong binding to abundant BiP.</td>
+<td>(pareja2018arolefor pages 26-31, pareja2018arolefor pages 31-36, ichhaporia2021roleofthe pages 4-5)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>Protein translocation into ER</td>
+<td>SIL1/Sls1 contributes to <strong>protein import/translocation into the ER lumen</strong> by supporting the Kar2/BiP cycle associated with the Sec61/Sec63 translocon. Loss of both SIL1 and the alternative NEF Lhs1 causes severe translocation failure.</td>
+<td>(bracher2015grpehsp110grp170hspbp1sil1 pages 19-21, ichhaporia2021roleofthe pages 4-5, verghese2012biologyofthe pages 24-25)</td>
+<td><em>S. cerevisiae</em>, <em>Yarrowia lipolytica</em></td>
+</tr>
+<tr>
+<td>Protein folding / ER proteostasis</td>
+<td>By regenerating ATP-bound BiP, SIL1 supports <strong>protein folding</strong>, client release, and general ER proteostasis; single-mutant phenotypes are often mild because the ER has a second BiP NEF, Lhs1/GRP170.</td>
+<td>(ichhaporia2021roleofthe pages 1-3, bracher2015grpehsp110grp170hspbp1sil1 pages 19-21, ichhaporia2018theroleof pages 42-46)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>ER-associated degradation (ERAD)</td>
+<td>Ortholog studies indicate SIL1 also supports <strong>ERAD</strong>, with loss of Sil1 reducing fitness in ERAD-defective backgrounds and slowing degradation of some ERAD substrates.</td>
+<td>(pareja2018arolefor pages 26-31, delic2013thesecretorypathway pages 10-13)</td>
+<td>Primarily <em>S. cerevisiae</em></td>
+</tr>
+<tr>
+<td>Reductant function</td>
+<td>In addition to NEF activity, yeast Sil1 has an <strong>unexpected reductant role</strong>: it reduces oxidized BiP and helps restore normal ATP-dependent chaperone activity after oxidative ER stress.</td>
+<td>(siegenthaler2017anunexpectedrole pages 1-2, david2019redoxsignalingthrough pages 66-70)</td>
+<td><em>S. cerevisiae</em></td>
+</tr>
+<tr>
+<td>Redox-active cysteines</td>
+<td>This reductant function depends on an <strong>N-terminal cysteine pair</strong> (Cys52/Cys57 in yeast Sil1). Removing both cysteines abolishes reduction of oxidized/glutathionylated BiP, while NEF activity remains intact.</td>
+<td>(siegenthaler2017anunexpectedrole pages 3-5, siegenthaler2017anunexpectedrole pages 8-9, siegenthaler2017anunexpectedrole pages 6-7)</td>
+<td><em>S. cerevisiae</em></td>
+</tr>
+<tr>
+<td>Relationship with Lhs1/GRP170</td>
+<td>SIL1 and <strong>Lhs1/GRP170</strong> are the two ER BiP NEFs. They are <strong>partially redundant but mechanistically distinct</strong>: double loss is lethal, yet they bind/activate BiP differently and may not serve identical substrate sets.</td>
+<td>(bracher2015grpehsp110grp170hspbp1sil1 pages 19-21, ichhaporia2021roleofthe pages 4-5, ichhaporia2018theroleof pages 42-46)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>Stress regulation / UPR connection</td>
+<td>SIL1-family factors are integrated into <strong>ER stress responses</strong>. SIL1 and Lhs1 can be upregulated during ER stress, helping expand ER folding capacity and reshape BiP-dependent quality control.</td>
+<td>(bracher2015grpehsp110grp170hspbp1sil1 pages 19-21, pareja2018arolefor pages 31-36)</td>
+<td>Yeast, mammals</td>
+</tr>
+<tr>
+<td>Regulation by N-glycosylation</td>
+<td>In budding yeast, Sil1 is <strong>Ost3-dependent N-glycosylated</strong> under basal conditions, but this glycosylation is selectively reduced under <strong>reductive ER stress</strong>. The unglycosylated form remains active and can better compensate for Lhs1 loss, suggesting adaptive tuning of BiP co-chaperone function by ER redox state.</td>
+<td>(stevens2017diminishedost3dependentnglycosylation pages 1-2, stevens2017diminishedost3dependentnglycosylation pages 4-5, stevens2017diminishedost3dependentnglycosylation pages 2-3, stevens2017diminishedost3dependentnglycosylation pages 3-4)</td>
+<td><em>S. cerevisiae</em></td>
+</tr>
+<tr>
+<td>Disease relevance</td>
+<td>In humans, <strong>loss-of-function mutations in SIL1</strong> cause <strong>Marinesco-Sjögren syndrome</strong>, establishing the biological importance of SIL1-mediated ER proteostasis and supporting the functional significance of SIL1 orthologs across eukaryotes.</td>
+<td>(ichhaporia2021roleofthe pages 1-3, ichhaporia2018theroleof pages 42-46)</td>
+<td>Human, mouse</td>
+</tr>
+<tr>
+<td>Best functional annotation for <em>S. pombe</em> sil1</td>
+<td>The most defensible annotation for <strong>SPAC1071.03c/Q9UTR0</strong> is: <strong>ER-luminal BiP/Kar2 nucleotide exchange factor of the SIL1 family</strong>, likely participating in ER protein translocation, folding, quality control, and possibly redox-responsive regulation, with partial functional overlap with Lhs1/GRP170.</td>
+<td>Inference integrating ortholog evidence (ichhaporia2021roleofthe pages 4-5, bracher2015grpehsp110grp170hspbp1sil1 pages 11-14, bracher2015grpehsp110grp170hspbp1sil1 pages 19-21, pareja2018arolefor pages 26-31)</td>
+<td><em>S. pombe</em> inferred from orthologs</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the most likely functions and properties of S. pombe sil1/SPAC1071.03c (Q9UTR0) based on ortholog evidence from yeast and mammals. It is useful for functional annotation because direct literature on the fission-yeast protein is lacking, so the strongest evidence comes from conserved SIL1-family mechanisms.</em></p>
+<h2 id="2-primary-molecular-function-nucleotide-exchange-factor-for-bipkar2">2. Primary Molecular Function: Nucleotide Exchange Factor for BiP/Kar2</h2>
+<p>The primary function of SIL1-family proteins is to serve as a <strong>nucleotide exchange factor (NEF) for the endoplasmic reticulum (ER) Hsp70 chaperone BiP</strong> (called Kar2 in yeast). BiP/Kar2 is a central regulator of ER function: it binds unfolded client proteins in an ADP-bound state and releases them upon ATP binding. SIL1 catalyzes the critical step of promoting ADP release from BiP's nucleotide-binding domain (NBD), allowing ATP to bind and triggering conformational changes that open BiP's substrate-binding domain (SBD) and release the polypeptide client, enabling it to fold (ichhaporia2021roleofthe pages 4-5, ichhaporia2021roleofthe pages 1-3). The mammalian SIL1 homolog (BAP, BiP-associated protein) stimulates BiP's ATP hydrolysis activity approximately two-fold independently and up to four-fold when combined with J-domain co-chaperones such as ERdj4 (pareja2018arolefor pages 26-31).</p>
+<h2 id="3-structural-basis-of-nef-activity">3. Structural Basis of NEF Activity</h2>
+<p>SIL1-family proteins adopt an elongated, kidney-bean-shaped structure composed of approximately 16 α-helices organized into <strong>four armadillo (ARM) repeats</strong> (ARM1–ARM4), each consisting of three α-helices packed into a superhelix (ichhaporia2021roleofthe pages 4-5). The ARM domain wraps around <strong>lobe IIb</strong> of BiP's NBD while making additional contacts with lobe Ib. This interaction introduces torsional strain that causes the two lobes to rotate apart, breaking the hydrogen bonds that coordinate the bound ADP molecule and facilitating its release (ichhaporia2021roleofthe pages 4-5).</p>
+<p>This mechanism is structurally distinct from that of the cytosolic paralog HspBP1, which distorts lobe I of the Hsp70 NBD rather than acting primarily through lobe IIb. Despite sharing a conserved ARM-repeat core fold, yeast Sil1p and mammalian HspBP1 employ different binding geometries to achieve nucleotide exchange (bracher2015grpehsp110grp170hspbp1sil1 pages 11-14). In addition to the core ARM domain, the N-terminal region of Sil1 contacts BiP's SBD and functions as a <strong>pseudo-substrate</strong>, modulating BiP's ATPase activity and promoting coordinated substrate release (pareja2018arolefor pages 31-36).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>SIL1 orthologs are <strong>ER-luminal proteins</strong>. They contain an N-terminal ER signal sequence that directs co-translational translocation into the ER lumen, and a C-terminal ER-retention motif (KELR in yeast Sls1p) (pareja2018arolefor pages 26-31, ichhaporia2018theroleof pages 34-38, ichhaporia2021roleofthe pages 4-5). Immunofluorescence studies confirm co-localization of SIL1 with BiP in the ER lumen (pareja2018arolefor pages 31-36). Interestingly, disruption of the KELR retention signal does not cause Sil1 secretion, suggesting that ER retention may be primarily mediated by SIL1's strong interaction with the highly abundant BiP, which is approximately 1,000-fold more concentrated than SIL1 in the ER lumen (pareja2018arolefor pages 26-31, pareja2018arolefor pages 31-36). By inference, the <em>S. pombe</em> sil1 gene product is predicted to localize to the ER lumen.</p>
+<h2 id="5-biological-processes-and-pathway-involvement">5. Biological Processes and Pathway Involvement</h2>
+<h3 id="51-protein-translocation-into-the-er">5.1 Protein Translocation into the ER</h3>
+<p>SIL1/Sls1 contributes to <strong>co-translational protein import</strong> into the ER lumen by supporting the BiP/Kar2 ATPase cycle associated with the Sec61/Sec63 translocon complex. In <em>S. cerevisiae</em>, Sil1 forms nucleotide-dependent interactions with Kar2p and stimulates Sec63p-mediated activation of Kar2p in a conformation-dependent manner (david2019redoxsignalingthrough pages 29-33, ichhaporia2021roleofthe pages 18-19). In <em>Y. lipolytica</em>, the ortholog Sls1 co-localizes with Kar2 and the Sec61 translocon, consistent with a role in co-translational translocation (delic2013thesecretorypathway pages 10-13).</p>
+<h3 id="52-protein-folding-and-er-proteostasis">5.2 Protein Folding and ER Proteostasis</h3>
+<p>By regenerating ATP-bound BiP, SIL1 supports the iterative cycles of client binding and release that constitute chaperone-assisted protein folding in the ER lumen (ichhaporia2021roleofthe pages 1-3, bracher2015grpehsp110grp170hspbp1sil1 pages 19-21). Loss of SIL1 in mammalian systems leads to compromised BiP function, activation of the unfolded protein response (UPR), and ultimately to proteostasis collapse in sensitive tissues (ichhaporia2018theroleof pages 42-46).</p>
+<h3 id="53-er-associated-degradation-erad">5.3 ER-Associated Degradation (ERAD)</h3>
+<p>SIL1 participates in <strong>ERAD</strong> pathways. In <em>S. cerevisiae</em>, Δ<em>sil1</em> mutants are primarily defective in ERAD; deletion of Sil1 reduces viability in ERAD-defective backgrounds and slows the degradation of ERAD substrates such as CPY* (pareja2018arolefor pages 26-31, delic2013thesecretorypathway pages 10-13).</p>
+<h3 id="54-redundancy-with-lhs1grp170">5.4 Redundancy with Lhs1/GRP170</h3>
+<p>SIL1 and <strong>Lhs1/GRP170</strong> are the two known ER-luminal NEFs for BiP/Kar2. They are partially redundant: single deletions of either factor produce comparatively mild phenotypes and trigger UPR activation, but <strong>combined loss of both SIL1 and Lhs1 is synthetically lethal</strong> and causes complete translocation failure (bracher2015grpehsp110grp170hspbp1sil1 pages 19-21, ichhaporia2021roleofthe pages 4-5, verghese2012biologyofthe pages 24-25). Despite this redundancy, the two NEFs are mechanistically distinct—they bind BiP through different molecular contacts, and point mutations that disrupt SIL1 binding do not affect GRP170/Lhs1 interaction with BiP (ichhaporia2021roleofthe pages 4-5, ichhaporia2018theroleof pages 34-38). Under normal conditions, Sil1p is approximately one order of magnitude more abundant than Lhs1p, although both constitute less than 0.1% of BiP content (bracher2015grpehsp110grp170hspbp1sil1 pages 19-21).</p>
+<h2 id="6-dual-reductant-function">6. Dual Reductant Function</h2>
+<p>A landmark discovery revealed that yeast Sil1 has an <strong>unexpected reductant function</strong> beyond its canonical NEF activity. During oxidative ER stress, a conserved cysteine in BiP's NBD (Cys63 in <em>S. cerevisiae</em> Kar2) becomes oxidized, converting BiP into an ATP-independent holdase that helps cells cope with stress. Sil1 can <strong>reverse this BiP cysteine oxidation</strong> through a redox-active cysteine pair (Cys52 and Cys57) located in its flexible N-terminal domain (siegenthaler2017anunexpectedrole pages 1-2). This reduction occurs via a dithiol-disulfide exchange mechanism, forming a transient BiP-Sil1 mixed-disulfide intermediate (siegenthaler2017anunexpectedrole pages 6-7). Sil1 is substantially more effective at reducing oxidized BiP than glutathione, requiring 100-fold less molar concentration to achieve comparable activity, owing to its high affinity for BiP (siegenthaler2017anunexpectedrole pages 5-6).</p>
+<p>Critically, the N-terminal cysteines are <strong>not required for NEF activity</strong> itself—the C52A/C57A double mutant retains normal nucleotide exchange function but completely loses reductant capacity (siegenthaler2017anunexpectedrole pages 8-9). In cells, loss of Sil1 dramatically slows the removal of BiP cysteine adducts post-oxidative stress, extending the half-life from approximately 6 minutes to more than 45 minutes (siegenthaler2017anunexpectedrole pages 3-5). Additionally, Sil1 may serve as an electron bridge between protein disulfide isomerase (PDI) and BiP, facilitating BiP reduction through multiple mechanisms (david2019redoxsignalingthrough pages 121-125).</p>
+<h2 id="7-regulation-by-n-glycosylation">7. Regulation by N-Glycosylation</h2>
+<p>In <em>S. cerevisiae</em>, Sil1 is subject to <strong>Ost3-dependent N-glycosylation</strong> that is dynamically regulated by the ER redox environment. Under reductive ER stress, the Ost3 thioredoxin-like domain becomes reduced, which inhibits N-glycosylation of Sil1 at Asn181. This produces an unglycosylated form (uSil1) that is functionally active and can more effectively compensate for Lhs1 loss than the glycosylated form (stevens2017diminishedost3dependentnglycosylation pages 1-2, stevens2017diminishedost3dependentnglycosylation pages 2-3, stevens2017diminishedost3dependentnglycosylation pages 3-4). This represents a specific adaptive mechanism, distinct from general UPR activation, by which cells tailor SIL1 activity to the redox status of the ER lumen (stevens2017diminishedost3dependentnglycosylation pages 2-2). Importantly, unglycosylatable Sil1 (N181Q variant) remains functional, demonstrating that N-glycosylation is not essential for NEF activity but rather serves a regulatory role (stevens2017diminishedost3dependentnglycosylation pages 2-3).</p>
+<h2 id="8-disease-relevance-and-evolutionary-conservation">8. Disease Relevance and Evolutionary Conservation</h2>
+<p>Loss-of-function mutations in human <em>SIL1</em> cause <strong>Marinesco-Sjögren syndrome (MSS)</strong>, an autosomal recessive multisystem disorder characterized by cerebellar ataxia, early-onset cataracts, and progressive myopathy (ichhaporia2021roleofthe pages 1-3, ichhaporia2018theroleof pages 42-46). The pathological importance of SIL1 in human disease underscores the functional significance of this protein family across eukaryotes and supports the inference that the <em>S. pombe</em> ortholog performs an analogous essential role in ER proteostasis.</p>
+<h2 id="9-conclusions-and-functional-annotation">9. Conclusions and Functional Annotation</h2>
+<p>Based on the conserved domain architecture (ARM-like repeats, SIL1/FES1/HPBP1 family membership) and extensive evidence from ortholog studies, the <em>S. pombe</em> sil1 gene product (SPAC1071.03c, Q9UTR0) is most parsimoniously annotated as an <strong>ER-luminal nucleotide exchange factor for the Hsp70 chaperone BiP/Kar2</strong>. It is predicted to participate in protein translocation into the ER, chaperone-assisted protein folding, ERAD, and potentially ER redox homeostasis. It likely functions in partial redundancy with the S. pombe Lhs1/GRP170 ortholog. Direct experimental characterization in <em>S. pombe</em> remains to be performed, but the strong conservation of domain architecture and the essential nature of this function across eukaryotes provide high confidence in this functional assignment.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(ichhaporia2021roleofthe pages 4-5): Viraj P. Ichhaporia and Linda M. Hendershot. Role of the hsp70 co-chaperone sil1 in health and disease. International Journal of Molecular Sciences, 22:1564, Feb 2021. URL: https://doi.org/10.3390/ijms22041564, doi:10.3390/ijms22041564. This article has 33 citations.</p>
+</li>
+<li>
+<p>(bracher2015grpehsp110grp170hspbp1sil1 pages 11-14): Andreas Bracher and Jacob Verghese. Grpe, hsp110/grp170, hspbp1/sil1 and bag domain proteins: nucleotide exchange factors for hsp70 molecular chaperones. Sub-cellular biochemistry, 78:1-33, Dec 2015. URL: https://doi.org/10.1007/978-3-319-11731-7_1, doi:10.1007/978-3-319-11731-7_1. This article has 88 citations.</p>
+</li>
+<li>
+<p>(david2019redoxsignalingthrough pages 29-33): Kevin David Siegenthaler. Redox signaling through the endoplasmic reticulum chaperone bip. Text, Jan 2019. URL: https://doi.org/10.7298/9fam-y122, doi:10.7298/9fam-y122. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ichhaporia2021roleofthe pages 1-3): Viraj P. Ichhaporia and Linda M. Hendershot. Role of the hsp70 co-chaperone sil1 in health and disease. International Journal of Molecular Sciences, 22:1564, Feb 2021. URL: https://doi.org/10.3390/ijms22041564, doi:10.3390/ijms22041564. This article has 33 citations.</p>
+</li>
+<li>
+<p>(pareja2018arolefor pages 31-36): Kristeen Alcaide Pareja. A role for the n-terminal domain in modulating the activities of the nucleotide exchange factor sil1. Text, Jan 2018. URL: https://doi.org/10.7298/x4t43rc8, doi:10.7298/x4t43rc8. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pareja2018arolefor pages 26-31): Kristeen Alcaide Pareja. A role for the n-terminal domain in modulating the activities of the nucleotide exchange factor sil1. Text, Jan 2018. URL: https://doi.org/10.7298/x4t43rc8, doi:10.7298/x4t43rc8. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bracher2015grpehsp110grp170hspbp1sil1 pages 19-21): Andreas Bracher and Jacob Verghese. Grpe, hsp110/grp170, hspbp1/sil1 and bag domain proteins: nucleotide exchange factors for hsp70 molecular chaperones. Sub-cellular biochemistry, 78:1-33, Dec 2015. URL: https://doi.org/10.1007/978-3-319-11731-7_1, doi:10.1007/978-3-319-11731-7_1. This article has 88 citations.</p>
+</li>
+<li>
+<p>(verghese2012biologyofthe pages 24-25): Jacob Verghese, Jennifer Abrams, Yanyu Wang, and Kevin A. Morano. Biology of the heat shock response and protein chaperones: budding yeast (saccharomyces cerevisiae) as a model system. Microbiology and Molecular Biology Reviews, 76:115-158, Jun 2012. URL: https://doi.org/10.1128/mmbr.05018-11, doi:10.1128/mmbr.05018-11. This article has 776 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ichhaporia2018theroleof pages 42-46): V. P. Ichhaporia. The role of bip co-chaperone sil1 in marinesco-sjögren syndrome pathogenesis. ArXiv, 2018. URL: https://doi.org/10.21007/etd.cghs.2018.0470, doi:10.21007/etd.cghs.2018.0470. This article has 1 citations.</p>
+</li>
+<li>
+<p>(delic2013thesecretorypathway pages 10-13): Marizela Delic, Minoska Valli, Alexandra B. Graf, Martin Pfeffer, Diethard Mattanovich, and Brigitte Gasser. The secretory pathway: exploring yeast diversity. FEMS microbiology reviews, 37 6:872-914, Nov 2013. URL: https://doi.org/10.1111/1574-6976.12020, doi:10.1111/1574-6976.12020. This article has 303 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(siegenthaler2017anunexpectedrole pages 1-2): Kevin D Siegenthaler, Kristeen A Pareja, Jie Wang, and Carolyn S Sevier. An unexpected role for the yeast nucleotide exchange factor sil1 as a reductant acting on the molecular chaperone bip. eLife, Mar 2017. URL: https://doi.org/10.7554/elife.24141, doi:10.7554/elife.24141. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(david2019redoxsignalingthrough pages 66-70): Kevin David Siegenthaler. Redox signaling through the endoplasmic reticulum chaperone bip. Text, Jan 2019. URL: https://doi.org/10.7298/9fam-y122, doi:10.7298/9fam-y122. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(siegenthaler2017anunexpectedrole pages 3-5): Kevin D Siegenthaler, Kristeen A Pareja, Jie Wang, and Carolyn S Sevier. An unexpected role for the yeast nucleotide exchange factor sil1 as a reductant acting on the molecular chaperone bip. eLife, Mar 2017. URL: https://doi.org/10.7554/elife.24141, doi:10.7554/elife.24141. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(siegenthaler2017anunexpectedrole pages 8-9): Kevin D Siegenthaler, Kristeen A Pareja, Jie Wang, and Carolyn S Sevier. An unexpected role for the yeast nucleotide exchange factor sil1 as a reductant acting on the molecular chaperone bip. eLife, Mar 2017. URL: https://doi.org/10.7554/elife.24141, doi:10.7554/elife.24141. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(siegenthaler2017anunexpectedrole pages 6-7): Kevin D Siegenthaler, Kristeen A Pareja, Jie Wang, and Carolyn S Sevier. An unexpected role for the yeast nucleotide exchange factor sil1 as a reductant acting on the molecular chaperone bip. eLife, Mar 2017. URL: https://doi.org/10.7554/elife.24141, doi:10.7554/elife.24141. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stevens2017diminishedost3dependentnglycosylation pages 1-2): Kofi L. P. Stevens, Amy L. Black, Kelsi M. Wells, K. Y. Benjamin Yeo, Robert F. L. Steuart, Colin J. Stirling, Benjamin L. Schulz, and Carl J. Mousley. Diminished ost3-dependent n-glycosylation of the bip nucleotide exchange factor sil1 is an adaptive response to reductive er stress. Proceedings of the National Academy of Sciences, 114:12489-12494, Nov 2017. URL: https://doi.org/10.1073/pnas.1705641114, doi:10.1073/pnas.1705641114. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stevens2017diminishedost3dependentnglycosylation pages 4-5): Kofi L. P. Stevens, Amy L. Black, Kelsi M. Wells, K. Y. Benjamin Yeo, Robert F. L. Steuart, Colin J. Stirling, Benjamin L. Schulz, and Carl J. Mousley. Diminished ost3-dependent n-glycosylation of the bip nucleotide exchange factor sil1 is an adaptive response to reductive er stress. Proceedings of the National Academy of Sciences, 114:12489-12494, Nov 2017. URL: https://doi.org/10.1073/pnas.1705641114, doi:10.1073/pnas.1705641114. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stevens2017diminishedost3dependentnglycosylation pages 2-3): Kofi L. P. Stevens, Amy L. Black, Kelsi M. Wells, K. Y. Benjamin Yeo, Robert F. L. Steuart, Colin J. Stirling, Benjamin L. Schulz, and Carl J. Mousley. Diminished ost3-dependent n-glycosylation of the bip nucleotide exchange factor sil1 is an adaptive response to reductive er stress. Proceedings of the National Academy of Sciences, 114:12489-12494, Nov 2017. URL: https://doi.org/10.1073/pnas.1705641114, doi:10.1073/pnas.1705641114. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stevens2017diminishedost3dependentnglycosylation pages 3-4): Kofi L. P. Stevens, Amy L. Black, Kelsi M. Wells, K. Y. Benjamin Yeo, Robert F. L. Steuart, Colin J. Stirling, Benjamin L. Schulz, and Carl J. Mousley. Diminished ost3-dependent n-glycosylation of the bip nucleotide exchange factor sil1 is an adaptive response to reductive er stress. Proceedings of the National Academy of Sciences, 114:12489-12494, Nov 2017. URL: https://doi.org/10.1073/pnas.1705641114, doi:10.1073/pnas.1705641114. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ichhaporia2018theroleof pages 34-38): V. P. Ichhaporia. The role of bip co-chaperone sil1 in marinesco-sjögren syndrome pathogenesis. ArXiv, 2018. URL: https://doi.org/10.21007/etd.cghs.2018.0470, doi:10.21007/etd.cghs.2018.0470. This article has 1 citations.</p>
+</li>
+<li>
+<p>(ichhaporia2021roleofthe pages 18-19): Viraj P. Ichhaporia and Linda M. Hendershot. Role of the hsp70 co-chaperone sil1 in health and disease. International Journal of Molecular Sciences, 22:1564, Feb 2021. URL: https://doi.org/10.3390/ijms22041564, doi:10.3390/ijms22041564. This article has 33 citations.</p>
+</li>
+<li>
+<p>(siegenthaler2017anunexpectedrole pages 5-6): Kevin D Siegenthaler, Kristeen A Pareja, Jie Wang, and Carolyn S Sevier. An unexpected role for the yeast nucleotide exchange factor sil1 as a reductant acting on the molecular chaperone bip. eLife, Mar 2017. URL: https://doi.org/10.7554/elife.24141, doi:10.7554/elife.24141. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(david2019redoxsignalingthrough pages 121-125): Kevin David Siegenthaler. Redox signaling through the endoplasmic reticulum chaperone bip. Text, Jan 2019. URL: https://doi.org/10.7298/9fam-y122, doi:10.7298/9fam-y122. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stevens2017diminishedost3dependentnglycosylation pages 2-2): Kofi L. P. Stevens, Amy L. Black, Kelsi M. Wells, K. Y. Benjamin Yeo, Robert F. L. Steuart, Colin J. Stirling, Benjamin L. Schulz, and Carl J. Mousley. Diminished ost3-dependent n-glycosylation of the bip nucleotide exchange factor sil1 is an adaptive response to reductive er stress. Proceedings of the National Academy of Sciences, 114:12489-12494, Nov 2017. URL: https://doi.org/10.1073/pnas.1705641114, doi:10.1073/pnas.1705641114. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="sil1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pareja2018arolefor pages 26-31</li>
+<li>ichhaporia2021roleofthe pages 4-5</li>
+<li>pareja2018arolefor pages 31-36</li>
+<li>delic2013thesecretorypathway pages 10-13</li>
+<li>ichhaporia2018theroleof pages 42-46</li>
+<li>siegenthaler2017anunexpectedrole pages 1-2</li>
+<li>siegenthaler2017anunexpectedrole pages 6-7</li>
+<li>siegenthaler2017anunexpectedrole pages 5-6</li>
+<li>siegenthaler2017anunexpectedrole pages 8-9</li>
+<li>siegenthaler2017anunexpectedrole pages 3-5</li>
+<li>david2019redoxsignalingthrough pages 121-125</li>
+<li>david2019redoxsignalingthrough pages 29-33</li>
+<li>ichhaporia2021roleofthe pages 1-3</li>
+<li>verghese2012biologyofthe pages 24-25</li>
+<li>david2019redoxsignalingthrough pages 66-70</li>
+<li>ichhaporia2018theroleof pages 34-38</li>
+<li>ichhaporia2021roleofthe pages 18-19</li>
+<li>https://doi.org/10.3390/ijms22041564,</li>
+<li>https://doi.org/10.1007/978-3-319-11731-7_1,</li>
+<li>https://doi.org/10.7298/9fam-y122,</li>
+<li>https://doi.org/10.7298/x4t43rc8,</li>
+<li>https://doi.org/10.1128/mmbr.05018-11,</li>
+<li>https://doi.org/10.21007/etd.cghs.2018.0470,</li>
+<li>https://doi.org/10.1111/1574-6976.12020,</li>
+<li>https://doi.org/10.7554/elife.24141,</li>
+<li>https://doi.org/10.1073/pnas.1705641114,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(sil1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UTR0" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sil1-spac107103c-s-pombe-curation-notes">sil1 (SPAC1071.03c) — S. pombe — curation notes</h1>
+<p>UniProt: Q9UTR0 (<code>YL33_SCHPO</code>, "Uncharacterized protein C1071.03c", 338 aa, PE=4 Predicted).<br />
+PomBase standard name: <strong>sil1</strong>; product (PomBase): "nucleotide exchange factor for the ER lumenal Hsp70 chaperone, Sil1".<br />
+Characterisation status (PomBase): <strong>"biological role inferred"</strong> — i.e. no dedicated experimental characterisation in fission yeast; function assigned by orthology. Deletion viability: <strong>viable</strong>.<br />
+Taxonomic distribution (PomBase): eukaryotes only, fungi and metazoa.</p>
+<h2 id="identity-orthology-known-with-high-confidence">Identity / orthology (KNOWN with high confidence)</h2>
+<ul>
+<li>Orthologs (PomBase <code>ortholog_annotations</code>): human <strong>SIL1</strong> (HGNC:24624) and <em>S. cerevisiae</em> <strong>SIL1/YOL031C</strong> (Sil1p). So the pombe protein is the fission-yeast member of the SIL1/BAP (BiP-associated protein) family.</li>
+<li>UniProt family/domain signatures: InterPro <strong>IPR050693 "SIL1/FES1/HPBP1"</strong>; <strong>IPR011989 ARM-like</strong> and <strong>IPR016024 ARM-type fold</strong>; Gene3D <strong>1.25.10.10 (Leucine-rich Repeat Variant / ARM)</strong>; SUPFAM <strong>SSF48371 ARM repeat</strong>. PANTHER family <strong>PTHR19316 "Hsp70 Nucleotide Exchange Factors and Inhibitors"</strong>, subfamily <strong>PTHR19316:SF18 "HSP70-BINDING PROTEIN 1"</strong>. [file:SCHPO/sil1/sil1-uniprot.txt DR lines]</li>
+<li>The armadillo-repeat/ARM-type fold is the structural hallmark of the SIL1/HspBP1 class of Hsp70 nucleotide-exchange factors (distinct from the Hsp110/Grp170 class and the BAG/GrpE classes).</li>
+</ul>
+<h2 id="domain-sequence-reasoning-inline-from-sil1-uniprottxt">Domain / sequence reasoning (inline, from sil1-uniprot.txt)</h2>
+<ul>
+<li>338 aa. UniProt/TMHMM predict a single N-terminal transmembrane / signal-anchor helix (<strong>TRANSMEM 20..40</strong>, ECO:0000255; PomBase TM 20..42, TMHMM). UniProt CC gives SUBCELLULAR LOCATION: Membrane, single-pass membrane protein (ECO:0000305, i.e. inferred, not experimental).</li>
+<li>Interpretation: the N-terminal hydrophobic segment is most consistent with an <strong>ER-targeting signal/signal-anchor</strong> for a lumenal ER protein of the SIL1 family. Canonical Sil1 orthologs are ER-lumenal (S. cerevisiae Sil1p is lumenal with an HDEL-type ER-retention signal; human SIL1 has a cleaved signal peptide and a C-terminal ER-retrieval signal). The pombe C-terminus ends "...PWPKKYNI" — I do <strong>not</strong> see a canonical HDEL/KDEL tetrapeptide, so the exact ER-retention mechanism in pombe is unresolved from sequence alone (a genuine uncertainty; do not over-assert lumenal topology). The UniProt "single-pass membrane protein" call is an automatic ECO:0000305 inference from the one predicted TM and should be read cautiously — for the ER-lumenal SIL1 family this hydrophobic stretch is more likely a signal/anchor than a bona fide type-II membrane topology.</li>
+<li>No catalytic motifs expected: SIL1-family NEFs are non-enzymatic; they act as an ARM-fold "clamp" on the Hsp70 nucleotide-binding domain to accelerate ADP release (nucleotide exchange), not as an enzyme.</li>
+</ul>
+<h2 id="function-known-by-orthology-not-directly-shown-in-pombe">Function (KNOWN by orthology; NOT directly shown in pombe)</h2>
+<p>The SIL1/Sil1p family are <strong>nucleotide-exchange factors (NEFs) for the ER Hsp70 BiP</strong> (Kar2p in <em>S. cerevisiae</em>):</p>
+<ul>
+<li><em>S. cerevisiae</em>: "The chaperone activity of Kar2p is regulated by its intrinsic ATPase activity that can be stimulated by two different nucleotide exchange factors, namely Sil1p and Lhs1p ... the IIB domain of Kar2p is sufficient for binding of Sil1p, and point mutations within IIB specifically blocked Sil1p-dependent activation while remaining competent for activation by Lhs1p." [PMID:20430899 "Interactions between Kar2p and its nucleotide exchange factors Sil1p and Lhs1p are mechanistically distinct", abstract]</li>
+<li>This establishes both (a) the <strong>adenyl-nucleotide exchange activity on BiP/Kar2</strong> (grounds GO:0000774) and (b) that BiP in yeast has <strong>two functionally distinct NEFs</strong> (Sil1p and Lhs1p) — the basis for the redundancy knowledge gap in pombe (pombe has an Lhs1/Grp170-type NEF too).</li>
+<li>Human SIL1: loss-of-function mutations cause <strong>Marinesco–Sjögren syndrome</strong> (cerebellar ataxia, cataracts, myopathy, intellectual disability); human SIL1 is a BiP NEF. [WebSearch of review literature — e.g. "BiP and its Nucleotide Exchange Factors Grp170 and Sil1", PMC4356644; not cached, used for background only]</li>
+<li>Structural mechanism (Sil1–BiP complex): Sil1 acts as a clamp on the BiP ATPase (nucleotide-binding) domain, rotating lobe IIb away from the ADP-binding pocket to promote nucleotide release. [background, review literature; not cached]</li>
+</ul>
+<h2 id="pombe-specific-evidence-what-actually-exists-for-this-gene">Pombe-specific evidence (what actually exists for THIS gene)</h2>
+<p>All pombe annotations for sil1 are indirect (IBA/IEA/ISO) or high-throughput:<br />
+- GOA (see sil1-goa.tsv):<br />
+  - GO:0000774 adenyl-nucleotide exchange factor activity — <strong>IBA</strong> (GO_REF:0000033), PANTHER PTN007671284 with S. cerevisiae SGD:S000000305, SGD:S000005391 and human UniProtKB:Q9H173.<br />
+  - GO:0005783 endoplasmic reticulum — <strong>IBA</strong> (GO_REF:0000033).<br />
+  - GO:0016020 membrane — <strong>IEA</strong> (GO_REF:0000044) from UniProt SubCell SL-0162 (the single predicted TM).<br />
+  - GO:0006616 SRP-dependent cotranslational protein targeting to membrane, translocation — <strong>ISO</strong> (GO_REF:0000024) transferred from S. cerevisiae SGD:S000005391.<br />
+- PomBase phenotypes (all from genome-wide/HTP screens, none a dedicated sil1 study):<br />
+  - <code>sil1Δ</code> is viable with normal cell morphology (FYPO:0002060/0002177). Deletion collection: PMID:20473289.<br />
+  - Broad drug/stress-resistance and -sensitivity phenotypes (e.g. resistance to cadmium/cycloheximide/diamide/hydroxyurea/various salts; sensitivity to bleomycin/brefeldin A/caffeine/EGTA/lithium/X-rays) from phenomics profiling. PMID:37787768 ("Broad functional profiling of fission yeast proteins using phenomics and machine learning") — note this paper explicitly targets <em>poorly characterized / 'priority unstudied'</em> proteins.<br />
+  - FYPO:0004806 "incomplete cell wall disassembly at cell fusion site" from a mating-morphology screen. PMID:28410370 ("A systematic screen for morphological abnormalities during fission yeast sexual reproduction ...").<br />
+  - 13 genetic interactions from network/interactome screens (PMID:23050226, PMID:22681890).<br />
+  These are consistent with a general ER-proteostasis housekeeping role (drug/stress pleiotropy, brefeldin-A sensitivity implicating secretory-pathway function) but do <strong>not</strong> independently establish the molecular BiP-NEF activity in pombe.</p>
+<h2 id="known-vs-not-known-summary">KNOWN vs NOT-KNOWN summary</h2>
+<p>KNOWN (high confidence, by orthology + domain):<br />
+- Member of the SIL1/HspBP1 ARM-fold family of Hsp70 nucleotide-exchange factors; ortholog of ScSil1p and human SIL1.<br />
+- Expected molecular function: adenyl-nucleotide exchange factor activity on the ER Hsp70 BiP (GO:0000774).<br />
+- Expected localization: endoplasmic reticulum (GO:0005783). N-terminal hydrophobic signal/anchor (aa ~20-40).<br />
+- Non-essential in pombe (viable deletion).</p>
+<p>NOT KNOWN / genuine gaps (pombe-specific):<br />
+- No direct biochemical demonstration in <em>S. pombe</em> that Sil1 stimulates nucleotide exchange on pombe BiP.<br />
+- The pombe BiP partner and the degree of functional redundancy with the pombe Lhs1/Grp170-type NEF are not experimentally defined; whether Sil1 NEF activity is individually required in vivo (vs redundant) is unknown — mirrors the two-NEF (Sil1/Lhs1) situation in <em>S. cerevisiae</em>.<br />
+- In-vivo clients / physiological pathways (e.g. specific secretory cargo, cell-fusion/cell-wall phenotype mechanism) are not established; phenotype data are HTP-screen-level only.<br />
+- Exact membrane topology / ER-retention mechanism (no canonical HDEL/KDEL evident by eye) is unresolved.</p>
+<h2 id="annotation-review-plan">Annotation review plan</h2>
+<ul>
+<li>GO:0000774 adenyl-nucleotide exchange factor activity (IBA): ACCEPT as core MF — well-supported by orthology + family; more informative than "protein binding".</li>
+<li>GO:0005783 endoplasmic reticulum (IBA): ACCEPT as core localization.</li>
+<li>GO:0016020 membrane (IEA, SubCell): MARK_AS_OVER_ANNOTATED / KEEP_AS_NON_CORE — derived from a single predicted TM; "membrane" is uninformative and the SIL1 family is ER-lumenal-associated; ER (GO:0005783) is the meaningful compartment. Keep but non-core.</li>
+<li>GO:0006616 SRP-dependent cotranslational protein targeting to membrane, translocation (ISO from Sc): UNDECIDED / KEEP_AS_NON_CORE — this ISO transfer reflects Sil1p's participation in ER protein import as a Kar2p co-factor in <em>S. cerevisiae</em>; it is a downstream process attribution, not the core NEF MF, and is not directly shown in pombe. Do not REMOVE (curator ISO from experimental Sc annotation); treat as non-core / process-level.</li>
+</ul>
+<h2 id="references-gathered">References gathered</h2>
+<ul>
+<li>PMID:20430899 — Sc Sil1p/Lhs1p NEFs for Kar2p; abstract cached-quotable. HIGH relevance (ortholog function basis).</li>
+<li>PMID:28410370 — pombe mating morphology screen (source of FYPO:0004806). LOW/MEDIUM (HTP phenotype only).</li>
+<li>PMID:37787768 — pombe phenomics/ML broad profiling (source of stress phenotypes; flags sil1 as poorly characterized). LOW/MEDIUM.</li>
+<li>GO_REF:0000033 (IBA), GO_REF:0000024 (ISO), GO_REF:0000044 (SubCell IEA) — evidence pipelines.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9UTR0
+gene_symbol: sil1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  sil1 (systematic name SPAC1071.03c; UniProt Q9UTR0) is the Schizosaccharomyces
+  pombe member of the SIL1/HspBP1 family of nucleotide-exchange factors (NEFs) for
+  Hsp70 chaperones. It is the one-to-one ortholog of human SIL1 (the gene mutated in
+  Marinesco-Sjogren syndrome) and of Saccharomyces cerevisiae Sil1p/YOL031C. The
+  338-residue protein is built around an armadillo-repeat (ARM-type) alpha-helical
+  fold, the structural hallmark of this NEF class, and carries an N-terminal
+  hydrophobic segment (residues ~20-42) that is most consistent with an
+  endoplasmic-reticulum signal/anchor sequence. By orthology, Sil1-family proteins
+  act in the endoplasmic reticulum, where they bind the ATPase (nucleotide-binding)
+  domain of the ER Hsp70 chaperone BiP (Kar2p in budding yeast) and accelerate ADP
+  release, thereby driving the BiP chaperone cycle that folds and translocates
+  nascent secretory proteins. In budding yeast BiP is served by two functionally
+  distinct NEFs, Sil1p and the Hsp110/Grp170-type Lhs1p; either single deletion is
+  viable but the double deletion is lethal, indicating that BiP nucleotide exchange
+  is essential and partly redundant. In fission yeast sil1 is non-essential (deletion
+  viable) and has not been characterized biochemically; the molecular NEF activity,
+  ER localization, and biological roles above are inferred from conserved domain
+  architecture and orthology rather than from direct experiments in this species.
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:20430899
+  title: &#34;Interactions between Kar2p and its nucleotide exchange factors Sil1p and Lhs1p are mechanistically distinct.&#34;
+  findings:
+  - statement: &gt;-
+      The ER Hsp70 Kar2p (BiP) is regulated by two nucleotide-exchange factors, Sil1p
+      and Lhs1p; NEFs promote ADP release to drive the next round of ATP binding in the
+      chaperone cycle.
+    supporting_text: &gt;-
+      Two NEFs have been identified for Kar2p in the ER lumen of Saccharomyces cerevisiae,
+      namely Lhs1p and Sil1p
+  - statement: &gt;-
+      Sil1p binds the IIB subdomain of the Kar2p ATPase domain to stimulate nucleotide
+      exchange, mechanistically distinct from Lhs1p.
+    supporting_text: &gt;-
+      These studies identified a role for the IIB domain of Kar2p in Sil1p binding and
+      Sil1p-stimulated nucleotide exchange
+  - statement: &gt;-
+      Single deletions of SIL1 or LHS1 are viable but the double deletion is lethal,
+      showing BiP nucleotide exchange is essential and the two NEFs are partly redundant.
+    supporting_text: &gt;-
+      Individual deletions of LHS1 (Δlhs1) and SIL1 (Δsil1) in yeast cells are viable
+      (13, 14), but the double deletion (Δlhs1Δsil1) is lethal suggesting that nucleotide
+      exchange is essential for Kar2p activity and cell viability
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC-verified full text (Hale, Lovell, de Keyzer &amp; Stirling, J Biol Chem 2010).
+      Primary S. cerevisiae biochemistry establishing Sil1p as a BiP/Kar2p NEF acting
+      on the ATPase domain; it is the orthology basis for the pombe sil1 IBA/ISO
+      annotations and directly supports the Sil1/Lhs1 redundancy knowledge gap. Work is
+      in budding yeast, not fission yeast; used here for conserved-function reasoning.
+- id: PMID:37787768
+  title: &#34;Broad functional profiling of fission yeast proteins using phenomics and machine learning.&#34;
+  findings:
+  - statement: &gt;-
+      Genome-wide phenomics/machine-learning profiling of S. pombe deletion mutants;
+      the study explicitly targets poorly characterized proteins, and sil1 phenotypes in
+      PomBase derive from this class of broad screen rather than a dedicated study.
+    supporting_text: &gt;-
+      Many proteins remain poorly characterized even in well-studied organisms
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC-verified (Rodriguez-Lopez et al., eLife 2023). Source of several high-throughput
+      drug/stress phenotypes recorded for sil1 in PomBase; illustrates that pombe evidence
+      for this gene is screen-level, not gene-specific characterization.
+- id: PMID:28410370
+  title: &#34;A systematic screen for morphological abnormalities during fission yeast sexual reproduction identifies a mechanism of actin aster formation for cell fusion.&#34;
+  findings:
+  - statement: &gt;-
+      Systematic mating-morphology deletion screen in S. pombe; the cell-fusion phenotype
+      recorded for sil1 in PomBase (incomplete cell wall disassembly at the fusion site)
+      originates from this genome-wide screen.
+    supporting_text: &gt;-
+      morphological abnormalities of the mating process in fission yeast
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC-verified (Dudin et al., PLoS Genet 2017). A genome-wide morphology screen, not a
+      sil1-focused study; the associated phenotype is HTP-level and does not establish
+      sil1 molecular function.
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Endoplasmic reticulum is the expected site of action for a SIL1-family BiP
+      nucleotide-exchange factor. The IBA (phylogenetic) inference is consistent with
+      the ER-lumenal localization of the S. cerevisiae and human orthologs and with the
+      N-terminal ER signal/anchor sequence of the pombe protein. This is the meaningful,
+      informative compartment for the gene and is retained as the core localization.
+      Direct localization data in fission yeast are not available.
+    action: ACCEPT
+- term:
+    id: GO:0000774
+    label: adenyl-nucleotide exchange factor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is the defining molecular function of the SIL1/HspBP1 family: binding the
+      ATPase (nucleotide-binding) domain of an ER Hsp70 (BiP/Kar2p) and stimulating
+      ADP release (nucleotide exchange). It is well supported by orthology to
+      experimentally characterized S. cerevisiae Sil1p and human SIL1, and by the
+      diagnostic armadillo-repeat fold. This is a specific, informative MF term
+      (preferable to generic protein binding) and is retained as the core function.
+      The activity has not been demonstrated biochemically in S. pombe itself.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:20430899
+      supporting_text: &gt;-
+        These studies identified a role for the IIB domain of Kar2p in Sil1p binding and
+        Sil1p-stimulated nucleotide exchange
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      This IEA annotation is an automatic mapping from the UniProt Subcellular Location
+      keyword (SL-0162 Membrane), which itself derives from a single predicted N-terminal
+      transmembrane/hydrophobic segment (residues ~20-42). For a SIL1-family protein this
+      hydrophobic stretch is more consistent with an ER signal/anchor than with a
+      genuine multi-compartment membrane residence, and generic membrane is uninformative
+      relative to the endoplasmic reticulum term already annotated. Retained as a
+      non-core, low-information electronic annotation.
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0006616
+    label: SRP-dependent cotranslational protein targeting to membrane, translocation
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This ISO annotation was transferred from a S. cerevisiae ortholog (SGD:S000005391)
+      and reflects the participation of the BiP/Kar2p chaperone system in translocation
+      of nascent secretory polypeptides into the ER. It is a downstream, process-level
+      attribution of the Sil1 NEF role (Sil1 assists BiP, which acts in ER protein import)
+      rather than sil1&#39;s core molecular function, and it is not directly demonstrated in
+      fission yeast. The essence of ER-protein-biogenesis involvement is defensible, so it
+      is kept as non-core rather than removed; the precise process term is broader than
+      what is established for sil1 specifically in pombe.
+    action: KEEP_AS_NON_CORE
+core_functions:
+- description: &gt;-
+    Nucleotide-exchange factor (NEF) for the endoplasmic-reticulum Hsp70 chaperone BiP.
+    sil1 is a SIL1/HspBP1-family, armadillo-repeat protein that binds the ATPase
+    (nucleotide-binding) domain of ER-lumenal BiP and accelerates ADP release, resetting
+    BiP for the next ATP-bound, substrate-engaging cycle. Through this activity it
+    supports BiP-dependent folding and translocation of nascent secretory proteins in
+    the ER. This molecular role is inferred from the diagnostic ARM fold and from
+    orthology to experimentally characterized S. cerevisiae Sil1p and human SIL1; the
+    activity, the BiP partner, and the in-vivo requirement have not been demonstrated in
+    S. pombe.
+  molecular_function:
+    id: GO:0000774
+    label: adenyl-nucleotide exchange factor activity
+  locations:
+  - id: GO:0005783
+    label: endoplasmic reticulum
+  supported_by:
+  - reference_id: PMID:20430899
+    supporting_text: &gt;-
+      Two NEFs have been identified for Kar2p in the ER lumen of Saccharomyces cerevisiae,
+      namely Lhs1p and Sil1p
+  knowledge_gaps:
+  - gap_statement: &gt;-
+      It has not been shown biochemically that S. pombe Sil1 binds fission-yeast BiP and
+      stimulates its nucleotide (ADP/ATP) exchange; the direct BiP partner and the
+      NEF activity are inferred from orthology, not measured in this species.
+    boundary: &gt;-
+      The ARM-fold NEF activity on BiP/Kar2p is firmly established for the S. cerevisiae
+      and human orthologs, and pombe sil1 is a clear one-to-one ortholog with the
+      conserved family fold, but no in-vitro exchange assay or BiP co-purification has been
+      reported for the pombe protein.
+    gap_kind:
+    - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      Confirms whether the strongly-inferred core function actually operates in fission
+      yeast, and whether pombe BiP regulation follows the conserved two-NEF logic.
+    resolution: &gt;-
+      In-vitro reconstitution of recombinant pombe Sil1 with pombe BiP measuring
+      Sil1-stimulated nucleotide exchange / ATPase activity, plus co-immunoprecipitation
+      of Sil1 with BiP from fission-yeast extracts.
+    provenance:
+    - reference_id: PMID:20430899
+      supporting_text: &gt;-
+        These studies identified a role for the IIB domain of Kar2p in Sil1p binding and
+        Sil1p-stimulated nucleotide exchange
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether Sil1 nucleotide-exchange activity is individually required in S. pombe, or is
+    functionally redundant with the fission-yeast Hsp110/Grp170-type NEF (the Lhs1/Grp170
+    class), is undetermined; the phenotypic consequence of losing sil1 versus losing both
+    BiP NEFs has not been tested in pombe.
+  boundary: &gt;-
+    In S. cerevisiae, single sil1 or lhs1 deletions are viable but the sil1 lhs1 double
+    deletion is lethal, showing the two NEFs are partly redundant and that BiP nucleotide
+    exchange is essential. In S. pombe, sil1 deletion is viable, but no analogous
+    single/double NEF-deletion analysis has been reported.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Determines whether sil1 is a dispensable, redundant NEF in pombe or contributes a
+    non-redundant function, and whether the conserved &#34;BiP has two NEFs, together
+    essential&#34; logic holds in fission yeast.
+  resolution: &gt;-
+    Construct and phenotype pombe sil1 single and sil1 (Lhs1/Grp170-ortholog) double
+    deletions for synthetic lethality and ER-stress sensitivity.
+  provenance:
+  - reference_id: PMID:20430899
+    supporting_text: &gt;-
+      Individual deletions of LHS1 (Δlhs1) and SIL1 (Δsil1) in yeast cells are viable
+      (13, 14), but the double deletion (Δlhs1Δsil1) is lethal suggesting that nucleotide
+      exchange is essential for Kar2p activity and cell viability
+- gap_statement: &gt;-
+    The in-vivo biological roles and physiological clients of sil1 in S. pombe are unknown;
+    the only pombe phenotypes are scattered drug/stress sensitivities and a cell-fusion
+    morphology defect drawn from genome-wide screens, none mechanistically connected to
+    its BiP-NEF activity.
+  boundary: &gt;-
+    sil1 deletion is viable with grossly normal morphology; genome-wide phenomics and a
+    mating-morphology screen recorded assorted stress phenotypes and an &#34;incomplete cell
+    wall disassembly at cell fusion site&#34; phenotype, but there is no dedicated study of
+    sil1 in fission yeast.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether sil1 has a specialized secretory/ER-proteostasis role in pombe (e.g. in mating
+    or cell-wall remodeling) beyond generic BiP support is unresolved.
+  resolution: &gt;-
+    Directed phenotyping of sil1 deletion under ER stress (tunicamycin, DTT) and mating
+    conditions, and identification of Sil1/BiP-dependent secretory cargo by proteomics.
+  provenance:
+  - reference_id: PMID:37787768
+    supporting_text: &gt;-
+      Many proteins remain poorly characterized even in well-studied organisms
+- gap_statement: &gt;-
+    The membrane topology and ER-retention mechanism of pombe Sil1 are unresolved: the
+    protein is annotated as a single-pass membrane protein from one predicted TM helix,
+    yet SIL1-family orthologs are ER-lumenal, and no canonical HDEL/KDEL retention motif
+    is evident in the pombe sequence.
+  boundary: &gt;-
+    UniProt/TMHMM predict one hydrophobic segment at residues ~20-42 and an ECO:0000305
+    single-pass membrane call; S. cerevisiae Sil1p and human SIL1 are ER-lumenal with
+    signal and ER-retention signals. The actual topology of the pombe protein has not
+    been determined experimentally.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Clarifies whether the N-terminal hydrophobic segment is a signal/anchor for an
+    ER-lumenal NEF (as in orthologs) and how the protein is retained in the ER.
+  resolution: &gt;-
+    Determine subcellular localization and topology (protease-protection, lumenal vs
+    membrane fractionation, tagged-protein imaging) of pombe Sil1.
+suggested_questions:
+- question: &gt;-
+    Does S. pombe Sil1 bind fission-yeast BiP and stimulate its nucleotide exchange, as
+    its orthologs do for Kar2p and mammalian BiP?
+  experts:
+  - ER chaperone / Hsp70 co-chaperone biochemists
+  - Fission-yeast secretory-pathway biologists
+- question: &gt;-
+    Is sil1 functionally redundant with the pombe Hsp110/Grp170-type BiP NEF, such that
+    the double deletion is synthetically lethal as in budding yeast?
+  experts:
+  - Yeast ER-proteostasis geneticists
+suggested_experiments:
+- experiment_type: In-vitro biochemistry
+  description: &gt;-
+    Reconstitute recombinant pombe Sil1 with pombe BiP and measure Sil1-stimulated
+    nucleotide exchange and ATPase activity to test the inferred NEF function directly.
+- experiment_type: Genetic interaction analysis
+  description: &gt;-
+    Build sil1 single and sil1 plus Lhs1/Grp170-ortholog double deletions and test for
+    synthetic lethality and ER-stress (tunicamycin, DTT) hypersensitivity to define
+    redundancy among pombe BiP NEFs.
+- experiment_type: Localization / topology
+  description: &gt;-
+    Determine the subcellular localization and membrane topology of tagged pombe Sil1
+    (ER lumen vs membrane; protease protection) to resolve the single-pass-membrane vs
+    lumenal ambiguity.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/spa1/spa1-ai-review.html
+++ b/genes/SCHPO/spa1/spa1-ai-review.html
@@ -1,0 +1,2532 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>spa1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>spa1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9USQ5" target="_blank" class="term-link">
+                        Q9USQ5
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "spa1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9USQ5" data-a="DESCRIPTION: spa1 (SPA) is the Schizosaccharomyces pombe ornith..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>spa1 (SPA) is the Schizosaccharomyces pombe ornithine decarboxylase antizyme (ODC-Az), the fungal member of the ODC antizyme family (Pfam PF02100 / InterPro IPR002993). It is a negative regulator of intracellular polyamine levels: it binds and inhibits ornithine decarboxylase (ODC), the rate-limiting enzyme of polyamine biosynthesis, thereby lowering putrescine, spermidine and cadaverine pools. Loss of spa1 causes accumulation of these polyamines, especially in stationary phase, while overexpression depletes them, indicating that spa1 is the principal negative regulator of ODC activity in fission yeast. Like metazoan antizymes, expression of full-length spa1 requires a polyamine-stimulated +1 programmed ribosomal frameshift between two overlapping open reading frames, forming an autoregulatory feedback loop in which rising polyamine levels increase antizyme production. By homology to mammalian antizyme, spa1 is thought to inhibit ODC by blocking assembly of the active ODC homodimer and to promote ubiquitin-independent proteasomal degradation of ODC monomers, although the degradation-targeting step has not been directly demonstrated in S. pombe. spa1 is dispensable for viability under standard growth conditions. It is unrelated to the mammalian Rap GTPase-activating protein SIPA1/SPA1.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9USQ5" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation from the antizyme tree, reflecting the cytoplasm-nucleus shuttling of mammalian antizymes. There is no experimental evidence that S. pombe spa1 localizes to or acts in the nucleus, and the only characterization paper (PMID:10775274) does not localize the protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization/action is an over-propagation from mammalian antizyme biology; it is not supported by any S. pombe data. spa1&#39;s demonstrated activity (ODC inhibition) and the polyamine biosynthetic machinery it regulates are cytoplasmic, so a nuclear location is not the core function and is likely an over-annotation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001616256</span>
+
+
+
+                                    <div class="propagation-comment">Antizyme family node (PTHR10279). The nucleus term reflects mammalian antizyme cytoplasm-nucleus shuttling; localization does not transfer to the S. pombe member.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q9UMX2</span>
+
+
+
+                                    <div class="propagation-comment">Mammalian antizyme with/from source; nuclear localization is a mammalian property not established for spa1.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9USQ5" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation. A cytoplasmic location is consistent with spa1&#39;s role in inhibiting cytoplasmic ODC, but no experimental localization exists for the S. pombe protein; this term is broad and uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible and not contradicted (ODC and polyamine biosynthesis are cytoplasmic), but purely inferred and non-specific. Retain as non-core context rather than as an established localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008073" target="_blank" class="term-link">
+                                    GO:0008073
+                                </a>
+                            </span>
+                            <span class="term-label">ornithine decarboxylase inhibitor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9USQ5" data-a="GO:0008073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the core molecular function of spa1 and is directly demonstrated experimentally: recombinant spa1 protein inhibits S. pombe ODC in vitro (PMID:10775274, Fig. 2). The IBA propagation from the antizyme family is therefore corroborated by direct evidence for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and experimentally supported core function; ODC inhibition is the defining, assayed activity of spa1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10775274" target="_blank" class="term-link">
+                                        PMID:10775274
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the recombinant protein can inhibit S.pombe ODC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008073" target="_blank" class="term-link">
+                                    GO:0008073
+                                </a>
+                            </span>
+                            <span class="term-label">ornithine decarboxylase inhibitor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9USQ5" data-a="GO:0008073" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping from the ODC antizyme domain (IPR002993 / Pfam PF02100), which spans essentially the whole protein. This assigns the same correct molecular function as the IBA/experimental annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Domain-based assignment of the correct core molecular function; redundant with the experimentally supported IBA annotation but not wrong.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10775274" target="_blank" class="term-link">
+                                        PMID:10775274
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the recombinant protein can inhibit S.pombe ODC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000051
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9USQ5" data-a="GO:0005829" data-r="GO_REF:0000051" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cytosol assignment from S. pombe keyword mapping (NAS, GO_REF:0000051), i.e. inferred from the antizyme annotation rather than from microscopy. It is a reasonable location for spa1 given that its substrate ODC and the polyamine biosynthetic pathway are cytosolic, but there is no experimental localization for the S. pombe protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible, more specific than the IBA cytoplasm term, and not contradicted, but keyword-inferred rather than experimentally determined. Keep as non-core localization context.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901305" target="_blank" class="term-link">
+                                    GO:1901305
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of spermidine biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000051
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9USQ5" data-a="GO:1901305" data-r="GO_REF:0000051" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Captures spa1&#39;s role in lowering polyamine levels; Δspa cells accumulate spermidine (along with putrescine and cadaverine) (PMID:10775274). However the effect is not spermidine-specific: spa1 inhibits ODC, the entry enzyme, reducing the whole polyamine pool. The broader term negative regulation of polyamine biosynthetic process (GO:0170066) — already used by PomBase/UniProt as TAS — more accurately describes the function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence (spa1 negatively regulates polyamine biosynthesis) is correct, but the spermidine-specific term is too narrow for an ODC inhibitor that reduces putrescine, spermidine and cadaverine. Generalize to the polyamine biosynthetic process term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0170066" target="_blank" class="term-link">
+                                    negative regulation of polyamine biosynthetic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10775274" target="_blank" class="term-link">
+                                        PMID:10775274
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cellular concentrations of putrescine, spermidine and cadaverine (but not spermine) were higher in the knockout strains than in wild-type cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Ornithine decarboxylase antizyme: binds and inhibits ornithine decarboxylase (ODC), the rate-limiting enzyme of polyamine biosynthesis, thereby negatively regulating intracellular polyamine (putrescine/spermidine) levels in fission yeast.</h3>
+                <span class="vote-buttons" data-g="Q9USQ5" data-a="FUNCTION: Ornithine decarboxylase antizyme: binds and inhibi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008073" target="_blank" class="term-link">
+                            ornithine decarboxylase inhibitor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10775274" target="_blank" class="term-link">
+                                PMID:10775274
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the recombinant protein can inhibit S.pombe ODC</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10775274" target="_blank" class="term-link">
+                            PMID:10775274
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Conservation of polyamine regulation by translational frameshifting from yeast to mammals.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Recombinant S. pombe SPA (spa1) protein directly inhibits S. pombe ornithine decarboxylase in vitro, establishing ODC inhibitor activity for this gene.</div>
+
+                        <div class="finding-text">"the recombinant protein can inhibit S.pombe ODC"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Deletion of spa1 raises intracellular putrescine, spermidine and cadaverine, while overexpression depletes all polyamines, showing spa1 negatively regulates polyamine biosynthesis.</div>
+
+                        <div class="finding-text">"The cellular concentrations of putrescine, spermidine and cadaverine (but not spermine) were higher in the knockout strains than in wild-type cells."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">spa1 is the primary negative regulator of ODC activity in S. pombe in both growing and non-dividing cells.</div>
+
+                        <div class="finding-text">"This suggests that SPA is the primary regulator of ODC activity in S.pombe, not only during cell growth (short term regulation) but also in non-dividing cells (longer term regulation)."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Full-length spa1 requires a polyamine-responsive +1 ribosomal frameshift for expression, forming an autoregulatory feedback circuit.</div>
+
+                        <div class="finding-text">"a significant reduction (6.5-fold) in frameshifting efficiency in SPA-overproducing cells that correlates with a decrease of polyamine content"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Complete deletion of spa1 does not affect viability, growth, mating or morphology under standard conditions.</div>
+
+                        <div class="finding-text">"Complete deletion of SPA (both ORFs) did not affect the viability of S.pombe cells in rich (YE) or minimal (MM) media."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10871270" target="_blank" class="term-link">
+                            PMID:10871270
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A homolog of mammalian antizyme is present in fission yeast Schizosaccharomyces pombe but not detected in budding yeast Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HMM-based comparative analysis identifies the S. pombe antizyme homolog and validates it via the conserved frameshift-promoting nucleotide element.</div>
+
+                        <div class="finding-text">"by the presence of a conserved nucleotide sequence that, in metazoa,"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000051.md" target="_blank" class="term-link">
+                            GO_REF:0000051
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">S. pombe keyword mapping</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe spa1 target ODC for ubiquitin-independent proteasomal degradation, or does it act purely as a stoichiometric inhibitor of ODC dimerization?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9USQ5" data-a="Q: Does S. pombe spa1 target ODC for ubiquitin-indepe..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does spa1 regulate a polyamine transporter in S. pombe, as suggested by the incomplete rescue of the overexpression phenotype by exogenous putrescine?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9USQ5" data-a="Q: Does spa1 regulate a polyamine transporter in S. p..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare endogenous ODC protein levels and turnover (cycloheximide chase, with and without proteasome inhibition) in wild-type versus Δspa cells, and test whether spa1 blocks ODC homodimer formation in vitro.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: spa1 destabilizes S. pombe ODC by targeting it for ubiquitin-independent proteasomal degradation.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: protein stability / biochemistry</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9USQ5" data-a="EXPERIMENT: Compare endogenous ODC protein levels and turnover..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the subcellular localization of endogenously tagged spa1 by live-cell fluorescence microscopy, accounting for the +1 frameshift required for full-length expression.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: spa1 localizes to the cytosol, where ODC and polyamine biosynthesis occur.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: fluorescence microscopy / localization</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9USQ5" data-a="EXPERIMENT: Determine the subcellular localization of endogeno..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of spa1 in S. pombe is undetermined; no microscopy or fractionation has placed the protein in a compartment.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> All cellular-component annotations for spa1 are inferences: cytosol from S. pombe keyword mapping (NAS) and cytoplasm/nucleus from phylogenetic (IBA) propagation of mammalian antizyme localization. A cytosolic site is plausible because spa1&#39;s substrate ODC and the polyamine biosynthetic pathway are cytosolic, but this has not been shown for the fission-yeast protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Whether spa1 accesses the nucleus (as mammalian antizymes do during shuttling) or is strictly cytosolic bears on whether it has functions beyond cytosolic ODC control.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous-tagging (e.g. GFP knock-in) live-cell microscopy, or the S. pombe ORFeome localization datasets, would directly establish spa1 localization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the growth rates, mating efficiencies and overall morphology of the knockout strains are apparently indistinguishable from those of wild-type cells"</em> — PMID:10775274</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether S. pombe spa1 promotes ubiquitin-independent proteasomal degradation of ODC (the mammalian antizyme mechanism), or only sterically inhibits ODC dimer assembly, has not been tested in fission yeast.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Direct ODC inhibition by spa1 is experimentally demonstrated (PMID:10775274). The monomer-binding / anti-dimerization and degradation-targeting steps are asserted only by orthology to mammalian antizyme 1 (UniProt Q02803, ISS), not assayed for spa1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The degradation-targeting step defines the difference between a simple competitive inhibitor and the antizyme&#39;s characteristic role in ubiquitin-independent ODC turnover, and determines whether fission-yeast ODC is regulated by the full conserved mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test ODC protein stability and proteasome dependence in wild-type vs Δspa cells, and assay spa1-ODC binding / inhibition of ODC dimerization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"were confirmed: SPA inhibition of ODC and the +1 translational frameshifting."</em> — PMID:10775274</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological purpose of the deeply conserved antizyme/frameshift feedback circuit is unknown, given that spa1 is dispensable for growth and its loss produces only condition-dependent polyamine accumulation and stress phenotypes.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> spa1 controls polyamine pools (largest effect in stationary phase) and is the principal negative regulator of ODC, yet Δspa cells are viable with no overt defect; the paper&#39;s authors explicitly note the conservation is unexplained.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Understanding why polyamine feedback by antizyme is preserved from fission yeast to human, despite being non-essential, could reveal a still-undetected aspect of polyamine biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic characterization of Δspa phenotypes across stresses, growth states and polyamine-limiting conditions, and dissection of a possible second target (polyamine transporter).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"It is not obvious why this very special mechanism is so exquisitely preserved over vast evolutionary time. Perhaps there is another whole aspect to the system that our experiments do not yet detect."</em> — PMID:10775274</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(spa1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9USQ5" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="spa1-spbc57714c-s-pombe-ornithine-decarboxylase-antizyme-review-notes">spa1 (SPBC577.14c) — S. pombe ornithine decarboxylase antizyme — review notes</h1>
+<blockquote>
+<p>Deep-research note: the automated deep-research job<br />
+(<code>scripts/deep_research_wrapper.py SCHPO spa1 falcon --fallback perplexity-lite</code>)<br />
+produced no output and did not create a report file after ~25 min; it was stopped.<br />
+This review is therefore grounded directly in the UniProt record (Q9USQ5), the GOA<br />
+annotations, the PomBase API record, verified GO term definitions (QuickGO), and the<br />
+cached primary literature (PMID:10775274 full text; PMID:10871270 abstract). No<br />
+<code>-deep-research-*.md</code> file was fabricated.</p>
+</blockquote>
+<h2 id="identity-verified-not-the-mammalian-spa1-gap">Identity (verified — NOT the mammalian SPA1 GAP)</h2>
+<ul>
+<li>UniProt <strong>Q9USQ5</strong> (<code>OAZ_SCHPO</code>), 226 aa; gene <code>spa1</code> (synonym <code>spa</code>); systematic <code>SPBC577.14c</code>; NCBI taxon 284812.</li>
+<li><strong>RecName: Ornithine decarboxylase antizyme (ODC-Az)</strong> [spa1-uniprot.txt lines 6–8].</li>
+<li>Family: ODC antizyme family (<code>ECO:0000305</code>) [spa1-uniprot.txt line 83]. Domain signatures: Pfam <strong>PF02100 (ODC_AZ)</strong>, InterPro <strong>IPR002993 (ODC_AZ)</strong> + IPR038581 (ODC_AZ_sf); Gene3D 3.40.630.60; SUPFAM SSF55729 (Acyl-CoA N-acyltransferase / NAT fold) [spa1-uniprot.txt lines 115–122]. The single antizyme domain spans essentially the whole ORF2-encoded chain.</li>
+<li>PANTHER family <strong>PTHR10279 ORNITHINE DECARBOXYLASE ANTIZYME</strong> (subfamily SF10) — the source of the IBA annotations [spa1-uniprot.txt lines 119–120].</li>
+<li>This is the fission-yeast antizyme, unrelated to human/mouse <strong>SPA1 (SIPA1)</strong> Rap GTPase-activating protein. Domain analysis (antizyme domain only; no GAP/RapGAP domain, no GTPase signature) confirms it is a bona fide OAZ-family protein, matching the name.</li>
+</ul>
+<h2 id="provenance-for-function-this-gene-is-directly-experimentally-characterized">Provenance for function — this gene is directly, experimentally characterized</h2>
+<p>Despite being an understudied ORF, spa1 was functionally characterized in a dedicated primary<br />
+paper:</p>
+<p><strong>PMID:10775274</strong> (Ivanov, Matsufuji, Murakami, Gesteland, Atkins, EMBO J 2000, "Conservation of<br />
+polyamine regulation by translational frameshifting from yeast to mammals"). Full text cached.<br />
+Key experimental results <strong>on the S. pombe gene itself</strong> (named "SPA" in the paper):</p>
+<ul>
+<li><strong>ODC inhibitory activity (direct assay).</strong> Recombinant GST–SPA fusion protein expressed in<br />
+  E. coli and purified inhibits <em>S. pombe</em> ODC in vitro; GST alone does not<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="The results (Figure 2) show that the recombinant protein can inhibit S.pombe ODC. GST alone (1 µg) does not inhibit S.pombe ODC">PMID:10775274</a>. → supports <strong>GO:0008073 ornithine decarboxylase inhibitor activity</strong> (experimental, IDA-grade).</li>
+<li><strong>Negative regulation of polyamine biosynthesis (loss-of-function genetics).</strong> Δspa knockouts<br />
+  accumulate putrescine, spermidine and cadaverine, most dramatically in stationary phase (up to<br />
+  ~40× putrescine)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="The cellular concentrations of putrescine, spermidine and cadaverine (but not spermine) were higher in the knockout strains than in wild-type cells">PMID:10775274</a>.<br />
+  Overexpression depletes all polyamines<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="overexpression of SPA results in significant reduction in the intracellular levels of all four polyamines">PMID:10775274</a>.<br />
+  → SPA is a negative regulator of polyamine biosynthesis. The authors conclude "SPA is the<br />
+  primary regulator of ODC activity in S.pombe"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="This suggests that SPA is the primary regulator of ODC activity in S.pombe, not only during cell growth (short term regulation) but also in non-dividing cells (longer term regulation)">PMID:10775274</a>.</li>
+<li><strong>Autoregulatory +1 ribosomal frameshifting.</strong> Expression of full-length SPA requires a<br />
+  polyamine-responsive +1 frameshift between ORF1 and ORF2<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="This result is consistent with +1 frameshifting being crucial for expression of SPA">PMID:10775274</a>;<br />
+  frameshift efficiency rises with spermidine<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="Addition of spermidine to the translation mixture to a final concentration of 1 mM results in a 3.7-fold increase in frameshifting">PMID:10775274</a><br />
+  and falls when polyamines are depleted by SPA overexpression, closing the autoregulatory loop<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="a significant reduction (6.5-fold) in frameshifting efficiency in SPA-overproducing cells that correlates with a decrease of polyamine content">PMID:10775274</a>.<br />
+  UniProt records the frameshift between Ser-67 and Glu-68 [spa1-uniprot.txt lines 76–82].</li>
+<li><strong>Deletion phenotype.</strong> Δspa is viable with no overt growth/morphology/mating defect<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="Complete deletion of SPA (both ORFs) did not affect the viability of S.pombe cells... the growth rates, mating efficiencies and overall morphology of the knockout strains are apparently indistinguishable from those of wild-type cells">PMID:10775274</a>.</li>
+</ul>
+<p><strong>PMID:10871270</strong> (Zhu, Karplus, Grate, Coffino, Bioinformatics 2000). HMM-based identification of<br />
+the <em>S. pombe</em> antizyme homolog; abstract-only cached. Establishes the sequence/family assignment<br />
+and the conserved frameshift signal<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10871270" title="The most divergent homolog detected was that of the fission yeast Schizosaccharomyces pombe... The authenticity of the S.POMBE: AZ is validated by the presence of a conserved nucleotide sequence that, in metazoa, promotes a +1 programmed ribosomal frameshift required for AZ expression">PMID:10871270</a>.<br />
+Note: sequence identity to metazoan antizymes is low (~10% identity / ~24% similarity per<br />
+PMID:10775274; 18–22% in the most conserved C-terminal regions per PMID:10871270).</p>
+<h2 id="mechanism-by-orthology-mammalian-az1-uniprot-q02803">Mechanism by orthology (mammalian AZ1, UniProt Q02803)</h2>
+<p>UniProt propagates by similarity (ISS from Q02803 = rat AZ1): antizyme binds ODC monomers,<br />
+sterically blocking assembly of the active ODC homodimer, and targets ODC monomers for<br />
+ubiquitin-independent degradation by the 26S proteasome<br />
+[spa1-uniprot.txt lines 67–75 "Binds to ODC monomers, inhibiting the assembly of the functional ODC homodimer, and targets the monomers for ubiquitin-independent proteolytic destruction by the 26S proteasome"].<br />
+The Ivanov paper directly demonstrated ODC <em>inhibition</em> by SPA but did NOT test the<br />
+degradation-targeting or monomer-binding mechanism in S. pombe — that specific mechanistic step<br />
+is inferred from the mammalian ortholog, not shown for spa1.</p>
+<h2 id="localization-known-vs-not-known">Localization — KNOWN vs NOT known</h2>
+<ul>
+<li><strong>No experimental localization exists for spa1.</strong> PomBase curated CC is only <strong>GO:0005829<br />
+  cytosol</strong>, and it derives from <strong>GO_REF:0000051 (S. pombe keyword mapping / NAS)</strong> — an<br />
+  inference from the antizyme keyword, not from microscopy (verified via PomBase API: the CC<br />
+  annotation for SPBC577.14c cites GO_REF:0000051).</li>
+<li>The GOA <strong>nucleus (GO:0005634)</strong> and <strong>cytoplasm (GO:0005737)</strong> annotations are <strong>IBA<br />
+  (GO_REF:0000033)</strong>, propagated from the PANTHER antizyme tree (mammalian AZ1/AZ2 shuttle between<br />
+  cytoplasm and nucleus). Neither is experimentally supported in <em>S. pombe</em>.</li>
+<li>The Ivanov paper does not report where SPA acts in the cell.</li>
+</ul>
+<h2 id="biological-role-and-phenotypes-context-not-go-review-targets">Biological role and phenotypes (context; not GO-review targets)</h2>
+<ul>
+<li>Core role: feedback control of intracellular polyamine (putrescine/spermidine) levels by<br />
+  inhibiting ODC (the rate-limiting biosynthetic enzyme), sensed via polyamine-dependent<br />
+  frameshifting. spa1 appears to be the principal negative regulator of ODC in S. pombe.</li>
+<li>PomBase records many single-locus deletion phenotypes from high-throughput screens (verified via<br />
+  PomBase API): viable vegetative population (FYPO:0002060; PMID:20473289, PMID:23697806),<br />
+  loss of viability in stationary phase (FYPO:0000245; PMID:34250083), sensitivity to hydroxyurea<br />
+  (FYPO:0000088; PMID:23173672), tert-butyl hydroperoxide (FYPO:0000797), NaCl (FYPO:0005889), and<br />
+  others (mostly PMID:37787768). These are consistent with polyamine dysregulation having<br />
+  pleiotropic, condition-dependent effects but do not by themselves define new GO functions.</li>
+</ul>
+<h2 id="annotation-review-plan">Annotation-review plan</h2>
+<table>
+<thead>
+<tr>
+<th>Term</th>
+<th>Aspect</th>
+<th>Ev</th>
+<th>Ref</th>
+<th>Planned action</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0008073 ornithine decarboxylase inhibitor activity</td>
+<td>MF</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT (core)</td>
+<td>Correct; also directly demonstrated in PMID:10775274</td>
+</tr>
+<tr>
+<td>GO:0008073 ornithine decarboxylase inhibitor activity</td>
+<td>MF</td>
+<td>IEA</td>
+<td>GO_REF:0000002 (InterPro IPR002993)</td>
+<td>ACCEPT (core)</td>
+<td>Same term, domain-supported; redundant but correct</td>
+</tr>
+<tr>
+<td>GO:1901305 negative regulation of spermidine biosynthetic process</td>
+<td>BP</td>
+<td>NAS</td>
+<td>GO_REF:0000051</td>
+<td>KEEP_AS_NON_CORE (or MODIFY)</td>
+<td>Real (Δspa raises spermidine) but overly specific; broader "negative regulation of polyamine biosynthetic process" (GO:0170066, which UniProt/PomBase now use as TAS) better captures the function</td>
+</tr>
+<tr>
+<td>GO:0005829 cytosol</td>
+<td>CC</td>
+<td>NAS</td>
+<td>GO_REF:0000051</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>Plausible but keyword-inferred, no experimental localization</td>
+</tr>
+<tr>
+<td>GO:0005634 nucleus</td>
+<td>CC</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>MARK_AS_OVER_ANNOTATED / REMOVE</td>
+<td>Propagated from mammalian AZ nuclear shuttling; no evidence in S. pombe</td>
+</tr>
+<tr>
+<td>GO:0005737 cytoplasm</td>
+<td>CC</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>KEEP_AS_NON_CORE</td>
+<td>Broad, consistent with cytosolic action; uninformative but not wrong</td>
+</tr>
+</tbody>
+</table>
+<p>Note UniProt DR lines show PomBase now curates <strong>GO:0170066 negative regulation of polyamine<br />
+biosynthetic process (TAS)</strong> [spa1-uniprot.txt line 114], the more appropriate parent of the<br />
+GOA GO:1901305 spermidine-specific term.</p>
+<h2 id="knowledge-gaps-for-the-review">Knowledge gaps (for the review)</h2>
+<ul>
+<li><strong>Localization is unknown</strong> (CC-dark): no microscopy has placed spa1 in a compartment; all CC<br />
+  annotations are inference/propagation.</li>
+<li><strong>Mechanism in S. pombe</strong> (residual sub-gap): whether spa1 targets S. pombe ODC for<br />
+  ubiquitin-independent proteasomal degradation (as mammalian AZ1 does) vs. only steric<br />
+  inhibition of ODC dimerization is not established in fission yeast; only ODC inhibition was<br />
+  assayed.</li>
+<li><strong>Physiological role of polyamine feedback</strong> (biology): why the antizyme frameshift circuit is<br />
+  so deeply conserved yet dispensable for growth is explicitly unresolved by the authors<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="It is not obvious why this very special mechanism is so exquisitely preserved over vast evolutionary time. Perhaps there is another whole aspect to the system that our experiments do not yet detect">PMID:10775274</a>.</li>
+<li><strong>Second target (polyamine transporter)?</strong> In mammals AZ also inhibits the polyamine<br />
+  transporter; the Ivanov paper raised but did not resolve whether SPA does so in S. pombe<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10775274" title="maybe SPA inhibits not only ODC but also the polyamine transporter. Further experiments will help to distinguish between these two models">PMID:10775274</a>.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9USQ5
+gene_symbol: spa1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  spa1 (SPA) is the Schizosaccharomyces pombe ornithine decarboxylase antizyme
+  (ODC-Az), the fungal member of the ODC antizyme family (Pfam PF02100 /
+  InterPro IPR002993). It is a negative regulator of intracellular polyamine
+  levels: it binds and inhibits ornithine decarboxylase (ODC), the rate-limiting
+  enzyme of polyamine biosynthesis, thereby lowering putrescine, spermidine and
+  cadaverine pools. Loss of spa1 causes accumulation of these polyamines,
+  especially in stationary phase, while overexpression depletes them, indicating
+  that spa1 is the principal negative regulator of ODC activity in fission yeast.
+  Like metazoan antizymes, expression of full-length spa1 requires a
+  polyamine-stimulated +1 programmed ribosomal frameshift between two overlapping
+  open reading frames, forming an autoregulatory feedback loop in which rising
+  polyamine levels increase antizyme production. By homology to mammalian
+  antizyme, spa1 is thought to inhibit ODC by blocking assembly of the active ODC
+  homodimer and to promote ubiquitin-independent proteasomal degradation of ODC
+  monomers, although the degradation-targeting step has not been directly
+  demonstrated in S. pombe. spa1 is dispensable for viability under standard
+  growth conditions. It is unrelated to the mammalian Rap GTPase-activating
+  protein SIPA1/SPA1.
+references:
+- id: PMID:10775274
+  title: &#39;Conservation of polyamine regulation by translational frameshifting from
+    yeast to mammals.&#39;
+  findings:
+  - statement: &gt;-
+      Recombinant S. pombe SPA (spa1) protein directly inhibits S. pombe ornithine
+      decarboxylase in vitro, establishing ODC inhibitor activity for this gene.
+    supporting_text: &gt;-
+      the recombinant protein can inhibit S.pombe ODC
+    reference_section_type: RESULTS
+  - statement: &gt;-
+      Deletion of spa1 raises intracellular putrescine, spermidine and cadaverine,
+      while overexpression depletes all polyamines, showing spa1 negatively
+      regulates polyamine biosynthesis.
+    supporting_text: &gt;-
+      The cellular concentrations of putrescine, spermidine and cadaverine (but not
+      spermine) were higher in the knockout strains than in wild-type cells.
+    reference_section_type: RESULTS
+  - statement: &gt;-
+      spa1 is the primary negative regulator of ODC activity in S. pombe in both
+      growing and non-dividing cells.
+    supporting_text: &gt;-
+      This suggests that SPA is the primary regulator of ODC activity in S.pombe,
+      not only during cell growth (short term regulation) but also in non-dividing
+      cells (longer term regulation).
+    reference_section_type: DISCUSSION
+  - statement: &gt;-
+      Full-length spa1 requires a polyamine-responsive +1 ribosomal frameshift for
+      expression, forming an autoregulatory feedback circuit.
+    supporting_text: &gt;-
+      a significant reduction (6.5-fold) in frameshifting efficiency in
+      SPA-overproducing cells that correlates with a decrease of polyamine content
+    reference_section_type: RESULTS
+  - statement: &gt;-
+      Complete deletion of spa1 does not affect viability, growth, mating or
+      morphology under standard conditions.
+    supporting_text: &gt;-
+      Complete deletion of SPA (both ORFs) did not affect the viability of S.pombe
+      cells in rich (YE) or minimal (MM) media.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary experimental characterization of the S. pombe gene itself (called
+      &#34;SPA&#34; in the paper; = spa1 / SPBC577.14c). Full text (PMC302018) verified;
+      directly demonstrates ODC inhibition, the deletion/overexpression polyamine
+      phenotypes, and polyamine-responsive +1 frameshifting for this gene.
+- id: PMID:10871270
+  title: &#39;A homolog of mammalian antizyme is present in fission yeast Schizosaccharomyces
+    pombe but not detected in budding yeast Saccharomyces cerevisiae.&#39;
+  findings:
+  - statement: &gt;-
+      HMM-based comparative analysis identifies the S. pombe antizyme homolog and
+      validates it via the conserved frameshift-promoting nucleotide element.
+    supporting_text: &gt;-
+      by the presence of a conserved nucleotide sequence that, in metazoa,
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache; establishes the family assignment (ODC antizyme) for
+      the S. pombe gene by remote-homology HMM search and notes the low sequence
+      identity (18-22% in the most conserved C-terminal regions).
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000051
+  title: S. pombe keyword mapping
+  findings: []
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation from the antizyme tree, reflecting the
+      cytoplasm-nucleus shuttling of mammalian antizymes. There is no experimental
+      evidence that S. pombe spa1 localizes to or acts in the nucleus, and the
+      only characterization paper (PMID:10775274) does not localize the protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Nuclear localization/action is an over-propagation from mammalian antizyme
+      biology; it is not supported by any S. pombe data. spa1&#39;s demonstrated
+      activity (ODC inhibition) and the polyamine biosynthetic machinery it
+      regulates are cytoplasmic, so a nuclear location is not the core function
+      and is likely an over-annotation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN001616256
+        comment: &gt;-
+          Antizyme family node (PTHR10279). The nucleus term reflects mammalian
+          antizyme cytoplasm-nucleus shuttling; localization does not transfer to
+          the S. pombe member.
+      - source_id: UniProtKB:Q9UMX2
+        comment: &gt;-
+          Mammalian antizyme with/from source; nuclear localization is a
+          mammalian property not established for spa1.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) propagation. A cytoplasmic location is consistent with
+      spa1&#39;s role in inhibiting cytoplasmic ODC, but no experimental localization
+      exists for the S. pombe protein; this term is broad and uninformative.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Plausible and not contradicted (ODC and polyamine biosynthesis are
+      cytoplasmic), but purely inferred and non-specific. Retain as non-core
+      context rather than as an established localization.
+- term:
+    id: GO:0008073
+    label: ornithine decarboxylase inhibitor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is the core molecular function of spa1 and is directly demonstrated
+      experimentally: recombinant spa1 protein inhibits S. pombe ODC in vitro
+      (PMID:10775274, Fig. 2). The IBA propagation from the antizyme family is
+      therefore corroborated by direct evidence for this gene.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and experimentally supported core function; ODC inhibition is the
+      defining, assayed activity of spa1.
+    supported_by:
+    - reference_id: PMID:10775274
+      supporting_text: &gt;-
+        the recombinant protein can inhibit S.pombe ODC
+- term:
+    id: GO:0008073
+    label: ornithine decarboxylase inhibitor activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping from the ODC antizyme domain (IPR002993 / Pfam PF02100),
+      which spans essentially the whole protein. This assigns the same correct
+      molecular function as the IBA/experimental annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Domain-based assignment of the correct core molecular function; redundant
+      with the experimentally supported IBA annotation but not wrong.
+    supported_by:
+    - reference_id: PMID:10775274
+      supporting_text: &gt;-
+        the recombinant protein can inhibit S.pombe ODC
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: NAS
+  original_reference_id: GO_REF:0000051
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cytosol assignment from S. pombe keyword mapping (NAS, GO_REF:0000051), i.e.
+      inferred from the antizyme annotation rather than from microscopy. It is a
+      reasonable location for spa1 given that its substrate ODC and the polyamine
+      biosynthetic pathway are cytosolic, but there is no experimental
+      localization for the S. pombe protein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Plausible, more specific than the IBA cytoplasm term, and not contradicted,
+      but keyword-inferred rather than experimentally determined. Keep as non-core
+      localization context.
+- term:
+    id: GO:1901305
+    label: negative regulation of spermidine biosynthetic process
+  evidence_type: NAS
+  original_reference_id: GO_REF:0000051
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Captures spa1&#39;s role in lowering polyamine levels; Δspa cells accumulate
+      spermidine (along with putrescine and cadaverine) (PMID:10775274). However
+      the effect is not spermidine-specific: spa1 inhibits ODC, the entry enzyme,
+      reducing the whole polyamine pool. The broader term negative regulation of
+      polyamine biosynthetic process (GO:0170066) — already used by PomBase/UniProt
+      as TAS — more accurately describes the function.
+    action: MODIFY
+    reason: &gt;-
+      The essence (spa1 negatively regulates polyamine biosynthesis) is correct,
+      but the spermidine-specific term is too narrow for an ODC inhibitor that
+      reduces putrescine, spermidine and cadaverine. Generalize to the polyamine
+      biosynthetic process term.
+    proposed_replacement_terms:
+    - id: GO:0170066
+      label: negative regulation of polyamine biosynthetic process
+    supported_by:
+    - reference_id: PMID:10775274
+      supporting_text: &gt;-
+        The cellular concentrations of putrescine, spermidine and cadaverine (but
+        not spermine) were higher in the knockout strains than in wild-type cells.
+core_functions:
+- description: &gt;-
+    Ornithine decarboxylase antizyme: binds and inhibits ornithine decarboxylase
+    (ODC), the rate-limiting enzyme of polyamine biosynthesis, thereby negatively
+    regulating intracellular polyamine (putrescine/spermidine) levels in fission
+    yeast.
+  molecular_function:
+    id: GO:0008073
+    label: ornithine decarboxylase inhibitor activity
+  supported_by:
+  - reference_id: PMID:10775274
+    supporting_text: &gt;-
+      the recombinant protein can inhibit S.pombe ODC
+knowledge_gaps:
+- gap_statement: &gt;-
+    The subcellular localization of spa1 in S. pombe is undetermined; no
+    microscopy or fractionation has placed the protein in a compartment.
+  boundary: &gt;-
+    All cellular-component annotations for spa1 are inferences: cytosol from
+    S. pombe keyword mapping (NAS) and cytoplasm/nucleus from phylogenetic (IBA)
+    propagation of mammalian antizyme localization. A cytosolic site is plausible
+    because spa1&#39;s substrate ODC and the polyamine biosynthetic pathway are
+    cytosolic, but this has not been shown for the fission-yeast protein.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Whether spa1 accesses the nucleus (as mammalian antizymes do during shuttling)
+    or is strictly cytosolic bears on whether it has functions beyond cytosolic
+    ODC control.
+  resolution: &gt;-
+    Endogenous-tagging (e.g. GFP knock-in) live-cell microscopy, or the S. pombe
+    ORFeome localization datasets, would directly establish spa1 localization.
+  provenance:
+  - reference_id: PMID:10775274
+    supporting_text: &gt;-
+      the growth rates, mating efficiencies and overall morphology of the knockout
+      strains are apparently indistinguishable from those of wild-type cells
+- gap_statement: &gt;-
+    Whether S. pombe spa1 promotes ubiquitin-independent proteasomal degradation
+    of ODC (the mammalian antizyme mechanism), or only sterically inhibits ODC
+    dimer assembly, has not been tested in fission yeast.
+  boundary: &gt;-
+    Direct ODC inhibition by spa1 is experimentally demonstrated (PMID:10775274).
+    The monomer-binding / anti-dimerization and degradation-targeting steps are
+    asserted only by orthology to mammalian antizyme 1 (UniProt Q02803, ISS), not
+    assayed for spa1.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    The degradation-targeting step defines the difference between a simple
+    competitive inhibitor and the antizyme&#39;s characteristic role in
+    ubiquitin-independent ODC turnover, and determines whether fission-yeast ODC
+    is regulated by the full conserved mechanism.
+  resolution: &gt;-
+    Test ODC protein stability and proteasome dependence in wild-type vs Δspa
+    cells, and assay spa1-ODC binding / inhibition of ODC dimerization.
+  provenance:
+  - reference_id: PMID:10775274
+    supporting_text: &gt;-
+      were confirmed: SPA inhibition of ODC and the +1 translational frameshifting.
+- gap_statement: &gt;-
+    The physiological purpose of the deeply conserved antizyme/frameshift feedback
+    circuit is unknown, given that spa1 is dispensable for growth and its loss
+    produces only condition-dependent polyamine accumulation and stress
+    phenotypes.
+  boundary: &gt;-
+    spa1 controls polyamine pools (largest effect in stationary phase) and is the
+    principal negative regulator of ODC, yet Δspa cells are viable with no overt
+    defect; the paper&#39;s authors explicitly note the conservation is unexplained.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Understanding why polyamine feedback by antizyme is preserved from fission
+    yeast to human, despite being non-essential, could reveal a still-undetected
+    aspect of polyamine biology.
+  resolution: &gt;-
+    Systematic characterization of Δspa phenotypes across stresses, growth states
+    and polyamine-limiting conditions, and dissection of a possible second target
+    (polyamine transporter).
+  provenance:
+  - reference_id: PMID:10775274
+    supporting_text: &gt;-
+      It is not obvious why this very special mechanism is so exquisitely preserved
+      over vast evolutionary time. Perhaps there is another whole aspect to the
+      system that our experiments do not yet detect.
+suggested_questions:
+- question: &gt;-
+    Does S. pombe spa1 target ODC for ubiquitin-independent proteasomal
+    degradation, or does it act purely as a stoichiometric inhibitor of ODC
+    dimerization?
+  experts: []
+- question: &gt;-
+    Does spa1 regulate a polyamine transporter in S. pombe, as suggested by the
+    incomplete rescue of the overexpression phenotype by exogenous putrescine?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    spa1 destabilizes S. pombe ODC by targeting it for ubiquitin-independent
+    proteasomal degradation.
+  description: &gt;-
+    Compare endogenous ODC protein levels and turnover (cycloheximide chase, with
+    and without proteasome inhibition) in wild-type versus Δspa cells, and test
+    whether spa1 blocks ODC homodimer formation in vitro.
+  experiment_type: protein stability / biochemistry
+- hypothesis: &gt;-
+    spa1 localizes to the cytosol, where ODC and polyamine biosynthesis occur.
+  description: &gt;-
+    Determine the subcellular localization of endogenously tagged spa1 by
+    live-cell fluorescence microscopy, accounting for the +1 frameshift required
+    for full-length expression.
+  experiment_type: fluorescence microscopy / localization
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/tam14/tam14-ai-review.html
+++ b/genes/SCHPO/tam14/tam14-ai-review.html
@@ -1,0 +1,2805 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>tam14 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>tam14</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G2TRT3" target="_blank" class="term-link">
+                        G2TRT3
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "tam14";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G2TRT3" data-a="DESCRIPTION: tam14 (systematic name SPCC330.20) is a small (70-..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>tam14 (systematic name SPCC330.20) is a small (70-residue) single-pass endoplasmic reticulum membrane protein of the RAMP4/SERP1 family (Pfam PF06624; InterPro IPR010580, &#34;ER stress-associated&#34;). Its architecture is a short polar/disordered N-terminal segment followed by a single C-terminal transmembrane helix, characteristic of the tail-anchored RAMP4/SERP1 proteins. It is a curated ortholog of human SERP1 (RAMP4) and SERP2 and of budding-yeast Ysy6. In its better-characterized mammalian and budding-yeast orthologs, this family constitutes a small accessory component of the ribosome-associated Sec61 translocon that contacts nascent polypeptides during co-translational translocation and stabilizes newly synthesized membrane proteins during endoplasmic reticulum stress, facilitating their subsequent glycosylation. The corresponding molecular activity, subcellular localization, and biological role of tam14 in fission yeast have not been directly measured; annotations rest on family/orthology inference. tam14 was identified as a novel gene whose transcript levels are altered during meiosis, but no meiotic function has been demonstrated.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRT3" data-a="GO:0005783" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Endoplasmic reticulum localization inferred electronically from the InterPro RAMP4/ ER-stress-associated domain (IPR010580). This is consistent with the family assignment and the single C-terminal transmembrane helix, but is more general than the endoplasmic reticulum membrane term that better captures a single-pass RAMP4/SERP1 protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in direction and family-supported, but subsumed by the more specific &#34;endoplasmic reticulum membrane&#34; annotations; retained as non-core because the membrane term is the precise location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">predicted to function as a **small accessory component of the Sec61 translocon** at the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRT3" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Endoplasmic reticulum membrane localization from UniProt Subcellular-Location mapping. This is the electronic counterpart of the ISS annotation below and is well-grounded by the RAMP4/SERP1 family assignment plus the single predicted transmembrane helix (residues 45-65). No direct localization has been shown in S. pombe, but the family/topology basis is strong.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The single-pass, tail-anchored RAMP4/SERP1 architecture localizes to the ER membrane; this is the most specific, best-supported location for tam14 and represents its core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">By family inference, tam14 is predicted to localize to the **endoplasmic reticulum membrane**</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRT3" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic &#34;membrane&#34; localization from Subcellular-Location mapping. This is a high-level parent of the endoplasmic reticulum membrane term and adds no specific information beyond it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative parent term redundant with the more specific &#34;endoplasmic reticulum membrane&#34; annotation; the specific term should carry the localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">By family inference, tam14 is predicted to localize to the **endoplasmic reticulum membrane**</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                                    GO:0003674
+                                </a>
+                            </span>
+                            <span class="term-label">molecular_function</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ND</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000015
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRT3" data-a="GO:0003674" data-r="GO_REF:0000015" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root molecular_function placeholder with ND (No Data) evidence, reflecting that no molecular function has been experimentally determined for tam14 in S. pombe. Although the RAMP4/SERP1 family has a described activity (accessory Sec61-translocon component that contacts translocating nascent chains and stabilizes membrane proteins during ER stress), that activity has never been assayed for tam14, and it has no clean, well-scoped GO molecular-function term to which it could be confidently transferred.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ND molecular_function annotation honestly reflects the current MF-dark state: family membership is clear but the specific in vivo molecular activity of tam14 is unmeasured and not cleanly expressible in GO. No specific MF term is asserted.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">no targeted deletion, localization, or biochemical study has been published specifically for tam14/SPCC330.20</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">rests primarily on **domain and family-level inference** from well-characterized orthologs</div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Knowledge gap:</div>
+
+                            <div class="support-item">
+                                <div>The molecular function of tam14 in S. pombe is undetermined. Whether it acts, like its RAMP4/SERP1 orthologs, as an accessory subunit of the Sec61 translocon that contacts translocating nascent chains and stabilizes newly synthesized membrane proteins during ER stress has never been assayed for the fission-yeast protein.
+                                    <span class="badge">OPEN</span>
+                                    <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                                    <span class="badge">MF_DARK</span>
+                                </div>
+
+                                <div class="support-text"><strong>Resolve:</strong> Assay tam14-Sec61 association and nascent-chain crosslinking in S. pombe; a separation-of-function analysis of the TM helix vs the N-terminal region. Ontology: a molecular-function term for &#34;Sec61 translocon accessory / nascent-chain stabilization&#34; activity would let the family role be expressed.</div>
+
+
+
+                                <div class="support-text"><em>"no targeted deletion, localization, or biochemical study has been published specifically for tam14/SPCC330.20"</em> — file:SCHPO/tam14/tam14-deep-research-falcon.md</div>
+
+                                <div class="support-text"><em>"Moderate for family-level annotation, low for gene-specific detail"</em> — file:SCHPO/tam14/tam14-deep-research-falcon.md</div>
+
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRT3" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator sequence-similarity transfer of ER membrane localization from the mammalian ortholog (UniProtKB:Q9R2C1, rat SERP1/RAMP4). Unlike the dubious orthology transfers seen for some fission-yeast orphan genes, this rests on a genuine, curated, reciprocal ortholog relationship (human SERP1/SERP2; S. cerevisiae Ysy6) and on the conserved single-pass tail-anchored topology. It is the best-supported location annotation and duplicates the IEA ER membrane row with stronger (ISS) evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-grounded ISS transfer within a real, conserved family; the ER membrane is the core cellular component of tam14.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">By family inference, tam14 is predicted to localize to the **endoplasmic reticulum membrane**</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="G2TRT3" data-a="GO:0016020" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic &#34;membrane&#34; localization transferred by sequence similarity from the mammalian ortholog. As with the IEA membrane row, this is a high-level parent that is subsumed by the specific endoplasmic reticulum membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative parent term redundant with &#34;endoplasmic reticulum membrane&#34;; the specific term should carry the localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">By family inference, tam14 is predicted to localize to the **endoplasmic reticulum membrane**</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Single-pass endoplasmic reticulum membrane protein of the RAMP4/SERP1 family. The well-supported, family/orthology-grounded statement about tam14 is its subcellular localization: a tail-anchored small protein of the ER membrane. No specific molecular function is asserted, because the RAMP4/SERP1 accessory-translocon activity has not been measured for tam14 in S. pombe and has no adequate GO molecular-function term.</h3>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="FUNCTION: Single-pass endoplasmic reticulum membrane protein..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">By family inference, tam14 is predicted to localize to the **endoplasmic reticulum membrane**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">predicted to function as a **small accessory component of the Sec61 translocon** at the endoplasmic reticulum membrane</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000015.md" target="_blank" class="term-link">
+                            GO_REF:0000015
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Use of the ND evidence code for Gene Ontology (GO) terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21270388" target="_blank" class="term-link">
+                            PMID:21270388
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Augmented annotation of the Schizosaccharomyces pombe genome reveals additional genes required for growth and viability</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">tam14 is one of 14 novel S. pombe loci named for having transcript levels altered during meiosis (tam1-tam14); this is an expression observation, not a functional determination.</div>
+
+                        <div class="finding-text">"We refer to the novel protein-coding genes with no apparent induction in meiosis as new1–new25 , and the 14 genes with t ranscripts a ltered in m eiosis as tam1–tam14"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Fourteen novel-gene transcripts, including tam14, were differentially expressed across a synchronized meiotic time course.</div>
+
+                        <div class="finding-text">"Fourteen transcripts were differentially expressed during meiosis."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">tam14 was NOT among the seven genes selected for deletion/functional assessment (tam2, new1, new5, tam7, new8, tam11, new21), so no tam14 deletion phenotype was reported.</div>
+
+                        <div class="finding-text">"three criteria were used to select seven genes ( tam2 , new1 , new5 , tam7 , new8 , tam11 , and new21 ) for functional assessment"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:SCHPO/tam14/tam14-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for tam14 (G2TRT3, SPCC330.20)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The functional annotation of tam14 rests on domain/family-level inference from orthologs (RAMP4/SERP1, Ysy6); no deletion, localization, or biochemical study exists for tam14 itself.</div>
+
+                        <div class="finding-text">"rests primarily on **domain and family-level inference** from well-characterized orthologs"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">No targeted deletion, localization, or biochemical study has been published specifically for tam14/SPCC330.20.</div>
+
+                        <div class="finding-text">"no targeted deletion, localization, or biochemical study has been published specifically for tam14/SPCC330.20"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">By family inference tam14 is a small accessory component of the Sec61 translocon at the ER membrane; RAMP4/SERP1 is a tail-anchored ER protein that intercalates the Sec61 lateral gate and contacts translocating nascent chains.</div>
+
+                        <div class="finding-text">"predicted to function as a **small accessory component of the Sec61 translocon** at the endoplasmic reticulum membrane"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">No direct localization data for tam14 in S. pombe cells has been reported.</div>
+
+                        <div class="finding-text">"No direct localization data for tam14 in *S. pombe* cells has been reported"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The meiotic expression change reflected in the gene&#39;s name does not imply a meiosis-specific biochemical function.</div>
+
+                        <div class="finding-text">"the meiotic expression change alone does not imply a meiosis-specific biochemical function"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">S. pombe UPR is mechanistically divergent (no Hac1/XBP1; Ire1-dependent RIDD), so the mammalian ER-stress-induction paradigm for RAMP4/SERP1 may not transfer.</div>
+
+                        <div class="finding-text">"*S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on Ire1-dependent mRNA decay (RIDD)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Overall functional confidence is moderate at the family level but low for gene-specific detail.</div>
+
+                        <div class="finding-text">"Moderate for family-level annotation, low for gene-specific detail"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does tam14 associate with the Sec61 translocon and contact translocating nascent chains in S. pombe, as its RAMP4/SERP1 orthologs do?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="Q: Does tam14 associate with the Sec61 translocon and..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the meiotic transcript change reflect a functional meiotic role (e.g. increased ER protein-biogenesis demand during sporulation), or is it an incidental expression change with no phenotype?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="Q: Does the meiotic transcript change reflect a funct..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Given that S. pombe uses an Ire1/RIDD-based UPR without Hac1/XBP1, is tam14 regulated by, or required for, the fission-yeast ER stress response at all?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="Q: Given that S. pombe uses an Ire1/RIDD-based UPR wi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity-purify tagged tam14 from S. pombe and test co-purification with Sec61 complex subunits; site-specific crosslinking to translocating nascent chains.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: tam14 is an accessory component of the S. pombe Sec61 translocon.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: co-immunoprecipitation / crosslinking-MS</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="EXPERIMENT: Affinity-purify tagged tam14 from S. pombe and tes..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Phenotype a tam14 deletion (and overexpression) for growth and viability, ER-stress sensitivity (tunicamycin, DTT), and membrane-protein secretion/glycosylation.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: tam14 contributes to ER proteostasis / stress tolerance.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / stress phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="EXPERIMENT: Phenotype a tam14 deletion (and overexpression) fo..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> GFP-tag tam14 and image localization in vegetative and meiotic/sporulating cells.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: tam14 localizes to the ER membrane and its distribution changes during meiosis.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: live-cell fluorescence microscopy</p>
+
+                </div>
+                <span class="vote-buttons" data-g="G2TRT3" data-a="EXPERIMENT: GFP-tag tam14 and image localization in vegetative..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No biological process has been established for tam14 in S. pombe. Despite its name (altered transcripts in meiosis), no meiotic — or any other — function has been demonstrated: tam14 was excluded from the deletion-phenotyping set in its discovery study, and no deletion, localization, or biochemical characterization has since been published.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Firmly established: tam14 is a bona fide, meiotically-regulated protein-coding gene of the conserved RAMP4/SERP1 family; its transcript level changes during a synchronized meiotic program. Undetermined: whether that expression change reflects any meiotic role, and whether tam14 participates (as its orthologs do) in co-translational ER protein biogenesis / ER proteostasis in fission yeast.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing an incidental meiotic expression change from a genuine meiotic or ER-proteostasis role would settle whether the &#34;tam&#34; name reflects biology, and would test whether the conserved RAMP4/SERP1 translocon-accessory role operates in an organism whose UPR is mechanistically divergent (S. pombe lacks Hac1/XBP1 and uses Ire1-dependent RIDD).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phenotype a tam14 deletion for growth, ER-stress sensitivity (e.g. tunicamycin/DTT), secretion/glycosylation defects, and sporulation/spore viability; GFP localization across the cell cycle and meiosis; measure tam14-Sec61 association.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"three criteria were used to select seven genes ( tam2 , new1 , new5 , tam7 , new8 , tam11 , and new21 ) for functional assessment"</em> — PMID:21270388</li>
+
+                <li><em>"the meiotic expression change alone does not imply a meiosis-specific biochemical function"</em> — file:SCHPO/tam14/tam14-deep-research-falcon.md</li>
+
+                <li><em>"*S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on Ire1-dependent mRNA decay (RIDD)"</em> — file:SCHPO/tam14/tam14-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tam14-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G2TRT3" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">17 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-06T17:23:14.352766</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="tam14-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-tam14-spcc33020-in-schizosaccharomyces-pombe">Comprehensive Research Report: tam14 (SPCC330.20) in <em>Schizosaccharomyces pombe</em></h2>
+<h3 id="1-gene-identity-and-discovery">1. Gene Identity and Discovery</h3>
+<p>The gene <em>tam14</em> (systematic name SPCC330.20; UniProt accession G2TRT3) encodes a small protein in the fission yeast <em>Schizosaccharomyces pombe</em> (strain 972 / ATCC 24843). It was identified through a systematic reappraisal of the <em>S. pombe</em> genome conducted by Bitton et al. (2011), which used an integrated pipeline combining proteogenomics, comparative genomics, and Pfam domain scanning to discover novel small protein-coding genes that had been missed by previous annotations due to the standard 100-amino-acid cutoff threshold (bitton2011augmentedannotationof pages 1-2). The <em>tam14</em> locus was specifically identified through a Pfam domain scan that detected a RAMP4-family domain (PF06624) in an intergenic region of the genome (bitton2011augmentedannotationof pages 3-4, bitton2011augmentedannotationof pages 8-10).</p>
+<p>The gene was named "tam14" because its transcript levels fluctuate during meiosis—the name stands for "Transcripts Altered in Meiosis protein 14." In the Bitton et al. study, 14 of the 39 newly discovered genes showed altered transcript levels during the sexual differentiation program induced by temperature-dependent inactivation of the Pat1 kinase in pat1.114 diploid cultures, and these were designated tam1–tam14 (bitton2011augmentedannotationof pages 8-10). Transcription at the <em>tam14</em> locus was confirmed by RT-PCR and RNA-Seq (bitton2011augmentedannotationof pages 1-2). Importantly, <em>tam14</em> was not among the seven genes selected for functional knockout analysis in the original study, so no deletion phenotype has been reported specifically for this gene (bitton2011augmentedannotationof pages 8-10).</p>
+<h3 id="2-protein-family-and-domain-architecture">2. Protein Family and Domain Architecture</h3>
+<p>Tam14 belongs to the <strong>RAMP4 protein family</strong> (Pfam PF06624) and carries an <strong>ER stress-associated domain</strong> (InterPro IPR010580). This family is defined by the mammalian protein RAMP4 (Ribosome-Associated Membrane Protein 4), also known as <strong>SERP1</strong> (Stress-associated Endoplasmic Reticulum Protein 1), and the <em>Saccharomyces cerevisiae</em> ortholog <strong>Ysy6</strong> (lewis2024structuralanalysisof pages 1-2).</p>
+<p>Structural characterization of mammalian RAMP4 reveals a small (~7 kDa) protein with two key structural domains: (i) a <strong>hook-shaped ribosome-binding domain (RBD)</strong> consisting of an N-terminal α-helix flanked by 3₁₀-helices, which binds 28S rRNA and ribosomal proteins eL19, eL22, and eL31 through electrostatic and hydrophobic interactions; and (ii) a <strong>kinked transmembrane domain (TMD)</strong> connected to the RBD by a flexible linker (lewis2024structuralanalysisof pages 4-6). The TMD is kinked approximately 40° at a conserved glycine residue. The cytoplasmic half of the TMD is hydrophobic and binds the Sec61 lateral gate, while the lumenal half is amphipathic, with its hydrophilic face oriented toward the channel interior, contributing to the hydrophilic lumenal funnel of the Sec61α subunit (lewis2024structuralanalysisof pages 4-6).</p>
+<p>RAMP4 is classified as a <strong>tail-anchored (TA) membrane protein</strong> and can be targeted to the ER membrane via multiple redundant pathways, including the SRP, SND, and TRC/GET pathways (sicking2021complexityandspecificity pages 9-11).</p>
+<h3 id="3-predicted-molecular-function">3. Predicted Molecular Function</h3>
+<p>Based on its RAMP4 family membership and domain architecture, tam14 is predicted to function as a <strong>small accessory component of the Sec61 translocon</strong> at the endoplasmic reticulum membrane. The following functional inferences are drawn from well-characterized RAMP4/SERP1 orthologs:</p>
+<p><strong>Association with the Sec61 translocon:</strong> RAMP4 is tightly associated near-stoichiometrically with ER-localized ribosome-Sec61 complexes. Cryo-EM structural analysis has revealed that RAMP4 intercalates into Sec61's lateral gate, widening the central pore and contributing to its hydrophilic interior (lewis2024structuralanalysisof pages 1-2). In native mammalian ER membranes, RAMP4 is present in approximately 81% of non-MPT (multipass translocon)-containing ribosome-translocon complexes, making it a near-constitutive component (lewis2024structuralanalysisof pages 4-6). RAMP4 can be crosslinked to nascent polypeptide chains translocating through the Sec61 channel, indicating direct interaction with substrates during protein translocation (lewis2024structuralanalysisof pages 1-2).</p>
+<p><strong>Facilitation of membrane protein integration:</strong> The recruitment of RAMP4 to the translocon is triggered when a transmembrane segment enters the ribosomal exit tunnel, where ribosomal protein Rpl17 recognizes the TM segment and signals RAMP4 recruitment. This process helps remodel the translocon to facilitate the switch from translocation mode to membrane integration mode (pool2009atransmembranesegment pages 11-12, pool2009atransmembranesegment pages 1-2, pool2009atransmembranesegment pages 9-11).</p>
+<p><strong>"Surrogate signal peptide" function:</strong> Lewis et al. (2024) proposed that RAMP4 functions as a "surrogate signal peptide" that maintains the Sec61 pore in a widened, hydrophilic configuration during later stages of translocation, after the original signal peptide has dissociated from the lateral gate. Unlike signal peptides, RAMP4 does not displace the plug helix—the plug moves with the widening pore ring, remaining plugged. This model suggests RAMP4 smooths protein transport through the channel and maintains translocation speed and efficiency for certain protein sequences (lewis2024structuralanalysisof pages 9-11).</p>
+<p><strong>Stabilization of membrane proteins and glycosylation:</strong> RAMP4/SERP1 has been implicated in stabilizing newly synthesized membrane proteins during ER stress conditions and in facilitating their subsequent N-linked glycosylation (spasic2005posttranslationalinsertionof pages 99-99, pool2009atransmembranesegment pages 1-2). This protective function becomes particularly critical under conditions of high secretory activity or ER stress.</p>
+<h3 id="4-subcellular-localization">4. Subcellular Localization</h3>
+<p>By family inference, tam14 is predicted to localize to the <strong>endoplasmic reticulum membrane</strong>, specifically at the <strong>ribosome-associated Sec61 translocon</strong> on the rough ER. RAMP4 family members are integral ER membrane proteins that associate with active ribosome-translocon complexes, positioning them at the interface between the cytoplasmic ribosome and the ER translocation channel (lewis2024structuralanalysisof pages 1-2, lewis2024structuralanalysisof pages 4-6). No direct localization data for tam14 in <em>S. pombe</em> cells has been reported.</p>
+<h3 id="5-pathway-context-and-biological-processes">5. Pathway Context and Biological Processes</h3>
+<p><strong>ER protein biogenesis pathway:</strong> The primary pathway in which tam14 is predicted to function is the <strong>co-translational protein translocation and membrane insertion pathway</strong> at the ER. This pathway involves the Sec61 translocon, the signal recognition particle (SRP) system, the oligosaccharyltransferase (OST) complex, the TRAP complex, and various accessory factors including RAMP4 family members (sicking2021complexityandspecificity pages 4-7, sicking2021complexityandspecificity pages 9-11).</p>
+<p><strong>ER stress response:</strong> RAMP4/SERP1 expression in mammals is strongly upregulated by ER stress-responsive transcription factors XBP1 and Hac1p, and animals lacking RAMP4 exhibit induction of the unfolded protein response (UPR) in secretory tissues such as the pancreas and pituitary gland (pool2009atransmembranesegment pages 11-12). Notably, the UPR in <em>S. pombe</em> differs fundamentally from both <em>S. cerevisiae</em> and mammalian cells: <em>S. pombe</em> lacks Hac1/XBP1 orthologs and instead relies primarily on Ire1-dependent mRNA decay (RIDD) rather than transcriptional upregulation to cope with ER stress (lewis2024structuralanalysisof pages 1-2). This means that the mechanism of tam14 transcriptional regulation during ER stress in <em>S. pombe</em> may differ from the canonical RAMP4/SERP1 paradigm in mammals.</p>
+<p><strong>Meiotic expression pattern:</strong> The "tam" designation reflects the observation that <em>tam14</em> transcript levels change during the meiotic differentiation program in <em>S. pombe</em>, as detected in pat1.114-induced synchronous meiotic cultures (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10). This meiotic expression pattern could reflect increased demand for ER-associated protein biogenesis during sporulation and ascospore formation, processes that require substantial membrane remodeling and protein secretion. However, the meiotic expression change alone does not imply a meiosis-specific biochemical function.</p>
+<h3 id="6-summary-of-evidence-levels">6. Summary of Evidence Levels</h3>
+<p>The functional annotation of tam14 rests primarily on <strong>domain and family-level inference</strong> from well-characterized orthologs (RAMP4/SERP1 in mammals, Ysy6 in <em>S. cerevisiae</em>), rather than on direct experimental characterization of the <em>S. pombe</em> gene product itself. The gene was identified and its transcription confirmed in the Bitton et al. (2011) genome re-annotation study (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10), but no targeted deletion, localization, or biochemical study has been published specifically for tam14/SPCC330.20. The structural and functional characterization of RAMP4 orthologs—particularly recent cryo-EM work by Lewis et al. (2024) showing RAMP4 intercalated in the Sec61 lateral gate (lewis2024structuralanalysisof pages 1-2, lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 9-11) and earlier work by Pool (2009) demonstrating TM segment-triggered recruitment (pool2009atransmembranesegment pages 11-12, pool2009atransmembranesegment pages 1-2, pool2009atransmembranesegment pages 9-11)—provides a strong basis for inferring that tam14 serves an analogous role as an accessory Sec61 translocon component in <em>S. pombe</em>.</p>
+<p>The following table summarizes the key properties of tam14:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description/Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>tam14</strong>; one of the 14 <em>S. pombe</em> loci named for having transcripts altered during meiosis in the augmented genome annotation study (bitton2011augmentedannotationof pages 8-10)</td>
+</tr>
+<tr>
+<td>Systematic name</td>
+<td><strong>SPCC330.20</strong> (UniProt entry provided by user; also listed in the augmented annotation table as the locus corresponding to tam14) (bitton2011augmentedannotationof pages 3-4)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>G2TRT3</strong> (user-supplied UniProt identifier)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Schizosaccharomyces pombe</em> strain 972 / ATCC 24843 (fission yeast) (user-supplied target definition)</td>
+</tr>
+<tr>
+<td>Protein description</td>
+<td>Protein tam14; alternative name: <strong>Transcripts altered in meiosis protein 14</strong> (user-supplied target definition)</td>
+</tr>
+<tr>
+<td>Evidence for existence in <em>S. pombe</em></td>
+<td>The locus was identified in the 2011 re-annotation of the <em>S. pombe</em> genome; transcription was supported by RT-PCR/RNA-seq in the study’s global validation pipeline, but tam14 was not among the genes selected for functional knockout characterization (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>RAMP4 family</strong> / ER stress-associated small membrane proteins; family-level functional inference is supported by RAMP4/SERP1 literature and domain assignment (lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2)</td>
+</tr>
+<tr>
+<td>Domain annotations</td>
+<td><strong>RAMP4 / PF06624</strong> and <strong>ER_stress-assoc. / IPR010580</strong>; in the Bitton et al. annotation table tam14 is associated with a Pfam-supported novel locus (bitton2011augmentedannotationof pages 3-4, bitton2011augmentedannotationof pages 8-10)</td>
+</tr>
+<tr>
+<td>Predicted molecular role</td>
+<td>Likely a <strong>small ER membrane accessory factor</strong> of the <strong>Sec61 ribosome-translocon complex</strong>, inferred from the conserved RAMP4 family: RAMP4/SERP1 associates near-stoichiometrically with ER-localized ribosome-Sec61 complexes and can contact translocating nascent chains (lewis2024structuralanalysisof pages 1-2)</td>
+</tr>
+<tr>
+<td>Predicted mechanistic function</td>
+<td>By family inference, likely helps <strong>optimize membrane protein biogenesis at the ER</strong>, especially during or after translocon remodeling for membrane protein insertion; RAMP4 is recruited when a TM segment enters the ribosome exit tunnel and can facilitate the switch to membrane integration mode (pool2009atransmembranesegment pages 11-12, pool2009atransmembranesegment pages 1-2)</td>
+</tr>
+<tr>
+<td>Predicted structural behavior</td>
+<td>RAMP4-family proteins contain a <strong>ribosome-binding region</strong> and a <strong>tail-anchored/kinked TM segment</strong> that occupies the <strong>Sec61 lateral gate</strong>, widens the central pore, and contributes to the channel’s hydrophilic interior; tam14 is therefore plausibly a very small ER membrane protein with analogous architecture (lewis2024structuralanalysisof pages 4-6)</td>
+</tr>
+<tr>
+<td>Predicted subcellular localization</td>
+<td><strong>Endoplasmic reticulum membrane</strong>, specifically the <strong>ribosome-associated Sec61 translocon</strong> at rough ER, by conserved family function (lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2, sicking2021complexityandspecificity pages 9-11)</td>
+</tr>
+<tr>
+<td>Pathway context</td>
+<td>Likely functions in <strong>co-translational ER protein translocation/membrane insertion</strong> and broader <strong>ER proteostasis</strong> rather than a meiosis-specific biochemical pathway; the meiosis-linked name reflects expression behavior, not proven primary function (bitton2011augmentedannotationof pages 8-10, sicking2021complexityandspecificity pages 9-11)</td>
+</tr>
+<tr>
+<td>Relation to ER stress</td>
+<td>Family inference suggests involvement in <strong>ER stress adaptation</strong>: mammalian RAMP4/SERP1 is ER-stress inducible and loss causes secretion/UPR phenotypes in secretory tissues; however, this has <strong>not been directly demonstrated for tam14 in <em>S. pombe</em></strong> (pool2009atransmembranesegment pages 11-12, lewis2024structuralanalysisof pages 1-2)</td>
+</tr>
+<tr>
+<td>Orthologs / homologous family members</td>
+<td><strong>Mammals:</strong> RAMP4 / SERP1; <strong>budding yeast:</strong> Ysy6; these are the relevant family comparators for functional inference to tam14 (lewis2024structuralanalysisof pages 1-2, sicking2021complexityandspecificity pages 9-11)</td>
+</tr>
+<tr>
+<td>Functional confidence level</td>
+<td><strong>Moderate for family-level annotation, low for gene-specific detail</strong>: there is strong domain/family evidence, but little direct experimental characterization specific to tam14/SPCC330.20 itself (bitton2011augmentedannotationof pages 8-10, lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2)</td>
+</tr>
+<tr>
+<td>Key evidence sources</td>
+<td>Primary <em>S. pombe</em> identification: Bitton et al. 2011 genome re-annotation (bitton2011augmentedannotationof pages 1-2, bitton2011augmentedannotationof pages 8-10); mechanistic family context: Pool 2009 and Lewis et al. 2024 on RAMP4/Sec61 structure-function (pool2009atransmembranesegment pages 11-12, lewis2024structuralanalysisof pages 4-6, lewis2024structuralanalysisof pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, annotation, predicted function, and likely localization of tam14/SPCC330.20 in fission yeast. It distinguishes direct evidence for the </em>S. pombe<em> gene from family-based inference drawn from better-characterized RAMP4/SERP1 proteins.</em></p>
+<h3 id="references">References</h3>
+<p>The principal sources supporting this report include Bitton et al. (2011) <em>Genetics</em> 187:1207–1217, which identified tam14 as a novel gene in <em>S. pombe</em>; Lewis et al. (2024) <em>eLife</em> 13, which provided cryo-EM structures of RAMP4 at the Sec61 translocon; and Pool (2009) <em>J. Cell Biol.</em> 185:889–902, which characterized RAMP4 recruitment mechanisms.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(bitton2011augmentedannotationof pages 1-2): Danny A Bitton, Valerie Wood, Paul J Scutt, Agnes Grallert, Tim Yates, Duncan L Smith, Iain M Hagan, and Crispin J Miller. Augmented annotation of the schizosaccharomyces pombe genome reveals additional genes required for growth and viability. Genetics, 187:1207-1217, Apr 2011. URL: https://doi.org/10.1534/genetics.110.123497, doi:10.1534/genetics.110.123497. This article has 32 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bitton2011augmentedannotationof pages 3-4): Danny A Bitton, Valerie Wood, Paul J Scutt, Agnes Grallert, Tim Yates, Duncan L Smith, Iain M Hagan, and Crispin J Miller. Augmented annotation of the schizosaccharomyces pombe genome reveals additional genes required for growth and viability. Genetics, 187:1207-1217, Apr 2011. URL: https://doi.org/10.1534/genetics.110.123497, doi:10.1534/genetics.110.123497. This article has 32 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bitton2011augmentedannotationof pages 8-10): Danny A Bitton, Valerie Wood, Paul J Scutt, Agnes Grallert, Tim Yates, Duncan L Smith, Iain M Hagan, and Crispin J Miller. Augmented annotation of the schizosaccharomyces pombe genome reveals additional genes required for growth and viability. Genetics, 187:1207-1217, Apr 2011. URL: https://doi.org/10.1534/genetics.110.123497, doi:10.1534/genetics.110.123497. This article has 32 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lewis2024structuralanalysisof pages 1-2): Aaron J. O. Lewis, Frank Zhong, Robert J. Keenan, and Ramanujan S. Hegde. Structural analysis of the dynamic ribosome-translocon complex. eLife, May 2024. URL: https://doi.org/10.1101/2023.12.22.572959, doi:10.1101/2023.12.22.572959. This article has 23 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lewis2024structuralanalysisof pages 4-6): Aaron J. O. Lewis, Frank Zhong, Robert J. Keenan, and Ramanujan S. Hegde. Structural analysis of the dynamic ribosome-translocon complex. eLife, May 2024. URL: https://doi.org/10.1101/2023.12.22.572959, doi:10.1101/2023.12.22.572959. This article has 23 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sicking2021complexityandspecificity pages 9-11): Mark Sicking, Sven Lang, Florian Bochen, Andreas Roos, Joost P. H. Drenth, Muhammad Zakaria, Richard Zimmermann, and Maximilian Linxweiler. Complexity and specificity of sec61-channelopathies: human diseases affecting gating of the sec61 complex. Cells, 10:1036, Apr 2021. URL: https://doi.org/10.3390/cells10051036, doi:10.3390/cells10051036. This article has 48 citations.</p>
+</li>
+<li>
+<p>(pool2009atransmembranesegment pages 11-12): Martin R. Pool. A trans-membrane segment inside the ribosome exit tunnel triggers ramp4 recruitment to the sec61p translocase. The Journal of Cell Biology, 185:889-902, Jun 2009. URL: https://doi.org/10.1083/jcb.200807066, doi:10.1083/jcb.200807066. This article has 67 citations.</p>
+</li>
+<li>
+<p>(pool2009atransmembranesegment pages 1-2): Martin R. Pool. A trans-membrane segment inside the ribosome exit tunnel triggers ramp4 recruitment to the sec61p translocase. The Journal of Cell Biology, 185:889-902, Jun 2009. URL: https://doi.org/10.1083/jcb.200807066, doi:10.1083/jcb.200807066. This article has 67 citations.</p>
+</li>
+<li>
+<p>(pool2009atransmembranesegment pages 9-11): Martin R. Pool. A trans-membrane segment inside the ribosome exit tunnel triggers ramp4 recruitment to the sec61p translocase. The Journal of Cell Biology, 185:889-902, Jun 2009. URL: https://doi.org/10.1083/jcb.200807066, doi:10.1083/jcb.200807066. This article has 67 citations.</p>
+</li>
+<li>
+<p>(lewis2024structuralanalysisof pages 9-11): Aaron J. O. Lewis, Frank Zhong, Robert J. Keenan, and Ramanujan S. Hegde. Structural analysis of the dynamic ribosome-translocon complex. eLife, May 2024. URL: https://doi.org/10.1101/2023.12.22.572959, doi:10.1101/2023.12.22.572959. This article has 23 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(spasic2005posttranslationalinsertionof pages 99-99): Milan Spasic. Post-translational insertion of a small tail-anchored protein into the membrane of the endoplasmic reticulum. ArXiv, Jan 2005. URL: https://doi.org/10.11588/heidok.00005525, doi:10.11588/heidok.00005525. This article has 0 citations.</p>
+</li>
+<li>
+<p>(sicking2021complexityandspecificity pages 4-7): Mark Sicking, Sven Lang, Florian Bochen, Andreas Roos, Joost P. H. Drenth, Muhammad Zakaria, Richard Zimmermann, and Maximilian Linxweiler. Complexity and specificity of sec61-channelopathies: human diseases affecting gating of the sec61 complex. Cells, 10:1036, Apr 2021. URL: https://doi.org/10.3390/cells10051036, doi:10.3390/cells10051036. This article has 48 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="tam14-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>bitton2011augmentedannotationof pages 1-2</li>
+<li>bitton2011augmentedannotationof pages 8-10</li>
+<li>lewis2024structuralanalysisof pages 1-2</li>
+<li>lewis2024structuralanalysisof pages 4-6</li>
+<li>sicking2021complexityandspecificity pages 9-11</li>
+<li>lewis2024structuralanalysisof pages 9-11</li>
+<li>pool2009atransmembranesegment pages 11-12</li>
+<li>bitton2011augmentedannotationof pages 3-4</li>
+<li>pool2009atransmembranesegment pages 1-2</li>
+<li>pool2009atransmembranesegment pages 9-11</li>
+<li>spasic2005posttranslationalinsertionof pages 99-99</li>
+<li>sicking2021complexityandspecificity pages 4-7</li>
+<li>https://doi.org/10.1534/genetics.110.123497,</li>
+<li>https://doi.org/10.1101/2023.12.22.572959,</li>
+<li>https://doi.org/10.3390/cells10051036,</li>
+<li>https://doi.org/10.1083/jcb.200807066,</li>
+<li>https://doi.org/10.11588/heidok.00005525,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tam14-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G2TRT3" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tam14-spcc33020-g2trt3-curation-notes">tam14 (SPCC330.20 / G2TRT3) — curation notes</h1>
+<p>Journal-style notes for the AI GO-annotation review of <em>S. pombe</em> tam14. Inline provenance<br />
+throughout as <code>[SOURCE "verbatim supporting text"]</code>.</p>
+<h2 id="identity-verified">Identity (verified)</h2>
+<ul>
+<li>UniProt <strong>G2TRT3</strong>, <code>TAM14_SCHPO</code>, 70 aa, Swiss-Prot reviewed.</li>
+<li>RecName <strong>Protein tam14</strong>; AltName <strong>Transcripts altered in meiosis protein 14</strong>.</li>
+<li>Gene <code>Name=tam14; ORFNames=SPCC330.20</code> (chromosome III).</li>
+<li><code>PE 2: Evidence at transcript level</code> (no protein-level evidence).</li>
+<li>[file:SCHPO/tam14/tam14-uniprot.txt]</li>
+<li>PomBase: gene name <strong>tam14</strong>, product <strong>"ER stress associated protein Tam14"</strong>,<br />
+  characterisation status <strong>"biological role inferred"</strong> (i.e. not experimentally<br />
+  characterised in fission yeast; role assigned by orthology).<br />
+  [PomBase API SPCC330.20, retrieved 2026-07]</li>
+</ul>
+<h2 id="family-domain-reasoning-verified-this-is-a-real-conserved-family">Family / domain reasoning (verified — this is a REAL, conserved family)</h2>
+<ul>
+<li>Pfam <strong>PF06624 (RAMP4)</strong>; InterPro <strong>IPR010580 ("ER stress-associated")</strong>.<br />
+  [file:SCHPO/tam14/tam14-uniprot.txt]</li>
+<li>UniProt: <code>SIMILARITY: Belongs to the RAMP4 family. {ECO:0000305}.</code></li>
+<li><strong>Orthologs (curated, reciprocal — PomBase):</strong></li>
+<li>Human <strong>SERP1</strong> (HGNC:10759) and <strong>SERP2</strong> (HGNC:20607)</li>
+<li><em>S. cerevisiae</em> <strong>YSY6</strong> (YBR162W-A)</li>
+<li><em>S. japonicus</em> SJAG_03611<br />
+  [PomBase API SPCC330.20]</li>
+<li>The RAMP4/SERP1 family is a genuine, broadly conserved eukaryotic family: mammalian<br />
+  RAMP4/SERP1, budding-yeast Ysy6, and even <em>Candida albicans</em> SERP1 have been studied.<br />
+  This is materially DIFFERENT from the sibling gene tam10, a fission-yeast-lineage<br />
+  "sequence orphan" whose ISS transfers were rejected. tam14's family placement rests on<br />
+  a curated, reciprocal ortholog set, so its ER-membrane localisation inference is<br />
+  well-grounded even though no pombe-specific function has been measured.</li>
+</ul>
+<h3 id="domain-architecture-from-uniprot-features">Domain architecture (from UniProt features)</h3>
+<ul>
+<li>CHAIN 1..70 (Protein tam14)</li>
+<li>TRANSMEM 45..65 "Helical" (ECO:0000255) — a single C-terminal transmembrane helix</li>
+<li>REGION 1..20 "Disordered" / COMPBIAS 1..19 "Polar residues" — short N-terminal<br />
+  disordered, polar-biased segment</li>
+<li>Architecture = short cytosolic/lumenal N-terminus + single C-terminal TM helix. This<br />
+  tail-anchored-like, single-pass topology is exactly the RAMP4/SERP1 architecture (a<br />
+  small Sec61-translocon-associated single-span ER membrane protein), consistent with the<br />
+  family assignment.<br />
+  [file:SCHPO/tam14/tam14-uniprot.txt]</li>
+</ul>
+<h2 id="the-mammalian-ortholog-q9r2c1-source-of-the-issiso-function-claims">The mammalian ortholog (Q9R2C1) — source of the ISS/ISO function claims</h2>
+<ul>
+<li>Q9R2C1 = <strong>SERP1_RAT</strong> (rat Serp1 / Ramp4). RAMP4 family; ER membrane; single-pass.<br />
+  UniProt FUNCTION (verbatim): "Interacts with target proteins during their translocation<br />
+  into the lumen of the endoplasmic reticulum. Protects unfolded target proteins against<br />
+  degradation during ER stress." Keywords include "Unfolded protein response".<br />
+  [UniProt Q9R2C1, retrieved 2026-07]</li>
+<li>Mammalian SERP1/RAMP4 biology (background, NOT measured for tam14):</li>
+<li>Yamaguchi et al. 1999 (J Cell Biol; PMID:10601334): "Stress-Associated Endoplasmic<br />
+    Reticulum Protein 1 (Serp1)/Ribosome-Associated Membrane Protein 4 (Ramp4) Stabilizes<br />
+    Membrane Proteins during Stress and Facilitates Subsequent Glycosylation"; interacts<br />
+    with Sec61alpha/Sec61beta and calnexin.</li>
+<li>Park et al. 2006 (MCB; PMID:16481402): SERP1/RAMP4 deletion → ER stress; SERP1-/- mice<br />
+    show growth retardation, increased mortality, impaired glucose tolerance.<br />
+  These establish the FAMILY function in mammals; they do NOT establish tam14's function<br />
+  in <em>S. pombe</em>. The tam14 UniProt FUNCTION comment is transferred <code>By similarity</code><br />
+  (<code>ECO:0000250|UniProtKB:Q9R2C1</code>), not observed in pombe.</li>
+</ul>
+<h2 id="discovery-the-only-pombe-specific-experimental-evidence">Discovery / the ONLY pombe-specific experimental evidence</h2>
+<ul>
+<li>tam14 is one of 14 "transcripts altered in meiosis" genes (tam1–tam14) newly annotated by<br />
+  Bitton et al. 2011 (Genetics; PMID:21270388), a proteogenomic/comparative reappraisal.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/21270388" title="We refer to the novel protein-coding genes with no apparent induction     in meiosis as new1–new25 , and the 14 genes with t ranscripts a ltered in m eiosis as     tam1–tam14">PMID:21270388</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/21270388" title="Fourteen transcripts were differentially expressed during meiosis.">PMID:21270388</a></li>
+<li>CRITICAL: tam14 was NOT among the seven genes selected for deletion phenotyping. The<br />
+  functionally assessed set was tam2, new1, new5, tam7, new8, tam11, new21<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21270388" title="three criteria were used to select seven genes ( tam2 , new1 , new5 ,   tam7 , new8 , tam11 , and new21 ) for functional assessment">PMID:21270388</a>. So NO tam14 deletion<br />
+  phenotype was reported, and no meiotic function was demonstrated — only differential<br />
+  meiotic transcript abundance. Meiotic expression change alone does NOT establish a<br />
+  meiotic biological process (correlation, not function).</li>
+<li>UniProt INDUCTION: "Differentially expressed during meiosis.<br />
+  {ECO:0000269|PubMed:21270388}." — this is an expression, not function, statement.</li>
+</ul>
+<h2 id="goa-annotations-to-review-6-rows-tam14-goatsv">GOA annotations to review (6 rows; tam14-goa.tsv)</h2>
+<ol>
+<li>GO:0005783 endoplasmic reticulum (CC) — IEA, GO_REF:0000002, InterPro:IPR010580.<br />
+   Domain(family)-based ER localisation. Reasonable but generic; the more specific ER<br />
+   membrane term below is preferable.</li>
+<li>GO:0005789 endoplasmic reticulum membrane (CC) — IEA, GO_REF:0000044,<br />
+   UniProtKB-SubCell:SL-0097. From SUBCELL mapping (ultimately the SERP1 By-similarity<br />
+   location). Well-grounded by the single TM helix + RAMP4 family. KEEP (core CC).</li>
+<li>GO:0016020 membrane (CC) — IEA, GO_REF:0000044, UniProtKB-SubCell:SL-0162. Generic<br />
+   parent of ER membrane; redundant/over-general → MARK_AS_OVER_ANNOTATED.</li>
+<li>GO:0003674 molecular_function (MF root) — ND, GO_REF:0000015, PomBase. Correct<br />
+   placeholder: no MF experimentally known and no MF term is confidently transferable<br />
+   (SERP1's "chaperone-like translocon-associated" activity has no clean GO MF term).<br />
+   ACCEPT (honest MF-dark placeholder).</li>
+<li>GO:0005789 endoplasmic reticulum membrane (CC) — ISS, GO_REF:0000024, UniProtKB:Q9R2C1.<br />
+   Curator sequence-similarity transfer from rat SERP1. Duplicate of #2 but with the<br />
+   stronger ISS evidence. KEEP.</li>
+<li>GO:0016020 membrane (CC) — ISS, GO_REF:0000024, UniProtKB:Q9R2C1. Over-general parent<br />
+   → MARK_AS_OVER_ANNOTATED (same reasoning as #3).</li>
+</ol>
+<p>Note the UniProt DR block also lists GO:0006986 "response to unfolded protein" (IEA,<br />
+UniProtKB-KW) — but this is NOT in the QuickGO goa.tsv snapshot (KW-derived GO may have<br />
+been retired from GOA), so it is not in existing_annotations. PomBase itself annotates the<br />
+BP "endoplasmic reticulum unfolded protein response" by orthology.</p>
+<h2 id="known-vs-not-known">KNOWN vs NOT-known</h2>
+<p>KNOWN (evidence-supported):<br />
+- Bona fide, meiotically-regulated protein-coding gene <a href="https://pubmed.ncbi.nlm.nih.gov/21270388">PMID:21270388</a>.<br />
+- Genuine RAMP4/SERP1-family, single-pass (C-terminal TM) small ER-membrane protein, by<br />
+  curated reciprocal orthology (human SERP1/SERP2; Sc YSY6) + Pfam PF06624.<br />
+- Differentially expressed during meiosis; low abundance (~5 copies/cell); phosphorylated<br />
+  (S8, T6) and ubiquitinylated (K18) per PomBase modification data.</p>
+<p>NOT known (the gaps):<br />
+- No experimentally determined molecular function IN <em>S. pombe</em> — the SERP1-family<br />
+  translocon-associated/UPR "chaperone-like" activity is a <code>By similarity</code> transfer, never<br />
+  assayed in fission yeast. (And even in mammals the activity has no clean GO MF term.)<br />
+- No pombe deletion phenotype reported; tam14 was excluded from the tam-gene functional<br />
+  assessment <a href="https://pubmed.ncbi.nlm.nih.gov/21270388">PMID:21270388</a>. Whether it has any meiotic role (vs incidental meiotic<br />
+  expression) is untested.<br />
+- No direct localisation data (GFP/immuno) in pombe; ER-membrane placement is<br />
+  orthology/topology inference.<br />
+- The HT-Y2H interactors (Cut11, Lem2, Ima1 — nuclear-envelope/INM proteins) are<br />
+  unvalidated single-method hits and do not by themselves establish function.</p>
+<h2 id="curation-plan">Curation plan</h2>
+<ul>
+<li>description: project-independent — RAMP4/SERP1-family single-pass ER-membrane protein,<br />
+  meiotically regulated, ortholog set, function inferred not measured. No curation<br />
+  commentary.</li>
+<li>CC ER membrane (ISS + IEA): KEEP as core location. ER (IEA/InterPro): ACCEPT/keep as<br />
+  non-core (more general than ER membrane). membrane (x2): MARK_AS_OVER_ANNOTATED (root).</li>
+<li>MF root ND: ACCEPT (honest MF-dark).</li>
+<li>core_functions: minimal — the confident statement is CC (ER membrane, RAMP4 family);<br />
+  do NOT assert an MF term (no defensible, branch-correct MF for the SERP1 activity).</li>
+<li>knowledge_gaps (REQUIRED): MF-dark biology gap (family known, pombe activity unmeasured)</li>
+<li>BP gap (meiotic role untested despite the gene's very name).</li>
+<li>reference_review for the two verified PMIDs.</li>
+</ul>
+<h2 id="falcon-deep-research-completed-2026-07-06-genuine-edison-output-17-citations">Falcon deep research (completed 2026-07-06; genuine Edison output, 17 citations)</h2>
+<p>The falcon report [file:SCHPO/tam14/tam14-deep-research-falcon.md] independently reaches the<br />
+same conclusions and adds mechanistic family context (verified against my own UniProt/PomBase<br />
+work). Key verbatim points:<br />
+- Family/orthologs: RAMP4 (PF06624) = mammalian RAMP4/SERP1 and Sc Ysy6; tam14 predicted to be<br />
+  "a <strong>small accessory component of the Sec61 translocon</strong> at the endoplasmic reticulum<br />
+  membrane". Mechanistic detail from Lewis et al. 2024 (eLife) cryo-EM of the<br />
+  ribosome-translocon (RAMP4 intercalates the Sec61 lateral gate, "surrogate signal peptide")<br />
+  and Pool 2009 (JCB) TM-segment-triggered RAMP4 recruitment. RAMP4 is a tail-anchored ER<br />
+  membrane protein.<br />
+- Evidence level: "rests primarily on <strong>domain and family-level inference</strong> from<br />
+  well-characterized orthologs ... but no targeted deletion, localization, or biochemical study<br />
+  has been published specifically for tam14/SPCC330.20." Confidence: "Moderate for family-level<br />
+  annotation, low for gene-specific detail".<br />
+- tam14 "was not among the seven genes selected for functional knockout analysis in the original<br />
+  study, so no deletion phenotype has been reported specifically for this gene."<br />
+- "No direct localization data for tam14 in <em>S. pombe</em> cells has been reported."<br />
+- Important pombe-specific caveat: "<em>S. pombe</em> lacks Hac1/XBP1 orthologs and instead relies<br />
+  primarily on Ire1-dependent mRNA decay (RIDD)" — so the mammalian ER-stress-induction /<br />
+  UPR-transcriptional paradigm for RAMP4/SERP1 may not transfer to fission yeast.<br />
+- "the meiotic expression change alone does not imply a meiosis-specific biochemical function".</p>
+<p>Note: falcon cites Lewis et al. 2024 and Pool 2009 by DOI/preprint. These are mammalian<br />
+mechanism papers (not tam14). I anchor gene-specific "unknown" provenance to the falcon file:<br />
+and to cached PMID:21270388; I do NOT add the mammalian DOIs as review references (cannot cache<br />
+/ verify their full text here, and they are not about tam14).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G2TRT3
+gene_symbol: tam14
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  tam14 (systematic name SPCC330.20) is a small (70-residue) single-pass endoplasmic
+  reticulum membrane protein of the RAMP4/SERP1 family (Pfam PF06624; InterPro IPR010580,
+  &#34;ER stress-associated&#34;). Its architecture is a short polar/disordered N-terminal segment
+  followed by a single C-terminal transmembrane helix, characteristic of the tail-anchored
+  RAMP4/SERP1 proteins. It is a curated ortholog of human SERP1 (RAMP4) and SERP2 and of
+  budding-yeast Ysy6. In its better-characterized mammalian and budding-yeast orthologs, this
+  family constitutes a small accessory component of the ribosome-associated Sec61 translocon
+  that contacts nascent polypeptides during co-translational translocation and stabilizes
+  newly synthesized membrane proteins during endoplasmic reticulum stress, facilitating their
+  subsequent glycosylation. The corresponding molecular activity, subcellular localization, and
+  biological role of tam14 in fission yeast have not been directly measured; annotations rest on
+  family/orthology inference. tam14 was identified as a novel gene whose transcript levels are
+  altered during meiosis, but no meiotic function has been demonstrated.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000015
+    title: Use of the ND evidence code for Gene Ontology (GO) terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+      by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+      mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: PMID:21270388
+    title: Augmented annotation of the Schizosaccharomyces pombe genome reveals additional genes
+      required for growth and viability
+    findings:
+      - statement: tam14 is one of 14 novel S. pombe loci named for having transcript levels
+          altered during meiosis (tam1-tam14); this is an expression observation, not a functional
+          determination.
+        supporting_text: We refer to the novel protein-coding genes with no apparent induction
+          in meiosis as new1–new25 , and the 14 genes with t ranscripts a ltered in m eiosis
+          as tam1–tam14
+        reference_section_type: RESULTS
+      - statement: Fourteen novel-gene transcripts, including tam14, were differentially expressed
+          across a synchronized meiotic time course.
+        supporting_text: Fourteen transcripts were differentially expressed during meiosis.
+        reference_section_type: RESULTS
+      - statement: tam14 was NOT among the seven genes selected for deletion/functional
+          assessment (tam2, new1, new5, tam7, new8, tam11, new21), so no tam14 deletion phenotype
+          was reported.
+        supporting_text: three criteria were used to select seven genes ( tam2 , new1 , new5
+          , tam7 , new8 , tam11 , and new21 ) for functional assessment
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Full text cached and verified. This is the discovery paper for tam14 and the only
+        publication with S. pombe-specific data on the gene. It establishes tam14 as a bona fide,
+        meiotically-regulated protein-coding gene but provides only transcript-level (expression)
+        evidence; tam14 was explicitly excluded from the deletion-phenotyping set, so no meiotic
+        or other function was demonstrated.
+  - id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+    title: Falcon deep research report for tam14 (G2TRT3, SPCC330.20)
+    findings:
+      - statement: The functional annotation of tam14 rests on domain/family-level inference from
+          orthologs (RAMP4/SERP1, Ysy6); no deletion, localization, or biochemical study exists
+          for tam14 itself.
+        supporting_text: rests primarily on **domain and family-level inference** from
+          well-characterized orthologs
+      - statement: No targeted deletion, localization, or biochemical study has been published
+          specifically for tam14/SPCC330.20.
+        supporting_text: no targeted deletion, localization, or biochemical study has been
+          published specifically for tam14/SPCC330.20
+      - statement: By family inference tam14 is a small accessory component of the Sec61 translocon
+          at the ER membrane; RAMP4/SERP1 is a tail-anchored ER protein that intercalates the
+          Sec61 lateral gate and contacts translocating nascent chains.
+        supporting_text: predicted to function as a **small accessory component of the Sec61
+          translocon** at the endoplasmic reticulum membrane
+      - statement: No direct localization data for tam14 in S. pombe cells has been reported.
+        supporting_text: No direct localization data for tam14 in *S. pombe* cells has been reported
+      - statement: The meiotic expression change reflected in the gene&#39;s name does not imply a
+          meiosis-specific biochemical function.
+        supporting_text: the meiotic expression change alone does not imply a meiosis-specific
+          biochemical function
+      - statement: S. pombe UPR is mechanistically divergent (no Hac1/XBP1; Ire1-dependent RIDD),
+          so the mammalian ER-stress-induction paradigm for RAMP4/SERP1 may not transfer.
+        supporting_text: &#34;*S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on
+          Ire1-dependent mRNA decay (RIDD)&#34;
+      - statement: Overall functional confidence is moderate at the family level but low for
+          gene-specific detail.
+        supporting_text: Moderate for family-level annotation, low for gene-specific detail
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        Genuine falcon/Edison deep-research output (17 citations, cached:false). Conclusions were
+        cross-checked against the UniProt record and the PomBase curated ortholog set and agree:
+        real conserved RAMP4/SERP1 family, no S. pombe-specific experimental characterization. Its
+        mechanistic sources (Lewis et al. 2024 eLife; Pool 2009 JCB) concern mammalian
+        RAMP4/SERP1, not tam14, and are used here only as family context, not as tam14-specific
+        evidence.
+existing_annotations:
+  - term:
+      id: GO:0005783
+      label: endoplasmic reticulum
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Endoplasmic reticulum localization inferred electronically from the InterPro RAMP4/
+        ER-stress-associated domain (IPR010580). This is consistent with the family assignment and
+        the single C-terminal transmembrane helix, but is more general than the endoplasmic
+        reticulum membrane term that better captures a single-pass RAMP4/SERP1 protein.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Correct in direction and family-supported, but subsumed by the more specific
+        &#34;endoplasmic reticulum membrane&#34; annotations; retained as non-core because the membrane
+        term is the precise location.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: predicted to function as a **small accessory component of the Sec61
+            translocon** at the endoplasmic reticulum membrane
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Endoplasmic reticulum membrane localization from UniProt Subcellular-Location mapping.
+        This is the electronic counterpart of the ISS annotation below and is well-grounded by the
+        RAMP4/SERP1 family assignment plus the single predicted transmembrane helix (residues
+        45-65). No direct localization has been shown in S. pombe, but the family/topology basis is
+        strong.
+      action: ACCEPT
+      reason: &gt;-
+        The single-pass, tail-anchored RAMP4/SERP1 architecture localizes to the ER membrane;
+        this is the most specific, best-supported location for tam14 and represents its core
+        cellular component.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Generic &#34;membrane&#34; localization from Subcellular-Location mapping. This is a high-level
+        parent of the endoplasmic reticulum membrane term and adds no specific information beyond
+        it.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Uninformative parent term redundant with the more specific &#34;endoplasmic reticulum
+        membrane&#34; annotation; the specific term should carry the localization.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+  - term:
+      id: GO:0003674
+      label: molecular_function
+    evidence_type: ND
+    original_reference_id: GO_REF:0000015
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Root molecular_function placeholder with ND (No Data) evidence, reflecting that no
+        molecular function has been experimentally determined for tam14 in S. pombe. Although the
+        RAMP4/SERP1 family has a described activity (accessory Sec61-translocon component that
+        contacts translocating nascent chains and stabilizes membrane proteins during ER stress),
+        that activity has never been assayed for tam14, and it has no clean, well-scoped GO
+        molecular-function term to which it could be confidently transferred.
+      action: ACCEPT
+      reason: &gt;-
+        The ND molecular_function annotation honestly reflects the current MF-dark state: family
+        membership is clear but the specific in vivo molecular activity of tam14 is unmeasured and
+        not cleanly expressible in GO. No specific MF term is asserted.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: no targeted deletion, localization, or biochemical study has been
+            published specifically for tam14/SPCC330.20
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: rests primarily on **domain and family-level inference** from
+            well-characterized orthologs
+      knowledge_gaps:
+        - gap_statement: &gt;-
+            The molecular function of tam14 in S. pombe is undetermined. Whether it acts, like its
+            RAMP4/SERP1 orthologs, as an accessory subunit of the Sec61 translocon that contacts
+            translocating nascent chains and stabilizes newly synthesized membrane proteins during
+            ER stress has never been assayed for the fission-yeast protein.
+          boundary: &gt;-
+            Firmly established: tam14 is a genuine RAMP4/SERP1-family, single-pass (C-terminal TM)
+            small ER-membrane protein by curated reciprocal orthology (human SERP1/SERP2;
+            S. cerevisiae Ysy6) and Pfam PF06624. Undetermined: any tam14-specific biochemical
+            activity, substrate, or translocon association measured in S. pombe.
+          gap_kind:
+            - BIOLOGY
+            - ONTOLOGY
+          dark_aspect: MF_DARK
+          status: OPEN
+          significance: &gt;-
+            RAMP4/SERP1 is a near-constitutive accessory of the ER protein-biogenesis machinery in
+            other eukaryotes; whether fission yeast uses tam14 the same way bears on the
+            conservation of translocon accessory factors, and the family activity has no adequate
+            GO MF term (an ontology shadow).
+          resolution: &gt;-
+            Assay tam14-Sec61 association and nascent-chain crosslinking in S. pombe; a
+            separation-of-function analysis of the TM helix vs the N-terminal region. Ontology:
+            a molecular-function term for &#34;Sec61 translocon accessory / nascent-chain
+            stabilization&#34; activity would let the family role be expressed.
+          provenance:
+            - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+              supporting_text: no targeted deletion, localization, or biochemical study has been
+                published specifically for tam14/SPCC330.20
+            - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+              supporting_text: Moderate for family-level annotation, low for gene-specific detail
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Curator sequence-similarity transfer of ER membrane localization from the mammalian
+        ortholog (UniProtKB:Q9R2C1, rat SERP1/RAMP4). Unlike the dubious orthology transfers seen
+        for some fission-yeast orphan genes, this rests on a genuine, curated, reciprocal ortholog
+        relationship (human SERP1/SERP2; S. cerevisiae Ysy6) and on the conserved single-pass
+        tail-anchored topology. It is the best-supported location annotation and duplicates the
+        IEA ER membrane row with stronger (ISS) evidence.
+      action: ACCEPT
+      reason: &gt;-
+        Well-grounded ISS transfer within a real, conserved family; the ER membrane is the core
+        cellular component of tam14.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        Generic &#34;membrane&#34; localization transferred by sequence similarity from the mammalian
+        ortholog. As with the IEA membrane row, this is a high-level parent that is subsumed by
+        the specific endoplasmic reticulum membrane annotation.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Uninformative parent term redundant with &#34;endoplasmic reticulum membrane&#34;; the specific
+        term should carry the localization.
+      supported_by:
+        - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+          supporting_text: By family inference, tam14 is predicted to localize to the
+            **endoplasmic reticulum membrane**
+core_functions:
+  - description: &gt;-
+      Single-pass endoplasmic reticulum membrane protein of the RAMP4/SERP1 family. The
+      well-supported, family/orthology-grounded statement about tam14 is its subcellular
+      localization: a tail-anchored small protein of the ER membrane. No specific molecular
+      function is asserted, because the RAMP4/SERP1 accessory-translocon activity has not been
+      measured for tam14 in S. pombe and has no adequate GO molecular-function term.
+    supported_by:
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: By family inference, tam14 is predicted to localize to the
+          **endoplasmic reticulum membrane**
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: predicted to function as a **small accessory component of the Sec61
+          translocon** at the endoplasmic reticulum membrane
+    locations:
+      - id: GO:0005789
+        label: endoplasmic reticulum membrane
+knowledge_gaps:
+  - gap_statement: &gt;-
+      No biological process has been established for tam14 in S. pombe. Despite its name (altered
+      transcripts in meiosis), no meiotic — or any other — function has been demonstrated: tam14
+      was excluded from the deletion-phenotyping set in its discovery study, and no deletion,
+      localization, or biochemical characterization has since been published.
+    boundary: &gt;-
+      Firmly established: tam14 is a bona fide, meiotically-regulated protein-coding gene of the
+      conserved RAMP4/SERP1 family; its transcript level changes during a synchronized meiotic
+      program. Undetermined: whether that expression change reflects any meiotic role, and whether
+      tam14 participates (as its orthologs do) in co-translational ER protein biogenesis / ER
+      proteostasis in fission yeast.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Distinguishing an incidental meiotic expression change from a genuine meiotic or
+      ER-proteostasis role would settle whether the &#34;tam&#34; name reflects biology, and would test
+      whether the conserved RAMP4/SERP1 translocon-accessory role operates in an organism whose
+      UPR is mechanistically divergent (S. pombe lacks Hac1/XBP1 and uses Ire1-dependent RIDD).
+    resolution: &gt;-
+      Phenotype a tam14 deletion for growth, ER-stress sensitivity (e.g. tunicamycin/DTT),
+      secretion/glycosylation defects, and sporulation/spore viability; GFP localization across
+      the cell cycle and meiosis; measure tam14-Sec61 association.
+    provenance:
+      - reference_id: PMID:21270388
+        supporting_text: three criteria were used to select seven genes ( tam2 , new1 , new5
+          , tam7 , new8 , tam11 , and new21 ) for functional assessment
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: the meiotic expression change alone does not imply a meiosis-specific
+          biochemical function
+      - reference_id: file:SCHPO/tam14/tam14-deep-research-falcon.md
+        supporting_text: &#34;*S. pombe* lacks Hac1/XBP1 orthologs and instead relies primarily on
+          Ire1-dependent mRNA decay (RIDD)&#34;
+suggested_questions:
+  - question: Does tam14 associate with the Sec61 translocon and contact translocating nascent
+      chains in S. pombe, as its RAMP4/SERP1 orthologs do?
+    experts: []
+  - question: Does the meiotic transcript change reflect a functional meiotic role (e.g. increased
+      ER protein-biogenesis demand during sporulation), or is it an incidental expression change
+      with no phenotype?
+    experts: []
+  - question: Given that S. pombe uses an Ire1/RIDD-based UPR without Hac1/XBP1, is tam14 regulated
+      by, or required for, the fission-yeast ER stress response at all?
+    experts: []
+suggested_experiments:
+  - hypothesis: tam14 is an accessory component of the S. pombe Sec61 translocon.
+    description: Affinity-purify tagged tam14 from S. pombe and test co-purification with Sec61
+      complex subunits; site-specific crosslinking to translocating nascent chains.
+    experiment_type: co-immunoprecipitation / crosslinking-MS
+  - hypothesis: tam14 contributes to ER proteostasis / stress tolerance.
+    description: Phenotype a tam14 deletion (and overexpression) for growth and viability, ER-stress
+      sensitivity (tunicamycin, DTT), and membrane-protein secretion/glycosylation.
+    experiment_type: genetics / stress phenotyping
+  - hypothesis: tam14 localizes to the ER membrane and its distribution changes during meiosis.
+    description: GFP-tag tam14 and image localization in vegetative and meiotic/sporulating cells.
+    experiment_type: live-cell fluorescence microscopy
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/FGFRL1/FGFRL1-ai-review.html
+++ b/genes/human/FGFRL1/FGFRL1-ai-review.html
@@ -4417,6 +4417,280 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">FGFRL1: A Kinase-Dead FGF Receptor-like Protein — Mechanism of Signaling, Adhesion, and Fusion</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FGFRL1-hypotheses/kgap-fgfrl1-kinase-dead-signaling-mechanism/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N441" data-a="DEEP_RESEARCH: FGFRL1: A Kinase-Dead FGF Receptor-like Protein — Mechanism of Signaling, Adhesion, and Fusion" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+
+
+
+
+
+
+
+                    <a href="FGFRL1-hypotheses/kgap-fgfrl1-kinase-dead-signaling-mechanism/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <h1 id="fgfrl1-a-kinase-dead-fgf-receptor-like-protein-mechanism-of-signaling-adhesion-and-fusion">FGFRL1: A Kinase-Dead FGF Receptor-like Protein — Mechanism of Signaling, Adhesion, and Fusion</h1>
+<p><strong>Research question.</strong> How does human FGFRL1, an atypical kinase-dead fibroblast growth<br />
+factor receptor-like protein, modulate FGF/FGFR signaling and cell adhesion/fusion in vivo?<br />
+Which mechanistic model(s) — ligand/heparin-binding decoy, inhibitory FGFR-complex component,<br />
+cytoplasmic Sprouty/Spred scaffold, or adhesion/fusion molecule — are supported, and should<br />
+FGFRL1 receive the canonical Gene Ontology term <em>fibroblast growth factor receptor activity</em>?</p>
+<blockquote>
+<p><strong>Evidence provenance.</strong> Findings below are drawn from <strong>direct FGFRL1-specific experiments</strong><br />
+(mostly the Trueb laboratory, Bern). Where I extend from canonical FGFR-family biology I flag it<br />
+as <strong>[FGFR-family inference]</strong>. PMIDs are given for every claim; DOIs that I could not verify<br />
+from the cached abstract metadata are flagged <strong>[DOI uncached — verify]</strong>.</p>
+</blockquote>
+<hr />
+<h2 id="1-summary-answer">1. Summary (answer)</h2>
+<p>FGFRL1 is best described as a <strong>multifunctional, kinase-dead ectodomain receptor</strong> whose in vivo<br />
+activity is carried almost entirely by its <strong>extracellular Ig domains, not by intracellular<br />
+signal transduction</strong>. Direct evidence supports three overlapping ectodomain-based roles — a<br />
+<strong>ligand/heparin-binding decoy (ligand sink)</strong>, a <strong>constitutively dimeric, HSPG-dependent<br />
+adhesion molecule</strong>, and an <strong>active cell–cell fusogen</strong> — while the <strong>cytoplasmic Sprouty/Spred<br />
+scaffold is real biochemically but genetically dispensable in vivo</strong>. Because FGFRL1 lacks the<br />
+tyrosine kinase domain and does not transduce FGF signals by transphosphorylation, assigning it<br />
+the canonical GO term <em>fibroblast growth factor receptor activity</em> (which denotes kinase-dependent<br />
+signal transduction) <strong>overstates its function</strong>; <em>FGF binding</em> + <em>heparin binding</em> + <em>cell<br />
+adhesion / cell–cell fusion / negative regulation of FGFR signaling</em> is the accurate annotation.</p>
+<hr />
+<h2 id="2-key-findings-with-statistical-experimental-evidence">2. Key findings with statistical / experimental evidence</h2>
+<h3 id="21-ligand-sink-decoy-model-strongly-supported-direct-evidence">2.1 Ligand-sink / decoy model — <strong>strongly supported (direct evidence)</strong></h3>
+<ul>
+<li>The recombinant ectodomain <strong>and</strong> the membrane-bound receptor bind <strong>FGF2, FGF3, FGF4, FGF8,<br />
+  FGF10, FGF22</strong> with high affinity (ligand dot-blot, cell-based binding, surface plasmon<br />
+  resonance). The ectodomain is <strong>proteolytically shed</strong> near the membrane, releasing a soluble<br />
+  ligand-binding fragment, and <strong>ectopic FGFRL1 antagonizes FGFR signaling in Xenopus embryos</strong><br />
+  (PMID <strong>19920134</strong>; Steinberg et al., 2010, <em>J Biol Chem</em> — [DOI uncached — verify]).</li>
+<li>Original characterization: FGFRL1 binds <strong>heparin and FGF2</strong> specifically and exerts a<br />
+<strong>negative effect on proliferation</strong> in MG-63 cells (PMID <strong>12813049</strong>; Trueb et al., 2003,<br />
+<em>J Biol Chem</em> — [DOI uncached — verify]).</li>
+<li><strong>FGF8 binds via the Ig2 domain</strong> with very high affinity (rapid on-rate, slow off-rate;<br />
+  ELISA + Biacore); constructs lacking Ig2 bind poorly (PMID <strong>33019532</strong>; Zhuang et al., 2020,<br />
+<em>Int J Mol Sci</em> — [DOI uncached — verify]).</li>
+</ul>
+<h3 id="22-constitutive-dimerization-hspg-dependent-adhesion-strongly-supported-direct">2.2 Constitutive dimerization + HSPG-dependent adhesion — <strong>strongly supported (direct)</strong></h3>
+<ul>
+<li>FRET and co-precipitation of differentially tagged polypeptides show <strong>constitutive homodimers</strong><br />
+  at the cell surface, enriched at <strong>cell–cell contacts</strong>. The ectodomain promotes <strong>adhesion but<br />
+  not spreading</strong>; adhesion is mediated by <strong>cell-surface heparan sulfate</strong>, is <strong>specifically<br />
+  blocked by soluble heparin</strong> (not other GAGs), is reduced by <strong>heparin-binding-site mutagenesis</strong>,<br />
+  and is neutralized by a <strong>synthetic heparin-binding-site peptide</strong>. The authors note FGFRL1<br />
+  "<strong>resembles the nectins</strong>" (PMID <strong>18061161</strong>; Rieckmann et al., 2008, <em>J Biol Chem</em> —<br />
+  [DOI uncached — verify]).</li>
+<li>Mechanistic significance: unlike canonical FGFRs, which <strong>dimerize upon ligand + heparan<br />
+  sulfate engagement to trigger kinase activation</strong> <strong>[FGFR-family inference]</strong>, FGFRL1 is<br />
+<strong>pre-dimerized</strong> and uses HSPGs for adhesion in trans — decoupling dimerization from any<br />
+  kinase output.</li>
+</ul>
+<h3 id="23-active-cellcell-fusion-via-ig3-transmembrane-domain-supported-direct">2.3 Active cell–cell fusion via Ig3 + transmembrane domain — <strong>supported (direct)</strong></h3>
+<ul>
+<li>FGFRL1 is the <strong>first mammalian protein shown to actively fuse cells</strong> into large syncytia;<br />
+  cytoplasmic-mixing reporters map fusion to <strong>Ig3 + transmembrane domain (necessary and<br />
+  sufficient)</strong>, and FGFRL1-transfected HEK293/HeLa fuse with <strong>untransfected CHO cells</strong> —<br />
+  implying a <strong>partner on the opposing membrane</strong> (PMID <strong>20851884</strong>; Steinberg et al., 2010,<br />
+<em>J Cell Sci</em> — [DOI uncached — verify]).</li>
+<li>Fusing contact sites form a <strong>net-like structure with ~1 µm pores</strong>, proposed fusion-pore<br />
+  precursors (PMID <strong>21980560</strong>; Trueb &amp; Steinberg, 2011 — [DOI uncached — verify]).</li>
+<li>In vivo correlate: FgfrL1 is upregulated during myoblast→myotube fusion; <strong>FgfrL1-null mice die<br />
+  at birth from a malformed diaphragm</strong> and <strong>specifically lack slow muscle fibers</strong> (PMID<br />
+<strong>25172430</strong>; Amann et al., 2014, <em>Dev Biol</em> — [DOI uncached — verify]).</li>
+<li><strong>Open question:</strong> the identity of the <strong>Ig3 trans-fusion partner is unknown</strong>.</li>
+</ul>
+<h3 id="24-cytoplasmic-sproutyspred-scaffold-real-biochemically-but-genetically-dispensable">2.4 Cytoplasmic Sprouty/Spred scaffold — <strong>real biochemically but genetically dispensable</strong></h3>
+<ul>
+<li>The <strong>C-terminal histidine-rich domain binds Spred1</strong> and other Sprouty/Spred proteins (via<br />
+  their shared SPR domain; yeast two-hybrid + co-precipitation + membrane co-distribution), and<br />
+  Spred1 increases FGFRL1 plasma-membrane retention (PMID <strong>21616146</strong>; Zhuang et al., 2011 —<br />
+  [DOI uncached — verify]).</li>
+<li><strong>But</strong> knock-in mice lacking the three conserved intracellular motifs (<strong>FgfrL1ΔC-GFP</strong>) are<br />
+<strong>viable, fertile, and phenotypically normal</strong> (normal diaphragm and kidney) (PMID <strong>25126760</strong>;<br />
+  Bluteau et al., 2014 — [DOI uncached — verify]).</li>
+<li>Systematic domain-deletion mice: <strong>intracellular-domain deletion → normal</strong>; <strong>Ig3 deletion →<br />
+  complete absence of metanephric kidneys</strong>; <strong>Ig2 deletion → hypoplastic kidneys</strong>. The<br />
+  principal function is attributed to <strong>Ig3</strong> (with Ig2 contributing to ligand binding) (PMID<br />
+<strong>31923383</strong>; Gerber et al., 2020, <em>Dev Biol</em> — [DOI uncached — verify]).</li>
+</ul>
+<h3 id="25-go-annotation-verdict-canonical-fgf-receptor-activity-overstates-fgfrl1">2.5 GO annotation verdict — canonical <em>FGF receptor activity</em> overstates FGFRL1</h3>
+<ul>
+<li>Every primary source states FGFRL1 <strong>lacks the tyrosine kinase domain required for FGF-mediated<br />
+  signal transduction by transphosphorylation</strong> (PMID <strong>12813049</strong>, <strong>19920134</strong>, <strong>40699684</strong>).</li>
+<li>GO:0005007 <em>fibroblast growth factor receptor activity</em> denotes <strong>combining with FGF and<br />
+  transmitting the signal across the membrane</strong> — a kinase-dependent transduction activity FGFRL1<br />
+  does not perform. <strong>Recommended annotations:</strong> <em>fibroblast growth factor binding</em> (GO:0017134),<br />
+<em>heparin binding</em> (GO:0008201), <em>cell-cell adhesion</em>, <em>cell-cell fusion / myoblast fusion</em>,<br />
+  and <em>negative regulation of fibroblast growth factor receptor signaling pathway</em>.</li>
+</ul>
+<hr />
+<h2 id="3-supported-vs-refuted-hypotheses">3. Supported vs. refuted hypotheses</h2>
+<table>
+<thead>
+<tr>
+<th>Model</th>
+<th>Verdict</th>
+<th>Basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Ligand/heparin-binding <strong>decoy (ligand sink)</strong></td>
+<td><strong>Supported</strong></td>
+<td>Multi-FGF binding, ectodomain shedding, Xenopus antagonism (19920134); heparin/FGF2 binding (12813049); Ig2→FGF8 (33019532)</td>
+</tr>
+<tr>
+<td><strong>HSPG-dependent adhesion</strong> molecule (nectin-like)</td>
+<td><strong>Supported</strong></td>
+<td>Constitutive dimers + heparin-specific adhesion + mutagenesis (18061161)</td>
+</tr>
+<tr>
+<td><strong>Active cell–cell fusogen</strong> with unknown Ig3 partner</td>
+<td><strong>Supported</strong></td>
+<td>Ig3+TM necessary/sufficient, fuses untransfected cells (20851884, 21980560); slow-fiber/diaphragm phenotype (25172430)</td>
+</tr>
+<tr>
+<td><strong>Inhibitory FGFR-complex</strong> component (heterodimer with FGFR1–4)</td>
+<td><strong>Plausible but not directly demonstrated</strong></td>
+<td>Antagonism of FGFR signaling is shown (19920134), but a physical FGFRL1·FGFR complex is inferred, not proven in the cached literature <strong>[FGFR-family inference]</strong></td>
+</tr>
+<tr>
+<td><strong>Cytoplasmic Sprouty/Spred scaffold</strong> as the essential mechanism</td>
+<td><strong>Refuted (for in vivo essential function)</strong></td>
+<td>ΔC mice normal (25126760); intracellular-deletion mice normal (31923383) — though Spred1 binding is real (21616146)</td>
+</tr>
+<tr>
+<td>Canonical GO <em>FGF receptor activity</em> (kinase signal transduction)</td>
+<td><strong>Refuted / overstated</strong></td>
+<td>No kinase domain; no transphosphorylation (12813049, 19920134, 40699684)</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Integrating view.</strong> The decoy, adhesion, and fusion activities are <strong>not mutually exclusive</strong>;<br />
+they are three read-outs of the <strong>same ligand/HSPG/partner-binding ectodomain</strong>. Notably the<br />
+<strong>Ig3 domain</strong> is required for both <strong>kidney development</strong> and <strong>fusion</strong>, and <strong>Ig2</strong> carries<br />
+<strong>FGF8 binding</strong> — suggesting a domain-partitioned mechanism: Ig2 = ligand sink, Ig3 = trans<br />
+adhesion/fusion partner engagement.</p>
+<hr />
+<h2 id="4-experiments-that-would-distinguish-the-four-models">4. Experiments that would distinguish the four models</h2>
+<ol>
+<li>
+<p><strong>Ligand-sink vs. receptor-complex (separation of function).</strong><br />
+   Compare an <strong>Ig2-only "ligand-trap" knock-in</strong> (binds FGF8, cannot fuse) against an<br />
+<strong>Ig3-only knock-in</strong> (fuses, weak ligand binding) in mice; if kidney rescue tracks with Ig3<br />
+   not with FGF sequestration, the essential role is adhesion/fusion, not ligand sink.<br />
+   Complement with <strong>quantitative FGF8 gradient imaging</strong> (reporter) in wild-type vs. FGFRL1-null<br />
+   metanephros to test whether FGFRL1 sharpens/limits the FGF8 field (ligand-sink prediction).</p>
+</li>
+<li>
+<p><strong>Physical FGFRL1·FGFR complex.</strong><br />
+<strong>Co-IP / proximity-ligation / BioID or split-nanoluc</strong> between endogenous FGFRL1 and FGFR1–4<br />
+   in nephrogenic cells ± FGF8/heparin; <strong>cross-linking mass spec</strong> on purified ectodomains.<br />
+   Functionally, test whether FGFRL1 <strong>cis-inhibits FGFR autophosphorylation</strong> in a defined<br />
+   co-expression system (pERK / pFRS2 dose–response) — distinguishes a true inhibitory-complex<br />
+   component from a purely extracellular ligand sink.</p>
+</li>
+<li>
+<p><strong>Adhesion vs. fusion (is adhesion a fusion intermediate?).</strong><br />
+   Use <strong>heparin-binding-site mutants</strong> and <strong>HSPG-deficient (e.g., Ext1/2-null or heparinase-<br />
+   treated) target cells</strong> in the CHO trans-fusion assay: if HSPG loss abolishes adhesion but<br />
+   fusion persists, adhesion and fusion are separable; if both fail, HSPG bridging is the fusion<br />
+   trigger. Live-imaging of the ~1 µm net-like pores with membrane/cytoplasmic dyes to order<br />
+   adhesion → pore → mixing.</p>
+</li>
+<li>
+<p><strong>Identify the Ig3 fusion partner (the central unknown).</strong><br />
+<strong>Recombinant FGFRL1-Ig3 ectodomain pulldown + mass spectrometry</strong> from myoblast/diaphragm<br />
+   membranes; <strong>CRISPR loss-of-function screen</strong> in the CHO trans-fusion reporter (FGFRL1+ cells<br />
+   fuse with a genome-wide-KO CHO library — dropout identifies the required partner);<br />
+<strong>cell-surface expression cloning</strong> for a factor conferring fusion competence on non-fusing<br />
+   cells. Validate candidate by conditional KO → expect diaphragm slow-fiber / syncytium defects<br />
+   phenocopying FgfrL1-null.</p>
+</li>
+<li>
+<p><strong>Cytoplasmic contribution (already largely answered).</strong><br />
+   The ΔC and intracellular-deletion mice (25126760, 31923383) already show the tail is<br />
+   dispensable in vivo; a targeted test would be a <strong>Spred1;FgfrL1 double-mutant</strong> to ask whether<br />
+   Spred recruitment fine-tunes ERK output in a sensitized background without being essential.</p>
+</li>
+</ol>
+<hr />
+<h2 id="5-limitations-and-future-directions">5. Limitations and future directions</h2>
+<ul>
+<li>Much of the mechanistic work is from <strong>one laboratory</strong> and relies on <strong>overexpression and<br />
+  heterologous (CHO/HEK/Xenopus) systems</strong>; endogenous-level, human, in-vivo confirmation is<br />
+  limited.</li>
+<li>A <strong>physical FGFRL1·FGFR heterocomplex</strong> is inferred but not directly demonstrated in the<br />
+  cached literature — the "inhibitory receptor-complex" model remains open.</li>
+<li>The <strong>Ig3 fusion partner is unidentified</strong>, leaving the fusion mechanism molecularly incomplete.</li>
+<li><strong>Cancer studies</strong> (SCLC/ENO1–PI3K/Akt PMID 31957179; rectal/ovarian/ESCC MAPK PMID 32098557,<br />
+  29675438, 29963148; miR-210-3p PMID 37062273) report FGFRL1-linked signaling changes but are<br />
+<strong>correlative/knockdown</strong> and may reflect context-specific or indirect effects rather than a<br />
+  cell-autonomous kinase activity.</li>
+<li><strong>DOIs were not machine-verifiable</strong> from the available metadata and are flagged accordingly;<br />
+  PMIDs are authoritative.</li>
+</ul>
+<hr />
+<h2 id="6-cited-literature-pmids">6. Cited literature (PMIDs)</h2>
+<ul>
+<li><strong>12813049</strong> Trueb et al. 2003 — first characterization; heparin/FGF2 binding; decoy hypothesis.</li>
+<li><strong>18061161</strong> Rieckmann et al. 2008 — constitutive dimers; HSPG-dependent adhesion; nectin-like.</li>
+<li><strong>19920134</strong> Steinberg et al. 2010 — ectodomain shedding; binds FGF2/3/4/8/10/22; Xenopus antagonism.</li>
+<li><strong>20851884</strong> Steinberg et al. 2010 — active cell fusion; Ig3+TM necessary/sufficient.</li>
+<li><strong>21080029</strong> Trueb 2011 — review; high-affinity FGF/heparin binding; human craniosynostosis frameshift.</li>
+<li><strong>21616146</strong> Zhuang et al. 2011 — Spred1/Sprouty binding via His-rich C-terminus.</li>
+<li><strong>21980560</strong> Trueb &amp; Steinberg 2011 — net-like pore structure during fusion.</li>
+<li><strong>23112089</strong> Trueb et al. 2013 — kidney development; FGFRL1 interacts mainly with Fgf8.</li>
+<li><strong>25126760</strong> Bluteau et al. 2014 — ΔC-GFP mice viable/normal (tail dispensable).</li>
+<li><strong>25172430</strong> Amann et al. 2014 — required for slow muscle fibers.</li>
+<li><strong>31923383</strong> Gerber et al. 2020 — domain-deletion mice; Ig3 essential for metanephric kidney.</li>
+<li><strong>33019532</strong> Zhuang et al. 2020 — FGF8 binds via Ig2 (SPR/Biacore).</li>
+<li><strong>40699684</strong> Guan et al. 2025 — recent review; kinase-dead, multifunctional.</li>
+<li>Cancer/context: 31957179, 32098557, 29675438, 29963148, 37062273 (correlative).</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist prompt: FGFRL1 kinase-dead signaling mechanism</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FGFRL1-hypotheses/kgap-fgfrl1-kinase-dead-signaling-mechanism/prompt.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N441" data-a="DEEP_RESEARCH: OpenScientist prompt: FGFRL1 kinase-dead signaling mechanism" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+
+                <h1 id="openscientist-prompt-fgfrl1-kinase-dead-signaling-mechanism">OpenScientist prompt: FGFRL1 kinase-dead signaling mechanism</h1>
+<p>Investigate how human FGFRL1, an atypical kinase-dead fibroblast growth factor receptor-like protein, modulates FGF/FGFR signaling and cell adhesion/fusion in vivo.</p>
+<p>Focus on:</p>
+<ul>
+<li>evidence for FGFRL1 as a ligand/heparin-binding decoy receptor versus an inhibitory FGFR complex component versus a cytoplasmic Sprouty/Spred-recruiting scaffold;</li>
+<li>the significance of constitutive dimerization, HSPG-dependent cell adhesion, the dispensable cytoplasmic tail, and the unknown Ig3-mediated fusion partner;</li>
+<li>whether FGFRL1 should receive canonical <code>fibroblast growth factor receptor activity</code> or whether that overstates kinase-dependent signal transduction;</li>
+<li>experiments that would distinguish ligand-sink, receptor-complex, adhesion, and fusion-partner models.</li>
+</ul>
+<p>Please include PMIDs and DOIs, flag uncached or uncertain citations, and clearly separate direct FGFRL1-specific evidence from canonical FGFR-family inference.</p>
+            </div>
+        </details>
+
     </div>
 
 


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3033 |
| Gene review HTML pages | 3033 |
| Project pages | 1108 |
| Module pages | 91 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
