### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/MCEE/MCEE-ai-review.html
+++ b/genes/human/MCEE/MCEE-ai-review.html
@@ -1,0 +1,3579 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCEE - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MCEE</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q96PE7" target="_blank" class="term-link">
+                        Q96PE7
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MCEE";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q96PE7" data-a="DESCRIPTION: MCEE encodes methylmalonyl-CoA epimerase (also cal..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MCEE encodes methylmalonyl-CoA epimerase (also called DL-methylmalonyl-CoA racemase; EC 5.1.99.1), a mitochondrial matrix enzyme of the vicinal-oxygen-chelate (VOC)/glyoxalase superfamily. It catalyses the interconversion of (2R)- and (2S)-methylmalonyl-CoA (D- and L-methylmalonyl-CoA), the epimerisation step that lies between propionyl-CoA carboxylase (PCC) and methylmalonyl-CoA mutase (MMUT) in the propionyl-CoA catabolic pathway. Propionyl-CoA arising from catabolism of the branched-chain and other amino acids (valine, isoleucine, threonine, methionine), odd-chain fatty acids, and cholesterol is carboxylated by PCC to (2S)-methylmalonyl-CoA, epimerised by MCEE to the (2R)/(S)-isomer that MMUT requires, and rearranged by MMUT to succinyl-CoA for entry into the citric acid cycle. The mature enzyme (after cleavage of an N-terminal mitochondrial transit peptide) binds a divalent metal ion, with cobalt modelled at the active site in the crystal structure. Loss-of-function variants cause methylmalonyl-CoA epimerase deficiency (MCEED), a usually mild autosomal recessive methylmalonic aciduria.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>metal ion binding</h3>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="metal ion binding" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding of a metal ion (a divalent cation, with cobalt modelled in the MCEE crystal structure) by methylmalonyl-CoA epimerase at its vicinal-oxygen-chelate active site.</p>
+
+
+
+            <p><strong>Justification:</strong> UniProt annotates MCEE with the keywords Cobalt and Metal-binding and the crystal structure (PDB 3RMU/6QH4) models a divalent metal (Co2+) coordinated by residues His50/Gln122/Glu172 in the VOC active site. The GO:0046872 metal ion binding IEA annotation is present in the UniProt cross-reference block but not in the current GOA TSV; it is biologically well supported and could be added (GO:0046872 already exists).</p>
+
+
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004493" target="_blank" class="term-link">
+                                    GO:0004493
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA epimerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0004493" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the defining molecular function of MCEE. Fully consistent with the experimental characterisation of the human enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of MCEE and is directly supported by the experimental IDA annotation from PMID:11481338 as well as the EC/RHEA mapping.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                        PMID:11481338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Subsequent biochemical studies confirmed this inference by showing that the prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA racemases.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046491" target="_blank" class="term-link">
+                                    GO:0046491
+                                </a>
+                            </span>
+                            <span class="term-label">L-methylmalonyl-CoA metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0046491" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of involvement in L-methylmalonyl-CoA metabolism, the process directly defined by the enzyme&#39;s substrate/product.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCEE interconverts D- and L-methylmalonyl-CoA, so it is directly involved in L-methylmalonyl-CoA metabolism. Duplicated by the experimental IDA line (PMID:11481338); both are correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71020
+
+                                </span>
+
+                                <div class="support-text">This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004493" target="_blank" class="term-link">
+                                    GO:0004493
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA epimerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0004493" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping of EC 5.1.99.1 / RHEA:20553 to the epimerase molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct EC/Rhea-based mapping of the enzyme&#39;s activity; the underlying EC assignment is experimentally validated (PMID:11481338). Redundant with the IBA/IDA/TAS lines for the same term but the mapping itself is sound.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                        PMID:11481338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Subsequent biochemical studies confirmed this inference by showing that the prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA racemases.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic SubCell mapping (SL-0173 Mitochondrion) of MCEE localisation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCEE has an N-terminal mitochondrial transit peptide (residues 1-36) and a UniProt SUBCELLULAR LOCATION of Mitochondrion; localisation is corroborated by experimental mito-proteome data (PMID:34800366) and Reactome (matrix). The more specific mitochondrial matrix term is captured elsewhere.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71020
+
+                                </span>
+
+                                <div class="support-text">This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a systematic proteome-scale binary (Y2H) interactome map.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Protein binding&#34; (GO:0005515) is uninformative and is derived here from a high-throughput binary interactome screen rather than a targeted study of MCEE. The reported interactors (AGTRAP, CMTM5 in this record; CD81, STX8 elsewhere) are membrane/trafficking proteins with no plausible functional relationship to a soluble mitochondrial-matrix epimerase, consistent with systematic-screen artifacts. Retained but flagged as over-annotation per curation policy (experimental IPI, so not removed).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                                        PMID:25416956
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">screening half of the interactome space with minimal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25910212
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread macromolecular interaction perturbations in human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a large-scale interactome-perturbation study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative &#34;protein binding&#34; from a high-throughput interactome dataset; the AGTRAP/CMTM5 interactions carry no functional insight for MCEE&#39;s epimerase activity. Flagged as over-annotation (experimental IPI, not removed).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                                        PMID:25910212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Widespread macromolecular interaction perturbations in human genetic disorders</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005515" data-r="PMID:31515488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a large-scale variant/protein-interaction screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative &#34;protein binding&#34; from a high-throughput PPI screen (AGTRAP, CMTM5); no bearing on MCEE&#39;s known molecular function. Flagged as over-annotation (experimental IPI, not removed).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                                        PMID:31515488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">disruption of protein interactions by genetic variants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI reference binary interactome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative &#34;protein binding&#34; from the systematic HuRI binary interactome; the reported partners (CD81, AGTRAP, CMTM5, STX8 across records) are surface/trafficking proteins unrelated to a matrix epimerase. Flagged as over-annotation (experimental IPI, not removed).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reference map of the human binary protein interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019626" target="_blank" class="term-link">
+                                    GO:0019626
+                                </a>
+                            </span>
+                            <span class="term-label">short-chain fatty acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71032
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0019626" data-r="Reactome:R-HSA-71032" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-asserted (Reactome) involvement in propionyl-CoA catabolism, annotated to the short-chain fatty acid catabolic process parent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCEE catalyses one of the three reactions of the propionyl-CoA catabolic pathway, which converts propionyl-CoA (a short-chain acyl-CoA derived from odd-chain fatty acids and amino-acid catabolism) to succinyl-CoA. The annotation correctly places MCEE in this catabolic process, though it is broader than the more specific methylmalonyl-CoA terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71032
+
+                                </span>
+
+                                <div class="support-text">The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an intermediate of the citric acid cycle.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004493" target="_blank" class="term-link">
+                                    GO:0004493
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA epimerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71020
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0004493" data-r="Reactome:R-HSA-71020" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-asserted (Reactome) epimerase molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome traceably assigns the methylmalonyl-CoA epimerase activity to MCEE for the D-/L-methylmalonyl-CoA interconversion reaction; concordant with the experimental IDA. Core molecular function (duplicate of the IBA/IEA/IDA lines).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71020
+
+                                </span>
+
+                                <div class="support-text">This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11481338
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human methylmalonyl-CoA racemase gene ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005739" data-r="PMID:11481338" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion that MCEE is active in the mitochondrion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the mitochondrial transit peptide, UniProt SUBCELLULAR LOCATION, and the enzyme&#39;s role in the mitochondrial propionyl-CoA pathway. The mitochondrial matrix (GO:0005759) term is more specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                        PMID:11481338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">human DL-methylmalonyl-CoA racemase gene</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901290" target="_blank" class="term-link">
+                                    GO:1901290
+                                </a>
+                            </span>
+                            <span class="term-label">succinyl-CoA biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11481338
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human methylmalonyl-CoA racemase gene ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:1901290" data-r="PMID:11481338" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) involvement in succinyl-CoA biosynthesis, the end product of the propionyl-CoA catabolic pathway in which MCEE acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCEE is the epimerase step immediately upstream of methylmalonyl-CoA mutase, which produces succinyl-CoA; MCEE is therefore genuinely involved in succinyl-CoA biosynthesis. Curator-attributed experimental annotation from the defining paper; retained (the process describes the pathway outcome rather than MCEE&#39;s direct chemistry, which is captured by the methylmalonyl-CoA terms).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                        PMID:11481338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both encode DL-methylmalonyl-CoA racemases</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71032
+
+                                </span>
+
+                                <div class="support-text">The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an intermediate of the citric acid cycle.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial-proteome detection of MCEE.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCEE is present in the high-confidence human mitochondrial proteome, corroborating the mitochondrial localisation from sequence-based prediction and Reactome. The matrix term (GO:0005759) is the most specific location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71020
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0005759" data-r="Reactome:R-HSA-71020" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-asserted (Reactome) localisation to the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The propionyl-CoA catabolic reactions, including the MCEE epimerase step, take place in the mitochondrial matrix. This is the most specific and appropriate location term for MCEE.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71020
+
+                                </span>
+
+                                <div class="support-text">This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004493" target="_blank" class="term-link">
+                                    GO:0004493
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA epimerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11481338
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human methylmalonyl-CoA racemase gene ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0004493" data-r="PMID:11481338" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental demonstration that the human MCEE gene product is a DL-methylmalonyl-CoA racemase (epimerase).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the primary experimental evidence for MCEE&#39;s core molecular function (EC 5.1.99.1); Bobik &amp; Rasche biochemically confirmed racemase activity for the human homolog. Definitive core-function annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                        PMID:11481338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Subsequent biochemical studies confirmed this inference by showing that the prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA racemases.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046491" target="_blank" class="term-link">
+                                    GO:0046491
+                                </a>
+                            </span>
+                            <span class="term-label">L-methylmalonyl-CoA metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11481338
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human methylmalonyl-CoA racemase gene ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96PE7" data-a="GO:0046491" data-r="PMID:11481338" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) involvement in L-methylmalonyl-CoA metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MCEE&#39;s characterised epimerase activity directly interconverts D- and L-methylmalonyl-CoA, so it is directly involved in L-methylmalonyl-CoA metabolism. Core biological process; duplicates the IBA line for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                        PMID:11481338
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both encode DL-methylmalonyl-CoA racemases</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Methylmalonyl-CoA epimerase (racemase) activity: reversible interconversion of (2R)- and (2S)-methylmalonyl-CoA (D-/L-methylmalonyl-CoA), the epimerisation step that provides methylmalonyl-CoA mutase (MMUT) with the isomer it requires.</h3>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="FUNCTION: Methylmalonyl-CoA epimerase (racemase) activity: r..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004493" target="_blank" class="term-link">
+                            methylmalonyl-CoA epimerase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046491" target="_blank" class="term-link">
+                                L-methylmalonyl-CoA metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                                PMID:11481338
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Subsequent biochemical studies confirmed this inference by showing that the prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA racemases.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>In the mitochondrial matrix, MCEE performs the epimerase step of propionyl-CoA catabolism, feeding the mutase reaction that produces succinyl-CoA for the citric acid cycle.</h3>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="FUNCTION: In the mitochondrial matrix, MCEE performs the epi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004493" target="_blank" class="term-link">
+                            methylmalonyl-CoA epimerase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019626" target="_blank" class="term-link">
+                                short-chain fatty acid catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-71032
+
+                        </span>
+
+                        <div class="finding-text">The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an intermediate of the citric acid cycle.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-71020
+
+                        </span>
+
+                        <div class="finding-text">This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11481338" target="_blank" class="term-link">
+                            PMID:11481338
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of the human methylmalonyl-CoA racemase gene based on the analysis of prokaryotic gene arrangements. Implications for decoding the human genome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Identified the human DL-methylmalonyl-CoA racemase (MCEE) gene and confirmed biochemically that the human protein and its prokaryotic homolog both encode DL-methylmalonyl-CoA racemases (epimerases) acting in propionyl-CoA metabolism.</div>
+
+                        <div class="finding-text">"Subsequent biochemical studies confirmed this inference by showing that the prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA racemases."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                            PMID:25910212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                            PMID:31515488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MCEE is detected in the high-confidence human mitochondrial proteome, supporting its mitochondrial localisation.</div>
+
+                        <div class="finding-text">"Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16752391" target="_blank" class="term-link">
+                            PMID:16752391
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A homozygous nonsense mutation in the methylmalonyl-CoA epimerase gene (MCEE) results in mild methylmalonic aciduria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A homozygous nonsense mutation in MCEE causes methylmalonyl-CoA epimerase deficiency (MCEED), a mild methylmalonic aciduria, confirming a physiological role for MCEE in propionyl-CoA/methylmalonyl-CoA catabolism.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71020
+
+                    </span>
+                </div>
+
+                <div class="reference-title">D-methylmalonyl-CoA &lt;=&gt; L-methylmalonyl-CoA</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MCEE mediates the reversible interconversion of D- and L-methylmalonyl-CoA in the mitochondrial matrix.</div>
+
+                        <div class="finding-text">"This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71032
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Propionyl-CoA catabolism</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The three-reaction propionyl-CoA catabolic pathway (including the MCEE epimerase step) converts propionyl-CoA to succinyl-CoA in the mitochondrial matrix.</div>
+
+                        <div class="finding-text">"The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an intermediate of the citric acid cycle."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiologically relevant catalytic metal ion for human MCEE in vivo (cobalt was used in the crystallization, but the native cofactor may differ)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="Q: What is the physiologically relevant catalytic met..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the reported binary interactors (AGTRAP, CD81, CMTM5, STX8) reflect any genuine physiological association, or are they artifacts of high-throughput Y2H screens given MCEE&#39;s mitochondrial-matrix localisation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="Q: Do the reported binary interactors (AGTRAP, CD81, ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the metal-ion specificity and catalytic parameters of recombinant human MCEE with different divalent cations (Co2+, Mg2+, Mn2+, Zn2+) to establish the native cofactor.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="EXPERIMENT: Determine the metal-ion specificity and catalytic ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Assess flux through the propionyl-CoA pathway and metabolite accumulation (methylmalonic acid, propionylcarnitine) in MCEE-knockout versus wild-type cells to quantify the contribution of the epimerase step relative to non-enzymatic epimerisation.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q96PE7" data-a="EXPERIMENT: Assess flux through the propionyl-CoA pathway and ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MCEE-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q96PE7" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mcee-q96pe7-review-notes">MCEE (Q96PE7) review notes</h1>
+<p>Human methylmalonyl-CoA epimerase, mitochondrial. HGNC:16732. EC 5.1.99.1.</p>
+<h2 id="deep-research-status">Deep research status</h2>
+<p><code>just deep-research-falcon human Q96PE7 --alias MCEE</code> failed in this environment:<br />
+<code>scripts/deep_research_wrapper.py</code> uses <code>dict | None</code> annotation syntax and raised<br />
+<code>TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'</code> (Python-version<br />
+incompatibility). No <code>MCEE-deep-research-*.md</code> was produced. Per instructions I did NOT<br />
+fabricate one. Review is grounded in UniProt (<code>MCEE-uniprot.txt</code>), the seeded GOA TSV,<br />
+cached <code>publications/PMID_*.md</code>, the two cached Reactome entries, and the dismech<br />
+Methylmalonic_Acidemia disorders KB (which covers MMUT/MMAA/MMAB; MCEE not detailed there).</p>
+<h2 id="core-verified-biology">Core verified biology</h2>
+<ul>
+<li>Function: methylmalonyl-CoA epimerase / DL-methylmalonyl-CoA racemase. Catalyses<br />
+  (R)-methylmalonyl-CoA = (S)-methylmalonyl-CoA (Rhea:RHEA:20553; ChEBI 57326/57327).<br />
+  [UniProt CATALYTIC ACTIVITY; ECO:0000269|PubMed:11481338]. This is the epimerisation<br />
+  step between propionyl-CoA carboxylase (PCC) and methylmalonyl-CoA mutase (MMUT),<br />
+  providing the (2S)/(R)-configured isomer that MMUT requires.</li>
+<li>PMID:11481338 (Bobik &amp; Rasche 2001) identified the human gene and confirmed<br />
+  DL-methylmalonyl-CoA racemase activity biochemically ("both encode<br />
+  DL-methylmalonyl-CoA racemases"). This is the IDA basis for GO:0004493, GO:0046491,<br />
+  and GO:1901290 (succinyl-CoA biosynthetic process — the pathway outcome).</li>
+<li>Localisation: mitochondrion / mitochondrial matrix. UniProt: TRANSIT 1..36<br />
+  (Mitochondrion), CHAIN 37..176. SUBCELLULAR LOCATION Mitochondrion. Supported by<br />
+  HTP mito-proteome (PMID:34800366) and Reactome (matrix). Multiple concordant lines.</li>
+<li>Fold/cofactor: VOC (vicinal-oxygen-chelate) / glyoxalase superfamily (PROSITE VOC<br />
+  PS51819; Pfam Glyoxalase_4; CDD MMCE cd07249; InterPro IPR029068/IPR017515). Binds a<br />
+  divalent metal — Co(2+) modelled in crystal structure (PDB 3RMU, 6QH4; BINDING 50,122,172<br />
+  to Co2+, Ref.8 SGC). UniProt keywords: Cobalt, Metal-binding. Note GO:0046872 "metal ion<br />
+  binding" IEA-UniProtKB-KW appears in the UniProt DR block but is NOT in the GOA TSV, so it<br />
+  is not an existing_annotation line; captured as a proposed_new_term instead.</li>
+<li>Disease: Methylmalonyl-CoA epimerase deficiency (MCEED, MIM:251120), a usually mild<br />
+  methylmalonic aciduria; homozygous nonsense mutation (PMID:16752391, INVOLVEMENT IN MCEED).</li>
+</ul>
+<h2 id="goa-annotation-dispositions">GOA annotation dispositions</h2>
+<ul>
+<li>GO:0004493 methylmalonyl-CoA epimerase activity — IBA / IEA(EC 5.1.99.1) / TAS(Reactome)<br />
+  / IDA(PMID:11481338). All ACCEPT; IDA is the experimental core; EC/RHEA IEA is a correct<br />
+  mapping. Core MF.</li>
+<li>GO:0046491 L-methylmalonyl-CoA metabolic process — IBA and IDA(11481338). ACCEPT.<br />
+  Directly describes the substrate/product it metabolises. Core BP.</li>
+<li>GO:1901290 succinyl-CoA biosynthetic process — IDA(11481338). Involved_in: MCEE is an<br />
+  intermediate step feeding succinyl-CoA production (via MMUT). ACCEPT as the pathway<br />
+  outcome (keep; slightly downstream but curator-attributed experimental, correct pathway).</li>
+<li>GO:0019626 short-chain fatty acid catabolic process — TAS(Reactome R-HSA-71032<br />
+  "Propionyl-CoA catabolism"). ACCEPT; this is the pathway MCEE genuinely acts in<br />
+  (propionyl-CoA is a short-chain acyl/fatty-acid-derived species). Keep.</li>
+<li>GO:0005739 mitochondrion (IEA-SubCell, TAS is_active_in PMID:11481338, HTP PMID:34800366)<br />
+  and GO:0005759 mitochondrial matrix (TAS Reactome) — ACCEPT all; matrix is most specific<br />
+  and is the core location.</li>
+<li>GO:0005515 protein binding — 4 IPI lines from large-scale interactome maps<br />
+  (PMID:25416956 proteome-scale map; 25910212 macromolecular perturbations; 31515488<br />
+  variant PPI disruption; 32296183 HuRI binary interactome). Interactors AGTRAP, CD81,<br />
+  CMTM5, STX8 are membrane/trafficking proteins — no plausible functional relationship to<br />
+  a soluble mitochondrial-matrix epimerase; these are almost certainly Y2H systematic-screen<br />
+  artifacts. Bare "protein binding" is uninformative. Per curation policy: MARK_AS_OVER_ANNOTATED<br />
+  (not REMOVE — they are experimental IPI).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q96PE7
+gene_symbol: MCEE
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  MCEE encodes methylmalonyl-CoA epimerase (also called DL-methylmalonyl-CoA racemase;
+  EC 5.1.99.1), a mitochondrial matrix enzyme of the vicinal-oxygen-chelate (VOC)/glyoxalase
+  superfamily. It catalyses the interconversion of (2R)- and (2S)-methylmalonyl-CoA
+  (D- and L-methylmalonyl-CoA), the epimerisation step that lies between propionyl-CoA
+  carboxylase (PCC) and methylmalonyl-CoA mutase (MMUT) in the propionyl-CoA catabolic
+  pathway. Propionyl-CoA arising from catabolism of the branched-chain and other amino acids
+  (valine, isoleucine, threonine, methionine), odd-chain fatty acids, and cholesterol is
+  carboxylated by PCC to (2S)-methylmalonyl-CoA, epimerised by MCEE to the (2R)/(S)-isomer
+  that MMUT requires, and rearranged by MMUT to succinyl-CoA for entry into the citric acid
+  cycle. The mature enzyme (after cleavage of an N-terminal mitochondrial transit peptide)
+  binds a divalent metal ion, with cobalt modelled at the active site in the crystal
+  structure. Loss-of-function variants cause methylmalonyl-CoA epimerase deficiency (MCEED),
+  a usually mild autosomal recessive methylmalonic aciduria.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PAN-GO/GO_Central phylogenetic (IBA) inference for the MCEE ortholog group; consistent
+      with the well-established epimerase function and mitochondrial localisation.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      SubCell mapping (SL-0173 Mitochondrion) to GO:0005739; consistent with the UniProt
+      SUBCELLULAR LOCATION and experimental mitochondrial-proteome data.
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      EC 5.1.99.1 / RHEA:20553 to GO:0004493 mapping; the EC and Rhea assignments are
+      experimentally supported (PMID:11481338) so this electronic mapping is correct.
+- id: PMID:11481338
+  title: Identification of the human methylmalonyl-CoA racemase gene based on the
+    analysis of prokaryotic gene arrangements. Implications for decoding the human
+    genome.
+  findings:
+  - statement: &gt;-
+      Identified the human DL-methylmalonyl-CoA racemase (MCEE) gene and confirmed
+      biochemically that the human protein and its prokaryotic homolog both encode
+      DL-methylmalonyl-CoA racemases (epimerases) acting in propionyl-CoA metabolism.
+    supporting_text: &gt;-
+      Subsequent biochemical studies confirmed this inference by showing that the
+      prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA
+      racemases.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary paper establishing MCEE function and catalytic activity; PubMed-verified.
+      Basis for the experimental (IDA) GO:0004493, GO:0046491 and GO:1901290 annotations.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Systematic proteome-scale binary (Y2H) interactome map (HI-II-14). Source of a
+      high-throughput &#34;protein binding&#34; IPI; no MCEE-specific functional insight.
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale interactome-perturbation study; source of a high-throughput &#34;protein
+      binding&#34; IPI, uninformative for MCEE molecular function.
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale variant/PPI screen; source of a high-throughput &#34;protein binding&#34; IPI,
+      not a targeted study of MCEE.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI reference binary interactome (Y2H); source of a high-throughput &#34;protein
+      binding&#34; IPI, uninformative for MCEE function.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings:
+  - statement: &gt;-
+      MCEE is detected in the high-confidence human mitochondrial proteome, supporting
+      its mitochondrial localisation.
+    supporting_text: &gt;-
+      Quantitative high-confidence human mitochondrial proteome and its dynamics in
+      cellular context.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput (HTP) mitochondrial-proteome study; corroborates the mitochondrion
+      localisation. Supporting_text is the study title (full text &gt;256KB, not inspected line-by-line).
+- id: PMID:16752391
+  title: A homozygous nonsense mutation in the methylmalonyl-CoA epimerase gene (MCEE)
+    results in mild methylmalonic aciduria.
+  full_text_unavailable: true
+  findings:
+  - statement: &gt;-
+      A homozygous nonsense mutation in MCEE causes methylmalonyl-CoA epimerase deficiency
+      (MCEED), a mild methylmalonic aciduria, confirming a physiological role for MCEE in
+      propionyl-CoA/methylmalonyl-CoA catabolism.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes MCEE deficiency as a human disease (MIM:251120); referenced in UniProt
+      (INVOLVEMENT IN MCEED). Not cited as an existing GOA annotation but relevant to
+      MCEE&#39;s biological role. Cached publication not available (abstract-only); title
+      matches the UniProt cross-reference.
+- id: Reactome:R-HSA-71020
+  title: D-methylmalonyl-CoA &lt;=&gt; L-methylmalonyl-CoA
+  findings:
+  - statement: &gt;-
+      MCEE mediates the reversible interconversion of D- and L-methylmalonyl-CoA in the
+      mitochondrial matrix.
+    supporting_text: &gt;-
+      This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the
+      &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome reaction for the epimerase step; consistent with UniProt catalytic activity
+      and mitochondrial-matrix localisation.
+- id: Reactome:R-HSA-71032
+  title: Propionyl-CoA catabolism
+  findings:
+  - statement: &gt;-
+      The three-reaction propionyl-CoA catabolic pathway (including the MCEE epimerase step)
+      converts propionyl-CoA to succinyl-CoA in the mitochondrial matrix.
+    supporting_text: &gt;-
+      The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an
+      intermediate of the citric acid cycle.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome pathway placing MCEE in propionyl-CoA catabolism; supports the
+      short-chain fatty acid catabolic process annotation.
+existing_annotations:
+- term:
+    id: GO:0004493
+    label: methylmalonyl-CoA epimerase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of the defining molecular function of MCEE. Fully
+      consistent with the experimental characterisation of the human enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      This is the core molecular function of MCEE and is directly supported by the
+      experimental IDA annotation from PMID:11481338 as well as the EC/RHEA mapping.
+    supported_by:
+    - reference_id: PMID:11481338
+      supporting_text: &gt;-
+        Subsequent biochemical studies confirmed this inference by showing that the
+        prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA
+        racemases.
+- term:
+    id: GO:0046491
+    label: L-methylmalonyl-CoA metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of involvement in L-methylmalonyl-CoA metabolism, the
+      process directly defined by the enzyme&#39;s substrate/product.
+    action: ACCEPT
+    reason: &gt;-
+      MCEE interconverts D- and L-methylmalonyl-CoA, so it is directly involved in
+      L-methylmalonyl-CoA metabolism. Duplicated by the experimental IDA line
+      (PMID:11481338); both are correct.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71020
+      supporting_text: &gt;-
+        This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the
+        &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.
+- term:
+    id: GO:0004493
+    label: methylmalonyl-CoA epimerase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic mapping of EC 5.1.99.1 / RHEA:20553 to the epimerase molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Correct EC/Rhea-based mapping of the enzyme&#39;s activity; the underlying EC assignment
+      is experimentally validated (PMID:11481338). Redundant with the IBA/IDA/TAS lines for
+      the same term but the mapping itself is sound.
+    supported_by:
+    - reference_id: PMID:11481338
+      supporting_text: &gt;-
+        Subsequent biochemical studies confirmed this inference by showing that the
+        prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA
+        racemases.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic SubCell mapping (SL-0173 Mitochondrion) of MCEE localisation.
+    action: ACCEPT
+    reason: &gt;-
+      MCEE has an N-terminal mitochondrial transit peptide (residues 1-36) and a
+      UniProt SUBCELLULAR LOCATION of Mitochondrion; localisation is corroborated by
+      experimental mito-proteome data (PMID:34800366) and Reactome (matrix). The more
+      specific mitochondrial matrix term is captured elsewhere.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71020
+      supporting_text: &gt;-
+        This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the
+        &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a systematic proteome-scale binary (Y2H) interactome map.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;Protein binding&#34; (GO:0005515) is uninformative and is derived here from a
+      high-throughput binary interactome screen rather than a targeted study of MCEE. The
+      reported interactors (AGTRAP, CMTM5 in this record; CD81, STX8 elsewhere) are
+      membrane/trafficking proteins with no plausible functional relationship to a soluble
+      mitochondrial-matrix epimerase, consistent with systematic-screen artifacts. Retained
+      but flagged as over-annotation per curation policy (experimental IPI, so not removed).
+    supported_by:
+    - reference_id: PMID:25416956
+      supporting_text: &gt;-
+        screening half of the interactome space with minimal
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a large-scale interactome-perturbation study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative &#34;protein binding&#34; from a high-throughput interactome dataset; the
+      AGTRAP/CMTM5 interactions carry no functional insight for MCEE&#39;s epimerase activity.
+      Flagged as over-annotation (experimental IPI, not removed).
+    supported_by:
+    - reference_id: PMID:25910212
+      supporting_text: &gt;-
+        Widespread macromolecular interaction perturbations in human genetic disorders
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a large-scale variant/protein-interaction screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative &#34;protein binding&#34; from a high-throughput PPI screen (AGTRAP, CMTM5);
+      no bearing on MCEE&#39;s known molecular function. Flagged as over-annotation
+      (experimental IPI, not removed).
+    supported_by:
+    - reference_id: PMID:31515488
+      supporting_text: &gt;-
+        disruption of protein interactions by genetic variants
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI reference binary interactome.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative &#34;protein binding&#34; from the systematic HuRI binary interactome; the
+      reported partners (CD81, AGTRAP, CMTM5, STX8 across records) are surface/trafficking
+      proteins unrelated to a matrix epimerase. Flagged as over-annotation (experimental
+      IPI, not removed).
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &gt;-
+        reference map of the human binary protein interactome
+- term:
+    id: GO:0019626
+    label: short-chain fatty acid catabolic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71032
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-asserted (Reactome) involvement in propionyl-CoA catabolism, annotated to the
+      short-chain fatty acid catabolic process parent.
+    action: ACCEPT
+    reason: &gt;-
+      MCEE catalyses one of the three reactions of the propionyl-CoA catabolic pathway,
+      which converts propionyl-CoA (a short-chain acyl-CoA derived from odd-chain fatty
+      acids and amino-acid catabolism) to succinyl-CoA. The annotation correctly places MCEE
+      in this catabolic process, though it is broader than the more specific methylmalonyl-CoA
+      terms.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71032
+      supporting_text: &gt;-
+        The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an
+        intermediate of the citric acid cycle.
+- term:
+    id: GO:0004493
+    label: methylmalonyl-CoA epimerase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71020
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Author-asserted (Reactome) epimerase molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome traceably assigns the methylmalonyl-CoA epimerase activity to MCEE for the
+      D-/L-methylmalonyl-CoA interconversion reaction; concordant with the experimental
+      IDA. Core molecular function (duplicate of the IBA/IEA/IDA lines).
+    supported_by:
+    - reference_id: Reactome:R-HSA-71020
+      supporting_text: &gt;-
+        This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the
+        &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: TAS
+  original_reference_id: PMID:11481338
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Traceable assertion that MCEE is active in the mitochondrion.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the mitochondrial transit peptide, UniProt SUBCELLULAR LOCATION, and
+      the enzyme&#39;s role in the mitochondrial propionyl-CoA pathway. The mitochondrial matrix
+      (GO:0005759) term is more specific.
+    supported_by:
+    - reference_id: PMID:11481338
+      supporting_text: &gt;-
+        human DL-methylmalonyl-CoA racemase gene
+- term:
+    id: GO:1901290
+    label: succinyl-CoA biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:11481338
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IDA) involvement in succinyl-CoA biosynthesis, the end product of the
+      propionyl-CoA catabolic pathway in which MCEE acts.
+    action: ACCEPT
+    reason: &gt;-
+      MCEE is the epimerase step immediately upstream of methylmalonyl-CoA mutase, which
+      produces succinyl-CoA; MCEE is therefore genuinely involved in succinyl-CoA
+      biosynthesis. Curator-attributed experimental annotation from the defining paper;
+      retained (the process describes the pathway outcome rather than MCEE&#39;s direct
+      chemistry, which is captured by the methylmalonyl-CoA terms).
+    supported_by:
+    - reference_id: PMID:11481338
+      supporting_text: &gt;-
+        both encode DL-methylmalonyl-CoA racemases
+    - reference_id: Reactome:R-HSA-71032
+      supporting_text: &gt;-
+        The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an
+        intermediate of the citric acid cycle.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial-proteome detection of MCEE.
+    action: ACCEPT
+    reason: &gt;-
+      MCEE is present in the high-confidence human mitochondrial proteome, corroborating the
+      mitochondrial localisation from sequence-based prediction and Reactome. The matrix
+      term (GO:0005759) is the most specific location.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: &gt;-
+        Quantitative high-confidence human mitochondrial proteome and its dynamics in
+        cellular context.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71020
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Author-asserted (Reactome) localisation to the mitochondrial matrix.
+    action: ACCEPT
+    reason: &gt;-
+      The propionyl-CoA catabolic reactions, including the MCEE epimerase step, take place
+      in the mitochondrial matrix. This is the most specific and appropriate location term
+      for MCEE.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71020
+      supporting_text: &gt;-
+        This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the
+        &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.
+- term:
+    id: GO:0004493
+    label: methylmalonyl-CoA epimerase activity
+  evidence_type: IDA
+  original_reference_id: PMID:11481338
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental demonstration that the human MCEE gene product is a
+      DL-methylmalonyl-CoA racemase (epimerase).
+    action: ACCEPT
+    reason: &gt;-
+      This is the primary experimental evidence for MCEE&#39;s core molecular function
+      (EC 5.1.99.1); Bobik &amp; Rasche biochemically confirmed racemase activity for the human
+      homolog. Definitive core-function annotation.
+    supported_by:
+    - reference_id: PMID:11481338
+      supporting_text: &gt;-
+        Subsequent biochemical studies confirmed this inference by showing that the
+        prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA
+        racemases.
+- term:
+    id: GO:0046491
+    label: L-methylmalonyl-CoA metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:11481338
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IDA) involvement in L-methylmalonyl-CoA metabolism.
+    action: ACCEPT
+    reason: &gt;-
+      MCEE&#39;s characterised epimerase activity directly interconverts D- and
+      L-methylmalonyl-CoA, so it is directly involved in L-methylmalonyl-CoA metabolism.
+      Core biological process; duplicates the IBA line for the same term.
+    supported_by:
+    - reference_id: PMID:11481338
+      supporting_text: &gt;-
+        both encode DL-methylmalonyl-CoA racemases
+core_functions:
+- description: &gt;-
+    Methylmalonyl-CoA epimerase (racemase) activity: reversible interconversion of
+    (2R)- and (2S)-methylmalonyl-CoA (D-/L-methylmalonyl-CoA), the epimerisation step
+    that provides methylmalonyl-CoA mutase (MMUT) with the isomer it requires.
+  molecular_function:
+    id: GO:0004493
+    label: methylmalonyl-CoA epimerase activity
+  directly_involved_in:
+  - id: GO:0046491
+    label: L-methylmalonyl-CoA metabolic process
+  supported_by:
+  - reference_id: PMID:11481338
+    supporting_text: &gt;-
+      Subsequent biochemical studies confirmed this inference by showing that the
+      prokaryotic gene PH0272 and its human homologue both encode DL-methylmalonyl-CoA
+      racemases.
+- description: &gt;-
+    In the mitochondrial matrix, MCEE performs the epimerase step of propionyl-CoA
+    catabolism, feeding the mutase reaction that produces succinyl-CoA for the citric
+    acid cycle.
+  molecular_function:
+    id: GO:0004493
+    label: methylmalonyl-CoA epimerase activity
+  directly_involved_in:
+  - id: GO:0019626
+    label: short-chain fatty acid catabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: Reactome:R-HSA-71032
+    supporting_text: &gt;-
+      The three reactions of this pathway convert propionyl-CoA to succinyl-CoA, an
+      intermediate of the citric acid cycle.
+  - reference_id: Reactome:R-HSA-71020
+    supporting_text: &gt;-
+      This reaction takes place in the &#39;mitochondrial matrix&#39; and  is mediated by the
+      &#39;methylmalonyl-CoA epimerase activity&#39; of &#39;methylmalonyl-CoA epimerase&#39;.
+proposed_new_terms:
+- proposed_name: metal ion binding
+  proposed_definition: &gt;-
+    Binding of a metal ion (a divalent cation, with cobalt modelled in the MCEE crystal
+    structure) by methylmalonyl-CoA epimerase at its vicinal-oxygen-chelate active site.
+  justification: &gt;-
+    UniProt annotates MCEE with the keywords Cobalt and Metal-binding and the crystal
+    structure (PDB 3RMU/6QH4) models a divalent metal (Co2+) coordinated by residues
+    His50/Gln122/Glu172 in the VOC active site. The GO:0046872 metal ion binding IEA
+    annotation is present in the UniProt cross-reference block but not in the current GOA
+    TSV; it is biologically well supported and could be added (GO:0046872 already exists).
+suggested_questions:
+- question: &gt;-
+    What is the physiologically relevant catalytic metal ion for human MCEE in vivo
+    (cobalt was used in the crystallization, but the native cofactor may differ)?
+- question: &gt;-
+    Do the reported binary interactors (AGTRAP, CD81, CMTM5, STX8) reflect any genuine
+    physiological association, or are they artifacts of high-throughput Y2H screens given
+    MCEE&#39;s mitochondrial-matrix localisation?
+suggested_experiments:
+- description: &gt;-
+    Determine the metal-ion specificity and catalytic parameters of recombinant human MCEE
+    with different divalent cations (Co2+, Mg2+, Mn2+, Zn2+) to establish the native cofactor.
+- description: &gt;-
+    Assess flux through the propionyl-CoA pathway and metabolite accumulation
+    (methylmalonic acid, propionylcarnitine) in MCEE-knockout versus wild-type cells to
+    quantify the contribution of the epimerase step relative to non-enzymatic epimerisation.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/MMAA/MMAA-ai-review.html
+++ b/genes/human/MMAA/MMAA-ai-review.html
@@ -1,0 +1,5479 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MMAA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MMAA</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8IVH4" target="_blank" class="term-link">
+                        Q8IVH4
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MMAA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8IVH4" data-a="DESCRIPTION: MMAA (methylmalonic aciduria type A protein; the h..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MMAA (methylmalonic aciduria type A protein; the human cblA protein) is a mitochondrial GTPase of the SIMIBI-class G3E GTPase family, ArgK/MeaB subfamily (Pfam MeaB; InterPro GTPase_ArgK). It is imported into the mitochondrial matrix via a cleaved N-terminal transit peptide and functions as a G-protein chaperone that assists delivery and maintenance of the adenosylcobalamin (AdoCbl, vitamin B12) cofactor for the enzyme methylmalonyl-CoA mutase (MMUT/MUT). MMAA itself is not the mutase and does not isomerize methylmalonyl-CoA; instead, in a GTP-binding- and GTP-hydrolysis-dependent manner it gates the transfer of AdoCbl from the adenosyltransferase MMAB onto MMUT apoenzyme, protects the MMUT-bound cofactor from oxidative inactivation, and reactivates MMUT by promoting exchange of the damaged cofactor. Its low intrinsic GTPase activity is strongly stimulated by MMUT (which acts as a GAP), and MMAA forms a homodimer that assembles into nucleotide-sensitive interconverting oligomeric complexes with MMUT. Loss-of-function variants cause methylmalonic aciduria, cblA type (MACA), an autosomal recessive disorder of B12/AdoCbl metabolism that is frequently vitamin-B12(hydroxocobalamin)-responsive.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (PAN-GO) inference placing MMAA activity in the cytoplasm. MMAA is synthesized with a mitochondrial transit peptide and is imported into the mitochondrial matrix where it performs its chaperone/GTPase function on MMUT. Cytoplasmic/cytosolic detection is real (precursor pool / partial import), but the core functional compartment is the mitochondrial matrix, not the general cytoplasm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The gene product has a cleaved mitochondrial transit peptide and colocalizes with MMUT in mitochondria, so &#34;cytoplasm&#34; is not the core functional location; retain as a non-core localization signal rather than the primary site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">for the first time, the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0003924" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GTPase activity is the central, phylogenetically conserved molecular function of MMAA and its ArgK/MeaB-subfamily orthologs. Directly demonstrated for the human protein and consistent with the conserved P-loop G-domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function; IBA is concordant with multiple experimental (IDA/IMP) annotations and with structural characterization of the GDP-bound protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that MMAA exhibits GTPase activity that is modulated by MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0003924" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (ARBA/InterPro/RHEA) assignment of GTPase activity mapped from the GTPase_ArgK domain and the GTP hydrolysis reaction (RHEA:19669). Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Electronic assignment agrees with the experimentally verified GTPase activity and the UniProt-annotated catalytic reaction GTP + H2O = GDP + phosphate + H(+).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This function of MMAA depends on its GTPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005525" target="_blank" class="term-link">
+                                    GO:0005525
+                                </a>
+                            </span>
+                            <span class="term-label">GTP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005525" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping of GTP binding from the GTPase_ArgK domain. MMAA binds GTP/GDP (crystallized in the GDP-bound form; defined GTP-binding loops), so this is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GTP binding is directly demonstrated experimentally and is an intrinsic property of the G-domain; electronic assignment is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Formation of a stable MMAA-MUT complex is nucleotide-selective for MMAA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt Subcellular Location &#34;Cytoplasm&#34; keyword. MMAA is detected in the cytoplasm but its core functional site is the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated UniProt subcellular location; kept as a non-core localization since the protein functions after mitochondrial import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt Subcellular Location &#34;Mitochondrion&#34; keyword. This is the core functional compartment of MMAA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Agrees with experimental (IDA/HTP) localization and with the presence of a cleaved mitochondrial transit peptide.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005515" data-r="PMID:20876572" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with MMUT (UniProtKB:P22033). The biologically meaningful interaction is the GTP-dependent MMAA-MMUT complex through which AdoCbl is delivered; the bare &#34;protein binding&#34; term is uninformative about this function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidance, generic &#34;protein binding&#34; is uninformative; the specific MMAA-MMUT interaction is better captured by the chaperone/complex-formation role and by the identical/homodimerization terms. Retained (not removed) as it records a real, experimentally supported interaction with MMUT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the two proteins interact in vitro and in vivo</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005515" data-r="PMID:28497574" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with MMUT (UniProtKB:P22033). As above, &#34;protein binding&#34; is uninformative; the functionally relevant interaction is the GTPase-stimulating, AdoCbl-gating MMAA-MMUT complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein-binding term over-annotates a specific, functionally important MMAA-MMUT interaction; kept as a real interaction record rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This function of MMAA depends on its GTPase activity, which is stimulated by an interaction with MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0042802" data-r="PMID:20876572" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction (homodimer) supported by IntAct and by the crystal structure, in which MMAA is an alpha2 homodimer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The homodimeric state is structurally and biochemically verified and is relevant to the protein&#39;s oligomerization behavior with MMUT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yet they show substantially different dimeric assembly and interaction, compared with their bacterial counterparts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759218
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0009235" data-r="Reactome:R-HSA-9759218" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion placing MMAA in cobalamin (vitamin B12) metabolism. MMAA is required for intracellular handling of B12, specifically the mitochondrial delivery and maintenance of the AdoCbl cofactor on MMUT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; consistent with experimental (IDA) annotations and with the cblA-type methylmalonic aciduria disease mechanism (reduced mitochondrial AdoCbl pool).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMAA (methylmalonic aciduria type A), is implicated in the mitochondrial assembly of AdoCbl into MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence (Human Protein Atlas) detection in the cytosol. MMAA is synthesized as a cytosolic precursor and imported into mitochondria; the functionally relevant pool is mitochondrial.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real immunofluorescence localization but not the core site of function; the protein acts in the mitochondrial matrix after transit-peptide cleavage.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteomics detected MMAA in the mitochondrion, corroborating its curated mitochondrial localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the core mitochondrial localization established by targeted immunofluorescence and by the cleaved mitochondrial transit peptide.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3159259
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0140104" data-r="Reactome:R-HSA-3159259" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (&#34;MMAA:MUT binds AdoCbl&#34;) assigning molecular carrier activity. MMAA does not itself carry cobalamin as cargo; it is the G-protein that gates the transfer of AdoCbl (produced by MMAB) onto MMUT in a GTP-dependent manner. &#34;Molecular carrier activity&#34; mislabels the gating/regulatory GTPase role as direct cofactor transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The precise molecular function is GTPase activity; the AdoCbl delivery is a gated protein-protein handoff between MMAB and MUT that MMAA regulates rather than a carrier activity that MMAA itself enables. Retained (not removed) because MMAA is genuinely required for cofactor delivery, but flagged as over-annotated at the MF level.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">our data point to a gatekeeping role for MMAA by favoring complex formation with MUT apoenzyme for AdoCbl assembly and releasing the AdoCbl-loaded holoenzyme from the complex, in a GTP-dependent manner</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">all mutations interfered with gating the transfer of AdoCbl from MMAB to MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31056463
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Allosteric Regulation of Oligomerization by a B(12) Traffick...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0009235" data-r="PMID:31056463" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay showing MMAA (CblA) allosterically regulates AdoCbl movement to/from MMUT; patient cblA mutations reduce the mitochondrial AdoCbl pool, placing MMAA upstream of or within cobalamin/AdoCbl metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported role in the mitochondrial B12/AdoCbl trafficking pathway; core biological process for MMAA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link">
+                                        PMID:31056463
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">chaperone CblA is transduced via three &#34;switch&#34; elements that gate the movement</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31056463
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Allosteric Regulation of Oligomerization by a B(12) Traffick...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0140104" data-r="PMID:31056463" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (MGI) assigning molecular carrier activity from the allosteric-oligomerization study. As with the Reactome annotation, MMAA gates B12 movement between MMAB and MMUT via its GTPase rather than acting as a direct molecular carrier of the cofactor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The paper demonstrates GTPase-gated cofactor movement and oligomer regulation, not a carrier/transport activity intrinsic to MMAA; the informative MF is GTPase activity. Kept as a record of the cofactor-movement role but flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link">
+                                        PMID:31056463
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">gate the movement of the B12 cofactor to and from MCM</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31056463
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Allosteric Regulation of Oligomerization by a B(12) Traffick...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0009235" data-r="PMID:31056463" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental involvement in cobalamin/AdoCbl metabolism: MMAA (CblA) gates B12 cofactor movement to/from MMUT, and cblA mutations lower the fibroblast AdoCbl pool.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by direct measurements of AdoCbl pool depletion in cblA patient cells and by the gating mechanism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link">
+                                        PMID:31056463
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AdoCbl represents 15.1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21138732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protection and reactivation of human methylmalonyl-CoA mutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0003924" data-r="PMID:21138732" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay of purified recombinant human MMAA showing GTP-hydrolysis-dependent reactivation of methylmalonyl-CoA mutase, demonstrating functional GTPase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, directly demonstrated; MMAA reactivates inactive mutase via GTP hydrolysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the addition of MMAA increases the enzymatic activity through GTP hydrolysis, indicating reactivation of MCM by exchange of the damaged cofactor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0003924" data-r="PMID:28943303" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay showing MMAA removes the damaged (oxidized) cofactor from inactive mutase through GTP hydrolysis, confirming functional GTPase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function; directly demonstrated GTP-hydrolysis-coupled cofactor exchange.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hMMAA is able to remove the damaged cofactor through GTP hydrolysis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21138732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protection and reactivation of human methylmalonyl-CoA mutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005515" data-r="PMID:21138732" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with MMUT (UniProtKB:P22033) confirmed by yeast two-hybrid. The functionally relevant interaction is the MMAA-MMUT chaperone complex; &#34;protein binding&#34; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein-binding term over-annotates the specific, experimentally verified MMAA-MMUT interaction; retained (not removed) as a real interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interaction between MCM and MMAA observed in vitro was confirmed in vivo by yeast two-hybrid system</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005515" data-r="PMID:28943303" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with MMUT (UniProtKB:P22033). As above, the informative description is the MMAA-MMUT complex through which cofactor protection/exchange occurs, not bare &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic term; the specific MMAA-MMUT complex is better captured elsewhere. Kept as a real, experimentally supported interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">restores methylmalonyl-CoA mutase activity through their complex formation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005737" data-r="PMID:28943303" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct localization detected MMAA in the cytoplasm in addition to mitochondria. The protein&#39;s core functional pool is mitochondrial (matrix), consistent with its transit peptide and MMUT colocalization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real localization but not the core functional compartment; MMAA acts on MMUT after mitochondrial import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005739" data-r="PMID:28943303" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct in vivo demonstration that MMAA localizes to and colocalizes with MMUT in human fibroblast mitochondria. This is the core functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular localization, directly demonstrated and consistent with the cleaved mitochondrial transit peptide.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0003924" data-r="PMID:20876572" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Structural and biochemical study directly demonstrating that human MMAA is a GTPase whose activity is modulated by MMUT; crystallized in the GDP-bound form.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, directly demonstrated with structural support (PDB 2WWW).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that MMAA exhibits GTPase activity that is modulated by MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0003924" data-r="PMID:28497574" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutational analysis of 15 purified MACA mutant proteins showed wild-type-like intrinsic GTPase activity for all but the GTP-binding-domain variant, confirming GTPase activity as an intrinsic MMAA function and dissecting the MUT-stimulated (GAP) component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function; IMP evidence corroborates the intrinsic GTPase activity and its MUT-dependent stimulation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All 15 purified mutant proteins demonstrated wild-type like intrinsic GTPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005525" target="_blank" class="term-link">
+                                    GO:0005525
+                                </a>
+                            </span>
+                            <span class="term-label">GTP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005525" data-r="PMID:20876572" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct demonstration of GTP/GDP binding by human MMAA, crystallized in the GDP-bound form with defined GTP-binding loops; complex formation with MMUT is nucleotide-selective.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GTP binding is directly demonstrated and structurally characterized; intrinsic property of the G-domain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Formation of a stable MMAA-MUT complex is nucleotide-selective for MMAA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005525" target="_blank" class="term-link">
+                                    GO:0005525
+                                </a>
+                            </span>
+                            <span class="term-label">GTP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005525" data-r="PMID:28497574" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assays of GTP/GDP binding across MACA mutants; only the GTP-binding-domain variant (p.Asp292Val) showed decreased GTP binding, confirming GTP binding as an intrinsic MMAA property.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GTP binding directly demonstrated; consistent with the conserved G-domain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">only one (p.Asp292Val), where the mutation is in the GTP binding domain, revealed decreased GTP binding</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0009235" data-r="PMID:28497574" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MMAA regulates incorporation of the AdoCbl cofactor into MMUT, placing it in cobalamin/AdoCbl metabolism; cblA mutations impair AdoCbl transfer and cause disease.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; strongly supported by the mechanistic and disease-variant data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0042802" data-r="PMID:20876572" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct structural demonstration that MMAA self-associates as a homodimer (alpha2), distinct from its bacterial counterparts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Homodimerization is structurally verified and relevant to MMAA oligomerization behavior.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yet they show substantially different dimeric assembly and interaction, compared with their bacterial counterparts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
+                                    GO:0042803
+                                </a>
+                            </span>
+                            <span class="term-label">protein homodimerization activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0042803" data-r="PMID:20876572" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MMAA forms a homodimer, directly demonstrated in the crystal structure. This self-association underlies its nucleotide-sensitive oligomerization with MMUT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Homodimerization activity is directly and structurally supported; a genuine, specific molecular property.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yet they show substantially different dimeric assembly and interaction, compared with their bacterial counterparts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3322135
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005759" data-r="Reactome:R-HSA-3322135" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMAA in the mitochondrial matrix (the &#34;Defective MMAA does not protect MUT&#34; reaction). This is the specific compartment where MMAA acts on MMUT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the cleaved mitochondrial transit peptide, matrix-localized MMUT, and the demonstrated mitochondrial colocalization; the most precise functional location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3159259
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005759" data-r="Reactome:R-HSA-3159259" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMAA in the mitochondrial matrix (the &#34;MMAA:MUT binds AdoCbl&#34; reaction). Correct core functional location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is consistent with mitochondrial import and MMUT colocalization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3322971
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005759" data-r="Reactome:R-HSA-3322971" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMAA in the mitochondrial matrix. Consistent with its functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is well supported; core functional location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71010
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0005759" data-r="Reactome:R-HSA-71010" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMAA in the mitochondrial matrix (associated with the MUT isomerization reaction module). Consistent with the functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is well supported by import signal and MMUT colocalization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043085" target="_blank" class="term-link">
+                                    GO:0043085
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21138732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protection and reactivation of human methylmalonyl-CoA mutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0043085" data-r="PMID:21138732" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MMAA reactivates inactive methylmalonyl-CoA mutase and protects it from inactivation, thereby positively regulating the catalytic activity of MMUT. This chaperone/reactivase role is well documented but is not captured by the existing GOA terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proposed new annotation capturing MMAA&#39;s protectase/reactivase function toward MMUT, demonstrated in vitro with purified proteins. Supports the corresponding core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the addition of MMAA increases the enzymatic activity through GTP hydrolysis, indicating reactivation of MCM by exchange of the damaged cofactor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">restores methylmalonyl-CoA mutase activity through their complex formation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q8IVH4" data-a="GO:0050821" data-r="PMID:28943303" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> By forming a complex with MMUT, MMAA slows formation of the oxidized inactive cofactor (OH2Cbl) and thereby protects/maintains functional MMUT, i.e. stabilizes the active holoenzyme. Documented mechanistically but not present in the existing GOA set.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proposed new annotation capturing MMAA&#39;s protective (protectase) role toward MMUT; supports the corresponding core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the complex formation of hMCM/hMMAA decreases the rate of oxidized cofactor formation, protecting the hMCM enzyme</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it prevents inactivation by guarding MCM</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Mitochondrial matrix GTPase that binds and hydrolyzes GTP; its low intrinsic GTPase activity is strongly stimulated by methylmalonyl-CoA mutase (MMUT/MUT), which acts as a GAP. This nucleotide cycle powers MMAA&#39;s chaperone functions toward MMUT.</h3>
+                <span class="vote-buttons" data-g="Q8IVH4" data-a="FUNCTION: Mitochondrial matrix GTPase that binds and hydroly..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                            GTPase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                cobalamin metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                PMID:20876572
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We show that MMAA exhibits GTPase activity that is modulated by MUT</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                PMID:28497574
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This function of MMAA depends on its GTPase activity, which is stimulated by an interaction with MUT</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>G-protein chaperone that, in a GTP-dependent manner, gates transfer of the adenosylcobalamin (AdoCbl) cofactor from the adenosyltransferase MMAB onto MMUT apoenzyme, protects the MMUT-bound cofactor from oxidative inactivation, and reactivates inactive MMUT by promoting exchange of the damaged cofactor. This maintains MMUT (and hence propionate/methylmalonyl-CoA) flux and is the process disrupted in cblA-type methylmalonic aciduria. MMAA is not itself the mutase and does not carry the cofactor as cargo; it regulates a gated protein-protein handoff.</h3>
+                <span class="vote-buttons" data-g="Q8IVH4" data-a="FUNCTION: G-protein chaperone that, in a GTP-dependent manne..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                            GTPase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                cobalamin metabolic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043085" target="_blank" class="term-link">
+                                positive regulation of catalytic activity
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                protein stabilization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                PMID:20876572
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">our data point to a gatekeeping role for MMAA by favoring complex formation with MUT apoenzyme for AdoCbl assembly and releasing the AdoCbl-loaded holoenzyme from the complex, in a GTP-dependent manner</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                PMID:21138732
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">it prevents inactivation by guarding MCM</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                PMID:28943303
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the complex formation of hMCM/hMMAA decreases the rate of oxidized cofactor formation, protecting the hMCM enzyme</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                            PMID:20876572
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of the human GTPase MMAA and vitamin B12-dependent methylmalonyl-CoA mutase and insight into their complex formation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                            PMID:21138732
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protection and reactivation of human methylmalonyl-CoA mutase by MMAA protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                            PMID:28497574
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protein destabilization and loss of protein-protein interaction are fundamental mechanisms in cblA-type methylmalonic aciduria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                            PMID:28943303
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human MMAA induces the release of inactive cofactor and restores methylmalonyl-CoA mutase activity through their complex formation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31056463" target="_blank" class="term-link">
+                            PMID:31056463
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Allosteric Regulation of Oligomerization by a B(12) Trafficking G-Protein Is Corrupted in Methylmalonic Aciduria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3159259
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MMAA:MUT binds AdoCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3322135
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective MMAA does not protect MUT</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3322971
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective MUT does not isomerise L-MM-CoA to SUCC-CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71010
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MUT isomerises L-MM-CoA to SUCC-CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759218
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cobalamin (Cbl) metabolism</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is MMAA best described at the molecular-function level by a dedicated cofactor-loading / GTPase-dependent chaperone term rather than the generic &#34;molecular carrier activity&#34;, given that it gates a protein-protein cofactor handoff rather than transporting cobalamin itself?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8IVH4" data-a="Q: Is MMAA best described at the molecular-function l..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiological significance of the cytoplasmic/cytosolic MMAA pool detected by immunofluorescence and proteomics, versus the functionally characterized mitochondrial matrix pool?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8IVH4" data-a="Q: What is the physiological significance of the cyto..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute the full human mitochondrial B12 pathway (MMAB/ATR, MMAA/CblA, MMUT) in vitro and use single-turnover/stopped-flow spectroscopy to quantify how GTP binding vs hydrolysis by MMAA controls the directionality of AdoCbl loading and cob(II)alamin offloading.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q8IVH4" data-a="EXPERIMENT: Reconstitute the full human mitochondrial B12 path..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use cryo-EM of the nucleotide-sensitive MMAA-MMUT oligomers to define the loading-ready state and map how cblA switch-region patient variants shift the oligomeric equilibrium.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q8IVH4" data-a="EXPERIMENT: Use cryo-EM of the nucleotide-sensitive MMAA-MMUT ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MMAA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8IVH4" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mmaa-q8ivh4-review-notes">MMAA (Q8IVH4) review notes</h1>
+<h2 id="summary-of-verified-biology">Summary of verified biology</h2>
+<p>MMAA = "Methylmalonic aciduria type A protein" = the human <strong>cblA</strong> protein. It is a<br />
+<strong>mitochondrial GTPase</strong> of the <strong>SIMIBI-class G3E GTPase family, ArgK/MeaB subfamily</strong><br />
+(UniProt SIMILARITY; InterPro IPR005129 GTPase_ArgK; Pfam PF03308 MeaB; CDD cd03114<br />
+MMAA-like). It is <strong>NOT the methylmalonyl-CoA mutase (MMUT/MUT)</strong> and does NOT itself<br />
+isomerize methylmalonyl-CoA. Instead it is a <strong>G-protein chaperone / cofactor-maintenance<br />
+protein for MMUT</strong>.</p>
+<p>Deep research: <code>just deep-research</code> recipe is absent in this worktree (no<br />
+<code>-deep-research-*.md</code> produced or fabricated). Grounded instead in the UniProt record,<br />
+the 6 cached primary publications, GOA, and <code>~/repos/dismech/kb/disorders/Methylmalonic_Acidemia.yaml</code>.</p>
+<h2 id="core-functional-facts-with-provenance">Core functional facts (with provenance)</h2>
+<ul>
+<li>
+<p><strong>GTPase / GTP binding.</strong> Crystallized GDP-bound (PDB 2WWW, res 72-418); binds and<br />
+  hydrolyzes GTP; GTPase activity is stimulated ~by MMUT (GAP effect).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20876572" title="We show that MMAA exhibits GTPase activity that is modulated by MUT and that the two proteins interact in vitro and in vivo">PMID:20876572</a><br />
+  [UniProt CATALYTIC ACTIVITY: "GTP + H2O = GDP + phosphate + H(+); Rhea:RHEA:19669"; ACTIVITY REGULATION "GTPase activity is stimulated by MMUT"]<br />
+  KM(GTP) 42 uM (PMID:28497574), kcat 0.201 min-1. GTP-binding loops at 150-158, 292, 328-330.</p>
+</li>
+<li>
+<p><strong>Gatekeeper / AdoCbl delivery to MMUT (GTP-dependent).</strong> Gates the transfer of<br />
+  adenosylcobalamin (AdoCbl) from MMAB (ATR) onto MUT apoenzyme; complex formation is<br />
+  nucleotide-selective (GMPPNP over GDP) and requires MUT apoenzyme.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20876572" title="our data point to a gatekeeping role for MMAA by favoring complex formation with MUT apoenzyme for AdoCbl assembly and releasing the AdoCbl-loaded holoenzyme from the complex, in a GTP-dependent manner">PMID:20876572</a><br />
+  [PMID:28497574 "MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT)"; "all mutations interfered with gating the transfer of AdoCbl from MMAB to MUT"]</p>
+</li>
+<li>
+<p><strong>Protectase + reactivase (dual chaperone role toward MMUT).</strong> Protects MUT from<br />
+  progressive inactivation (slows formation of oxidized OH2Cbl / cob(II)alamin) and<br />
+  reactivates inactive MUT by GTP-hydrolysis-driven exchange of the damaged cofactor.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21138732" title="MMAA plays dual roles in MCM activity. When it was added at the beginning of the reaction, it prevents inactivation by guarding MCM. After 60 min of reaction, when MCM is inactive, the addition of MMAA increases the enzymatic activity through GTP hydrolysis, indicating reactivation of MCM by exchange of the damaged cofactor">PMID:21138732</a><br />
+  [PMID:28943303 "the complex formation of hMCM/hMMAA decreases the rate of oxidized cofactor formation, protecting the hMCM enzyme"; "hMMAA is able to remove the damaged cofactor through GTP hydrolysis"]</p>
+</li>
+<li>
+<p><strong>Allosteric regulation of oligomerization.</strong> Human MCM-CblA(MMAA) forms interconverting<br />
+  nucleotide-sensitive oligomers (M2C1, M2C2, M3C3...); GTPase-driven resolution to the<br />
+  loading-ready M2C1 state is required to load MCM with AdoCbl. Switch III patient<br />
+  mutations corrupt this. [PMID:31056463 full text].</p>
+</li>
+<li>
+<p><strong>Homodimer.</strong> [PMID:20876572 "MMAA ... α2 homodimer"; UniProt SUBUNIT "Homodimer";<br />
+  GO:0042802/GO:0042803 IDA].</p>
+</li>
+<li>
+<p><strong>Localization.</strong> Mitochondrion (matrix; has cleaved mitochondrial transit peptide 1-65),<br />
+  colocalizes with MMUT; also detected cytoplasm/cytosol (IDA/HPA).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28943303" title="in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated">PMID:28943303</a><br />
+  [UniProt SUBCELLULAR LOCATION: Mitochondrion; Cytoplasm; TRANSIT 1..65 Mitochondrion]</p>
+</li>
+<li>
+<p><strong>Disease.</strong> Deficiency = methylmalonic aciduria, cblA type (MACA; MIM 251100), autosomal<br />
+  recessive, often vitamin-B12(hydroxocobalamin)-responsive. cblA mutations reduce the<br />
+  mitochondrial AdoCbl pool. [UniProt DISEASE; disorders KB Methylmalonic_Acidemia.yaml;<br />
+  PMID:31056463 "AdoCbl ... reduced to 3.3±1.6 % of the total pool in fibroblasts from cblA patients"]</p>
+</li>
+</ul>
+<h2 id="annotation-level-notes">Annotation-level notes</h2>
+<ul>
+<li>MF GTPase activity (GO:0003924) IDA x3 (20876572, 28943303, 21138732), IMP (28497574),<br />
+  IBA, IEA — all ACCEPT; this is a core MF.</li>
+<li>MF GTP binding (GO:0005525) IDA x2, IEA — ACCEPT (component of the GTPase MF).</li>
+<li>MF molecular carrier activity (GO:0140104) TAS(Reactome R-HSA-3159259) + IDA(31056463,<br />
+  MGI). MMAA does not itself carry/bind cobalamin as its cargo — it is the G-protein that<br />
+  GATES AdoCbl transfer (AdoCbl is carried/handed off between MMAB and MUT). "Molecular<br />
+  carrier activity" is a defensible but imprecise/over-annotation of the gating role; the<br />
+  more precise MF is GTPase activity and the role is a regulatory/chaperone one. MODIFY /<br />
+  MARK_AS_OVER_ANNOTATED (not itself the cofactor carrier).</li>
+<li>BP cobalamin metabolic process (GO:0009235) IDA/TAS — ACCEPT (core BP: intracellular B12<br />
+  handling / AdoCbl delivery).</li>
+<li>protein binding (GO:0005515) IPI with MMUT (P22033) — bare "protein binding"; the real<br />
+  interactant is MMUT and captured better as the chaperone/complex-formation role.<br />
+  MARK_AS_OVER_ANNOTATED (do NOT REMOVE per policy).</li>
+<li>identical protein binding / protein homodimerization (GO:0042802/GO:0042803) IDA/IPI —<br />
+  ACCEPT (homodimer is real, structurally verified).</li>
+<li>CC mitochondrion (GO:0005739) IDA/IEA/HTP, mitochondrial matrix (GO:0005759) TAS x4 —<br />
+  ACCEPT. Mitochondrion IDA is core. Matrix (Reactome) is consistent.</li>
+<li>CC cytoplasm (GO:0005737) IBA/IEA/IDA and cytosol (GO:0005829) IDA(HPA) — MMAA is<br />
+  synthesized with a mito transit peptide and functions in the matrix; cytoplasm/cytosol<br />
+  signal likely reflects precursor / partial import / antibody localization. KEEP_AS_NON_CORE<br />
+  (real detection but not the core functional location).</li>
+<li>PMID:34800366 HTP mitochondrion — ACCEPT as corroborating (large-scale mito proteome).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8IVH4
+gene_symbol: MMAA
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  MMAA (methylmalonic aciduria type A protein; the human cblA protein) is a mitochondrial
+  GTPase of the SIMIBI-class G3E GTPase family, ArgK/MeaB subfamily (Pfam MeaB;
+  InterPro GTPase_ArgK). It is imported into the mitochondrial matrix via a cleaved
+  N-terminal transit peptide and functions as a G-protein chaperone that assists delivery
+  and maintenance of the adenosylcobalamin (AdoCbl, vitamin B12) cofactor for the enzyme
+  methylmalonyl-CoA mutase (MMUT/MUT). MMAA itself is not the mutase and does not isomerize
+  methylmalonyl-CoA; instead, in a GTP-binding- and GTP-hydrolysis-dependent manner it gates
+  the transfer of AdoCbl from the adenosyltransferase MMAB onto MMUT apoenzyme, protects the
+  MMUT-bound cofactor from oxidative inactivation, and reactivates MMUT by promoting exchange
+  of the damaged cofactor. Its low intrinsic GTPase activity is strongly stimulated by MMUT
+  (which acts as a GAP), and MMAA forms a homodimer that assembles into nucleotide-sensitive
+  interconverting oligomeric complexes with MMUT. Loss-of-function variants cause
+  methylmalonic aciduria, cblA type (MACA), an autosomal recessive disorder of B12/AdoCbl
+  metabolism that is frequently vitamin-B12(hydroxocobalamin)-responsive.
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (PAN-GO) inference placing MMAA activity in the cytoplasm. MMAA is
+      synthesized with a mitochondrial transit peptide and is imported into the
+      mitochondrial matrix where it performs its chaperone/GTPase function on MMUT.
+      Cytoplasmic/cytosolic detection is real (precursor pool / partial import), but the
+      core functional compartment is the mitochondrial matrix, not the general cytoplasm.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The gene product has a cleaved mitochondrial transit peptide and colocalizes with MMUT
+      in mitochondria, so &#34;cytoplasm&#34; is not the core functional location; retain as a
+      non-core localization signal rather than the primary site of action.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        for the first time, the in vivo localization of hMMAA and its colocalization with
+        hMCM in human fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      GTPase activity is the central, phylogenetically conserved molecular function of MMAA
+      and its ArgK/MeaB-subfamily orthologs. Directly demonstrated for the human protein and
+      consistent with the conserved P-loop G-domain.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function; IBA is concordant with multiple experimental (IDA/IMP)
+      annotations and with structural characterization of the GDP-bound protein.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: We show that MMAA exhibits GTPase activity that is modulated by MUT
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Automated (ARBA/InterPro/RHEA) assignment of GTPase activity mapped from the
+      GTPase_ArgK domain and the GTP hydrolysis reaction (RHEA:19669). Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Electronic assignment agrees with the experimentally verified GTPase activity and the
+      UniProt-annotated catalytic reaction GTP + H2O = GDP + phosphate + H(+).
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: This function of MMAA depends on its GTPase activity
+- term:
+    id: GO:0005525
+    label: GTP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping of GTP binding from the GTPase_ArgK domain. MMAA binds GTP/GDP
+      (crystallized in the GDP-bound form; defined GTP-binding loops), so this is correct.
+    action: ACCEPT
+    reason: &gt;-
+      GTP binding is directly demonstrated experimentally and is an intrinsic property of the
+      G-domain; electronic assignment is appropriate.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: Formation of a stable MMAA-MUT complex is nucleotide-selective for MMAA
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping from the UniProt Subcellular Location &#34;Cytoplasm&#34; keyword. MMAA is
+      detected in the cytoplasm but its core functional site is the mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with the curated UniProt subcellular location; kept as a non-core
+      localization since the protein functions after mitochondrial import.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping from the UniProt Subcellular Location &#34;Mitochondrion&#34; keyword. This
+      is the core functional compartment of MMAA.
+    action: ACCEPT
+    reason: &gt;-
+      Agrees with experimental (IDA/HTP) localization and with the presence of a cleaved
+      mitochondrial transit peptide.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with MMUT (UniProtKB:P22033). The biologically meaningful
+      interaction is the GTP-dependent MMAA-MMUT complex through which AdoCbl is delivered;
+      the bare &#34;protein binding&#34; term is uninformative about this function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidance, generic &#34;protein binding&#34; is uninformative; the specific
+      MMAA-MMUT interaction is better captured by the chaperone/complex-formation role and by
+      the identical/homodimerization terms. Retained (not removed) as it records a real,
+      experimentally supported interaction with MMUT.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: the two proteins interact in vitro and in vivo
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28497574
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with MMUT (UniProtKB:P22033). As above, &#34;protein binding&#34; is
+      uninformative; the functionally relevant interaction is the GTPase-stimulating,
+      AdoCbl-gating MMAA-MMUT complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein-binding term over-annotates a specific, functionally important
+      MMAA-MMUT interaction; kept as a real interaction record rather than removed.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        This function of MMAA depends on its GTPase activity, which is stimulated by an
+        interaction with MUT
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Self-interaction (homodimer) supported by IntAct and by the crystal structure, in which
+      MMAA is an alpha2 homodimer.
+    action: ACCEPT
+    reason: &gt;-
+      The homodimeric state is structurally and biochemically verified and is relevant to the
+      protein&#39;s oligomerization behavior with MMUT.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: &gt;-
+        yet they show substantially different dimeric assembly and interaction, compared with
+        their bacterial counterparts
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759218
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome traceable assertion placing MMAA in cobalamin (vitamin B12) metabolism. MMAA
+      is required for intracellular handling of B12, specifically the mitochondrial delivery
+      and maintenance of the AdoCbl cofactor on MMUT.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; consistent with experimental (IDA) annotations and with the
+      cblA-type methylmalonic aciduria disease mechanism (reduced mitochondrial AdoCbl pool).
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: &gt;-
+        MMAA (methylmalonic aciduria type A), is implicated in the mitochondrial assembly of
+        AdoCbl into MUT
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence (Human Protein Atlas) detection in the cytosol. MMAA is synthesized
+      as a cytosolic precursor and imported into mitochondria; the functionally relevant
+      pool is mitochondrial.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real immunofluorescence localization but not the core site of function; the protein
+      acts in the mitochondrial matrix after transit-peptide cleavage.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteomics detected MMAA in the mitochondrion,
+      corroborating its curated mitochondrial localization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the core mitochondrial localization established by targeted
+      immunofluorescence and by the cleaved mitochondrial transit peptide.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3159259
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome TAS (&#34;MMAA:MUT binds AdoCbl&#34;) assigning molecular carrier activity. MMAA does
+      not itself carry cobalamin as cargo; it is the G-protein that gates the transfer of
+      AdoCbl (produced by MMAB) onto MMUT in a GTP-dependent manner. &#34;Molecular carrier
+      activity&#34; mislabels the gating/regulatory GTPase role as direct cofactor transport.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The precise molecular function is GTPase activity; the AdoCbl delivery is a gated
+      protein-protein handoff between MMAB and MUT that MMAA regulates rather than a carrier
+      activity that MMAA itself enables. Retained (not removed) because MMAA is genuinely
+      required for cofactor delivery, but flagged as over-annotated at the MF level.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: &gt;-
+        our data point to a gatekeeping role for MMAA by favoring complex formation with MUT
+        apoenzyme for AdoCbl assembly and releasing the AdoCbl-loaded holoenzyme from the
+        complex, in a GTP-dependent manner
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        all mutations interfered with gating the transfer of AdoCbl from MMAB to MUT
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:31056463
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      Direct assay showing MMAA (CblA) allosterically regulates AdoCbl movement to/from MMUT;
+      patient cblA mutations reduce the mitochondrial AdoCbl pool, placing MMAA upstream of or
+      within cobalamin/AdoCbl metabolism.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported role in the mitochondrial B12/AdoCbl trafficking pathway; core
+      biological process for MMAA.
+    supported_by:
+    - reference_id: PMID:31056463
+      supporting_text: &#39;chaperone CblA is transduced via three &#34;switch&#34; elements that gate the movement&#39;
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: IDA
+  original_reference_id: PMID:31056463
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA (MGI) assigning molecular carrier activity from the allosteric-oligomerization
+      study. As with the Reactome annotation, MMAA gates B12 movement between MMAB and MMUT
+      via its GTPase rather than acting as a direct molecular carrier of the cofactor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The paper demonstrates GTPase-gated cofactor movement and oligomer regulation, not a
+      carrier/transport activity intrinsic to MMAA; the informative MF is GTPase activity.
+      Kept as a record of the cofactor-movement role but flagged as over-annotated.
+    supported_by:
+    - reference_id: PMID:31056463
+      supporting_text: &gt;-
+        gate the movement of the B12 cofactor to and from MCM
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:31056463
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental involvement in cobalamin/AdoCbl metabolism: MMAA (CblA) gates B12
+      cofactor movement to/from MMUT, and cblA mutations lower the fibroblast AdoCbl pool.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process supported by direct measurements of AdoCbl pool depletion in
+      cblA patient cells and by the gating mechanism.
+    supported_by:
+    - reference_id: PMID:31056463
+      supporting_text: &gt;-
+        AdoCbl represents 15.1
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IDA
+  original_reference_id: PMID:21138732
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay of purified recombinant human MMAA showing GTP-hydrolysis-dependent
+      reactivation of methylmalonyl-CoA mutase, demonstrating functional GTPase activity.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function, directly demonstrated; MMAA reactivates inactive mutase via
+      GTP hydrolysis.
+    supported_by:
+    - reference_id: PMID:21138732
+      supporting_text: &gt;-
+        the addition of MMAA increases the enzymatic activity through GTP hydrolysis,
+        indicating reactivation of MCM by exchange of the damaged cofactor
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assay showing MMAA removes the damaged (oxidized) cofactor from inactive mutase
+      through GTP hydrolysis, confirming functional GTPase activity.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function; directly demonstrated GTP-hydrolysis-coupled cofactor exchange.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: hMMAA is able to remove the damaged cofactor through GTP hydrolysis
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21138732
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with MMUT (UniProtKB:P22033) confirmed by yeast two-hybrid. The
+      functionally relevant interaction is the MMAA-MMUT chaperone complex; &#34;protein binding&#34;
+      is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein-binding term over-annotates the specific, experimentally verified
+      MMAA-MMUT interaction; retained (not removed) as a real interaction.
+    supported_by:
+    - reference_id: PMID:21138732
+      supporting_text: &gt;-
+        Interaction between MCM and MMAA observed in vitro was confirmed in vivo by yeast
+        two-hybrid system
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28943303
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with MMUT (UniProtKB:P22033). As above, the informative description is the
+      MMAA-MMUT complex through which cofactor protection/exchange occurs, not bare &#34;protein
+      binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative generic term; the specific MMAA-MMUT complex is better captured elsewhere.
+      Kept as a real, experimentally supported interaction.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        restores methylmalonyl-CoA mutase activity through their complex formation
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct localization detected MMAA in the cytoplasm in addition to mitochondria. The
+      protein&#39;s core functional pool is mitochondrial (matrix), consistent with its transit
+      peptide and MMUT colocalization.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real localization but not the core functional compartment; MMAA acts on MMUT after
+      mitochondrial import.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct in vivo demonstration that MMAA localizes to and colocalizes with MMUT in human
+      fibroblast mitochondria. This is the core functional compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular localization, directly demonstrated and consistent with the cleaved
+      mitochondrial transit peptide.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Structural and biochemical study directly demonstrating that human MMAA is a GTPase
+      whose activity is modulated by MMUT; crystallized in the GDP-bound form.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function, directly demonstrated with structural support (PDB 2WWW).
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: We show that MMAA exhibits GTPase activity that is modulated by MUT
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IMP
+  original_reference_id: PMID:28497574
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Mutational analysis of 15 purified MACA mutant proteins showed wild-type-like intrinsic
+      GTPase activity for all but the GTP-binding-domain variant, confirming GTPase activity
+      as an intrinsic MMAA function and dissecting the MUT-stimulated (GAP) component.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function; IMP evidence corroborates the intrinsic GTPase activity and its
+      MUT-dependent stimulation.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        All 15 purified mutant proteins demonstrated wild-type like intrinsic GTPase activity
+- term:
+    id: GO:0005525
+    label: GTP binding
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct demonstration of GTP/GDP binding by human MMAA, crystallized in the GDP-bound
+      form with defined GTP-binding loops; complex formation with MMUT is nucleotide-selective.
+    action: ACCEPT
+    reason: &gt;-
+      GTP binding is directly demonstrated and structurally characterized; intrinsic property
+      of the G-domain.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: Formation of a stable MMAA-MUT complex is nucleotide-selective for MMAA
+- term:
+    id: GO:0005525
+    label: GTP binding
+  evidence_type: IDA
+  original_reference_id: PMID:28497574
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct assays of GTP/GDP binding across MACA mutants; only the GTP-binding-domain
+      variant (p.Asp292Val) showed decreased GTP binding, confirming GTP binding as an
+      intrinsic MMAA property.
+    action: ACCEPT
+    reason: &gt;-
+      GTP binding directly demonstrated; consistent with the conserved G-domain.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        only one (p.Asp292Val), where the mutation is in the GTP binding domain, revealed
+        decreased GTP binding
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: TAS
+  original_reference_id: PMID:28497574
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      MMAA regulates incorporation of the AdoCbl cofactor into MMUT, placing it in
+      cobalamin/AdoCbl metabolism; cblA mutations impair AdoCbl transfer and cause disease.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; strongly supported by the mechanistic and disease-variant data.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl),
+        generated from the MMAB adenosyltransferase, into the destination enzyme
+        methylmalonyl-CoA mutase (MUT)
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct structural demonstration that MMAA self-associates as a homodimer (alpha2),
+      distinct from its bacterial counterparts.
+    action: ACCEPT
+    reason: &gt;-
+      Homodimerization is structurally verified and relevant to MMAA oligomerization behavior.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: &gt;-
+        yet they show substantially different dimeric assembly and interaction, compared with
+        their bacterial counterparts
+- term:
+    id: GO:0042803
+    label: protein homodimerization activity
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: &gt;-
+      MMAA forms a homodimer, directly demonstrated in the crystal structure. This
+      self-association underlies its nucleotide-sensitive oligomerization with MMUT.
+    action: ACCEPT
+    reason: &gt;-
+      Homodimerization activity is directly and structurally supported; a genuine, specific
+      molecular property.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: &gt;-
+        yet they show substantially different dimeric assembly and interaction, compared with
+        their bacterial counterparts
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3322135
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS placing MMAA in the mitochondrial matrix (the &#34;Defective MMAA does not
+      protect MUT&#34; reaction). This is the specific compartment where MMAA acts on MMUT.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the cleaved mitochondrial transit peptide, matrix-localized MMUT, and
+      the demonstrated mitochondrial colocalization; the most precise functional location.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3159259
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS placing MMAA in the mitochondrial matrix (the &#34;MMAA:MUT binds AdoCbl&#34;
+      reaction). Correct core functional location.
+    action: ACCEPT
+    reason: &gt;-
+      Matrix localization is consistent with mitochondrial import and MMUT colocalization.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3322971
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS placing MMAA in the mitochondrial matrix. Consistent with its functional
+      compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Matrix localization is well supported; core functional location.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71010
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS placing MMAA in the mitochondrial matrix (associated with the MUT
+      isomerization reaction module). Consistent with the functional compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Matrix localization is well supported by import signal and MMUT colocalization.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the in vivo localization of hMMAA and its colocalization with hMCM in human
+        fibroblasts mitochondria were demonstrated
+- term:
+    id: GO:0043085
+    label: positive regulation of catalytic activity
+  evidence_type: IDA
+  original_reference_id: PMID:21138732
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      MMAA reactivates inactive methylmalonyl-CoA mutase and protects it from inactivation,
+      thereby positively regulating the catalytic activity of MMUT. This chaperone/reactivase
+      role is well documented but is not captured by the existing GOA terms.
+    action: NEW
+    reason: &gt;-
+      Proposed new annotation capturing MMAA&#39;s protectase/reactivase function toward MMUT,
+      demonstrated in vitro with purified proteins. Supports the corresponding core function.
+    supported_by:
+    - reference_id: PMID:21138732
+      supporting_text: &gt;-
+        the addition of MMAA increases the enzymatic activity through GTP hydrolysis,
+        indicating reactivation of MCM by exchange of the damaged cofactor
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        restores methylmalonyl-CoA mutase activity through their complex formation
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      By forming a complex with MMUT, MMAA slows formation of the oxidized inactive cofactor
+      (OH2Cbl) and thereby protects/maintains functional MMUT, i.e. stabilizes the active
+      holoenzyme. Documented mechanistically but not present in the existing GOA set.
+    action: NEW
+    reason: &gt;-
+      Proposed new annotation capturing MMAA&#39;s protective (protectase) role toward MMUT;
+      supports the corresponding core function.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: &gt;-
+        the complex formation of hMCM/hMMAA decreases the rate of oxidized cofactor
+        formation, protecting the hMCM enzyme
+    - reference_id: PMID:21138732
+      supporting_text: &gt;-
+        it prevents inactivation by guarding MCM
+core_functions:
+- description: &gt;-
+    Mitochondrial matrix GTPase that binds and hydrolyzes GTP; its low intrinsic GTPase
+    activity is strongly stimulated by methylmalonyl-CoA mutase (MMUT/MUT), which acts as a
+    GAP. This nucleotide cycle powers MMAA&#39;s chaperone functions toward MMUT.
+  molecular_function:
+    id: GO:0003924
+    label: GTPase activity
+  directly_involved_in:
+  - id: GO:0009235
+    label: cobalamin metabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:20876572
+    supporting_text: We show that MMAA exhibits GTPase activity that is modulated by MUT
+  - reference_id: PMID:28497574
+    supporting_text: &gt;-
+      This function of MMAA depends on its GTPase activity, which is stimulated by an
+      interaction with MUT
+- description: &gt;-
+    G-protein chaperone that, in a GTP-dependent manner, gates transfer of the
+    adenosylcobalamin (AdoCbl) cofactor from the adenosyltransferase MMAB onto MMUT
+    apoenzyme, protects the MMUT-bound cofactor from oxidative inactivation, and reactivates
+    inactive MMUT by promoting exchange of the damaged cofactor. This maintains MMUT (and
+    hence propionate/methylmalonyl-CoA) flux and is the process disrupted in cblA-type
+    methylmalonic aciduria. MMAA is not itself the mutase and does not carry the cofactor as
+    cargo; it regulates a gated protein-protein handoff.
+  molecular_function:
+    id: GO:0003924
+    label: GTPase activity
+  directly_involved_in:
+  - id: GO:0009235
+    label: cobalamin metabolic process
+  - id: GO:0043085
+    label: positive regulation of catalytic activity
+  - id: GO:0050821
+    label: protein stabilization
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:20876572
+    supporting_text: &gt;-
+      our data point to a gatekeeping role for MMAA by favoring complex formation with MUT
+      apoenzyme for AdoCbl assembly and releasing the AdoCbl-loaded holoenzyme from the
+      complex, in a GTP-dependent manner
+  - reference_id: PMID:21138732
+    supporting_text: &gt;-
+      it prevents inactivation by guarding MCM
+  - reference_id: PMID:28943303
+    supporting_text: &gt;-
+      the complex formation of hMCM/hMMAA decreases the rate of oxidized cofactor formation,
+      protecting the hMCM enzyme
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Is MMAA best described at the molecular-function level by a dedicated cofactor-loading /
+    GTPase-dependent chaperone term rather than the generic &#34;molecular carrier activity&#34;,
+    given that it gates a protein-protein cofactor handoff rather than transporting cobalamin
+    itself?
+- question: &gt;-
+    What is the physiological significance of the cytoplasmic/cytosolic MMAA pool detected by
+    immunofluorescence and proteomics, versus the functionally characterized mitochondrial
+    matrix pool?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute the full human mitochondrial B12 pathway (MMAB/ATR, MMAA/CblA, MMUT) in
+    vitro and use single-turnover/stopped-flow spectroscopy to quantify how GTP binding vs
+    hydrolysis by MMAA controls the directionality of AdoCbl loading and cob(II)alamin
+    offloading.
+- description: &gt;-
+    Use cryo-EM of the nucleotide-sensitive MMAA-MMUT oligomers to define the loading-ready
+    state and map how cblA switch-region patient variants shift the oligomeric equilibrium.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:20876572
+  title: Structures of the human GTPase MMAA and vitamin B12-dependent methylmalonyl-CoA
+    mutase and insight into their complex formation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Structural/biochemical study establishing MMAA as a GTPase modulated
+      by MUT, homodimer (PDB 2WWW), and its GTP-dependent gatekeeping role for AdoCbl assembly
+      into MUT.
+- id: PMID:21138732
+  title: Protection and reactivation of human methylmalonyl-CoA mutase by MMAA protein.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Demonstrates MMAA&#39;s dual protectase/reactivase role toward MCM and the
+      GTP-hydrolysis-dependent cofactor exchange.
+- id: PMID:28497574
+  title: Protein destabilization and loss of protein-protein interaction are fundamental
+    mechanisms in cblA-type methylmalonic aciduria.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Large patient/mutant series showing intrinsic GTPase is retained while
+      MUT-stimulated GTPase, MUT binding, and AdoCbl gating are lost in disease variants.
+- id: PMID:28943303
+  title: Human MMAA induces the release of inactive cofactor and restores methylmalonyl-CoA
+    mutase activity through their complex formation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Shows OH2Cbl accumulation causes MCM inactivation, MMAA complex slows
+      this, and MMAA removes the damaged cofactor via GTP hydrolysis; first in vivo mito
+      colocalization of hMMAA with hMCM.
+- id: PMID:31056463
+  title: Allosteric Regulation of Oligomerization by a B(12) Trafficking G-Protein
+    Is Corrupted in Methylmalonic Aciduria.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified, full text available. Human MCM-CblA form nucleotide-sensitive
+      interconverting oligomers; GTPase-driven resolution to the loading-ready state is
+      needed for AdoCbl loading; cblA switch III mutations reduce the fibroblast AdoCbl pool.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Large-scale mitochondrial proteomics; corroborates mitochondrial
+      localization of MMAA but does not directly address molecular function.
+- id: Reactome:R-HSA-3159259
+  title: MMAA:MUT binds AdoCbl
+  findings: []
+- id: Reactome:R-HSA-3322135
+  title: Defective MMAA does not protect MUT
+  findings: []
+- id: Reactome:R-HSA-3322971
+  title: Defective MUT does not isomerise L-MM-CoA to SUCC-CoA
+  findings: []
+- id: Reactome:R-HSA-71010
+  title: MUT isomerises L-MM-CoA to SUCC-CoA
+  findings: []
+- id: Reactome:R-HSA-9759218
+  title: Cobalamin (Cbl) metabolism
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/MMAB/MMAB-ai-review.html
+++ b/genes/human/MMAB/MMAB-ai-review.html
@@ -1,0 +1,4025 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MMAB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MMAB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q96EY8" target="_blank" class="term-link">
+                        Q96EY8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MMAB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q96EY8" data-a="DESCRIPTION: MMAB is the human mitochondrial ATP:cob(I)alamin a..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MMAB is the human mitochondrial ATP:cob(I)alamin adenosyltransferase (ATR, cblB), a homotrimeric enzyme of the mitochondrial matrix that catalyses the final step of adenosylcobalamin (AdoCbl, coenzyme B12) synthesis. It transfers the 5&#39;-deoxyadenosyl group from ATP to reduced cob(I)alamin, producing adenosylcob(III)alamin plus inorganic triphosphate. Beyond catalysis, MMAB acts as an escort that delivers the newly made AdoCbl directly to methylmalonyl-CoA mutase (MMUT/MCM), the AdoCbl-dependent isomerase that converts (R)-methylmalonyl-CoA to succinyl-CoA; this hand-off is stimulated by ATP binding to MMAB and gated by the cblA G-protein chaperone MMAA. MMAB binds cobalamin in a base-off state and uses ATP-organized coordination chemistry to raise the cobalt redox potential and permit reduction to cob(I)alamin prior to adenosylation, and it can sacrificially cleave the newly formed cobalt-carbon bond to sequester the cofactor as tightly bound cob(II)alamin when the mutase is unavailable. Loss-of-function variants cause methylmalonic aciduria, cblB type, an autosomal recessive disorder of AdoCbl synthesis that is frequently responsive to vitamin B12.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred corrinoid (cob(I)alamin) adenosyltransferase activity, the established core molecular function of MMAB. This matches the direct experimental evidence and the UniProt catalytic activity assignment (Rhea:56796).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the correct core molecular function and is corroborated by multiple independent experimental annotations (EXP/IDA) plus the ARBA electronic assignment; the IBA is at the right level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion of cobalamins into Ado-B12.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of mitochondrial localization from the UniProt Subcellular Location vocabulary. MMAB carries a cleaved N-terminal mitochondrial transit peptide (residues 1-32) and acts in the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment; consistent with the UniProt SUBCELLULAR LOCATION (Mitochondrion), the predicted transit peptide, and high-confidence mitochondrial proteomics. The more specific matrix location is captured by separate annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA), a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the target enzyme, MCM (or Mut)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning electronic assignment of the core corrinoid adenosyltransferase activity, consistent with the experimental and phylogenetic evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the ARBA mapping agrees with EXP/IDA/IBA evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion of cobalamins into Ado-B12.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0009235" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of involvement in cobalamin metabolism. MMAB performs the terminal step of adenosylcobalamin (coenzyme B12) synthesis, so it is correctly placed in cobalamin metabolic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct biological process at an appropriate grain for a human enzyme (humans do not perform de novo corrin ring biosynthesis; MMAB acts in cofactor conversion/tailoring of dietary B12).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion of cobalamins into Ado-B12.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25910212
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread macromolecular interaction perturbations in human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding from a large-scale interactome perturbation study (IntAct interactor CBY2, Q8NA61-2). Provides no specific information about MMAB molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein binding derived from a high-throughput screen; the cited paper does not characterize MMAB function. Per curation policy, retained but marked as over-annotated rather than removed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding from a neurodegenerative-disease interactome map (IntAct interactors CALR/P27797, DLST/P36957, NEK7/Q8TDX7, OPTN/Q96CV9). Uninformative for molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding from a large-scale two-hybrid/AP-MS network; no functional MMAB characterization in the source. Retained but marked as over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding from a proteome-scale interactome network (IntAct interactor DBT/P11182). Notably DBT (a mitochondrial 2-oxo acid dehydrogenase E2 subunit) is a plausible matrix neighbour, but the annotation itself conveys no specific function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding from a high-throughput interactome; uninformative molecular-function term. Retained but marked as over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding from a multimodal cell-map study (IntAct interactor DBT/P11182). Duplicates the DBT interaction and conveys no specific molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding from a large-scale mapping resource; uninformative term. Retained but marked as over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759218
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0009235" data-r="Reactome:R-HSA-9759218" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-curated involvement of MMAB in cobalamin metabolism, reflecting its role in the AdoCbl branch of the intracellular cobalamin trafficking/processing pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct biological process, well supported by the enzyme&#39;s characterized role in producing the AdoCbl cofactor from dietary cobalamin.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in any of these three proteins lead to isolated methylmalonic aciduria while sparing the MeCbl branch of the trafficking pathway.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15913339" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15913339
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Spectroscopic evidence for the formation of a four-coordinat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="PMID:15913339" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (spectroscopic) study of human ATR (MMAB) demonstrating cobalamin binding and the ATP-dependent coordination chemistry that underlies its adenosyltransferase function, forming a four-coordinate Co2+ cobalamin species that raises the redox potential toward the physiological range to enable cob(I)alamin formation prior to adenosylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence on the human enzyme for its corrinoid adenosyltransferase mechanism; supports the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15913339" target="_blank" class="term-link">
+                                        PMID:15913339
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human adenosyltransferase hATR converts exogenous cobalamin into coenzyme B12 by transferring the adenosyl group from cosubstrate ATP to a transiently formed Co1+cobalamin (Co1+Cbl) species.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30282455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30282455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sacrificial Cobalt-Carbon Bond Homolysis in Coenzyme B(12) a...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="PMID:30282455" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental study confirming that human ATR (MMAB) synthesizes AdoCbl by adenosylation of cob(I)alamin by ATP and directly delivers the product to methylmalonyl-CoA mutase; also demonstrates the sacrificial Co-C bond homolysis cofactor-conservation activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence on the human enzyme supporting corrinoid adenosyltransferase activity (the AdoCbl-synthesizing reaction).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30282455" target="_blank" class="term-link">
+                                        PMID:30282455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AdoCbl is synthesized by adenosyltransferase (ATR), which catalyzes the adenosylation of cob(I)alamin by ATP in a direct nucleophilic displacement reaction that leads to cobalt−carbon (Co−C) bond formation yielding AdoCbl and inorganic triphosphate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33797888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Redox-Linked Coordination Chemistry Directs Vitamin B(12) Tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="PMID:33797888" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Review/primary account (Banerjee lab) describing the human adenosyltransferase (ATR/MMAB) homotrimer that catalyses adenosylation of cob(I)alamin by ATP, with detailed loop-dynamics and redox-linked coordination chemistry underlying the reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supports the core corrinoid adenosyltransferase activity of the human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATR, an 81 kDa homotrimer with active sites housed at the subunit interfaces (Fig. 5A),62 catalyzes the adenosylation of cob(I)alamin by ATP.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3322125
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="Reactome:R-HSA-3322125" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-curated corrinoid adenosyltransferase activity of MMAB, corresponding to the reaction MMAB adenosylates cob(I)alamin. Consistent with all experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function, curated by Reactome and matching the experimental record.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion of cobalamins into Ado-B12.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput assignment of MMAB to the mitochondrion from a quantitative high-confidence human mitochondrial proteome. Consistent with the transit peptide and matrix function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment, corroborating the UniProt localization and the enzyme&#39;s matrix role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA), a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the target enzyme, MCM (or Mut)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12514191
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human and bovine ATP:Cob(I)alamin aden...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0009235" data-r="PMID:12514191" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence placing MMAB in cobalamin metabolism: the human ATR cDNA complemented an ATR-deficient bacterial mutant and its dysregulation was shown in cblB methylmalonic aciduria cell lines, establishing MMAB as the enzyme performing the terminal conversion of cobalamin to coenzyme B12.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported biological-process annotation from the defining functional study of MMAB.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We propose that inborn errors in the human ATR gene identified here result in methylmalonyl aciduria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016765" target="_blank" class="term-link">
+                                    GO:0016765
+                                </a>
+                            </span>
+                            <span class="term-label">transferase activity, transferring alkyl or aryl (other than methyl) groups</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12514191
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human and bovine ATP:Cob(I)alamin aden...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0016765" data-r="PMID:12514191" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that MMAB is a transferase transferring a (non-methyl) alkyl group — the 5&#39;-deoxyadenosyl group — but this is a parent term of the specific corrinoid adenosyltransferase activity (GO:0008817 is a subclass of GO:0016765). The specific term is warranted.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in essence but too general: the transferred group is specifically the deoxyadenosyl moiety onto cob(I)alamin, which is captured precisely by GO:0008817 corrinoid adenosyltransferase activity (an is-a descendant of GO:0016765). Replace with the specific term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    corrinoid adenosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion of cobalamins into Ado-B12.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0009235" data-r="PMID:28497574" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement placing MMAB in cobalamin metabolism: the paper describes MMAB as the adenosyltransferase that generates AdoCbl for delivery to methylmalonyl-CoA mutase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct biological process; the source explicitly frames MMAB as the AdoCbl-generating enzyme in the mitochondrial cobalamin pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0031419" data-r="PMID:28497574" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that MMAB binds cobalamin (adenosylcobalamin). MMAB binds the cofactor in a base-off state and holds the AdoCbl product prior to hand-off to the mutase; UniProt cites this reference for adenosylcobalamin-binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin binding is an integral, experimentally supported feature of MMAB&#39;s function as a B12 adenosyltransferase and escort.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                                    GO:0008817
+                                </a>
+                            </span>
+                            <span class="term-label">corrinoid adenosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12514191
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the human and bovine ATP:Cob(I)alamin aden...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0008817" data-r="PMID:12514191" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental demonstration of corrinoid (cob(I)alamin) adenosyltransferase activity for the human enzyme: recombinant human ATR produced measurable ATR activity and complemented an ATR-deficient bacterial mutant for Ado-B12-dependent growth.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Gold-standard direct assay of the core molecular function on the human protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                        PMID:12514191
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Enzyme assays showed that expression strains produced 87 and 98 nmol/min/mg ATR activity, respectively.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3322125
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005759" data-r="Reactome:R-HSA-3322125" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-curated mitochondrial matrix localization for MMAB, the compartment where AdoCbl is synthesized and delivered to methylmalonyl-CoA mutase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and appropriately specific subcellular location, consistent with the matrix role of the AdoCbl-synthesis/delivery machinery.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA), a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the target enzyme, MCM (or Mut)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3159253
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005759" data-r="Reactome:R-HSA-3159253" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-curated mitochondrial matrix localization (from the MMAB adenosylates cob(I)alamin reaction). Duplicate compartment assignment; correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct specific location; consistent with the enzyme&#39;s matrix function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA), a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the target enzyme, MCM (or Mut)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17176040" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17176040
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of ATP-bound human ATP:cobalamin adenosyltransfera...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q96EY8" data-a="GO:0005524" data-r="PMID:17176040" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP binding is a defining feature of MMAB: it is the adenosyl-donor cosubstrate and ATP binding also organizes the high-affinity cobalamin pocket and gates cofactor delivery to the mutase. The ATP-bound human ATR crystal structure (PDB 2IDX) and UniProt ATP-binding features (residues 60-63, 68-69, 78, 190-194, 214) directly establish this. Present in UniProt (GO:0005524 IEA:UniProtKB-KW) but absent from the current GOA TSV, so added here.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structurally and biochemically established, functionally central molecular function (ATP is the adenosyl donor) that is missing from the GOA set; added with the ATP-bound structure as evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                                        PMID:33797888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ATP binding organizes a high affinity cob(II)alamin pocket in human ATR.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyses the terminal step of adenosylcobalamin (coenzyme B12) synthesis, transferring the 5&#39;-deoxyadenosyl group from ATP to reduced cob(I)alamin to produce adenosylcob(III)alamin, and uses ATP as the adenosyl donor.</h3>
+                <span class="vote-buttons" data-g="Q96EY8" data-a="FUNCTION: Catalyses the terminal step of adenosylcobalamin (..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008817" target="_blank" class="term-link">
+                            corrinoid adenosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                cobalamin metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                                PMID:12514191
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion of cobalamins into Ado-B12.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30282455" target="_blank" class="term-link">
+                                PMID:30282455
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">AdoCbl is synthesized by adenosyltransferase (ATR), which catalyzes the adenosylation of cob(I)alamin by ATP in a direct nucleophilic displacement reaction that leads to cobalt−carbon (Co−C) bond formation yielding AdoCbl and inorganic triphosphate</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds cobalamin (in a base-off state) and, in an ATP-dependent manner, holds the AdoCbl product and delivers it directly to methylmalonyl-CoA mutase, functioning as a cobalamin-binding cofactor escort in the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="Q96EY8" data-a="FUNCTION: Binds cobalamin (in a base-off state) and, in an A..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                cobalamin metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30282455" target="_blank" class="term-link">
+                                PMID:30282455
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ATR also delivers the AdoCbl product directly to MCM, thereby averting cofactor loss by release into solution.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                PMID:28497574
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT).</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12514191" target="_blank" class="term-link">
+                            PMID:12514191
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of the human and bovine ATP:Cob(I)alamin adenosyltransferase cDNAs based on complementation of a bacterial mutant.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15913339" target="_blank" class="term-link">
+                            PMID:15913339
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Spectroscopic evidence for the formation of a four-coordinate Co2+ cobalamin species upon binding to the human ATP:cobalamin adenosyltransferase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                            PMID:25910212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                            PMID:28497574
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protein destabilization and loss of protein-protein interaction are fundamental mechanisms in cblA-type methylmalonic aciduria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30282455" target="_blank" class="term-link">
+                            PMID:30282455
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sacrificial Cobalt-Carbon Bond Homolysis in Coenzyme B(12) as a Cofactor Conservation Strategy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" target="_blank" class="term-link">
+                            PMID:33797888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Redox-Linked Coordination Chemistry Directs Vitamin B(12) Trafficking.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17176040" target="_blank" class="term-link">
+                            PMID:17176040
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of ATP-bound human ATP:cobalamin adenosyltransferase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3159253
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MMAB adenosylates cob(I)alamin</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3322125
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective MMAB does not transfer adenosyl group from ATP to B12s</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759218
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cobalamin (Cbl) metabolism</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MMAB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q96EY8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mmab-q96ey8-curation-notes">MMAB (Q96EY8) — curation notes</h1>
+<p>Human MMAB / cblB, mitochondrial <strong>ATP:cob(I)alamin adenosyltransferase (ATR)</strong>. HGNC:19331. Chromosome 12.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>MMAB is the mitochondrial adenosyltransferase (ATR) that catalyses the <strong>final step of<br />
+  adenosylcobalamin (AdoCbl / coenzyme B12) synthesis</strong>: it transfers the 5'-deoxyadenosyl group<br />
+  from ATP to reduced cob(I)alamin, producing adenosylcob(III)alamin (AdoCbl) plus inorganic<br />
+  triphosphate. AdoCbl is the essential cofactor of methylmalonyl-CoA mutase (MMUT/MCM).</li>
+<li>UniProt CATALYTIC ACTIVITY (Rhea:56796): "cob(I)alamin-[corrinoid adenosyltransferase] + ATP =<br />
+    apo-[corrinoid adenosyltransferase] + adenosylcob(III)alamin + triphosphate" [ECO:0000269|PubMed:12514191].</li>
+<li>[PMID:12514191 abstract, "ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step<br />
+    in the conversion of cobalamins into Ado-B12"]. Human cDNA complemented an ATR-deficient bacterial<br />
+    mutant; recombinant enzyme showed 98 nmol/min/mg ATR activity.</li>
+<li><strong>Homotrimer</strong> with active sites at subunit interfaces; ATP-bound crystal structures (PMID:17176040,<br />
+  PDB 2IDX; also 6D5K/6D5X/7RUT). <a href="https://pubmed.ncbi.nlm.nih.gov/33797888" title="ATR, an 81 kDa homotrimer with active sites housed   at the subunit interfaces...catalyzes the adenosylation of cob(I)alamin by ATP">PMID:33797888</a>.</li>
+<li><strong>Escort / direct hand-off</strong>: ATR does not just synthesize AdoCbl, it delivers it directly to MCM<br />
+  (avoiding release into solution); transfer is stimulated by ATP binding to MMAB and gated by MMAA<br />
+  (cblA G-protein). <a href="https://pubmed.ncbi.nlm.nih.gov/30282455" title="ATR also delivers the AdoCbl product directly to MCM, thereby   averting cofactor loss by release into solution">PMID:30282455</a>; [PMID:28497574 abstract "gating the transfer of<br />
+  AdoCbl from MMAB to MUT"].</li>
+<li><strong>Cobalamin binding / coordination chemistry</strong>: ATR binds cobalamin in the base-off state; ATP<br />
+  binding organizes a high-affinity cob(II)alamin pocket and, via a 4-coordinate square-planar Co(II)<br />
+  state, raises the Co2+/1+ redox potential to allow reduction to cob(I)alamin before adenosylation.<br />
+  [PMID:15913339 abstract "the interaction between Co2+Cbl and hATR promotes partial conversion of the<br />
+  cofactor to its 'base-off' form...leading to the formation of an unprecedented Co2+Cbl species with<br />
+  spectroscopic signatures consistent with an essentially four-coordinate, square-planar Co2+ center"].<br />
+  UniProt cites PMID:28497574 for adenosylcobalamin-binding (GO:0031419 IDA).</li>
+<li><strong>Sacrificial homolysis / cofactor conservation</strong>: if MCM is unavailable, ATR homolytically cleaves<br />
+  the newly formed Co–C bond of AdoCbl (reverse of the SN2 making reaction) to give tightly-bound<br />
+  cob(II)alamin, sequestering the precious cofactor. <a href="https://pubmed.ncbi.nlm.nih.gov/30282455">PMID:30282455</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/33797888">PMID:33797888</a>.</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Mitochondrion / mitochondrial matrix. N-terminal transit peptide (1–32) cleaved. Supported by<br />
+  UniProt SUBCELLULAR LOCATION, Reactome, and high-confidence mitochondrial proteome<br />
+  [PMID:34800366, HTP mitochondrion].</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li><strong>Methylmalonic aciduria, cblB type (MACB; MIM:251110)</strong> — autosomal recessive, defective AdoCbl<br />
+  synthesis; frequently vitamin B12-responsive (Orphanet 79311 "Vitamin B12-responsive methylmalonic<br />
+  acidemia type cblB"). Confirmed in dismech disorder KB Methylmalonic_Acidemia.yaml (MMAB listed<br />
+  under MMUT/AdoCbl pathway molecular-function deficiency; <a href="https://pubmed.ncbi.nlm.nih.gov/27653704" title="genes encoding the enzymes   responsible for the generation of 5-deoxyadenosylcobalamin (AdoCbl) cofactor of Mut (MMAA and MMAB)">PMID:27653704</a>).</li>
+</ul>
+<h2 id="goa-annotation-notes">GOA annotation notes</h2>
+<ul>
+<li>GO:0008817 corrinoid adenosyltransferase activity — core MF, multiple independent EXP/IDA + IBA + IEA. ACCEPT.</li>
+<li>GO:0016765 transferase activity, transferring alkyl or aryl groups (IDA, PMID:12514191) — correct<br />
+  but a <strong>parent</strong> of GO:0008817 (entailed_edge confirms GO:0008817 ⊆ GO:0016765). Too general → MODIFY to GO:0008817.</li>
+<li>GO:0009235 cobalamin metabolic process — BP; ACCEPT (multiple lines). MMAB acts in AdoCbl (coenzyme<br />
+  B12) synthesis; humans do not perform de novo corrin biosynthesis so "cobalamin metabolic process"<br />
+  is the right-grain BP (not GO:0009236 de novo biosynthetic).</li>
+<li>GO:0031419 cobalamin binding (IDA, PMID:28497574) — ACCEPT; ATR demonstrably binds AdoCbl/cobalamin.</li>
+<li>GO:0005739 mitochondrion (IEA + HTP) / GO:0005759 mitochondrial matrix (TAS Reactome) — ACCEPT.</li>
+<li>7 GO:0005515 protein binding IPIs (IntAct high-throughput interactome/proteome screens: CBY2, CALR,<br />
+  DBT, DLST, NEK7, OPTN, DBT). Uninformative bare protein binding; per policy MARK_AS_OVER_ANNOTATED<br />
+  (not REMOVE). None of the cited papers (25910212, 32814053, 33961781, 40205054) discuss MMAB function;<br />
+  they are large-scale networks reporting the interaction in supplementary data only.</li>
+<li>ATP binding (GO:0005524, UniProt-KW) is in UniProt DR but NOT in GOA TSV — add as NEW (structurally<br />
+  established, PMID:17176040 ATP-bound structure; UniProt BINDING features). MF.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>falcon deep-research file (MMAB-deep-research-falcon.md) was ABSENT at review time (polled up to 8 min).<br />
+Review grounded in UniProt (Q96EY8), seeded GOA TSV, cached publications PMID_*.md, and the dismech<br />
+disorder KB Methylmalonic_Acidemia.yaml.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q96EY8
+gene_symbol: MMAB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  MMAB is the human mitochondrial ATP:cob(I)alamin adenosyltransferase (ATR, cblB),
+  a homotrimeric enzyme of the mitochondrial matrix that catalyses the final step of
+  adenosylcobalamin (AdoCbl, coenzyme B12) synthesis. It transfers the 5&#39;-deoxyadenosyl
+  group from ATP to reduced cob(I)alamin, producing adenosylcob(III)alamin plus inorganic
+  triphosphate. Beyond catalysis, MMAB acts as an escort that delivers the newly made AdoCbl
+  directly to methylmalonyl-CoA mutase (MMUT/MCM), the AdoCbl-dependent isomerase that converts
+  (R)-methylmalonyl-CoA to succinyl-CoA; this hand-off is stimulated by ATP binding to MMAB and
+  gated by the cblA G-protein chaperone MMAA. MMAB binds cobalamin in a base-off state and uses
+  ATP-organized coordination chemistry to raise the cobalt redox potential and permit reduction
+  to cob(I)alamin prior to adenosylation, and it can sacrificially cleave the newly formed
+  cobalt-carbon bond to sequester the cofactor as tightly bound cob(II)alamin when the mutase is
+  unavailable. Loss-of-function variants cause methylmalonic aciduria, cblB type, an autosomal
+  recessive disorder of AdoCbl synthesis that is frequently responsive to vitamin B12.
+existing_annotations:
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred corrinoid (cob(I)alamin) adenosyltransferase activity, the
+      established core molecular function of MMAB. This matches the direct experimental evidence
+      and the UniProt catalytic activity assignment (Rhea:56796).
+    action: ACCEPT
+    reason: &gt;-
+      This is the correct core molecular function and is corroborated by multiple independent
+      experimental annotations (EXP/IDA) plus the ARBA electronic assignment; the IBA is at the
+      right level of specificity.
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion
+        of cobalamins into Ado-B12.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic assignment of mitochondrial localization from the UniProt Subcellular Location
+      vocabulary. MMAB carries a cleaved N-terminal mitochondrial transit peptide (residues 1-32)
+      and acts in the mitochondrial matrix.
+    action: ACCEPT
+    reason: &gt;-
+      Correct compartment; consistent with the UniProt SUBCELLULAR LOCATION (Mitochondrion), the
+      predicted transit peptide, and high-confidence mitochondrial proteomics. The more specific
+      matrix location is captured by separate annotations.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA),
+        a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the
+        target enzyme, MCM (or Mut)
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA machine-learning electronic assignment of the core corrinoid adenosyltransferase
+      activity, consistent with the experimental and phylogenetic evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function; the ARBA mapping agrees with EXP/IDA/IBA evidence.
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion
+        of cobalamins into Ado-B12.
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment of involvement in cobalamin metabolism. MMAB performs the terminal step
+      of adenosylcobalamin (coenzyme B12) synthesis, so it is correctly placed in cobalamin
+      metabolic process.
+    action: ACCEPT
+    reason: &gt;-
+      Correct biological process at an appropriate grain for a human enzyme (humans do not perform
+      de novo corrin ring biosynthesis; MMAB acts in cofactor conversion/tailoring of dietary B12).
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion
+        of cobalamins into Ado-B12.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare protein binding from a large-scale interactome perturbation study (IntAct interactor
+      CBY2, Q8NA61-2). Provides no specific information about MMAB molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative generic protein binding derived from a high-throughput screen; the cited paper
+      does not characterize MMAB function. Per curation policy, retained but marked as over-annotated
+      rather than removed.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare protein binding from a neurodegenerative-disease interactome map (IntAct interactors
+      CALR/P27797, DLST/P36957, NEK7/Q8TDX7, OPTN/Q96CV9). Uninformative for molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein binding from a large-scale two-hybrid/AP-MS network; no functional MMAB
+      characterization in the source. Retained but marked as over-annotated per policy.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare protein binding from a proteome-scale interactome network (IntAct interactor DBT/P11182).
+      Notably DBT (a mitochondrial 2-oxo acid dehydrogenase E2 subunit) is a plausible matrix
+      neighbour, but the annotation itself conveys no specific function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein binding from a high-throughput interactome; uninformative molecular-function
+      term. Retained but marked as over-annotated per policy.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare protein binding from a multimodal cell-map study (IntAct interactor DBT/P11182).
+      Duplicates the DBT interaction and conveys no specific molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein binding from a large-scale mapping resource; uninformative term. Retained but
+      marked as over-annotated per policy.
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759218
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome-curated involvement of MMAB in cobalamin metabolism, reflecting its role in the
+      AdoCbl branch of the intracellular cobalamin trafficking/processing pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Correct biological process, well supported by the enzyme&#39;s characterized role in producing
+      the AdoCbl cofactor from dietary cobalamin.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        Mutations in any of these three proteins lead to isolated methylmalonic aciduria while
+        sparing the MeCbl branch of the trafficking pathway.
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: EXP
+  original_reference_id: PMID:15913339
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (spectroscopic) study of human ATR (MMAB) demonstrating cobalamin binding and the
+      ATP-dependent coordination chemistry that underlies its adenosyltransferase function, forming a
+      four-coordinate Co2+ cobalamin species that raises the redox potential toward the physiological
+      range to enable cob(I)alamin formation prior to adenosylation.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence on the human enzyme for its corrinoid adenosyltransferase
+      mechanism; supports the core molecular function.
+    supported_by:
+    - reference_id: PMID:15913339
+      supporting_text: &gt;-
+        The human adenosyltransferase hATR converts exogenous cobalamin into coenzyme B12 by
+        transferring the adenosyl group from cosubstrate ATP to a transiently formed Co1+cobalamin
+        (Co1+Cbl) species.
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: EXP
+  original_reference_id: PMID:30282455
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental study confirming that human ATR (MMAB) synthesizes AdoCbl by adenosylation of
+      cob(I)alamin by ATP and directly delivers the product to methylmalonyl-CoA mutase; also
+      demonstrates the sacrificial Co-C bond homolysis cofactor-conservation activity.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence on the human enzyme supporting corrinoid adenosyltransferase
+      activity (the AdoCbl-synthesizing reaction).
+    supported_by:
+    - reference_id: PMID:30282455
+      supporting_text: &gt;-
+        AdoCbl is synthesized by adenosyltransferase (ATR), which catalyzes the adenosylation of
+        cob(I)alamin by ATP in a direct nucleophilic displacement reaction that leads to
+        cobalt−carbon (Co−C) bond formation yielding AdoCbl and inorganic triphosphate
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: EXP
+  original_reference_id: PMID:33797888
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Review/primary account (Banerjee lab) describing the human adenosyltransferase (ATR/MMAB)
+      homotrimer that catalyses adenosylation of cob(I)alamin by ATP, with detailed loop-dynamics and
+      redox-linked coordination chemistry underlying the reaction.
+    action: ACCEPT
+    reason: &gt;-
+      Supports the core corrinoid adenosyltransferase activity of the human enzyme.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        ATR, an 81 kDa homotrimer with active sites housed at the subunit interfaces (Fig. 5A),62
+        catalyzes the adenosylation of cob(I)alamin by ATP.
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3322125
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-curated corrinoid adenosyltransferase activity of MMAB, corresponding to the reaction
+      MMAB adenosylates cob(I)alamin. Consistent with all experimental evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function, curated by Reactome and matching the experimental record.
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion
+        of cobalamins into Ado-B12.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput assignment of MMAB to the mitochondrion from a quantitative high-confidence
+      human mitochondrial proteome. Consistent with the transit peptide and matrix function.
+    action: ACCEPT
+    reason: &gt;-
+      Correct compartment, corroborating the UniProt localization and the enzyme&#39;s matrix role.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA),
+        a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the
+        target enzyme, MCM (or Mut)
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:12514191
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence placing MMAB in cobalamin metabolism: the human ATR cDNA
+      complemented an ATR-deficient bacterial mutant and its dysregulation was shown in cblB
+      methylmalonic aciduria cell lines, establishing MMAB as the enzyme performing the terminal
+      conversion of cobalamin to coenzyme B12.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported biological-process annotation from the defining functional study of MMAB.
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        We propose that inborn errors in the human ATR gene identified here result in methylmalonyl
+        aciduria.
+- term:
+    id: GO:0016765
+    label: transferase activity, transferring alkyl or aryl (other than methyl) groups
+  evidence_type: IDA
+  original_reference_id: PMID:12514191
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct evidence that MMAB is a transferase transferring a (non-methyl) alkyl group — the
+      5&#39;-deoxyadenosyl group — but this is a parent term of the specific corrinoid adenosyltransferase
+      activity (GO:0008817 is a subclass of GO:0016765). The specific term is warranted.
+    action: MODIFY
+    reason: &gt;-
+      Correct in essence but too general: the transferred group is specifically the deoxyadenosyl
+      moiety onto cob(I)alamin, which is captured precisely by GO:0008817 corrinoid adenosyltransferase
+      activity (an is-a descendant of GO:0016765). Replace with the specific term.
+    proposed_replacement_terms:
+    - id: GO:0008817
+      label: corrinoid adenosyltransferase activity
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion
+        of cobalamins into Ado-B12.
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: TAS
+  original_reference_id: PMID:28497574
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Traceable author statement placing MMAB in cobalamin metabolism: the paper describes MMAB as the
+      adenosyltransferase that generates AdoCbl for delivery to methylmalonyl-CoA mutase.
+    action: ACCEPT
+    reason: &gt;-
+      Correct biological process; the source explicitly frames MMAB as the AdoCbl-generating enzyme
+      in the mitochondrial cobalamin pathway.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from
+        the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT).
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:28497574
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct evidence that MMAB binds cobalamin (adenosylcobalamin). MMAB binds the cofactor in a
+      base-off state and holds the AdoCbl product prior to hand-off to the mutase; UniProt cites this
+      reference for adenosylcobalamin-binding.
+    action: ACCEPT
+    reason: &gt;-
+      Cobalamin binding is an integral, experimentally supported feature of MMAB&#39;s function as a B12
+      adenosyltransferase and escort.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: &gt;-
+        MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from
+        the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT).
+- term:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:12514191
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental demonstration of corrinoid (cob(I)alamin) adenosyltransferase activity for
+      the human enzyme: recombinant human ATR produced measurable ATR activity and complemented an
+      ATR-deficient bacterial mutant for Ado-B12-dependent growth.
+    action: ACCEPT
+    reason: &gt;-
+      Gold-standard direct assay of the core molecular function on the human protein.
+    supported_by:
+    - reference_id: PMID:12514191
+      supporting_text: &gt;-
+        Enzyme assays showed that expression strains produced 87 and 98 nmol/min/mg ATR activity,
+        respectively.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3322125
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-curated mitochondrial matrix localization for MMAB, the compartment where AdoCbl is
+      synthesized and delivered to methylmalonyl-CoA mutase.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and appropriately specific subcellular location, consistent with the matrix role of the
+      AdoCbl-synthesis/delivery machinery.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA),
+        a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the
+        target enzyme, MCM (or Mut)
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3159253
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-curated mitochondrial matrix localization (from the MMAB adenosylates cob(I)alamin
+      reaction). Duplicate compartment assignment; correct.
+    action: ACCEPT
+    reason: &gt;-
+      Correct specific location; consistent with the enzyme&#39;s matrix function.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        In the matrix, adenosyltransferase (ATR, also known as MMAB or CblB) and CblA (or MMAA),
+        a G-protein chaperone, are recruited for the synthesis and delivery of AdoCbl to the
+        target enzyme, MCM (or Mut)
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IDA
+  original_reference_id: PMID:17176040
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ATP binding is a defining feature of MMAB: it is the adenosyl-donor cosubstrate and ATP binding
+      also organizes the high-affinity cobalamin pocket and gates cofactor delivery to the mutase.
+      The ATP-bound human ATR crystal structure (PDB 2IDX) and UniProt ATP-binding features
+      (residues 60-63, 68-69, 78, 190-194, 214) directly establish this. Present in UniProt (GO:0005524
+      IEA:UniProtKB-KW) but absent from the current GOA TSV, so added here.
+    action: NEW
+    reason: &gt;-
+      Structurally and biochemically established, functionally central molecular function (ATP is the
+      adenosyl donor) that is missing from the GOA set; added with the ATP-bound structure as evidence.
+    supported_by:
+    - reference_id: PMID:33797888
+      supporting_text: &gt;-
+        ATP binding organizes a high affinity cob(II)alamin pocket in human ATR.
+core_functions:
+- description: &gt;-
+    Catalyses the terminal step of adenosylcobalamin (coenzyme B12) synthesis, transferring the
+    5&#39;-deoxyadenosyl group from ATP to reduced cob(I)alamin to produce adenosylcob(III)alamin, and
+    uses ATP as the adenosyl donor.
+  molecular_function:
+    id: GO:0008817
+    label: corrinoid adenosyltransferase activity
+  supported_by:
+  - reference_id: PMID:12514191
+    supporting_text: &gt;-
+      ATP:cob(I)alamin adenosyltransferase (ATR) catalyzes the terminal step in the conversion
+      of cobalamins into Ado-B12.
+  - reference_id: PMID:30282455
+    supporting_text: &gt;-
+      AdoCbl is synthesized by adenosyltransferase (ATR), which catalyzes the adenosylation of
+      cob(I)alamin by ATP in a direct nucleophilic displacement reaction that leads to
+      cobalt−carbon (Co−C) bond formation yielding AdoCbl and inorganic triphosphate
+  directly_involved_in:
+  - id: GO:0009235
+    label: cobalamin metabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+- description: &gt;-
+    Binds cobalamin (in a base-off state) and, in an ATP-dependent manner, holds the AdoCbl product
+    and delivers it directly to methylmalonyl-CoA mutase, functioning as a cobalamin-binding cofactor
+    escort in the mitochondrial matrix.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  supported_by:
+  - reference_id: PMID:30282455
+    supporting_text: &gt;-
+      ATR also delivers the AdoCbl product directly to MCM, thereby averting cofactor loss by
+      release into solution.
+  - reference_id: PMID:28497574
+    supporting_text: &gt;-
+      MMAA regulates the incorporation of the cofactor adenosylcobalamin (AdoCbl), generated from
+      the MMAB adenosyltransferase, into the destination enzyme methylmalonyl-CoA mutase (MUT).
+  directly_involved_in:
+  - id: GO:0009235
+    label: cobalamin metabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:12514191
+  title: Identification of the human and bovine ATP:Cob(I)alamin adenosyltransferase
+    cDNAs based on complementation of a bacterial mutant.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defining functional study of human MMAB/ATR; directly establishes corrinoid adenosyltransferase
+      activity, the AdoCbl-synthesis role, and the link to cblB methylmalonic aciduria. Abstract-only
+      in cache but supporting quotes verified verbatim against the cached record.
+- id: PMID:15913339
+  title: Spectroscopic evidence for the formation of a four-coordinate Co2+ cobalamin
+    species upon binding to the human ATP:cobalamin adenosyltransferase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Spectroscopy of the human ATR mechanism (cobalamin binding, ATP-dependent coordination
+      chemistry); supports the adenosyltransferase activity and cobalamin binding.
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale interactome perturbation study; source of a generic protein-binding IPI (CBY2). Does
+      not characterize MMAB function.
+- id: PMID:28497574
+  title: Protein destabilization and loss of protein-protein interaction are fundamental
+    mechanisms in cblA-type methylmalonic aciduria.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primarily an MMAA (cblA) study, but assays MMAB adenosylcobalamin binding and the MMAB-&gt;MUT
+      AdoCbl transfer; UniProt cites it for MMAB adenosylcobalamin-binding. Abstract-only in cache;
+      supporting quotes verified verbatim.
+- id: PMID:30282455
+  title: Sacrificial Cobalt-Carbon Bond Homolysis in Coenzyme B(12) as a Cofactor
+    Conservation Strategy.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available; directly documents MMAB/ATR AdoCbl synthesis, direct delivery to MCM, and
+      the sacrificial Co-C homolysis cofactor-conservation activity.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale neurodegenerative-disease interactome; source of generic protein-binding IPIs
+      (CALR, DLST, NEK7, OPTN). No functional MMAB characterization.
+- id: PMID:33797888
+  title: Redox-Linked Coordination Chemistry Directs Vitamin B(12) Trafficking.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Authoritative account of the mitochondrial B12 trafficking pathway; describes MMAB/ATR as the
+      homotrimeric adenosyltransferase and escort in the matrix. Full text available; quotes verified.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale interactome; source of a generic protein-binding IPI (DBT). No functional MMAB
+      characterization.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-confidence mitochondrial proteome supporting MMAB mitochondrial localization (HTP).
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Multimodal cell-map resource; source of a generic protein-binding IPI (DBT). No functional MMAB
+      characterization.
+- id: PMID:17176040
+  title: Structure of ATP-bound human ATP:cobalamin adenosyltransferase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure of ATP-bound human MMAB (PDB 2IDX), establishing the homotrimer and ATP
+      binding site; cited by UniProt for ATP-binding features and SUBUNIT. Used to support the NEW
+      ATP binding annotation.
+- id: Reactome:R-HSA-3159253
+  title: MMAB adenosylates cob(I)alamin
+  findings: []
+- id: Reactome:R-HSA-3322125
+  title: Defective MMAB does not transfer adenosyl group from ATP to B12s
+  findings: []
+- id: Reactome:R-HSA-9759218
+  title: Cobalamin (Cbl) metabolism
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/MMUT/MMUT-ai-review.html
+++ b/genes/human/MMUT/MMUT-ai-review.html
@@ -1,0 +1,7311 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MMUT - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MMUT</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P22033" target="_blank" class="term-link">
+                        P22033
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MMUT";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P22033" data-a="DESCRIPTION: Methylmalonyl-CoA mutase (MMUT, formerly MUT; EC 5..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Methylmalonyl-CoA mutase (MMUT, formerly MUT; EC 5.4.99.2) is the mitochondrial matrix adenosylcobalamin (5&#39;-deoxyadenosylcobalamin / coenzyme B12)-dependent enzyme that catalyzes the reversible carbon-skeleton isomerization of (R)-methylmalonyl-CoA (L-methylmalonyl-CoA) to succinyl-CoA. This is the final step of propionyl-CoA catabolism, channeling propionate derived from the breakdown of the amino acids valine, isoleucine, methionine and threonine, from odd-chain fatty acids, and from the cholesterol side chain into the tricarboxylic acid cycle as succinyl-CoA. The active enzyme is a homodimer; each protomer has an N-terminal (beta/alpha)8 TIM-barrel substrate-binding domain and a C-terminal cobalamin-binding domain in which the cobalt of adenosylcobalamin is axially coordinated by a conserved histidine. Catalysis proceeds through reactive radical intermediates generated by homolysis of the cobalt-carbon bond of the cofactor. The apoenzyme is loaded with adenosylcobalamin, and inactive oxidized cofactor is removed and replaced, through a GTP-dependent interaction with the accessory GTPase MMAA (cblA), which acts together with the cobalamin adenosyltransferase MMAB (cblB). Loss of MMUT function causes isolated methylmalonic acidemia/aciduria of the mut type.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) localization to cytoplasm. MMUT is a mitochondrial-matrix enzyme; cytoplasm is a broad, less-informative localization for this protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT is imported into the mitochondrial matrix after cleavage of its N-terminal transit peptide and its activity localizes to the mitochondria; cytoplasm captures at best a minor apoenzyme/import-intermediate pool and is far less precise than the mitochondrial-matrix annotation. The informative localization terms (mitochondrial matrix / mitochondrion) are retained.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the activity of these two enzymes was demonstrated to be in the mitochondria and those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902859" target="_blank" class="term-link">
+                                    GO:1902859
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:1902859" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of MMUT to propionyl-CoA catabolism. This is the correct, non-obsolete biological-process term for MMUT&#39;s role, funneling propionate into the TCA cycle via succinyl-CoA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT catalyzes the terminal step of propionyl-CoA catabolism (methylmalonyl-CoA to succinyl-CoA); this is its core physiological pathway. Note GO:0019678 &#34;propionate metabolic process, methylmalonyl pathway&#34; is now obsolete, so GO:1902859 is the appropriate BP term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                        PMID:25125334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In humans, this reaction represents an important step in propionate catabolism, funneling metabolites from the breakdown of amino acids (valine, isoleucine, methionine, and threonine), odd‐chain fatty acids, and the side chain of cholesterol into the tricarboxylic acid cycle.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the defining molecular function, methylmalonyl-CoA mutase activity. This is the core function of MMUT and is strongly supported experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA agrees with direct human enzyme assays and with the deeply conserved family assignment (EC 5.4.99.2). This is the central catalytic activity of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29056341" target="_blank" class="term-link">
+                                        PMID:29056341
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MUT is a mitochondrial matrix enzyme that uses coenzyme B12 or</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0031419" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of cobalamin binding. MMUT is an adenosylcobalamin-dependent enzyme; cobalamin (B12) binding is an essential cofactor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT requires adenosylcobalamin (AdoCbl) as its cofactor, coordinated in the C-terminal B12-binding domain; the cobalt is axially bound by His627. Cobalamin binding is a core, experimentally supported molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                                        PMID:1978672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent enzyme that catalyses isomerization between methylmalonyl-CoA and succinyl-CoA (3-carboxypropionyl-CoA).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) mitochondrial localization. Consistent with all experimental and predictive evidence that MMUT is a mitochondrial enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT carries a cleavable mitochondrial transit peptide and is active in the mitochondrial matrix; the mitochondrion annotation is correct (matrix is the more precise term, annotated separately).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the activity of these two enzymes was demonstrated to be in the mitochondria and those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of the generic parent term catalytic activity. True but uninformative relative to the specific methylmalonyl-CoA mutase activity annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT is an enzyme, so catalytic activity is correct. It is a broad ancestor of the specific term GO:0004494; retaining it as a valid, non-misleading electronic rollup is acceptable, though it is not core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                        PMID:25125334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment (multiple IEA methods, RHEA:22888 / EC 5.4.99.2) of the defining molecular function. Concordant with direct experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The electronic mapping to methylmalonyl-CoA mutase activity is correct and corroborated by human enzyme assays; this is the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                        PMID:25125334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mitochondrial methylmalonyl‐CoA mutase (MUT, EC 5.4.99.2) catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA, requiring vitamin B12 (cobalamin) in the form of adenosylcobalamin (AdoCbl) as a cofactor.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location keyword mapping to cytoplasm (SL-0086). MMUT is a mitochondrial-matrix enzyme; cytoplasm is imprecise.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytoplasm keyword derives from the UniProt SUBCELLULAR LOCATION statement that lists Cytoplasm alongside Mitochondrion/matrix (from PMID:28943303), but the functional, activity-bearing localization is the mitochondrial matrix. Cytoplasm is a broad, less-informative term for MMUT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the activity of these two enzymes was demonstrated to be in the mitochondria and those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location keyword mapping to mitochondrion (SL-0173). Correct localization for MMUT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT is a mitochondrial protein; the electronic localization is accurate. The mitochondrial matrix annotation is the more precise term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the activity of these two enzymes was demonstrated to be in the mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location keyword mapping to mitochondrial matrix (SL-0170). This is the precise, correct localization of the active enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct fractionation studies localize MMUT activity to the mitochondrial matrix (loosely bound to the inner membrane-matrix compartment); the electronic annotation matches the experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016853" target="_blank" class="term-link">
+                                    GO:0016853
+                                </a>
+                            </span>
+                            <span class="term-label">isomerase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0016853" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of the parent term isomerase activity. True (MMUT is an intramolecular isomerase/mutase) but broad relative to GO:0004494.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT is EC 5.4.99.2, an isomerase; the term is a correct ancestor of the specific methylmalonyl-CoA mutase activity term. Valid non-core electronic rollup.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                        PMID:25125334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016866" target="_blank" class="term-link">
+                                    GO:0016866
+                                </a>
+                            </span>
+                            <span class="term-label">intramolecular transferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0016866" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of intramolecular transferase activity (mutase). Correct intermediate parent of methylmalonyl-CoA mutase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Methylmalonyl-CoA mutase is a carbon-skeleton mutase (intramolecular transfer of the thioester/carboxyl-bearing group), so GO:0016866 is an accurate ancestor of the specific term. Valid non-core electronic rollup.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                        PMID:25125334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0031419" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of cobalamin binding, based on the B12-binding domain signatures. Concordant with the experimental cofactor requirement.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT contains a cobalamin-binding domain and requires adenosylcobalamin; the electronic annotation matches the direct experimental evidence for cofactor binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                                        PMID:1978672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent enzyme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of metal ion binding, reflecting the cobalt ion of the bound adenosylcobalamin cofactor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cofactor adenosylcobalamin contains a cobalt ion that is axially coordinated by His627 of MMUT, so metal (cobalt) ion binding is correct, if broad. It is captured more informatively by cobalamin binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">vitamin B12-dependent methylmalonyl-CoA mutase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:20876572" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (partner MMAA, Q8IVH4). Bare protein binding is uninformative as a molecular function; the biologically meaningful apo-MUT:MMAA interaction is captured by the homodimerization and positive-regulation-of-GTPase annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidance, generic protein binding does not convey a specific molecular function and should not be treated as a core annotation. The underlying MMAA interaction is real and is documented; it is represented more usefully elsewhere.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the two proteins interact in vitro and in vivo</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:28497574" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (partner MMAA, Q8IVH4) from the cblA-type MMA study. Bare protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding is not an informative molecular function. The MUT-MMAA interaction it reflects is documented, but is better represented by the positive-regulation-of-GTPase-activity annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which is stimulated by an interaction with MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (partner HTT/huntingtin, P42858) from a neurodegenerative-disease interactome map. Bare protein binding is uninformative and this is a large-scale network interaction of uncertain physiological relevance to MMUT function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding conveys no specific molecular function. This is a high-throughput interactome/aggregation screen; the interaction does not inform MMUT&#39;s characterized enzymatic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                                        PMID:32814053
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interactome maps are valuable resources to elucidate protein function and disease mechanisms.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (partner CRYZ, Q08257) from a proteome-scale interactome study. Bare protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding is not an informative molecular function. This is a large-scale affinity-purification network dataset; the interaction does not inform MMUT&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These networks model the interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (partner CRYZ, Q08257) from a multimodal cell-map study. Bare protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding conveys no specific molecular function. This is a large-scale mapping dataset; the interaction does not inform MMUT&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0042802" data-r="PMID:20876572" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (self, P22033), reflecting the MMUT homodimer. Real but represented more informatively by protein homodimerization activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT is a homodimer, so self-association is genuine, but identical protein binding is a weaker restatement of the homodimerization annotation; keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">crystallized human MMAA in the GDP-bound form and human MUT in the apo, holo, and substrate-bound ternary forms</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901290" target="_blank" class="term-link">
+                                    GO:1901290
+                                </a>
+                            </span>
+                            <span class="term-label">succinyl-CoA biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:1901290" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of succinyl-CoA biosynthetic process. This is an accurate product-oriented description of the MMUT reaction (MM-CoA to succinyl-CoA).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT produces succinyl-CoA from methylmalonyl-CoA; the term correctly describes the product-forming aspect of its reaction. Complementary to the propionyl-CoA catabolic process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29056341" target="_blank" class="term-link">
+                                        PMID:29056341
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It catalyzes the conversion of methylmalonyl-CoA into succinyl-CoA, which allows recycling of branched carbon chains from amino acids and lipids into the tricarboxylic acid cycle (TCA cycle).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1346616" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1346616
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning and expression of a mutant methylmalonyl coenzyme A ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:1346616" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) demonstration of methylmalonyl-CoA mutase activity via cloning and expression of human MCM and characterization of a cobalamin-affinity mutant. Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This study expressed human MCM and characterized its catalytic behavior (including the G717V mut- mutant with ~1000-fold elevated Km for adenosylcobalamin), directly supporting methylmalonyl-CoA mutase activity as the gene&#39;s function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1346616" target="_blank" class="term-link">
+                                        PMID:1346616
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an apparent Km (adenosylcobalamin) 1,000-fold higher than normal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25125334
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional characterization and categorization of missense m...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:25125334" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) characterization of MUT activity across 23 recombinant patient missense variants, measuring succinate production from methylmalonyl-CoA. Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Wild-type and mutant MUT were assayed for conversion of [14C]methylmalonyl-CoA to [14C]succinate, directly measuring methylmalonyl-CoA mutase activity and its cofactor/substrate kinetics.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                        PMID:25125334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MUT activity was assayed in crude cell lysates by measuring the production of [14C]succinate from [14C]methylmalonyl‐CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29056341" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29056341
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Human Knockout Gene CLYBL Connects Itaconate to Vitamin ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:29056341" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) work using recombinant human MUT reconstituted with coenzyme B12; establishes methylmalonyl-CoA mutase activity and its inhibition by itaconyl-CoA. Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The study characterized recombinant human MUT enzymology (conversion of methylmalonyl-CoA to succinyl-CoA using coenzyme B12) and identified itaconyl-CoA as a cofactor-inactivating inhibitor, directly supporting the mutase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29056341" target="_blank" class="term-link">
+                                        PMID:29056341
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">itaconyl-CoA is a cofactor-inactivating, substrate-analog inhibitor of the mitochondrial B12-dependent methylmalonyl-CoA mutase (MUT)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901290" target="_blank" class="term-link">
+                                    GO:1901290
+                                </a>
+                            </span>
+                            <span class="term-label">succinyl-CoA biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1978672
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure and activity of mouse methylmalonyl-CoA mu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:1901290" data-r="PMID:1978672" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of mutase activity producing succinyl-CoA from methylmalonyl-CoA. Accurate product-oriented description of the MMUT reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Enzyme assays of MCM demonstrated isomerization between methylmalonyl-CoA and succinyl-CoA, supporting involvement in succinyl-CoA biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                                        PMID:1978672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an adenosylcobalamin-dependent enzyme that catalyses isomerization between methylmalonyl-CoA and succinyl-CoA (3-carboxypropionyl-CoA)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (HTP) mitochondrial proteome study placing MMUT among the high-confidence mitochondrial proteins (MitoCoP). Consistent with all other evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT was classified in the &gt;1,100-protein high-confidence human mitochondrial proteome, corroborating its mitochondrial localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">defined a mitochondrial high-confidence proteome of &gt;1,100 proteins (MitoCoP)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3322971
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005759" data-r="Reactome:R-HSA-3322971" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion (TAS) placing MMUT in the mitochondrial matrix (in the context of defective MUT failing to isomerise L-MM-CoA to succinyl-CoA). Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome curates MMUT as a mitochondrial matrix enzyme; consistent with direct fractionation evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1978672
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure and activity of mouse methylmalonyl-CoA mu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:1978672" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of methylmalonyl-CoA mutase activity for the cloned enzyme, with reaction kinetics similar to the human enzyme. Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The enzyme was directly assayed and shown to isomerize methylmalonyl-CoA to succinyl-CoA in an adenosylcobalamin-dependent manner, defining the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                                        PMID:1978672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyses isomerization between methylmalonyl-CoA and succinyl-CoA (3-carboxypropionyl-CoA)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21138732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protection and reactivation of human methylmalonyl-CoA mutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:21138732" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of purified recombinant human MCM catalytic activity (and its protection/reactivation by MMAA). Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Purified recombinant MCM was assayed for its methylmalonyl-CoA mutase reaction kinetics, directly establishing the activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we examined the influence of human MMAA protein on the kinetics of the reaction catalyzed by methylmalonyl-CoA mutase (MCM) by testing both purified recombinant proteins in vitro</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Intracellular localization of hepatic propionyl-CoA carboxyl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:24458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of methylmalonyl-CoA mutase activity in hepatic mitochondrial fractions (a rapid mutase assay was described). Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Methylmalonyl-CoA mutase activity was measured in mitochondrial fractions of human and rat liver, directly supporting the molecular function and its mitochondrial localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a rapid enzymatic assay for methylmalonyl-CoA mutase was described.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2453061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2453061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning of L-methylmalonyl-CoA mutase: gene transf...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:2453061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of MCM activity constituted by gene transfer of the cloned human MCM cDNA into COS cells. Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cells transformed with the human MCM cDNA expressed increased methylmalonyl-CoA mutase enzymatic activity, directly demonstrating the function of the cloned gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2453061" target="_blank" class="term-link">
+                                        PMID:2453061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cells transformed with this clone expressed increased levels of MCM enzymatic activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:28943303" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of recombinant human MCM activity, including altered kinetics in the presence of MMAA/GTP. Core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Recombinant hMCM was assayed for its mutase reaction and cofactor kinetics (Km/Vmax for methylmalonyl-CoA), directly establishing methylmalonyl-CoA mutase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human mitochondrial methylmalonyl-CoA mutase (hMCM) is an isomerase that converts methylmalonyl-CoA to succinyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21138732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protection and reactivation of human methylmalonyl-CoA mutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:21138732" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (partner MMAA, Q8IVH4). MUT-MMAA interaction confirmed by yeast two-hybrid. Bare protein binding is uninformative as an MF.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding is not an informative molecular function. The real MUT-MMAA interaction is documented and is better represented by the positive-regulation-of-GTPase-activity annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interaction between MCM and MMAA observed in vitro was confirmed in vivo by yeast two-hybrid system.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005515" data-r="PMID:28943303" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (partner MMAA, Q8IVH4). Bare protein binding is uninformative as an MF; the MUT-MMAA complex is the biologically meaningful interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding conveys no specific molecular function. The MUT-MMAA complex formation demonstrated here is better captured by the regulatory and localization annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">restores methylmalonyl-CoA mutase activity through their complex formation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005737" data-r="PMID:28943303" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) localization including a cytoplasmic signal in human fibroblasts. MMUT is a mitochondrial-matrix enzyme; cytoplasm is imprecise/over-broad.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This study reported the in vivo localization and colocalization of hMMAA with hMCM in fibroblast mitochondria; the functional pool of MMUT is mitochondrial-matrix. Cytoplasm at best reflects a minor apoenzyme/import-intermediate signal and is a less informative localization than the mitochondrial matrix annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005739" data-r="PMID:28943303" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) mitochondrial localization of hMCM in human fibroblasts. Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Immunolocalization showed hMCM in fibroblast mitochondria (colocalizing with hMMAA), directly supporting the mitochondrial annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the in vivo localization of hMMAA and its colocalization with hMCM in human fibroblasts mitochondria were demonstrated.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Intracellular localization of hepatic propionyl-CoA carboxyl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005759" data-r="PMID:24458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) localization of MMUT activity to the mitochondrial inner-membrane/matrix compartment by subcellular fractionation. Precise, core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> All MMUT activity fractionated with mitochondria and was loosely bound to the inner membrane-matrix portion, directly establishing the mitochondrial-matrix localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1978672
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure and activity of mouse methylmalonyl-CoA mu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0031419" data-r="PMID:1978672" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) establishing adenosylcobalamin dependence/binding (cofactor requirement, Km for adenosylcobalamin). Core cofactor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The enzyme is adenosylcobalamin-dependent with a defined Km for the cofactor, directly supporting cobalamin binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                                        PMID:1978672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent enzyme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21138732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protection and reactivation of human methylmalonyl-CoA mutas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0031419" data-r="PMID:21138732" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of the cobalamin cofactor role, including cofactor oxidation during catalysis and its exchange by MMAA. Core cofactor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The study addressed inactivation due to oxidation of the bound cobalamin and its reactivation by cofactor exchange, directly supporting cobalamin binding by MCM.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                                        PMID:21138732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">some adenosylcobalamin-dependent enzymes suffer inactivation during catalysis due to the oxidation of cobalamin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28943303
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human MMAA induces the release of inactive cofactor and rest...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0031419" data-r="PMID:28943303" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (IDA) of the AdoCbl cofactor role, including OH2Cbl formation and removal/replacement of damaged cofactor. Core cofactor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> hMCM uses adenosylcobalamin (AdoCbl) and its oxidized inactive form (OH2Cbl) is removed via MMAA, directly supporting cobalamin binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                        PMID:28943303
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">employs highly reactive radicals from its cofactor (adenosylcobalamin, AdoCbl)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GO:0003924
+                                </a>
+                            </span>
+                            <span class="term-label">GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0003924" data-r="PMID:20876572" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation of GTPase activity to MMUT. In this paper the demonstrated GTPase is MMAA (the partner protein), whose GTPase activity is modulated by MUT; MUT itself is a B12 mutase with no GTPase domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The abstract explicitly attributes GTPase activity to MMAA (&#34;MMAA exhibits GTPase activity that is modulated by MUT&#34;), and MMUT has no P-loop/GTPase fold, so assigning GTPase activity to MMUT appears to be a mis-attribution of the partner&#39;s activity. However, per curation policy I cannot read the full text to confirm exactly what was assayed for MMUT, so I flag this rather than removing an experimental annotation; if the assignment cannot be substantiated it should be removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMAA exhibits GTPase activity that is modulated by MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0031419" data-r="PMID:20876572" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay/structure (IDA) with adenosylcobalamin bound to MUT (holo and ternary crystal structures), supporting cobalamin binding. Core cofactor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The crystal structures of human MUT were solved in apo, holo, and substrate-bound (ternary) forms with adenosylcobalamin, directly demonstrating cobalamin binding (the cobalt is axially coordinated by His627).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">human MUT in the apo, holo, and substrate-bound ternary forms</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0042802" data-r="PMID:20876572" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA of self-association (MMUT homodimer) from crystallographic subunit analysis. Real but a weaker restatement of homodimerization activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMUT is a homodimer, so identical protein binding is genuine; it duplicates the more informative protein homodimerization activity annotation and is not a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they show substantially different dimeric assembly and interaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
+                                    GO:0042803
+                                </a>
+                            </span>
+                            <span class="term-label">protein homodimerization activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0042803" data-r="PMID:20876572" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA of homodimerization from the human MUT crystal structure. MMUT is an active homodimer; a genuine, structurally supported property.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The human MUT crystal structures establish a homodimeric assembly. This is a real structural property enabling function, but it is ancillary to the core catalytic annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they show substantially different dimeric assembly and interaction, compared with their bacterial counterparts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043547" target="_blank" class="term-link">
+                                    GO:0043547
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20876572
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human GTPase MMAA and vitamin B12-dependen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0043547" data-r="PMID:20876572" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA that MUT modulates (stimulates) the GTPase activity of its partner MMAA. A genuine regulatory role, but ancillary to MMUT&#39;s core catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The apo-MUT:MMAA interaction modulates MMAA&#39;s GTPase activity; this GAP-like regulatory role is documented but is peripheral to MMUT&#39;s core mutase function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                                        PMID:20876572
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMAA exhibits GTPase activity that is modulated by MUT</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043547" target="_blank" class="term-link">
+                                    GO:0043547
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of GTPase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28497574
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein destabilization and loss of protein-protein interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0043547" data-r="PMID:28497574" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA that MUT stimulates MMAA GTPase activity; loss of this stimulation underlies cblA-type MMA. Genuine regulatory role, ancillary to core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MMAA&#39;s GTPase activity is stimulated by interaction with MUT, and disease mutations reduce this stimulation; the regulatory role is supported but is not MMUT&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                                        PMID:28497574
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This function of MMAA depends on its GTPase activity, which is stimulated by an interaction with MUT.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28101778" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28101778
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Eight novel MUT loss-of-function missense mutations in Chine...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:28101778" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP evidence from patient loss-of-function missense mutations that reduce MCM enzymatic activity in a functional assay. Supports the core mutase function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Eight novel MUT missense mutations reduced MCM protein and activity in a permissive assay, genetically implicating MMUT in methylmalonyl-CoA mutase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28101778" target="_blank" class="term-link">
+                                        PMID:28101778
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the MCM activity of the mutations was reduced in a permissive assay.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                                    GO:0004494
+                                </a>
+                            </span>
+                            <span class="term-label">methylmalonyl-CoA mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27167370" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27167370
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular Genetic Characterization of 151 Mut-Type Methylmal...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0004494" data-r="PMID:27167370" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP evidence from a large mut-type MMA patient cohort (110 mutations) showing reduced MUT protein/activity. Supports the core mutase function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Molecular-genetic characterization of 151 mut-type MMA patients links MUT mutations to loss of MUT function (reduced protein and propionate incorporation), supporting methylmalonyl-CoA mutase activity as the gene&#39;s function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27167370" target="_blank" class="term-link">
+                                        PMID:27167370
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Western blot analysis revealed reduced MUT protein for all 34 cell lines (27 mut(0) , seven mut(-) ) tested, suggesting protein instability as a major mechanism of deficiency in mut-type MMA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3159259
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005759" data-r="Reactome:R-HSA-3159259" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMUT in the mitochondrial matrix (MMAA:MUT binds AdoCbl reaction). Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome curates MMUT (and the MMAA:MUT complex) in the mitochondrial matrix, consistent with the experimental localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3322135
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005759" data-r="Reactome:R-HSA-3322135" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMUT in the mitochondrial matrix (Defective MMAA does not protect MUT reaction). Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome consistently curates MMUT in the mitochondrial matrix; consistent with the experimental fractionation evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71010
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005759" data-r="Reactome:R-HSA-71010" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing MMUT in the mitochondrial matrix (MUT isomerises L-MM-CoA to SUCC-CoA reaction). Correct localization for the catalytic step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome curates the MUT-catalyzed isomerization of L-methylmalonyl-CoA to succinyl-CoA in the mitochondrial matrix, matching the experimental localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                                        PMID:24458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">those enzymes were shown to be loosely bound to the inner membrane-matrix portion of the mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050667" target="_blank" class="term-link">
+                                    GO:0050667
+                                </a>
+                            </span>
+                            <span class="term-label">homocysteine metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20031578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0050667" data-r="PMID:20031578" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation derived from a GWAS association of a MUT-locus SNP with plasma homocysteine. The paper itself states MUT&#39;s catalytic activity is &#34;hardly related to homocysteine&#34;; any link is indirect (shared B12 dependence), not a direct molecular role of MMUT in homocysteine metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The association is epidemiological/genetic and, per the authors, only indirectly related to MMUT function (via competition for vitamin B12 between mitochondrial MUT and cytosolic methionine synthase). MMUT does not act on homocysteine or its metabolites, so involvement in homocysteine metabolic process is an over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link">
+                                        PMID:20031578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">While its catalytic activity is hardly related to homocysteine, MUT has frequently been associated with homocysteine metabolism because it is one of three vitamin B 12 dependant enzymes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072341" target="_blank" class="term-link">
+                                    GO:0072341
+                                </a>
+                            </span>
+                            <span class="term-label">modified amino acid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20031578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0072341" data-r="PMID:20031578" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation from the same homocysteine GWAS paper. There is no biochemical demonstration that MMUT binds a modified amino acid; its characterized ligands are methylmalonyl-CoA and adenosylcobalamin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GWAS study did not assay MMUT binding to any modified amino acid; MMUT&#39;s substrate is a CoA thioester and its cofactor is a corrinoid, not a modified amino acid. This molecular-function annotation does not fit the characterized biochemistry.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link">
+                                        PMID:20031578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MUT encodes for the mitochondrial enzyme methylmalonyl-Coa mutase and as such, catalyses the isomeration of methylmalonyl-Coa into succinyl-Coa.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2567699" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2567699
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning of full-length methylmalonyl-CoA mutase from a cDNA ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P22033" data-a="GO:0005739" data-r="PMID:2567699" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion (TAS) of mitochondrial localization; the full-length cDNA cloning identified the N-terminal mitochondrial transit peptide. Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cloning of full-length human MCM defined its mitochondrial-targeting N-terminus (the transit peptide, residues 1-32), supporting mitochondrial localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2567699" target="_blank" class="term-link">
+                                        PMID:2567699
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cloning of full-length methylmalonyl-CoA mutase from a cDNA library using the polymerase chain reaction.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Adenosylcobalamin (coenzyme B12)-dependent methylmalonyl-CoA mutase that catalyzes the reversible isomerization of (R)-methylmalonyl-CoA (L-methylmalonyl-CoA) to succinyl-CoA, the terminal step of propionyl-CoA catabolism, in the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="P22033" data-a="FUNCTION: Adenosylcobalamin (coenzyme B12)-dependent methylm..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004494" target="_blank" class="term-link">
+                            methylmalonyl-CoA mutase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902859" target="_blank" class="term-link">
+                                propionyl-CoA catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                                PMID:25125334
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Mitochondrial methylmalonyl‐CoA mutase (MUT, EC 5.4.99.2) catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA, requiring vitamin B12 (cobalamin) in the form of adenosylcobalamin (AdoCbl) as a cofactor. In humans, this reaction represents an important step in propionate catabolism</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds adenosylcobalamin (vitamin B12) as an essential catalytic cofactor; the cobalt of the corrinoid is axially coordinated by a conserved histidine in the C-terminal cobalamin-binding domain, and homolysis of the cobalt-carbon bond generates the radical intermediates required for isomerization.</h3>
+                <span class="vote-buttons" data-g="P22033" data-a="FUNCTION: Binds adenosylcobalamin (vitamin B12) as an essent..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                                PMID:1978672
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent enzyme that catalyses isomerization between methylmalonyl-CoA and succinyl-CoA</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                                PMID:28943303
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">employs highly reactive radicals from its cofactor (adenosylcobalamin, AdoCbl)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1346616" target="_blank" class="term-link">
+                            PMID:1346616
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning and expression of a mutant methylmalonyl coenzyme A mutase with altered cobalamin affinity that causes mut- methylmalonic aciduria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1978672" target="_blank" class="term-link">
+                            PMID:1978672
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Primary structure and activity of mouse methylmalonyl-CoA mutase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20031578" target="_blank" class="term-link">
+                            PMID:20031578
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma homocysteine in a healthy population: a genome-wide evaluation of 13 974 participants in the Women&#39;s Genome Health Study.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20876572" target="_blank" class="term-link">
+                            PMID:20876572
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of the human GTPase MMAA and vitamin B12-dependent methylmalonyl-CoA mutase and insight into their complex formation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21138732" target="_blank" class="term-link">
+                            PMID:21138732
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protection and reactivation of human methylmalonyl-CoA mutase by MMAA protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24458" target="_blank" class="term-link">
+                            PMID:24458
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Intracellular localization of hepatic propionyl-CoA carboxylase and methylmalonyl-CoA mutase in humans and normal and vitamin B12 deficient rats.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2453061" target="_blank" class="term-link">
+                            PMID:2453061
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular cloning of L-methylmalonyl-CoA mutase: gene transfer and analysis of mut cell lines.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25125334" target="_blank" class="term-link">
+                            PMID:25125334
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional characterization and categorization of missense mutations that cause methylmalonyl-CoA mutase (MUT) deficiency.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2567699" target="_blank" class="term-link">
+                            PMID:2567699
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning of full-length methylmalonyl-CoA mutase from a cDNA library using the polymerase chain reaction.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27167370" target="_blank" class="term-link">
+                            PMID:27167370
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular Genetic Characterization of 151 Mut-Type Methylmalonic Aciduria Patients and Identification of 41 Novel Mutations in MUT.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28101778" target="_blank" class="term-link">
+                            PMID:28101778
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Eight novel MUT loss-of-function missense mutations in Chinese patients with isolated methylmalonic academia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28497574" target="_blank" class="term-link">
+                            PMID:28497574
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protein destabilization and loss of protein-protein interaction are fundamental mechanisms in cblA-type methylmalonic aciduria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28943303" target="_blank" class="term-link">
+                            PMID:28943303
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human MMAA induces the release of inactive cofactor and restores methylmalonyl-CoA mutase activity through their complex formation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29056341" target="_blank" class="term-link">
+                            PMID:29056341
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Human Knockout Gene CLYBL Connects Itaconate to Vitamin B(12).</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3159259
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MMAA:MUT binds AdoCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3322135
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective MMAA does not protect MUT</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3322971
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective MUT does not isomerise L-MM-CoA to SUCC-CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71010
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MUT isomerises L-MM-CoA to SUCC-CoA</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MMUT-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P22033" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mmut-p22033-review-notes">MMUT (P22033) review notes</h1>
+<p>Deep research file <code>MMUT-deep-research-falcon.md</code> did not materialize within the 8-min poll<br />
+window; review grounded in the UniProt record (<code>MMUT-uniprot.txt</code>), seeded GOA<br />
+(<code>MMUT-goa.tsv</code>), cached <code>publications/PMID_*.md</code>, and the disorder KB<br />
+<code>~/repos/dismech/kb/disorders/Methylmalonic_Acidemia.yaml</code>.</p>
+<h2 id="core-biology-well-established">Core biology (well established)</h2>
+<ul>
+<li>MMUT (formerly MUT; UniProt MUTA_HUMAN, EC 5.4.99.2) is the mitochondrial-matrix<br />
+<strong>adenosylcobalamin (AdoCbl / coenzyme B12)-dependent methylmalonyl-CoA mutase</strong>. It<br />
+  catalyses the reversible carbon-skeleton isomerization <strong>(R)-methylmalonyl-CoA<br />
+  (L-methylmalonyl-CoA) &lt;-&gt; succinyl-CoA</strong> (Rhea:RHEA:22888), the final step of<br />
+  propionyl-CoA catabolism [PMID:25125334, PMID:29056341, UniProt CC FUNCTION].</li>
+<li>Physiological direction is left-to-right (MM-CoA -&gt; succinyl-CoA); this funnels<br />
+  propionate derived from Ile/Val/Met/Thr, odd-chain fatty acids, and the cholesterol<br />
+  side chain into the TCA cycle as succinyl-CoA (anaplerosis) [PMID:25125334, PMID:29056341].</li>
+<li><strong>Homodimer</strong> (PDB 2XIJ/2XIQ/3BIC); each protomer has an N-terminal (β/α)8 TIM-barrel<br />
+  substrate-binding domain and a C-terminal B12-binding domain (residues ~614-746). The<br />
+  cofactor Co is axially coordinated by His627 [UniProt FT BINDING 627; PMID:20876572].</li>
+<li>Cofactor delivery / repair: apo-MUT interacts with the <strong>MMAA</strong> GTPase (cblA) in a<br />
+  GTP-dependent manner; MMAA gates loading of AdoCbl (made by <strong>MMAB</strong>, cblB) into MUT<br />
+  and, via GTP hydrolysis, removes/replaces oxidized inactive cofactor (OH2Cbl) formed<br />
+  during catalysis, protecting/reactivating MUT [PMID:20876572, PMID:21138732, PMID:28943303].</li>
+<li>Inhibited by itaconyl-CoA, a suicide substrate analog that inactivates the B12 cofactor<br />
+  (links immunometabolite itaconate / CLYBL loss to functional B12 deficiency)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29056341">PMID:29056341</a>; also inhibited by malyl-CoA [UniProt CC, PMID:40108300].</li>
+<li>Disease: biallelic loss-of-function -&gt; <strong>isolated methylmalonic aciduria/acidemia,<br />
+  mut type (MAMM; MIM 251000)</strong>, mut0 (no residual activity) vs mut- (residual, partly<br />
+  OHCbl-responsive). Distinct from cblA (MMAA) and cblB (MMAB) cofactor-delivery defects<br />
+  [PMID:25125334, PMID:27167370, PMID:28101778; disorder KB].</li>
+</ul>
+<h2 id="annotation-triage-rationale">Annotation triage rationale</h2>
+<ul>
+<li><strong>GO:0004494 methylmalonyl-CoA mutase activity</strong> — core MF. Supported by many EXP/IDA/IMP<br />
+  and IBA/IEA lines. ACCEPT all (duplicates across evidence codes are fine).</li>
+<li><strong>GO:0031419 cobalamin binding</strong> — core MF (AdoCbl cofactor). ACCEPT (IDA + IBA); IEA ACCEPT.</li>
+<li><strong>GO:1902859 propionyl-CoA catabolic process</strong> (IBA) — correct BP; the valid,<br />
+  non-obsolete term for MUT's pathway role (GO:0019678 "propionate metabolic process,<br />
+  methylmalonyl pathway" is now OBSOLETE). ACCEPT; use as core BP.</li>
+<li><strong>GO:1901290 succinyl-CoA biosynthetic process</strong> (IDA PMID:1978672; IEA) — accurate<br />
+  product-oriented description of the same reaction. ACCEPT (IDA); IEA ACCEPT.</li>
+<li><strong>GO:0005759 mitochondrial matrix</strong> (IDA PMID:24458; TAS Reactome; IEA) — correct<br />
+  localization. ACCEPT the experimental/loosest one as core; keep others.</li>
+<li><strong>GO:0005739 mitochondrion</strong> (IBA/IEA/IDA/HTP/TAS) — parent of matrix; ACCEPT.</li>
+<li><strong>GO:0005737 cytoplasm</strong> (IBA/IEA/IDA PMID:28943303) — MUT is matrix; cytoplasm is a<br />
+  broad/less-precise localization (UniProt lists Cytoplasm from PMID:28943303, likely<br />
+  reflecting apoenzyme/import-intermediate pool). MARK_AS_OVER_ANNOTATED (imprecise; matrix<br />
+  is the informative term). Not REMOVE (has an IDA behind it).</li>
+<li><strong>GO:0003824 catalytic activity / GO:0016853 isomerase activity / GO:0016866<br />
+  intramolecular transferase activity</strong> (IEA InterPro) — correct but general ancestors of<br />
+  GO:0004494. Keep (ACCEPT the broad ones as non-misleading IEA rollups; they are valid,<br />
+  just less specific). Per guidance, broad IEAs above a well-supported specific term can be<br />
+  accepted.</li>
+<li><strong>GO:0046872 metal ion binding</strong> (IEA) — MUT binds Co (in AdoCbl). Broad but true. ACCEPT.</li>
+<li><strong>GO:0005515 protein binding</strong> (IPI x7, various partners: MMAA Q8IVH4, HTT P42858,<br />
+  CRYZ Q08257) — bare, uninformative MF. Per policy MARK_AS_OVER_ANNOTATED (do not REMOVE<br />
+  IPIs; do not attach a functional MF label). The biologically meaningful interaction<br />
+  (apo-MUT with MMAA) is captured better elsewhere.</li>
+<li><strong>GO:0042802 identical protein binding / GO:0042803 protein homodimerization activity</strong><br />
+  (IDA PMID:20876572) — MUT is a homodimer; homodimerization is real and structurally<br />
+  supported. ACCEPT homodimerization (informative); identical protein binding is the<br />
+  weaker synonym — KEEP_AS_NON_CORE.</li>
+<li><strong>GO:0003924 GTPase activity</strong> (IDA PMID:20876572) — the GTPase in that paper is <strong>MMAA</strong>,<br />
+  not MUT. MUT has no GTPase activity/domain (no P-loop; it is a B12 mutase). This IDA<br />
+  appears to be a mis-assignment of MMAA's activity to its partner MUT. However, per the<br />
+  do-not-overrule-experimental-IDA policy and inability to read full text to confirm the<br />
+  assay attribution, use UNDECIDED (flag the concern; the abstract explicitly attributes<br />
+  GTPase activity to MMAA and shows it is "modulated by MUT").</li>
+<li><strong>GO:0043547 positive regulation of GTPase activity</strong> (IDA PMID:20876572, PMID:28497574)<br />
+  — MUT (apoenzyme) stimulates MMAA's GTPase activity via their interaction; this is<br />
+  documented (28497574: GTPase activity "stimulated by an interaction with MUT"). ACCEPT<br />
+  as KEEP_AS_NON_CORE (regulatory, not the core catalytic function).</li>
+<li><strong>GO:0050667 homocysteine metabolic process</strong> (IDA PMID:20031578) — this is a GWAS<br />
+  association of a MUT-locus SNP with plasma homocysteine; the paper itself states MUT's<br />
+  "catalytic activity is hardly related to homocysteine." Not a direct molecular role of<br />
+  MUT in homocysteine metabolism. MARK_AS_OVER_ANNOTATED (indirect/associative; not a<br />
+  bona fide involvement). Not REMOVE per policy caution around experimental codes, but the<br />
+  claim is only an epidemiological/mechanistically-indirect link.</li>
+<li><strong>GO:0072341 modified amino acid binding</strong> (IDA PMID:20031578) — same GWAS paper; there<br />
+  is no biochemical demonstration that MUT binds a modified amino acid. The term does not<br />
+  fit MUT's characterized ligands (methylmalonyl-CoA, AdoCbl). MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<h2 id="core_functions-author-supplied-ids-strictly-validated-against-current-godb">core_functions (author-supplied ids — strictly validated against current go.db)</h2>
+<ul>
+<li>MF: GO:0004494 methylmalonyl-CoA mutase activity</li>
+<li>MF (cofactor): GO:0031419 cobalamin binding</li>
+<li>directly_involved_in BP: GO:1902859 propionyl-CoA catabolic process</li>
+<li>location: GO:0005759 mitochondrial matrix</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P22033
+gene_symbol: MMUT
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Methylmalonyl-CoA mutase (MMUT, formerly MUT; EC 5.4.99.2) is the mitochondrial
+  matrix adenosylcobalamin (5&#39;-deoxyadenosylcobalamin / coenzyme B12)-dependent enzyme
+  that catalyzes the reversible carbon-skeleton isomerization of (R)-methylmalonyl-CoA
+  (L-methylmalonyl-CoA) to succinyl-CoA. This is the final step of propionyl-CoA catabolism,
+  channeling propionate derived from the breakdown of the amino acids valine, isoleucine,
+  methionine and threonine, from odd-chain fatty acids, and from the cholesterol side chain
+  into the tricarboxylic acid cycle as succinyl-CoA. The active enzyme is a homodimer;
+  each protomer has an N-terminal (beta/alpha)8 TIM-barrel substrate-binding domain and a
+  C-terminal cobalamin-binding domain in which the cobalt of adenosylcobalamin is axially
+  coordinated by a conserved histidine. Catalysis proceeds through reactive radical
+  intermediates generated by homolysis of the cobalt-carbon bond of the cofactor. The
+  apoenzyme is loaded with adenosylcobalamin, and inactive oxidized cofactor is removed
+  and replaced, through a GTP-dependent interaction with the accessory GTPase MMAA (cblA),
+  which acts together with the cobalamin adenosyltransferase MMAB (cblB). Loss of MMUT
+  function causes isolated methylmalonic acidemia/aciduria of the mut type.
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) localization to cytoplasm. MMUT is a mitochondrial-matrix
+      enzyme; cytoplasm is a broad, less-informative localization for this protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: MMUT is imported into the mitochondrial matrix after cleavage of its N-terminal
+      transit peptide and its activity localizes to the mitochondria; cytoplasm captures at
+      best a minor apoenzyme/import-intermediate pool and is far less precise than the
+      mitochondrial-matrix annotation. The informative localization terms (mitochondrial
+      matrix / mitochondrion) are retained.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - GRANULARITY_MISMATCH
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: All of the activity of these two enzymes was demonstrated to be in
+        the mitochondria and those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:1902859
+    label: propionyl-CoA catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) assignment of MMUT to propionyl-CoA catabolism. This is the
+      correct, non-obsolete biological-process term for MMUT&#39;s role, funneling propionate
+      into the TCA cycle via succinyl-CoA.
+    action: ACCEPT
+    reason: MMUT catalyzes the terminal step of propionyl-CoA catabolism (methylmalonyl-CoA
+      to succinyl-CoA); this is its core physiological pathway. Note GO:0019678 &#34;propionate
+      metabolic process, methylmalonyl pathway&#34; is now obsolete, so GO:1902859 is the
+      appropriate BP term.
+    supported_by:
+    - reference_id: PMID:25125334
+      supporting_text: In humans, this reaction represents an important step in propionate
+        catabolism, funneling metabolites from the breakdown of amino acids (valine,
+        isoleucine, methionine, and threonine), odd‐chain fatty acids, and the side chain
+        of cholesterol into the tricarboxylic acid cycle.
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of the defining molecular function,
+      methylmalonyl-CoA mutase activity. This is the core function of MMUT and is strongly
+      supported experimentally.
+    action: ACCEPT
+    reason: The IBA agrees with direct human enzyme assays and with the deeply conserved
+      family assignment (EC 5.4.99.2). This is the central catalytic activity of the gene.
+    supported_by:
+    - reference_id: PMID:29056341
+      supporting_text: MUT is a mitochondrial matrix enzyme that uses coenzyme B12 or
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of cobalamin binding. MMUT is an
+      adenosylcobalamin-dependent enzyme; cobalamin (B12) binding is an essential cofactor
+      function.
+    action: ACCEPT
+    reason: MMUT requires adenosylcobalamin (AdoCbl) as its cofactor, coordinated in the
+      C-terminal B12-binding domain; the cobalt is axially bound by His627. Cobalamin
+      binding is a core, experimentally supported molecular function.
+    supported_by:
+    - reference_id: PMID:1978672
+      supporting_text: Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent
+        enzyme that catalyses isomerization between methylmalonyl-CoA and succinyl-CoA
+        (3-carboxypropionyl-CoA).
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) mitochondrial localization. Consistent with all
+      experimental and predictive evidence that MMUT is a mitochondrial enzyme.
+    action: ACCEPT
+    reason: MMUT carries a cleavable mitochondrial transit peptide and is active in the
+      mitochondrial matrix; the mitochondrion annotation is correct (matrix is the more
+      precise term, annotated separately).
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: All of the activity of these two enzymes was demonstrated to be in
+        the mitochondria and those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic assignment of the generic parent term catalytic
+      activity. True but uninformative relative to the specific methylmalonyl-CoA mutase
+      activity annotation.
+    action: ACCEPT
+    reason: MMUT is an enzyme, so catalytic activity is correct. It is a broad ancestor of
+      the specific term GO:0004494; retaining it as a valid, non-misleading electronic
+      rollup is acceptable, though it is not core.
+    supported_by:
+    - reference_id: PMID:25125334
+      supporting_text: catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to
+        succinyl‐CoA
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic assignment (multiple IEA methods, RHEA:22888 / EC 5.4.99.2) of the
+      defining molecular function. Concordant with direct experimental evidence.
+    action: ACCEPT
+    reason: The electronic mapping to methylmalonyl-CoA mutase activity is correct and
+      corroborated by human enzyme assays; this is the core function.
+    supported_by:
+    - reference_id: PMID:25125334
+      supporting_text: Mitochondrial methylmalonyl‐CoA mutase (MUT, EC 5.4.99.2) catalyzes
+        the reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA, requiring
+        vitamin B12 (cobalamin) in the form of adenosylcobalamin (AdoCbl) as a cofactor.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt subcellular-location keyword mapping to cytoplasm (SL-0086). MMUT is a
+      mitochondrial-matrix enzyme; cytoplasm is imprecise.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The cytoplasm keyword derives from the UniProt SUBCELLULAR LOCATION statement
+      that lists Cytoplasm alongside Mitochondrion/matrix (from PMID:28943303), but the
+      functional, activity-bearing localization is the mitochondrial matrix. Cytoplasm is a
+      broad, less-informative term for MMUT.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: All of the activity of these two enzymes was demonstrated to be in
+        the mitochondria and those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt subcellular-location keyword mapping to mitochondrion (SL-0173).
+      Correct localization for MMUT.
+    action: ACCEPT
+    reason: MMUT is a mitochondrial protein; the electronic localization is accurate. The
+      mitochondrial matrix annotation is the more precise term.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: All of the activity of these two enzymes was demonstrated to be in
+        the mitochondria
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt subcellular-location keyword mapping to mitochondrial matrix
+      (SL-0170). This is the precise, correct localization of the active enzyme.
+    action: ACCEPT
+    reason: Direct fractionation studies localize MMUT activity to the mitochondrial matrix
+      (loosely bound to the inner membrane-matrix compartment); the electronic annotation
+      matches the experimental evidence.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0016853
+    label: isomerase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic assignment of the parent term isomerase activity. True
+      (MMUT is an intramolecular isomerase/mutase) but broad relative to GO:0004494.
+    action: ACCEPT
+    reason: MMUT is EC 5.4.99.2, an isomerase; the term is a correct ancestor of the
+      specific methylmalonyl-CoA mutase activity term. Valid non-core electronic rollup.
+    supported_by:
+    - reference_id: PMID:25125334
+      supporting_text: catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to
+        succinyl‐CoA
+- term:
+    id: GO:0016866
+    label: intramolecular transferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic assignment of intramolecular transferase activity
+      (mutase). Correct intermediate parent of methylmalonyl-CoA mutase activity.
+    action: ACCEPT
+    reason: Methylmalonyl-CoA mutase is a carbon-skeleton mutase (intramolecular transfer
+      of the thioester/carboxyl-bearing group), so GO:0016866 is an accurate ancestor of
+      the specific term. Valid non-core electronic rollup.
+    supported_by:
+    - reference_id: PMID:25125334
+      supporting_text: catalyzes the reversible isomerisation of l‐methylmalonyl‐CoA to
+        succinyl‐CoA
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic assignment of cobalamin binding, based on the B12-binding
+      domain signatures. Concordant with the experimental cofactor requirement.
+    action: ACCEPT
+    reason: MMUT contains a cobalamin-binding domain and requires adenosylcobalamin; the
+      electronic annotation matches the direct experimental evidence for cofactor binding.
+    supported_by:
+    - reference_id: PMID:1978672
+      supporting_text: Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent
+        enzyme
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic assignment of metal ion binding, reflecting the cobalt
+      ion of the bound adenosylcobalamin cofactor.
+    action: ACCEPT
+    reason: The cofactor adenosylcobalamin contains a cobalt ion that is axially
+      coordinated by His627 of MMUT, so metal (cobalt) ion binding is correct, if broad. It
+      is captured more informatively by cobalamin binding.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: vitamin B12-dependent methylmalonyl-CoA mutase
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: IntAct IPI (partner MMAA, Q8IVH4). Bare protein binding is uninformative as a
+      molecular function; the biologically meaningful apo-MUT:MMAA interaction is captured
+      by the homodimerization and positive-regulation-of-GTPase annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per curation guidance, generic protein binding does not convey a specific
+      molecular function and should not be treated as a core annotation. The underlying
+      MMAA interaction is real and is documented; it is represented more usefully elsewhere.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: the two proteins interact in vitro and in vivo
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28497574
+  qualifier: enables
+  review:
+    summary: IntAct IPI (partner MMAA, Q8IVH4) from the cblA-type MMA study. Bare protein
+      binding is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding is not an informative molecular function. The MUT-MMAA
+      interaction it reflects is documented, but is better represented by the
+      positive-regulation-of-GTPase-activity annotation.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: which is stimulated by an interaction with MUT
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: IntAct IPI (partner HTT/huntingtin, P42858) from a neurodegenerative-disease
+      interactome map. Bare protein binding is uninformative and this is a large-scale
+      network interaction of uncertain physiological relevance to MMUT function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding conveys no specific molecular function. This is a
+      high-throughput interactome/aggregation screen; the interaction does not inform
+      MMUT&#39;s characterized enzymatic role.
+    supported_by:
+    - reference_id: PMID:32814053
+      supporting_text: Interactome maps are valuable resources to elucidate protein
+        function and disease mechanisms.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IntAct IPI (partner CRYZ, Q08257) from a proteome-scale interactome study.
+      Bare protein binding is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding is not an informative molecular function. This is a
+      large-scale affinity-purification network dataset; the interaction does not inform
+      MMUT&#39;s core function.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: These networks model the interactome
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: IntAct IPI (partner CRYZ, Q08257) from a multimodal cell-map study. Bare
+      protein binding is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding conveys no specific molecular function. This is a
+      large-scale mapping dataset; the interaction does not inform MMUT&#39;s core function.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: Multimodal cell maps as a foundation for structural and functional
+        genomics.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: IntAct IPI (self, P22033), reflecting the MMUT homodimer. Real but represented
+      more informatively by protein homodimerization activity.
+    action: KEEP_AS_NON_CORE
+    reason: MMUT is a homodimer, so self-association is genuine, but identical protein
+      binding is a weaker restatement of the homodimerization annotation; keep as non-core.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: crystallized human MMAA in the GDP-bound form and human MUT in the
+        apo, holo, and substrate-bound ternary forms
+- term:
+    id: GO:1901290
+    label: succinyl-CoA biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic assignment of succinyl-CoA biosynthetic process. This is an
+      accurate product-oriented description of the MMUT reaction (MM-CoA to succinyl-CoA).
+    action: ACCEPT
+    reason: MMUT produces succinyl-CoA from methylmalonyl-CoA; the term correctly describes
+      the product-forming aspect of its reaction. Complementary to the propionyl-CoA
+      catabolic process annotation.
+    supported_by:
+    - reference_id: PMID:29056341
+      supporting_text: It catalyzes the conversion of methylmalonyl-CoA into succinyl-CoA,
+        which allows recycling of branched carbon chains from amino acids and lipids into
+        the tricarboxylic acid cycle (TCA cycle).
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: EXP
+  original_reference_id: PMID:1346616
+  qualifier: enables
+  review:
+    summary: Experimental (EXP) demonstration of methylmalonyl-CoA mutase activity via
+      cloning and expression of human MCM and characterization of a cobalamin-affinity
+      mutant. Core function.
+    action: ACCEPT
+    reason: This study expressed human MCM and characterized its catalytic behavior
+      (including the G717V mut- mutant with ~1000-fold elevated Km for adenosylcobalamin),
+      directly supporting methylmalonyl-CoA mutase activity as the gene&#39;s function.
+    supported_by:
+    - reference_id: PMID:1346616
+      supporting_text: an apparent Km (adenosylcobalamin) 1,000-fold higher than normal
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: EXP
+  original_reference_id: PMID:25125334
+  qualifier: enables
+  review:
+    summary: Experimental (EXP) characterization of MUT activity across 23 recombinant
+      patient missense variants, measuring succinate production from methylmalonyl-CoA.
+      Core function.
+    action: ACCEPT
+    reason: Wild-type and mutant MUT were assayed for conversion of [14C]methylmalonyl-CoA
+      to [14C]succinate, directly measuring methylmalonyl-CoA mutase activity and its
+      cofactor/substrate kinetics.
+    supported_by:
+    - reference_id: PMID:25125334
+      supporting_text: MUT activity was assayed in crude cell lysates by measuring the
+        production of [14C]succinate from [14C]methylmalonyl‐CoA
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: EXP
+  original_reference_id: PMID:29056341
+  qualifier: enables
+  review:
+    summary: Experimental (EXP) work using recombinant human MUT reconstituted with coenzyme
+      B12; establishes methylmalonyl-CoA mutase activity and its inhibition by itaconyl-CoA.
+      Core function.
+    action: ACCEPT
+    reason: The study characterized recombinant human MUT enzymology (conversion of
+      methylmalonyl-CoA to succinyl-CoA using coenzyme B12) and identified itaconyl-CoA as
+      a cofactor-inactivating inhibitor, directly supporting the mutase activity.
+    supported_by:
+    - reference_id: PMID:29056341
+      supporting_text: itaconyl-CoA is a cofactor-inactivating, substrate-analog inhibitor
+        of the mitochondrial B12-dependent methylmalonyl-CoA mutase (MUT)
+- term:
+    id: GO:1901290
+    label: succinyl-CoA biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:1978672
+  qualifier: involved_in
+  review:
+    summary: Direct assay (IDA) of mutase activity producing succinyl-CoA from
+      methylmalonyl-CoA. Accurate product-oriented description of the MMUT reaction.
+    action: ACCEPT
+    reason: Enzyme assays of MCM demonstrated isomerization between methylmalonyl-CoA and
+      succinyl-CoA, supporting involvement in succinyl-CoA biosynthesis.
+    supported_by:
+    - reference_id: PMID:1978672
+      supporting_text: an adenosylcobalamin-dependent enzyme that catalyses isomerization
+        between methylmalonyl-CoA and succinyl-CoA (3-carboxypropionyl-CoA)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: High-throughput (HTP) mitochondrial proteome study placing MMUT among the
+      high-confidence mitochondrial proteins (MitoCoP). Consistent with all other evidence.
+    action: ACCEPT
+    reason: MMUT was classified in the &gt;1,100-protein high-confidence human mitochondrial
+      proteome, corroborating its mitochondrial localization.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: defined a mitochondrial high-confidence proteome of &gt;1,100 proteins
+        (MitoCoP)
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3322971
+  qualifier: located_in
+  review:
+    summary: Reactome traceable assertion (TAS) placing MMUT in the mitochondrial matrix
+      (in the context of defective MUT failing to isomerise L-MM-CoA to succinyl-CoA).
+      Correct localization.
+    action: ACCEPT
+    reason: Reactome curates MMUT as a mitochondrial matrix enzyme; consistent with direct
+      fractionation evidence.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:1978672
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of methylmalonyl-CoA mutase activity for the cloned enzyme,
+      with reaction kinetics similar to the human enzyme. Core function.
+    action: ACCEPT
+    reason: The enzyme was directly assayed and shown to isomerize methylmalonyl-CoA to
+      succinyl-CoA in an adenosylcobalamin-dependent manner, defining the core molecular
+      function.
+    supported_by:
+    - reference_id: PMID:1978672
+      supporting_text: catalyses isomerization between methylmalonyl-CoA and succinyl-CoA
+        (3-carboxypropionyl-CoA)
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:21138732
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of purified recombinant human MCM catalytic activity (and
+      its protection/reactivation by MMAA). Core function.
+    action: ACCEPT
+    reason: Purified recombinant MCM was assayed for its methylmalonyl-CoA mutase reaction
+      kinetics, directly establishing the activity.
+    supported_by:
+    - reference_id: PMID:21138732
+      supporting_text: we examined the influence of human MMAA protein on the kinetics of
+        the reaction catalyzed by methylmalonyl-CoA mutase (MCM) by testing both purified
+        recombinant proteins in vitro
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:24458
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of methylmalonyl-CoA mutase activity in hepatic
+      mitochondrial fractions (a rapid mutase assay was described). Core function.
+    action: ACCEPT
+    reason: Methylmalonyl-CoA mutase activity was measured in mitochondrial fractions of
+      human and rat liver, directly supporting the molecular function and its mitochondrial
+      localization.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: a rapid enzymatic assay for methylmalonyl-CoA mutase was described.
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:2453061
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of MCM activity constituted by gene transfer of the cloned
+      human MCM cDNA into COS cells. Core function.
+    action: ACCEPT
+    reason: Cells transformed with the human MCM cDNA expressed increased methylmalonyl-CoA
+      mutase enzymatic activity, directly demonstrating the function of the cloned gene.
+    supported_by:
+    - reference_id: PMID:2453061
+      supporting_text: Cells transformed with this clone expressed increased levels of MCM
+        enzymatic activity.
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of recombinant human MCM activity, including altered
+      kinetics in the presence of MMAA/GTP. Core function.
+    action: ACCEPT
+    reason: Recombinant hMCM was assayed for its mutase reaction and cofactor kinetics
+      (Km/Vmax for methylmalonyl-CoA), directly establishing methylmalonyl-CoA mutase
+      activity.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: Human mitochondrial methylmalonyl-CoA mutase (hMCM) is an isomerase
+        that converts methylmalonyl-CoA to succinyl-CoA
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21138732
+  qualifier: enables
+  review:
+    summary: IPI (partner MMAA, Q8IVH4). MUT-MMAA interaction confirmed by yeast two-hybrid.
+      Bare protein binding is uninformative as an MF.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding is not an informative molecular function. The real
+      MUT-MMAA interaction is documented and is better represented by the
+      positive-regulation-of-GTPase-activity annotation.
+    supported_by:
+    - reference_id: PMID:21138732
+      supporting_text: Interaction between MCM and MMAA observed in vitro was confirmed in
+        vivo by yeast two-hybrid system.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28943303
+  qualifier: enables
+  review:
+    summary: IPI (partner MMAA, Q8IVH4). Bare protein binding is uninformative as an MF; the
+      MUT-MMAA complex is the biologically meaningful interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding conveys no specific molecular function. The MUT-MMAA
+      complex formation demonstrated here is better captured by the regulatory and
+      localization annotations.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: restores methylmalonyl-CoA mutase activity through their complex
+        formation
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: located_in
+  review:
+    summary: Direct-assay (IDA) localization including a cytoplasmic signal in human
+      fibroblasts. MMUT is a mitochondrial-matrix enzyme; cytoplasm is imprecise/over-broad.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This study reported the in vivo localization and colocalization of hMMAA with
+      hMCM in fibroblast mitochondria; the functional pool of MMUT is mitochondrial-matrix.
+      Cytoplasm at best reflects a minor apoenzyme/import-intermediate signal and is a less
+      informative localization than the mitochondrial matrix annotation.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: the in vivo localization of hMMAA and its colocalization with hMCM in
+        human fibroblasts mitochondria were demonstrated.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: located_in
+  review:
+    summary: Direct-assay (IDA) mitochondrial localization of hMCM in human fibroblasts.
+      Correct localization.
+    action: ACCEPT
+    reason: Immunolocalization showed hMCM in fibroblast mitochondria (colocalizing with
+      hMMAA), directly supporting the mitochondrial annotation.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: the in vivo localization of hMMAA and its colocalization with hMCM in
+        human fibroblasts mitochondria were demonstrated.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:24458
+  qualifier: located_in
+  review:
+    summary: Direct-assay (IDA) localization of MMUT activity to the mitochondrial
+      inner-membrane/matrix compartment by subcellular fractionation. Precise, core
+      localization.
+    action: ACCEPT
+    reason: All MMUT activity fractionated with mitochondria and was loosely bound to the
+      inner membrane-matrix portion, directly establishing the mitochondrial-matrix
+      localization.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:1978672
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) establishing adenosylcobalamin dependence/binding (cofactor
+      requirement, Km for adenosylcobalamin). Core cofactor function.
+    action: ACCEPT
+    reason: The enzyme is adenosylcobalamin-dependent with a defined Km for the cofactor,
+      directly supporting cobalamin binding.
+    supported_by:
+    - reference_id: PMID:1978672
+      supporting_text: Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent
+        enzyme
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:21138732
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of the cobalamin cofactor role, including cofactor oxidation
+      during catalysis and its exchange by MMAA. Core cofactor function.
+    action: ACCEPT
+    reason: The study addressed inactivation due to oxidation of the bound cobalamin and its
+      reactivation by cofactor exchange, directly supporting cobalamin binding by MCM.
+    supported_by:
+    - reference_id: PMID:21138732
+      supporting_text: some adenosylcobalamin-dependent enzymes suffer inactivation during
+        catalysis due to the oxidation of cobalamin
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:28943303
+  qualifier: enables
+  review:
+    summary: Direct assay (IDA) of the AdoCbl cofactor role, including OH2Cbl formation and
+      removal/replacement of damaged cofactor. Core cofactor function.
+    action: ACCEPT
+    reason: hMCM uses adenosylcobalamin (AdoCbl) and its oxidized inactive form (OH2Cbl) is
+      removed via MMAA, directly supporting cobalamin binding.
+    supported_by:
+    - reference_id: PMID:28943303
+      supporting_text: employs highly reactive radicals from its cofactor (adenosylcobalamin,
+        AdoCbl)
+- term:
+    id: GO:0003924
+    label: GTPase activity
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: IDA annotation of GTPase activity to MMUT. In this paper the demonstrated GTPase
+      is MMAA (the partner protein), whose GTPase activity is modulated by MUT; MUT itself
+      is a B12 mutase with no GTPase domain.
+    action: UNDECIDED
+    reason: The abstract explicitly attributes GTPase activity to MMAA (&#34;MMAA exhibits GTPase
+      activity that is modulated by MUT&#34;), and MMUT has no P-loop/GTPase fold, so assigning
+      GTPase activity to MMUT appears to be a mis-attribution of the partner&#39;s activity.
+      However, per curation policy I cannot read the full text to confirm exactly what was
+      assayed for MMUT, so I flag this rather than removing an experimental annotation; if
+      the assignment cannot be substantiated it should be removed.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: MMAA exhibits GTPase activity that is modulated by MUT
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: Direct assay/structure (IDA) with adenosylcobalamin bound to MUT (holo and
+      ternary crystal structures), supporting cobalamin binding. Core cofactor function.
+    action: ACCEPT
+    reason: The crystal structures of human MUT were solved in apo, holo, and
+      substrate-bound (ternary) forms with adenosylcobalamin, directly demonstrating
+      cobalamin binding (the cobalt is axially coordinated by His627).
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: human MUT in the apo, holo, and substrate-bound ternary forms
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: IDA of self-association (MMUT homodimer) from crystallographic subunit analysis.
+      Real but a weaker restatement of homodimerization activity.
+    action: KEEP_AS_NON_CORE
+    reason: MMUT is a homodimer, so identical protein binding is genuine; it duplicates the
+      more informative protein homodimerization activity annotation and is not a core
+      function.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: they show substantially different dimeric assembly and interaction
+- term:
+    id: GO:0042803
+    label: protein homodimerization activity
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: enables
+  review:
+    summary: IDA of homodimerization from the human MUT crystal structure. MMUT is an active
+      homodimer; a genuine, structurally supported property.
+    action: KEEP_AS_NON_CORE
+    reason: The human MUT crystal structures establish a homodimeric assembly. This is a real
+      structural property enabling function, but it is ancillary to the core catalytic
+      annotation.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: they show substantially different dimeric assembly and interaction,
+        compared with their bacterial counterparts
+- term:
+    id: GO:0043547
+    label: positive regulation of GTPase activity
+  evidence_type: IDA
+  original_reference_id: PMID:20876572
+  qualifier: involved_in
+  review:
+    summary: IDA that MUT modulates (stimulates) the GTPase activity of its partner MMAA.
+      A genuine regulatory role, but ancillary to MMUT&#39;s core catalytic function.
+    action: KEEP_AS_NON_CORE
+    reason: The apo-MUT:MMAA interaction modulates MMAA&#39;s GTPase activity; this GAP-like
+      regulatory role is documented but is peripheral to MMUT&#39;s core mutase function.
+    supported_by:
+    - reference_id: PMID:20876572
+      supporting_text: MMAA exhibits GTPase activity that is modulated by MUT
+- term:
+    id: GO:0043547
+    label: positive regulation of GTPase activity
+  evidence_type: IDA
+  original_reference_id: PMID:28497574
+  qualifier: involved_in
+  review:
+    summary: IDA that MUT stimulates MMAA GTPase activity; loss of this stimulation underlies
+      cblA-type MMA. Genuine regulatory role, ancillary to core function.
+    action: KEEP_AS_NON_CORE
+    reason: MMAA&#39;s GTPase activity is stimulated by interaction with MUT, and disease
+      mutations reduce this stimulation; the regulatory role is supported but is not MMUT&#39;s
+      core function.
+    supported_by:
+    - reference_id: PMID:28497574
+      supporting_text: This function of MMAA depends on its GTPase activity, which is
+        stimulated by an interaction with MUT.
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IMP
+  original_reference_id: PMID:28101778
+  qualifier: enables
+  review:
+    summary: IMP evidence from patient loss-of-function missense mutations that reduce MCM
+      enzymatic activity in a functional assay. Supports the core mutase function.
+    action: ACCEPT
+    reason: Eight novel MUT missense mutations reduced MCM protein and activity in a
+      permissive assay, genetically implicating MMUT in methylmalonyl-CoA mutase activity.
+    supported_by:
+    - reference_id: PMID:28101778
+      supporting_text: the MCM activity of the mutations was reduced in a permissive assay.
+- term:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  evidence_type: IMP
+  original_reference_id: PMID:27167370
+  qualifier: enables
+  review:
+    summary: IMP evidence from a large mut-type MMA patient cohort (110 mutations) showing
+      reduced MUT protein/activity. Supports the core mutase function.
+    action: ACCEPT
+    reason: Molecular-genetic characterization of 151 mut-type MMA patients links MUT
+      mutations to loss of MUT function (reduced protein and propionate incorporation),
+      supporting methylmalonyl-CoA mutase activity as the gene&#39;s function.
+    supported_by:
+    - reference_id: PMID:27167370
+      supporting_text: Western blot analysis revealed reduced MUT protein for all 34 cell
+        lines (27 mut(0) , seven mut(-) ) tested, suggesting protein instability as a major
+        mechanism of deficiency in mut-type MMA.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3159259
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing MMUT in the mitochondrial matrix (MMAA:MUT binds AdoCbl
+      reaction). Correct localization.
+    action: ACCEPT
+    reason: Reactome curates MMUT (and the MMAA:MUT complex) in the mitochondrial matrix,
+      consistent with the experimental localization.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3322135
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing MMUT in the mitochondrial matrix (Defective MMAA does not
+      protect MUT reaction). Correct localization.
+    action: ACCEPT
+    reason: Reactome consistently curates MMUT in the mitochondrial matrix; consistent with
+      the experimental fractionation evidence.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71010
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing MMUT in the mitochondrial matrix (MUT isomerises L-MM-CoA
+      to SUCC-CoA reaction). Correct localization for the catalytic step.
+    action: ACCEPT
+    reason: Reactome curates the MUT-catalyzed isomerization of L-methylmalonyl-CoA to
+      succinyl-CoA in the mitochondrial matrix, matching the experimental localization.
+    supported_by:
+    - reference_id: PMID:24458
+      supporting_text: those enzymes were shown to be loosely bound to the inner
+        membrane-matrix portion of the mitochondria.
+- term:
+    id: GO:0050667
+    label: homocysteine metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:20031578
+  qualifier: involved_in
+  review:
+    summary: Annotation derived from a GWAS association of a MUT-locus SNP with plasma
+      homocysteine. The paper itself states MUT&#39;s catalytic activity is &#34;hardly related to
+      homocysteine&#34;; any link is indirect (shared B12 dependence), not a direct molecular
+      role of MMUT in homocysteine metabolism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The association is epidemiological/genetic and, per the authors, only indirectly
+      related to MMUT function (via competition for vitamin B12 between mitochondrial MUT and
+      cytosolic methionine synthase). MMUT does not act on homocysteine or its metabolites,
+      so involvement in homocysteine metabolic process is an over-annotation.
+    supported_by:
+    - reference_id: PMID:20031578
+      supporting_text: While its catalytic activity is hardly related to homocysteine, MUT
+        has frequently been associated with homocysteine metabolism because it is one of
+        three vitamin B 12 dependant enzymes
+- term:
+    id: GO:0072341
+    label: modified amino acid binding
+  evidence_type: IDA
+  original_reference_id: PMID:20031578
+  qualifier: enables
+  review:
+    summary: Annotation from the same homocysteine GWAS paper. There is no biochemical
+      demonstration that MMUT binds a modified amino acid; its characterized ligands are
+      methylmalonyl-CoA and adenosylcobalamin.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The GWAS study did not assay MMUT binding to any modified amino acid; MMUT&#39;s
+      substrate is a CoA thioester and its cofactor is a corrinoid, not a modified amino
+      acid. This molecular-function annotation does not fit the characterized biochemistry.
+    supported_by:
+    - reference_id: PMID:20031578
+      supporting_text: MUT encodes for the mitochondrial enzyme methylmalonyl-Coa mutase and
+        as such, catalyses the isomeration of methylmalonyl-Coa into succinyl-Coa.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: TAS
+  original_reference_id: PMID:2567699
+  qualifier: located_in
+  review:
+    summary: Traceable assertion (TAS) of mitochondrial localization; the full-length cDNA
+      cloning identified the N-terminal mitochondrial transit peptide. Correct localization.
+    action: ACCEPT
+    reason: The cloning of full-length human MCM defined its mitochondrial-targeting
+      N-terminus (the transit peptide, residues 1-32), supporting mitochondrial
+      localization.
+    supported_by:
+    - reference_id: PMID:2567699
+      supporting_text: Cloning of full-length methylmalonyl-CoA mutase from a cDNA library
+        using the polymerase chain reaction.
+core_functions:
+- description: Adenosylcobalamin (coenzyme B12)-dependent methylmalonyl-CoA mutase that
+    catalyzes the reversible isomerization of (R)-methylmalonyl-CoA (L-methylmalonyl-CoA) to
+    succinyl-CoA, the terminal step of propionyl-CoA catabolism, in the mitochondrial matrix.
+  molecular_function:
+    id: GO:0004494
+    label: methylmalonyl-CoA mutase activity
+  directly_involved_in:
+  - id: GO:1902859
+    label: propionyl-CoA catabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:25125334
+    supporting_text: Mitochondrial methylmalonyl‐CoA mutase (MUT, EC 5.4.99.2) catalyzes the
+      reversible isomerisation of l‐methylmalonyl‐CoA to succinyl‐CoA, requiring vitamin B12
+      (cobalamin) in the form of adenosylcobalamin (AdoCbl) as a cofactor. In humans, this
+      reaction represents an important step in propionate catabolism
+- description: Binds adenosylcobalamin (vitamin B12) as an essential catalytic cofactor; the
+    cobalt of the corrinoid is axially coordinated by a conserved histidine in the
+    C-terminal cobalamin-binding domain, and homolysis of the cobalt-carbon bond generates
+    the radical intermediates required for isomerization.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:1978672
+    supporting_text: Methylmalonyl-CoA mutase (MCM) is an adenosylcobalamin-dependent enzyme
+      that catalyses isomerization between methylmalonyl-CoA and succinyl-CoA
+  - reference_id: PMID:28943303
+    supporting_text: employs highly reactive radicals from its cofactor (adenosylcobalamin,
+      AdoCbl)
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:1346616
+  title: Cloning and expression of a mutant methylmalonyl coenzyme A mutase with altered cobalamin
+    affinity that causes mut- methylmalonic aciduria.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Human MCM expressed and assayed; characterizes the G717V mut- variant with
+      ~1000-fold elevated Km for adenosylcobalamin. Supports mutase activity and cofactor
+      binding.
+- id: PMID:1978672
+  title: Primary structure and activity of mouse methylmalonyl-CoA mutase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Establishes MCM as an adenosylcobalamin-dependent isomerase (MM-CoA to
+      succinyl-CoA); mouse enzyme is 94% identical to human and complements human deficiency.
+- id: PMID:20031578
+  title: &#39;Novel associations of CPS1, MUT, NOX4, and DPEP1 with plasma homocysteine in a healthy
+    population: a genome-wide evaluation of 13 974 participants in the Women&#39;&#39;s Genome Health
+    Study.&#39;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: MISCITED
+    review_notes: A GWAS associating a MUT-locus SNP with plasma homocysteine. The paper itself
+      states MUT&#39;s catalytic activity is &#34;hardly related to homocysteine&#34;; it does not support
+      direct involvement of MMUT in homocysteine metabolic process or binding of a modified
+      amino acid, so the IDA annotations to GO:0050667 and GO:0072341 are over-interpretations.
+- id: PMID:20876572
+  title: Structures of the human GTPase MMAA and vitamin B12-dependent methylmalonyl-CoA mutase
+    and insight into their complex formation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Crystal structures of human MUT (apo/holo/ternary with AdoCbl and malonyl-CoA)
+      and MMAA; MUT is a homodimer and forms a GTP-dependent complex with MMAA. Note the GTPase
+      activity characterized is MMAA&#39;s (modulated by MUT), not MUT&#39;s own activity.
+- id: PMID:21138732
+  title: Protection and reactivation of human methylmalonyl-CoA mutase by MMAA protein.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: In vitro assays of purified recombinant hMCM and hMMAA; MMAA protects/reactivates
+      MCM by cofactor exchange via GTP hydrolysis. Supports mutase activity, cobalamin binding,
+      and the MMAA interaction.
+- id: PMID:24458
+  title: Intracellular localization of hepatic propionyl-CoA carboxylase and methylmalonyl-CoA
+    mutase in humans and normal and vitamin B12 deficient rats.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Subcellular fractionation localizes all MCM activity to the mitochondria,
+      loosely bound to the inner membrane-matrix compartment. Supports mitochondrial-matrix
+      localization and mutase activity.
+- id: PMID:2453061
+  title: &#39;Molecular cloning of L-methylmalonyl-CoA mutase: gene transfer and analysis of mut
+    cell lines.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cloning of human MCM cDNA; gene transfer into COS cells constitutes increased
+      MCM enzymatic activity. Supports the identity and mutase activity of the gene product.
+- id: PMID:25125334
+  title: Functional characterization and categorization of missense mutations that cause methylmalonyl-CoA
+    mutase (MUT) deficiency.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full text available; comprehensive enzymology of 23 recombinant MUT variants
+      (activity, thermostability, Km for AdoCbl and MM-CoA). Excellent verbatim support for
+      the core mutase function, cofactor requirement, and propionate-catabolism context.
+- id: PMID:2567699
+  title: Cloning of full-length methylmalonyl-CoA mutase from a cDNA library using the polymerase
+    chain reaction.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Full-length cloning that defined the N-terminal mitochondrial transit peptide;
+      basis of the TAS mitochondrial localization.
+- id: PMID:27167370
+  title: Molecular Genetic Characterization of 151 Mut-Type Methylmalonic Aciduria Patients
+    and Identification of 41 Novel Mutations in MUT.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Large mut-type MMA cohort; MUT mutations cause loss of function (reduced
+      protein, propionate incorporation). Supports mutase activity via IMP.
+- id: PMID:28101778
+  title: Eight novel MUT loss-of-function missense mutations in Chinese patients with isolated
+    methylmalonic academia.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Functional (HEK293T) assays show patient missense mutations reduce MCM
+      protein/activity. Supports mutase activity via IMP.
+- id: PMID:28497574
+  title: Protein destabilization and loss of protein-protein interaction are fundamental mechanisms
+    in cblA-type methylmalonic aciduria.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: MMAA-focused study; MMAA GTPase activity is stimulated by interaction with
+      MUT, and cblA-type mutations reduce this. Supports the positive-regulation-of-GTPase
+      annotation (MUT as the stimulator of MMAA).
+- id: PMID:28943303
+  title: Human MMAA induces the release of inactive cofactor and restores methylmalonyl-CoA
+    mutase activity through their complex formation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Recombinant hMCM enzymology; identifies OH2Cbl as the inactivating oxidized
+      cofactor and MMAA-mediated cofactor exchange; demonstrates mitochondrial colocalization
+      of hMCM and hMMAA. Supports mutase activity, cobalamin binding, and localization.
+- id: PMID:29056341
+  title: The Human Knockout Gene CLYBL Connects Itaconate to Vitamin B(12).
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full text available; recombinant human MUT enzymology and clear statement of
+      MUT as the mitochondrial-matrix B12-dependent mutase converting MM-CoA to succinyl-CoA;
+      identifies itaconyl-CoA as a cofactor-inactivating inhibitor. Strong core-function support.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers
+    Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput neurodegenerative-disease interactome/aggregation map;
+      source of a bare protein-binding IPI (partner HTT). Does not inform MMUT&#39;s core function.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale AP-MS interactome dataset; source of a bare protein-binding
+      IPI (partner CRYZ). Does not inform MMUT&#39;s core function.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular
+    context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: High-confidence human mitochondrial proteome (MitoCoP) includes MMUT;
+      corroborates mitochondrial localization (HTP).
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale multimodal cell-mapping dataset; source of a bare protein-binding
+      IPI (partner CRYZ). Does not inform MMUT&#39;s core function.
+- id: Reactome:R-HSA-3159259
+  title: MMAA:MUT binds AdoCbl
+  findings: []
+- id: Reactome:R-HSA-3322135
+  title: Defective MMAA does not protect MUT
+  findings: []
+- id: Reactome:R-HSA-3322971
+  title: Defective MUT does not isomerise L-MM-CoA to SUCC-CoA
+  findings: []
+- id: Reactome:R-HSA-71010
+  title: MUT isomerises L-MM-CoA to SUCC-CoA
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PCCA/PCCA-ai-review.html
+++ b/genes/human/PCCA/PCCA-ai-review.html
@@ -1,0 +1,5858 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PCCA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PCCA</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P05165" target="_blank" class="term-link">
+                        P05165
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PCCA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P05165" data-a="DESCRIPTION: PCCA encodes the biotin-containing alpha subunit o..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PCCA encodes the biotin-containing alpha subunit of mitochondrial propionyl-CoA carboxylase (PCC; EC 6.4.1.3), a biotin-dependent carboxylase of the mitochondrial matrix. PCC catalyses the first, committed, ATP-dependent step of propionyl-CoA catabolism, converting propanoyl-CoA + bicarbonate + ATP into (S)-methylmalonyl-CoA + ADP + phosphate; the methylmalonyl-CoA product is subsequently converted to succinyl-CoA and enters the tricarboxylic acid cycle. Propionyl-CoA arises from the catabolism of the amino acids isoleucine, valine, methionine and threonine, of odd-chain fatty acids, and of cholesterol. The functional holoenzyme is a large alpha6-beta6 dodecamer (~750 kDa) built from six PCCA (alpha) and six PCCB (beta) subunits. The alpha subunit carries the biotin carboxylase (BC) domain and the C-terminal biotin-carboxyl-carrier-protein (BCCP) domain to which biotin is covalently attached (at Lys694, by holocarboxylase synthetase); it binds ATP and bicarbonate and catalyses the Mg2+-dependent carboxylation of biotin, whereas the beta subunit (PCCB) supplies the carboxyltransferase activity that transfers the carboxyl group to propionyl-CoA. The alpha subunit is synthesized with a cleavable N-terminal mitochondrial targeting presequence and matures in the matrix. Loss of PCC activity through biallelic pathogenic variants in PCCA (or PCCB) causes propionic acidemia, an autosomal recessive organic acidemia.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0004658" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred propionyl-CoA carboxylase activity. This is the core, defining molecular function of PCCA as the biotin-containing alpha subunit of the PCC holoenzyme, directly supported by biochemistry and disease genetics.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported core function; the IBA is at the correct level of specificity and concordant with experimental (IDA/IMP) annotations and the EC 6.4.1.3 assignment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA carboxylase (PCC) is the enzyme which catalyzes the carboxylation of propionyl-CoA to methylmalonyl-CoA and is encoded by the genes PCCA and PCCB to form a hetero-dodecamer.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred mitochondrial localization/activity. Correct: PCC is a mitochondrial matrix enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental matrix localization (below); mitochondrion is a correct, if less specific, compartment for where the enzyme is active.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-coenzyme A carboxylase (PCC), a mitochondrial biotin-dependent enzyme, is essential for the catabolism of the amino acids Thr, Val, Ile and Met, cholesterol and fatty acids with an odd number of carbon atoms.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0004658" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (RHEA:23720 / EC 6.4.1.3 mapping) assignment of propionyl-CoA carboxylase activity. Redundant with, and confirmed by, the experimental IDA/IMP annotations of the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the EC/RHEA mapping matches the demonstrated catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have purified propionyl-CoA carboxylase from normal, postmortem human liver to homogeneity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based ATP binding. The alpha subunit contains an ATP-grasp domain and catalyses the ATP-dependent carboxylation of biotin; ATP is a substrate of the BC reaction (Km ~0.08 mM).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by the catalytic mechanism, the ATP-grasp domain, and multiple ATP binding-site features in UniProt; ATP binding is integral to the alpha-subunit biotin carboxylase step.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt subcellular location / ARBA) assignment of mitochondrial matrix. Correct and concordant with experimental EXP/IDA matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PCC is a matrix enzyme; the electronic assignment matches the curated UniProt subcellular location and experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009374" target="_blank" class="term-link">
+                                    GO:0009374
+                                </a>
+                            </span>
+                            <span class="term-label">biotin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0009374" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic assignment of biotin binding. Biotin is the obligate cofactor of PCC and is covalently attached to the C-terminal biotinyl domain of the alpha subunit; each holoenzyme carries biotin almost entirely on the alpha subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strongly supported: biotin is the defining cofactor of this biotin-dependent carboxylase and is carried by PCCA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Each mole of native enzyme contains 4 mol of bound biotin, virtually all of which is found with the larger (alpha) subunit.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016885" target="_blank" class="term-link">
+                                    GO:0016885
+                                </a>
+                            </span>
+                            <span class="term-label">ligase activity, forming carbon-carbon bonds</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0016885" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic assignment of the parent ligase term. This is the correct broad catalytic class (EC 6.4 ligases forming C-C bonds) for propionyl-CoA carboxylase, but is less informative than the specific GO:0004658 already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct parent activity; not wrong, but subsumed by the more specific propionyl-CoA carboxylase activity. Retained as a valid, if general, IEA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA carboxylase (PCC) is the enzyme which catalyzes the carboxylation of propionyl-CoA to methylmalonyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based metal ion binding. The alpha-subunit biotin carboxylase/ATP-grasp domain binds two divalent metal ions (Mg2+ or Mn2+) per subunit that are required for the ATP-dependent carboxylation step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by UniProt cofactor annotation (binds 2 Mg2+/Mn2+ per subunit) and metal-binding site features; a general but correct molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The active site of the BC domain is conserved with that of E. coli BC, and all the residues that interact with the substrates of this reaction have essentially the same conformation in both structures</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20725044
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the alpha(6)beta(6) holoenzyme of propi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005515" data-r="PMID:20725044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated binary interaction with PCCB (P05166), the beta subunit. This is the genuine, obligate holoenzyme partnership (alpha6-beta6), but the bare &#34;protein binding&#34; term is uninformative about the actual molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation policy, bare protein binding IPIs are not removed. The interaction itself (with PCCB) is real and biologically central, but &#34;protein binding&#34; adds no functional specificity beyond what is captured by the propionyl-CoA carboxylase complex membership; a more informative term (structural constituent of the PCC holoenzyme) would be preferable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/HuRI systematic binary interactome hit, here with MCC (MCCC1, P23508), a paralogous biotin-dependent carboxylase. Bare &#34;protein binding&#34; from a high-throughput all-by-all screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative term from a proteome-scale Y2H screen; not the core function. Retained per policy (not removed) but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we present a human &#39;all-by-all&#39; reference interactome map of human binary protein interactions, or &#39;HuRI&#39;.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with PCCB (P05166) from a proteome-scale interactome study (BioPlex-type). Again the genuine beta-subunit partner, reported via the uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real interaction (PCCB, the holoenzyme partner) but bare protein binding is not the core molecular function; retained per policy and flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with PCCB (P05166) from a multimodal cell-map / genomics study. The beta-subunit partner again, via bare &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine PCCB partnership but uninformative term; retained per policy and flagged as over-annotation rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence (Human Protein Atlas) localization to mitochondrion. Correct, if less specific than the matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct localization evidence consistent with PCC being a mitochondrial matrix enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="PMID:29033250" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-6169) NAS assignment of mitochondrial matrix, from the PCC review. Correct compartment for the holoenzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental EXP/IDA matrix evidence and the curated UniProt subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006631" target="_blank" class="term-link">
+                                    GO:0006631
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0006631" data-r="PMID:29033250" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS: PCC participates in fatty acid metabolism, since propionyl-CoA is the end product of beta-oxidation of odd-chain fatty acids and PCC channels it into the TCA cycle. Broad process term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real but non-core physiological context. PCC acts on the propionyl-CoA node of odd-chain fatty acid catabolism; the direct reaction is more precisely propionyl-CoA carboxylation/propionate catabolism than generic fatty acid metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of PCC leads to accumulation of odd-chain fatty acids (FA), as propionyl-CoA is the end product of beta oxidation of odd-numbered FA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009081" target="_blank" class="term-link">
+                                    GO:0009081
+                                </a>
+                            </span>
+                            <span class="term-label">branched-chain amino acid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0009081" data-r="PMID:29033250" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS: PCC is downstream in the catabolism of branched-chain and other amino acids (isoleucine, valine, methionine, threonine) that generate propionyl-CoA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Valid physiological role (Ile and Val catabolism converge on propionyl-CoA), but not the direct reaction PCCA catalyses; kept as a relevant non-core process. Note GO:0009081 covers isoleucine/leucine/valine; PCC also serves Met/Thr, which are not branched-chain, so this term is a partial view of PCC&#39;s amino-acid role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain fatty acids, methionine, isoleucine and threonine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902494" target="_blank" class="term-link">
+                                    GO:1902494
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20725044
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the alpha(6)beta(6) holoenzyme of propi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:1902494" data-r="PMID:20725044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IPI: PCCA is part of a catalytic complex, i.e. the alpha6-beta6 PCC holoenzyme (ComplexPortal CPX-6169, Mitochondrial propionyl-CoA carboxylase complex).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct: PCCA is an obligate structural subunit of the catalytic PCC holoenzyme. A dedicated &#34;propionyl-CoA carboxylase complex&#34; GO term does not currently exist (only acetyl-CoA and methylcrotonoyl-CoA carboxylase complexes), so the general &#34;catalytic complex&#34; is retained rather than modified to a nonexistent term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10101253" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10101253
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic heterogeneity in propionic acidemia patients with al...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="PMID:10101253" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental import/localization: in vitro-expressed PCCA precursor is imported into mitochondria and processed to the mature matrix form. Supports mitochondrial matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for mitochondrial import and maturation, consistent with the matrix location of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10101253" target="_blank" class="term-link">
+                                        PMID:10101253
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both wild-type and mutant proteins were imported into mitochondria and processed into the mature form with similar efficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901290" target="_blank" class="term-link">
+                                    GO:1901290
+                                </a>
+                            </span>
+                            <span class="term-label">succinyl-CoA biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8434582
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning of functional alpha propionyl CoA carboxylase and co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:1901290" data-r="PMID:8434582" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (propionate-flux complementation) linking PCCA to production of succinyl-CoA. PCC catalyses the first step (propionyl-CoA -&gt; methylmalonyl-CoA); succinyl-CoA is the downstream product of the three-step propanoyl-CoA degradation pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PCC&#39;s direct product is (S)-methylmalonyl-CoA, not succinyl-CoA; succinyl-CoA formation requires the downstream MCEE and MUT steps. The annotation reflects PCCA&#39;s contribution to the pathway output rather than its direct catalytic product, so it is kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link">
+                                        PMID:8434582
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both clones reconstitute propionate flux to normal levels in fibroblasts from patients genetically deficient in PCCA (pccA).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteomics assignment to mitochondrion. Concordant with the established mitochondrial matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-confidence mitochondrial proteome evidence consistent with the curated compartment; correct though less specific than matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome and its dynamics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16023992
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial targeting signals and mature peptides of 3-met...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="PMID:16023992" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence: the mature PCCA amino-terminus and cleavable N-terminal targeting presequence were defined, showing import into the mitochondrial matrix by the classical presequence pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental determination of the mitochondrial targeting signal and mature matrix peptide directly supports matrix localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                                        PMID:16023992
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the two subunits of the enzyme (MCCalpha; MCCbeta) are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6765947
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation and characterization of propionyl-CoA carboxylase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0004658" data-r="PMID:6765947" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct biochemical demonstration: PCC purified from human liver to homogeneity, shown to be a biotin-containing alpha/beta enzyme carboxylating propionyl-CoA with defined kinetic parameters. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Definitive experimental evidence for propionyl-CoA carboxylase activity; anchors this as the core function of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019626" target="_blank" class="term-link">
+                                    GO:0019626
+                                </a>
+                            </span>
+                            <span class="term-label">short-chain fatty acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6765947
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation and characterization of propionyl-CoA carboxylase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0019626" data-r="PMID:6765947" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator inference (from GO:0004658) that PCC participates in short-chain fatty acid catabolism. Propionate/propionyl-CoA is a short-chain acid, but a more precise process term is available.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The reaction PCC catalyses is specifically the committed step of propionyl-CoA catabolism; &#34;short-chain fatty acid catabolic process&#34; is broader and less accurate than the dedicated term. Propose replacement with propionyl-CoA catabolic process.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902859" target="_blank" class="term-link">
+                                    propionyl-CoA catabolic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PCC&#39;s primary function is to catalyze the carboxylation of propionyl-CoA to produce methylmalonyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019626" target="_blank" class="term-link">
+                                    GO:0019626
+                                </a>
+                            </span>
+                            <span class="term-label">short-chain fatty acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8434582
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning of functional alpha propionyl CoA carboxylase and co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0019626" data-r="PMID:8434582" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second curator inference (from GO:0004658) of short-chain fatty acid catabolism, based on the propionate-flux complementation study. Same over-broad term as above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As above, the direct process is propionyl-CoA / propionate catabolism; replace the broad short-chain fatty acid term with the specific propionyl-CoA catabolic process.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902859" target="_blank" class="term-link">
+                                    propionyl-CoA catabolic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link">
+                                        PMID:8434582
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both clones reconstitute propionate flux to normal levels in fibroblasts from patients genetically deficient in PCCA (pccA).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8434582
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning of functional alpha propionyl CoA carboxylase and co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0004658" data-r="PMID:8434582" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP: recombinant human PCCA rescues (complements) the propionate-flux defect in PCCA-deficient (pccA) patient fibroblasts, demonstrating that PCCA is required for propionyl-CoA carboxylase activity in cells. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genetic complementation directly ties PCCA to the propionyl-CoA carboxylase activity and propionate flux; strong support for the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link">
+                                        PMID:8434582
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We describe cDNA clones expressing human PCCA and complementation of the genetic defect in pccA fibroblasts by DNA-mediated gene transfer.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-2993447
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005829" data-r="Reactome:R-HSA-2993447" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing PCCA in the cytosol, reflecting the pre-import apo-precursor and the Reactome &#34;HLCS biotinylates 6x(PCCA:PCCB)&#34; / cytosolic-to-matrix translocation events. PCC is not catalytically active in the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functional, biotinylated, active holoenzyme resides in the mitochondrial matrix; the cytosolic assignment reflects the transient apo-precursor stage before mitochondrial import (any cytosolic biotinylation is likely non-functional). Kept as a non-core, transient localization rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The PCCA precursor does not contain biotin until imported into the mitochondrion and cleaved</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3323111
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005829" data-r="Reactome:R-HSA-3323111" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (cytosolic carboxylases translocate to mitochondrial matrix) placing the PCCA precursor in the cytosol prior to import.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As above: transient pre-import cytosolic localization of the apo-precursor; the active enzyme is a matrix enzyme. Non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The PCCA precursor does not contain biotin until imported into the mitochondrion and cleaved</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9035990
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005829" data-r="Reactome:R-HSA-9035990" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (defective HLCS does not biotinylate 6x(PCCA:PCCB)) placing PCCA in the cytosol as part of the biotinylation/multiple-carboxylase-deficiency pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same transient cytosolic apo-precursor context; not the functional compartment. Kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The PCCA precursor does not contain biotin until imported into the mitochondrion and cleaved</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3065959
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="Reactome:R-HSA-3065959" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS assignment of mitochondrial matrix (from the carboxylase degradation reaction). Correct functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental matrix evidence; the mature active enzyme is in the matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3323111
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="Reactome:R-HSA-3323111" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS assignment of mitochondrial matrix (post-translocation destination in the cytosol-&gt;matrix translocation reaction). Correct functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches the established matrix localization of the mature enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71031
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0005759" data-r="Reactome:R-HSA-71031" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS assignment of mitochondrial matrix, associated with the core PCC reaction (propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + Pi). This is the compartment where the catalytic reaction occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct: the propionyl-CoA carboxylase reaction takes place in the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
+                                    GO:0019899
+                                </a>
+                            </span>
+                            <span class="term-label">enzyme binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19157941" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19157941
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    N- and C-terminal domains in human holocarboxylase synthetas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0019899" data-r="PMID:19157941" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI interaction with holocarboxylase synthetase (HLCS, P50747), the enzyme that covalently attaches biotin to PCCA. The study used the PCCA-derived C-terminal p67 polypeptide (biotinylation site K669/K694) as the HLCS substrate in Y2H and docking assays, defining the PCCA-HLCS substrate-enzyme interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A real and biologically meaningful interaction (PCCA is the substrate of HLCS- mediated biotinylation, essential for activity), but it describes a post-translational modification relationship rather than PCCA&#39;s own core molecular function. &#34;Enzyme binding&#34; is more informative than bare protein binding, so it is retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19157941" target="_blank" class="term-link">
+                                        PMID:19157941
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The polypeptide p67 comprises the 67 C-terminal amino acids in human PCC (GenBank accession #AAA60035), including the biotin-binding site K669</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009374" target="_blank" class="term-link">
+                                    GO:0009374
+                                </a>
+                            </span>
+                            <span class="term-label">biotin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3460076" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3460076
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation of cDNA clones coding for the alpha and beta chain...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05165" data-a="GO:0009374" data-r="PMID:3460076" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS (ProtInc) biotin binding, from the cDNA-cloning paper that identified the alpha chain via its conserved Ala-Met-Lys-Met biotin-binding-site motif. Biotin is the obligate cofactor carried by PCCA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-established core cofactor relationship; the alpha chain was in fact identified through its biotin-binding-site sequence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3460076" target="_blank" class="term-link">
+                                        PMID:3460076
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One class contained the anticipated Ala-Met-Lys-Met sequence, corresponding to the biotin binding site found in several biotin-dependent carboxylases, thus confirming the alpha-chain assignment of these clones.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Propionyl-CoA carboxylase alpha subunit: within the alpha6-beta6 PCC holoenzyme, the alpha subunit binds ATP and bicarbonate and catalyses the Mg2+-dependent ATP-driven carboxylation of its covalently bound biotin, contributing the biotin carboxylase half-reaction of propionyl-CoA carboxylase activity (conversion of propanoyl-CoA to (S)-methylmalonyl-CoA), the first committed step of propionyl-CoA / propionate catabolism in the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="P05165" data-a="FUNCTION: Propionyl-CoA carboxylase alpha subunit: within th..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                            propionyl-CoA carboxylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902859" target="_blank" class="term-link">
+                                propionyl-CoA catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                PMID:6765947
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                PMID:29033250
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PCC&#39;s primary function is to catalyze the carboxylation of propionyl-CoA to produce methylmalonyl-CoA</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Biotin cofactor carrier: the alpha subunit carries the C-terminal biotinyl (BCCP) domain and binds biotin, which is covalently attached (by holocarboxylase synthetase) and is obligately required for catalytic activity of the biotin-dependent carboxylase.</h3>
+                <span class="vote-buttons" data-g="P05165" data-a="FUNCTION: Biotin cofactor carrier: the alpha subunit carries..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009374" target="_blank" class="term-link">
+                            biotin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                PMID:6765947
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Each mole of native enzyme contains 4 mol of bound biotin, virtually all of which is found with the larger (alpha) subunit.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP binding: the alpha subunit ATP-grasp/biotin carboxylase domain binds ATP (Km ~0.08 mM) as a substrate of the ATP-dependent biotin carboxylation step.</h3>
+                <span class="vote-buttons" data-g="P05165" data-a="FUNCTION: ATP binding: the alpha subunit ATP-grasp/biotin ca..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                            ATP binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                PMID:6765947
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10101253" target="_blank" class="term-link">
+                            PMID:10101253
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic heterogeneity in propionic acidemia patients with alpha-subunit defects. Identification of five novel mutations, one of them causing instability of the protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                            PMID:16023992
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial targeting signals and mature peptides of 3-methylcrotonyl-CoA carboxylase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19157941" target="_blank" class="term-link">
+                            PMID:19157941
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">N- and C-terminal domains in human holocarboxylase synthetase participate in substrate recognition.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                            PMID:20725044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of the alpha(6)beta(6) holoenzyme of propionyl-coenzyme A carboxylase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                            PMID:29033250
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Propionyl-CoA carboxylase - A review.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3460076" target="_blank" class="term-link">
+                            PMID:3460076
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Isolation of cDNA clones coding for the alpha and beta chains of human propionyl-CoA carboxylase: chromosomal assignments and DNA polymorphisms associated with PCCA and PCCB genes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                            PMID:6765947
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Isolation and characterization of propionyl-CoA carboxylase from normal human liver. Evidence for a protomeric tetramer of nonidentical subunits.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8434582" target="_blank" class="term-link">
+                            PMID:8434582
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning of functional alpha propionyl CoA carboxylase and correction of enzyme deficiency in pccA fibroblasts.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-2993447
+
+                    </span>
+                </div>
+
+                <div class="reference-title">HLCS biotinylates 6x(PCCA:PCCB)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3065959
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An unknown protease degrades hCBXs</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3323111
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cytosolic carboxylases translocate to mitochondrial matrix</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71031
+
+                    </span>
+                </div>
+
+                <div class="reference-title">propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + orthophosphate</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9035990
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective HLCS does not biotinylate 6x(PCCA:PCCB)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the three PCCA splice isoforms (P05165-1/-2/-3) differ in enzymatic function, holoenzyme incorporation, or tissue distribution? Their functional impact has not been well characterized.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P05165" data-a="Q: Do the three PCCA splice isoforms (P05165-1/-2/-3)..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does PCCA (or the PCC holoenzyme) have any moonlighting or regulatory role beyond carboxylation, e.g. via its reported acetylation/succinylation and interactions with SIRT3/4/5?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P05165" data-a="Q: Does PCCA (or the PCC holoenzyme) have any moonlig..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Isoform-resolved enzyme kinetics and holoenzyme-assembly assays for P05165-2 and P05165-3 versus the canonical isoform, to determine whether alternative splicing alters propionyl-CoA carboxylase activity.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P05165" data-a="EXPERIMENT: Isoform-resolved enzyme kinetics and holoenzyme-as..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative biotinylation/acylation site mapping of PCCA in matched control and propionic-acidemia cells to test how post-translational modification state modulates PCC activity.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P05165" data-a="EXPERIMENT: Quantitative biotinylation/acylation site mapping ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PCCA-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P05165" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: PCCA (Propionyl-CoA Carboxylase Alpha Chain, Mitochondrial)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">33 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-07T00:48:23.487410</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="PCCA-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="PCCA-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-pcca-propionyl-coa-carboxylase-alpha-chain-mitochondrial">Comprehensive Research Report: PCCA (Propionyl-CoA Carboxylase Alpha Chain, Mitochondrial)</h1>
+<p><strong>Gene:</strong> PCCA | <strong>UniProt:</strong> P05165 | <strong>EC:</strong> 6.4.1.3 | <strong>Organism:</strong> Homo sapiens</p>
+<h2 id="1-gene-and-protein-overview">1. Gene and Protein Overview</h2>
+<p>The <em>PCCA</em> gene (HGNC:8653) is located on human chromosome 13 and encodes the alpha (α) subunit of propionyl-CoA carboxylase (PCC), a biotin-dependent mitochondrial enzyme (kelson1996chaperoninmediatedassemblyof pages 1-2). The α subunit has a molecular mass of approximately 70 kDa and is synthesized as a precursor protein containing an N-terminal mitochondrial targeting presequence of approximately 25 amino acids, which is proteolytically cleaved upon import into the mitochondrial matrix, yielding a mature protein beginning at residue 26 (kelson1996chaperoninmediatedassemblyof pages 2-3, kelson1996chaperoninmediatedassemblyof pages 1-2). The gene product functions together with the β subunit (encoded by <em>PCCB</em>) to form the active holoenzyme.</p>
+<p>The following table summarizes the key properties of PCCA:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name</td>
+<td><strong>PCCA</strong>; encodes the mitochondrial <strong>propionyl-CoA carboxylase alpha chain</strong> in human, matching UniProt accession <strong>P05165</strong> (kelson1996chaperoninmediatedassemblyof pages 1-2)</td>
+</tr>
+<tr>
+<td>UniProt accession</td>
+<td><strong>P05165</strong> (user-provided target context)</td>
+</tr>
+<tr>
+<td>Chromosomal location</td>
+<td><strong>Chromosome 13</strong> in human (kelson1996chaperoninmediatedassemblyof pages 1-2)</td>
+</tr>
+<tr>
+<td>Protein size</td>
+<td><strong>~70 kDa</strong> alpha subunit of PCC (kelson1996chaperoninmediatedassemblyof pages 1-2)</td>
+</tr>
+<tr>
+<td>Enzyme classification</td>
+<td><strong>EC 6.4.1.3</strong>, propionyl-CoA carboxylase (erdal2025aminoacidmetabolism pages 9-10, kelson1996chaperoninmediatedassemblyof pages 1-2)</td>
+</tr>
+<tr>
+<td>Cofactor</td>
+<td><strong>Biotin</strong>; PCC is a <strong>biotin-dependent carboxylase</strong> (erdal2025aminoacidmetabolism pages 9-10, jitrapakdee2003thebiotinenzyme pages 4-6)</td>
+</tr>
+<tr>
+<td>Reaction catalyzed</td>
+<td><strong>Propionyl-CoA + HCO3− + ATP → D-methylmalonyl-CoA + ADP + Pi</strong>; ATP-dependent biotin-mediated carboxylation (erdal2025aminoacidmetabolism pages 9-10, kelson1996chaperoninmediatedassemblyof pages 1-2, zhou2024structuralinsightsinto pages 4-6)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td><strong>Mitochondrial matrix</strong> (kelson1996chaperoninmediatedassemblyof pages 1-2)</td>
+</tr>
+<tr>
+<td>Mitochondrial targeting</td>
+<td>Synthesized as a precursor with an <strong>N-terminal mitochondrial leader/presequence</strong>; mature alpha subunit begins at about <strong>residue 26</strong>, implying a ~25 aa targeting peptide (kelson1996chaperoninmediatedassemblyof pages 2-3, kelson1996chaperoninmediatedassemblyof pages 1-2)</td>
+</tr>
+<tr>
+<td>Holoenzyme assembly</td>
+<td><strong>α6β6 dodecamer</strong>; four-layer architecture with six β subunits forming the core and α subunits arranged on top and bottom (kelson1996chaperoninmediatedassemblyof pages 1-2, zhou2024structuralinsightsinto pages 4-6, zhou2024structuralinsightsinto pages 1-4)</td>
+</tr>
+<tr>
+<td>Key domains</td>
+<td><strong>Alpha/PCCA:</strong> <strong>BC</strong> (biotin carboxylase), <strong>BT</strong> linker/hub domain, <strong>BCCP</strong> (biotin carboxyl carrier protein); <strong>Beta/PCCB:</strong> <strong>CT</strong> (carboxyltransferase) domain with CT-N and CT-C subdomains (zhou2024structuralinsightsinto pages 4-6, zhou2024structuralinsightsinto pages 1-4, jitrapakdee2003thebiotinenzyme pages 4-6)</td>
+</tr>
+<tr>
+<td>Primary metabolic pathway</td>
+<td><strong>Propionate metabolism</strong>: propionyl-CoA → D-methylmalonyl-CoA → L-methylmalonyl-CoA → <strong>succinyl-CoA</strong>, which enters the <strong>TCA cycle</strong> and supports gluconeogenesis (erdal2025aminoacidmetabolism pages 9-10, erdal2025aminoacidmetabolism pages 6-9)</td>
+</tr>
+<tr>
+<td>Metabolic inputs to pathway</td>
+<td>Propionyl-CoA arises from catabolism of <strong>isoleucine, valine, threonine, methionine</strong>, <strong>odd-chain fatty acids</strong>, and <strong>cholesterol side chains</strong> (kelson1996chaperoninmediatedassemblyof pages 1-2, erdal2025aminoacidmetabolism pages 9-10, erdal2025aminoacidmetabolism pages 6-9)</td>
+</tr>
+<tr>
+<td>Disease association</td>
+<td>Biallelic loss-of-function variants in <strong>PCCA</strong> cause <strong>propionic acidemia</strong>, a severe autosomal recessive organic acidemia with metabolic decompensation, neurologic disease, and cardiomyopathy risk (maines2023understandingthepathogenesis pages 1-2, riverabarahona2018identificationof34 pages 1-5)</td>
+</tr>
+<tr>
+<td>Substrate specificity</td>
+<td><strong>Primary substrate:</strong> propionyl-CoA. Human PCC can also carboxylate <strong>acetyl-CoA</strong> at a much lower rate, about <strong>1.5%</strong> of the propionyl-CoA rate; recent structural work found acetyl-CoA and propionyl-CoA bind in highly similar modes (zhou2024structuralinsightsinto pages 6-7, jitrapakdee2003thebiotinenzyme pages 10-11)</td>
+</tr>
+<tr>
+<td>Representative recent structural data</td>
+<td>High-resolution human PCC cryo-EM structures reported in 2024: <strong>apo 3.02 Å</strong>, <strong>propionyl-CoA-bound 2.80 Å</strong>, with overall structures reported in the <strong>2.29–3.38 Å</strong> range; PDB entries include <strong>8XL3, 8XL4, 8XL5</strong> (zhou2024structuralinsightsinto pages 4-6, zhou2024structuralinsightsinto pages 11-14, zhou2024structuralinsightsinto pages 9-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core molecular, biochemical, structural, and disease-related properties of human PCCA/propionyl-CoA carboxylase alpha chain. It is useful as a compact reference for functional annotation and for linking enzyme function to propionic acidemia.</em></p>
+<h2 id="2-enzymatic-function-and-reaction-mechanism">2. Enzymatic Function and Reaction Mechanism</h2>
+<p>PCC catalyzes the ATP-dependent, biotin-mediated carboxylation of propionyl-CoA to produce D-methylmalonyl-CoA, using bicarbonate (HCO₃⁻) as the CO₂ donor (erdal2025aminoacidmetabolism pages 9-10, kelson1996chaperoninmediatedassemblyof pages 1-2). This reaction (EC 6.4.1.3) proceeds via a two-step mechanism characteristic of all biotin-dependent carboxylases:</p>
+<p><strong>Step 1 — Biotin carboxylation (in the BC domain of the α subunit):</strong> ATP activates bicarbonate to form a carboxyphosphate intermediate, which then transfers its carboxyl group to the N1′ atom of the covalently attached biotin prosthetic group (zhou2024structuralinsightsinto pages 4-6).</p>
+<p><strong>Step 2 — Carboxyl transfer (in the CT domain of the β subunit):</strong> The carboxylated biotin swings from the BC domain to the CT domain, where the carboxyl group is transferred to the C-α of propionyl-CoA, generating D-methylmalonyl-CoA. This process involves decarboxylation of carboxybiotin to produce free CO₂ and activated biotin, followed by deprotonation of the acyl moiety to attack the CO₂ (zhou2024structuralinsightsinto pages 4-6).</p>
+<h3 id="substrate-specificity">Substrate Specificity</h3>
+<p>PCC exhibits strong selectivity for propionyl-CoA as its primary substrate. However, recent cryo-EM structural analyses have demonstrated that PCC can also carboxylate acetyl-CoA, albeit at a dramatically reduced rate—approximately 1.5% of the propionyl-CoA carboxylation rate (zhou2024structuralinsightsinto pages 6-7). Structural studies revealed that propionyl-CoA and acetyl-CoA bind to PCC with nearly identical binding modes, indicating that the acyl-CoA specificity is largely attributable to subtle differences in interactions mediated by the acyl groups, although these differences were not fully resolved in the available cryo-EM densities (zhou2024structuralinsightsinto pages 6-7, zhou2024structuralinsightsinto pages 4-6). The carboxyltransferase domains of PCC, acetyl-CoA carboxylase, and 3-methylcrotonyl-CoA carboxylase show no sequence identity, underscoring the uniqueness of each enzyme's substrate binding site (jitrapakdee2003thebiotinenzyme pages 10-11).</p>
+<h2 id="3-protein-structure-and-domain-architecture">3. Protein Structure and Domain Architecture</h2>
+<h3 id="domain-organization">Domain Organization</h3>
+<p>The PCCA-encoded α subunit contains three functional domains arranged from N- to C-terminus (zhou2024structuralinsightsinto pages 4-6, zhou2024structuralinsightsinto pages 1-4, jitrapakdee2003thebiotinenzyme pages 4-6):</p>
+<ul>
+<li>
+<p><strong>Biotin carboxylase (BC) domain:</strong> Located at the N-terminus, this domain contains the ATP-grasp fold and catalyzes the first half-reaction—the ATP-dependent carboxylation of the covalently attached biotin cofactor using bicarbonate as the CO₂ source.</p>
+</li>
+<li>
+<p><strong>BT (BC-CT interaction) domain:</strong> An intermediate hub domain that mediates interactions between the BC and CT functional regions.</p>
+</li>
+<li>
+<p><strong>Biotin carboxyl carrier protein (BCCP) domain:</strong> Located at the C-terminus, this domain contains the conserved lysine residue to which biotin is covalently attached via an amide bond. The BCCP domain positions the biotinyl group adjacent to the acyl-CoA binding pocket in the CT domain.</p>
+</li>
+</ul>
+<p>The β subunit (encoded by <em>PCCB</em>) consists solely of the carboxyltransferase (CT) domain, which is divided into CT-N and CT-C subdomains. The CT domain catalyzes the second half-reaction—transfer of the carboxyl group from carboxybiotin to propionyl-CoA (zhou2024structuralinsightsinto pages 4-6).</p>
+<h3 id="holoenzyme-assembly">Holoenzyme Assembly</h3>
+<p>The PCC holoenzyme assembles as an α₆β₆ dodecamer with a distinctive four-layer architecture: six β subunits form the core in two layers, with six α subunits positioned at the top and bottom in two additional layers. Each α subunit binds to one β subunit (kelson1996chaperoninmediatedassemblyof pages 1-2, zhou2024structuralinsightsinto pages 4-6, zhou2024structuralinsightsinto pages 1-4). The assembly of the holoenzyme requires molecular chaperones; studies in <em>E. coli</em> expression systems demonstrated that chaperonin (GroEL/GroES) facilitates proper folding and assembly of both wild-type and mutant PCC subunits (kelson1996chaperoninmediatedassemblyof pages 1-2).</p>
+<h3 id="high-resolution-structures">High-Resolution Structures</h3>
+<p>A major structural advance came in 2024, when Zhou et al. reported the first high-resolution cryo-EM structures of human PCC holoenzyme in multiple states: the apo form at 3.02 Å resolution, the propionyl-CoA-bound form (PCC-PCO) at 2.80 Å resolution, and the acetyl-CoA-bound form (PCC-ACO) at 3.38 Å resolution. These structures have been deposited in the Protein Data Bank (PDB entries 8XL3, 8XL4, 8XL5) (zhou2024structuralinsightsinto pages 4-6, zhou2024structuralinsightsinto pages 11-14, zhou2024structuralinsightsinto pages 9-11). Notably, in all PCC structures analyzed, the covalently linked biotin binds to an exo-site distant (&gt;7 Å) from the catalytic residues G437 and A438 in the CT domain, suggesting the enzyme was captured in a catalytically incompetent conformation (zhou2024structuralinsightsinto pages 6-7).</p>
+<h2 id="4-subcellular-localization">4. Subcellular Localization</h2>
+<p>PCC functions exclusively in the <strong>mitochondrial matrix</strong>, where it processes propionyl-CoA generated from multiple catabolic pathways (kelson1996chaperoninmediatedassemblyof pages 1-2). Both the α and β subunit precursors contain N-terminal mitochondrial matrix targeting presequences. The α subunit precursor undergoes proteolytic cleavage at a conserved motif for mitochondrial-targeted protein processing, with the mature α subunit beginning at approximately residue 26 (kelson1996chaperoninmediatedassemblyof pages 2-3). When expressed with its full-length sequence including the mitochondrial leader in mammalian cells, the β subunit precursor is correctly transported to mitochondria, confirming the functionality of the targeting sequence (kelson1996chaperoninmediatedassemblyof pages 1-2).</p>
+<h2 id="5-metabolic-pathways-and-biochemical-context">5. Metabolic Pathways and Biochemical Context</h2>
+<h3 id="the-propionate-metabolism-pathway">The Propionate Metabolism Pathway</h3>
+<p>PCC occupies a critical position in the propionate catabolism pathway, catalyzing the first committed step in the conversion of propionyl-CoA to succinyl-CoA, a TCA cycle intermediate (erdal2025aminoacidmetabolism pages 9-10). The complete pathway proceeds as follows:</p>
+<ol>
+<li><strong>Propionyl-CoA → D-methylmalonyl-CoA</strong> (catalyzed by PCC; biotin- and ATP-dependent)</li>
+<li><strong>D-methylmalonyl-CoA → L-methylmalonyl-CoA</strong> (catalyzed by methylmalonyl-CoA epimerase)</li>
+<li><strong>L-methylmalonyl-CoA → Succinyl-CoA</strong> (catalyzed by methylmalonyl-CoA mutase, requiring vitamin B₁₂)</li>
+</ol>
+<p>Succinyl-CoA then enters the TCA cycle and can support gluconeogenesis (erdal2025aminoacidmetabolism pages 9-10, erdal2025aminoacidmetabolism pages 6-9).</p>
+<h3 id="sources-of-propionyl-coa">Sources of Propionyl-CoA</h3>
+<p>Propionyl-CoA is generated from multiple metabolic sources (kelson1996chaperoninmediatedassemblyof pages 1-2, erdal2025aminoacidmetabolism pages 9-10, erdal2025aminoacidmetabolism pages 6-9):</p>
+<ul>
+<li><strong>Branched-chain amino acid catabolism:</strong> Isoleucine and valine degradation pathways converge to generate propionyl-CoA</li>
+<li><strong>Other amino acids:</strong> Threonine and methionine catabolism also produce propionyl-CoA</li>
+<li><strong>Odd-chain fatty acid β-oxidation:</strong> The final three-carbon unit from odd-chain fatty acids yields propionyl-CoA</li>
+<li><strong>Cholesterol side chain oxidation:</strong> Cholesterol metabolism generates propionyl-CoA</li>
+<li><strong>Gut microbiome-derived propionate:</strong> The liver is the primary organ for clearing propionate produced by intestinal bacteria (erdal2025aminoacidmetabolism pages 9-10)</li>
+</ul>
+<p>The liver is the dominant organ for propionyl-CoA metabolism, with kidney and pancreas also possessing significant metabolic capacity (lu2026lossofpropionylcoa pages 1-5). In healthy individuals, efficient hepatic propionate metabolism maintains low circulating propionate levels (0.4–5 µM) (chen2025elevatedpropionateand pages 2-3).</p>
+<h3 id="metabolic-consequences-of-pcca-deficiency">Metabolic Consequences of PCCA Deficiency</h3>
+<p>Studies using CRISPR-edited PCCA-null HepG2 cells have revealed that PCCA deficiency causes widespread metabolic reprogramming beyond simple propionyl-CoA accumulation (lu2026lossofpropionylcoa pages 5-8, lu2026lossofpropionylcoa pages 1-5, lu2026lossofpropionylcoa pages 8-11):</p>
+<ul>
+<li><strong>Reduced mitochondrial fatty acid oxidation</strong>, with decreased incorporation of fatty acid-derived acetyl-CoA into the TCA cycle</li>
+<li><strong>Impaired pyruvate anaplerosis</strong> via pyruvate carboxylase, reducing gluconeogenic and lipogenic capacity</li>
+<li><strong>Reduced branched-chain amino acid catabolism</strong>, evidenced by decreased downstream metabolites</li>
+<li><strong>CoA and carnitine depletion</strong>, as excess propionyl-CoA sequesters these cofactors</li>
+<li><strong>Accumulation of toxic metabolites</strong> including methylcitrate, propionylcarnitine, and propionylglutamate, which impair ammonia detoxification and disrupt the TCA cycle (lu2026lossofpropionylcoa pages 1-5)</li>
+</ul>
+<h2 id="6-disease-association-propionic-acidemia">6. Disease Association: Propionic Acidemia</h2>
+<h3 id="clinical-features">Clinical Features</h3>
+<p>Propionic acidemia (PA; OMIM #606054) is an autosomal recessive inborn error of metabolism caused by biallelic mutations in either <em>PCCA</em> or <em>PCCB</em>, resulting in deficient PCC enzyme activity (maines2023understandingthepathogenesis pages 1-2, riverabarahona2018identificationof34 pages 1-5). The clinical presentation includes:</p>
+<ul>
+<li><strong>Neonatal/early-onset form:</strong> Ketoacidosis, feeding refusal, lethargy, failure to thrive, seizures, and encephalopathy (riverabarahona2018identificationof34 pages 1-5)</li>
+<li><strong>Late-onset form:</strong> Milder presentation with developmental delay</li>
+<li><strong>Neurological complications:</strong> Psychomotor retardation, dystonia, developmental and speech delays, seizures, stroke-like episodes, optic neuropathy, and intellectual disability (chen2025elevatedpropionateand pages 3-4)</li>
+<li><strong>Cardiac complications:</strong> Hypertrophic or dilated cardiomyopathy and acquired long QT syndrome (aLQTS), which are major causes of morbidity and mortality (maines2023understandingthepathogenesis pages 1-2)</li>
+<li><strong>Other complications:</strong> Pancreatitis, hyperammonemia, and hematologic abnormalities (riverabarahona2018identificationof34 pages 1-5)</li>
+</ul>
+<h3 id="pathophysiological-mechanisms">Pathophysiological Mechanisms</h3>
+<p>The pathophysiology of PA extends beyond simple metabolite toxicity and involves multiple cellular pathways (maines2023understandingthepathogenesis pages 1-2, maines2023understandingthepathogenesis pages 4-5, chen2025elevatedpropionateand pages 3-4):</p>
+<ul>
+<li><strong>TCA cycle dysfunction:</strong> Decreased succinyl-CoA availability and inhibition of TCA enzymes (pyruvate dehydrogenase, oxoglutarate dehydrogenase, succinyl-CoA ligase) by propionate and methylcitrate</li>
+<li><strong>Mitochondrial electron transport chain dysfunction:</strong> Documented deficiencies in complexes I, III, and IV; propionyl-CoA acts as a mitochondrial toxin impairing oxidative phosphorylation</li>
+<li><strong>Oxidative stress:</strong> Increased reactive oxygen species production; mtDNA depletion and ultrastructural mitochondrial abnormalities</li>
+<li><strong>Neurological damage:</strong> The basal ganglia are particularly vulnerable due to high energy demands; propionate accumulates in GABAergic neurons where it inhibits GABA transaminase, leading to GABA accumulation and lethargy (chen2025elevatedpropionateand pages 7-7)</li>
+<li><strong>CoQ10 deficiency, carnitine depletion, and epigenetic/miRNA dysregulation</strong> also contribute to disease pathology (maines2023understandingthepathogenesis pages 11-13)</li>
+</ul>
+<h2 id="7-current-and-emerging-therapeutic-approaches">7. Current and Emerging Therapeutic Approaches</h2>
+<p>The following table summarizes current and emerging therapeutic strategies for propionic acidemia:</p>
+<table>
+<thead>
+<tr>
+<th>Therapy type</th>
+<th>Mechanism</th>
+<th>Development stage</th>
+<th>Key findings</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Conventional management: dietary protein restriction, carnitine supplementation, metronidazole/other antibiotics</td>
+<td>Reduces propiogenic substrate load from isoleucine, valine, methionine, threonine and lowers gut microbiota-derived propionate; carnitine promotes formation/excretion of propionylcarnitine and helps maintain carnitine pools</td>
+<td>Standard of care / established clinical management</td>
+<td>Current treatment is mainly supportive rather than curative. Dietary restriction, carnitine, and metronidazole/antibiotics are widely used and have improved survival, but many patients still develop chronic complications including neurologic and cardiac disease despite metabolic management (riverabarahona2018identificationof34 pages 1-5, erdal2025aminoacidmetabolism pages 9-10)</td>
+</tr>
+<tr>
+<td>Liver transplantation</td>
+<td>Provides a major new source of functional hepatic PCC activity, increasing systemic propionyl-CoA clearance and reducing recurrent metabolic instability</td>
+<td>Established option for selected severe patients</td>
+<td>Considered for severe disease; can stabilize metabolic control and may improve or reverse cardiomyopathy in some patients, but does not fully cure extrahepatic disease and is limited by transplant eligibility and risks (maines2023understandingthepathogenesis pages 1-2, maines2023understandingthepathogenesis pages 13-14)</td>
+</tr>
+<tr>
+<td>mRNA-3927 dual mRNA-LNP therapy (encodes PCCA and PCCB)</td>
+<td>Intravenous lipid nanoparticle delivery of therapeutic mRNAs to liver cells, enabling translation of both PCC subunits and reconstitution of active PCC enzyme</td>
+<td>Clinical; first-in-human Phase 1/2 with interim results published in <em>Nature</em> (2024)</td>
+<td>In 16 participants across 5 dose cohorts, 346 IV doses were administered over 15.69 person-years with no dose-limiting toxicities. Among 8 participants with pretreatment metabolic decompensation events, treatment was associated with a 70% reduction in risk; biomarkers including 3-HP, 2-MC, propionylcarnitine, and n-propionylglycine generally decreased after treatment (koeberl2024interimanalysesof pages 1-2, koeberl2024interimanalysesof pages 2-3, koeberl2024interimanalysesof pages 5-6)</td>
+</tr>
+<tr>
+<td>Antisense oligonucleotide therapy targeting PCCA pseudoexon</td>
+<td>Splice-switching ASOs suppress aberrant pseudoexon inclusion in mutant PCCA pre-mRNA to restore normal splicing and rescue enzyme expression/activity</td>
+<td>Preclinical / experimental personalized RNA therapy</td>
+<td>Recent work demonstrated modulation of PCCA pseudoexon splicing as a plausible mutation-specific rescue strategy, highlighting pseudoexon activation as a therapeutically actionable mechanism in propionic acidemia (chen2025elevatedpropionateand pages 7-7)</td>
+</tr>
+<tr>
+<td>Metabolic rerouting approaches</td>
+<td>Diverts upstream propiogenic flux away from propionyl-CoA production, for example by genetically or pharmacologically reducing valine/isoleucine catabolic steps that feed propionate metabolism</td>
+<td>Preclinical proof-of-concept</td>
+<td>In zebrafish models of disorders of propionyl-CoA metabolism, proximal interruption of valine/isoleucine oxidation improved survival and reduced propionate-derived toxic metabolites, supporting metabolic rerouting as a candidate strategy for PA (chen2025elevatedpropionateand pages 7-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes current and emerging therapeutic approaches for propionic acidemia associated with PCCA deficiency, spanning standard management, transplantation, RNA therapeutics, and experimental metabolic strategies. It is useful for comparing mechanism, maturity, and evidence across interventions.</em></p>
+<h3 id="mrna-3927-a-landmark-clinical-advance">mRNA-3927: A Landmark Clinical Advance</h3>
+<p>The most significant recent therapeutic development for PA is the first-in-human phase 1/2 clinical trial of mRNA-3927, a dual mRNA therapy encapsulated in lipid nanoparticles (LNPs) that encodes both human PCCA and PCCB subunits. As reported in <em>Nature</em> in April 2024, the interim analysis enrolled 16 participants across 5 dose cohorts (0.30–0.90 mg/kg administered intravenously every 2–3 weeks) (koeberl2024interimanalysesof pages 1-2, koeberl2024interimanalysesof pages 2-3). Key findings include:</p>
+<ul>
+<li>A total of 346 intravenous doses were administered over 15.69 person-years of treatment</li>
+<li>No dose-limiting toxicities were observed</li>
+<li>A <strong>70% reduction in the risk of metabolic decompensation events</strong> among the 8 participants who reported them in the 12-month pretreatment period (koeberl2024interimanalysesof pages 1-2)</li>
+<li>Most patients showed reductions in disease biomarkers (3-hydroxypropionate, 2-methylcitrate, propionylcarnitine, and n-propionylglycine) after treatment (koeberl2024interimanalysesof pages 2-3)</li>
+<li>The most common adverse events were pyrexia (68.8%), diarrhea (50%), and vomiting (50%); infusion-related reactions occurred in 31.3% of participants but were generally grade 1–2 (koeberl2024interimanalysesof pages 2-3)</li>
+<li>The mRNA was successfully transported into liver cells, enabling protein translation and post-translational modification into the active PCC enzyme (koeberl2024interimanalysesof pages 5-6)</li>
+</ul>
+<h3 id="antisense-oligonucleotide-approaches">Antisense Oligonucleotide Approaches</h3>
+<p>An innovative personalized therapeutic strategy involves splice-modulating antisense oligonucleotides (ASOs) targeting a PCCA pseudoexon. The c.1285-1416A&gt;G variant in intron 14 of the <em>PCCA</em> gene activates a pseudoexon, and ASOs designed to suppress this aberrant splicing event have been shown to rescue normal PCCA mRNA expression and enzyme activity in cellular models (chen2025elevatedpropionateand pages 7-7).</p>
+<h2 id="8-evolutionary-context">8. Evolutionary Context</h2>
+<p>PCC belongs to the ancient family of biotin-dependent carboxylases, which are widespread across all three domains of life. Phylogenomic analyses suggest that CoA-bearing-substrate carboxylases, including PCC, arose from an ancestral enzyme present in the last common ancestor of Bacteria that could carry out non-specific carboxylation of several CoA-bearing substrates. Eukaryotes most likely acquired their biotin-dependent carboxylases through the mitochondrial endosymbiosis, consistent with the exclusive mitochondrial localization of PCC in eukaryotic cells (jitrapakdee2003thebiotinenzyme pages 4-6). The conserved domain architecture—BC, BCCP, and CT domains—is shared across PCC, acetyl-CoA carboxylase, 3-methylcrotonyl-CoA carboxylase, and pyruvate carboxylase, reflecting their common evolutionary origin, though the CT domains diverge to accommodate different substrate specificities (jitrapakdee2003thebiotinenzyme pages 4-6, jitrapakdee2003thebiotinenzyme pages 10-11).</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>PCCA encodes the α subunit of propionyl-CoA carboxylase, a biotin-dependent mitochondrial matrix enzyme that catalyzes the ATP-dependent carboxylation of propionyl-CoA to D-methylmalonyl-CoA (EC 6.4.1.3). This reaction is the first committed step in the conversion of propionyl-CoA to succinyl-CoA for entry into the TCA cycle. The enzyme functions as an α₆β₆ dodecamer, with the α subunit housing the biotin carboxylase and biotin carboxyl carrier protein domains, and the β subunit providing the carboxyltransferase domain. PCC is essential for the catabolism of branched-chain amino acids (isoleucine, valine), threonine, methionine, odd-chain fatty acids, and cholesterol side chains, as well as for clearance of gut-derived propionate. Loss-of-function mutations in <em>PCCA</em> cause propionic acidemia, a severe inborn error of metabolism with multisystem complications including neurological damage, cardiomyopathy, and recurrent metabolic crises. Recent high-resolution cryo-EM structures (2024) have provided unprecedented structural insights, and the landmark mRNA-3927 clinical trial has demonstrated the feasibility of dual mRNA replacement therapy for this devastating disorder.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(kelson1996chaperoninmediatedassemblyof pages 1-2): T. L. Kelson, T. Ohura, and J. Kraus. Chaperonin-mediated assembly of wild-type and mutant subunits of human propionyl-coa carboxylase expressed in escherichia coli. Human molecular genetics, 5 3:331-7, Mar 1996. URL: https://doi.org/10.1093/hmg/5.3.331, doi:10.1093/hmg/5.3.331. This article has 37 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelson1996chaperoninmediatedassemblyof pages 2-3): T. L. Kelson, T. Ohura, and J. Kraus. Chaperonin-mediated assembly of wild-type and mutant subunits of human propionyl-coa carboxylase expressed in escherichia coli. Human molecular genetics, 5 3:331-7, Mar 1996. URL: https://doi.org/10.1093/hmg/5.3.331, doi:10.1093/hmg/5.3.331. This article has 37 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(erdal2025aminoacidmetabolism pages 9-10): Ranya Erdal, Kıvanç Birsoy, and Gokhan Unlu. Amino acid metabolism in liver mitochondria: from homeostasis to disease. Metabolites, 15:446, Jul 2025. URL: https://doi.org/10.3390/metabo15070446, doi:10.3390/metabo15070446. This article has 7 citations.</p>
+</li>
+<li>
+<p>(jitrapakdee2003thebiotinenzyme pages 4-6): Sarawut Jitrapakdee and John Wallace. The biotin enzyme family: conserved structural motifs and domain rearrangements. Jun 2003. URL: https://doi.org/10.2174/1389203033487199, doi:10.2174/1389203033487199. This article has 142 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2024structuralinsightsinto pages 4-6): Fayang Zhou, Yuanyuan Zhang, Yuyao Zhu, Qiang Zhou, Yigong Shi, and Qiuyu Hu. Structural insights into human propionyl-coa carboxylase (pcc) and 3-methylcrotonyl-coa carboxylase (mcc). bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.04.30.591959, doi:10.1101/2024.04.30.591959. This article has 10 citations.</p>
+</li>
+<li>
+<p>(zhou2024structuralinsightsinto pages 1-4): Fayang Zhou, Yuanyuan Zhang, Yuyao Zhu, Qiang Zhou, Yigong Shi, and Qiuyu Hu. Structural insights into human propionyl-coa carboxylase (pcc) and 3-methylcrotonyl-coa carboxylase (mcc). bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.04.30.591959, doi:10.1101/2024.04.30.591959. This article has 10 citations.</p>
+</li>
+<li>
+<p>(erdal2025aminoacidmetabolism pages 6-9): Ranya Erdal, Kıvanç Birsoy, and Gokhan Unlu. Amino acid metabolism in liver mitochondria: from homeostasis to disease. Metabolites, 15:446, Jul 2025. URL: https://doi.org/10.3390/metabo15070446, doi:10.3390/metabo15070446. This article has 7 citations.</p>
+</li>
+<li>
+<p>(maines2023understandingthepathogenesis pages 1-2): Evelina Maines, Michele Moretti, Nicola Vitturi, Giorgia Gugelmo, Ilaria Fasan, Livia Lenzini, Giovanni Piccoli, Vincenza Gragnaniello, Arianna Maiorana, Massimo Soffiati, Alberto Burlina, and Roberto Franceschi. Understanding the pathogenesis of cardiac complications in patients with propionic acidemia and exploring therapeutic alternatives for those who are not eligible or are waiting for liver transplantation. Metabolites, 13(4):563, Apr 2023. URL: https://doi.org/10.3390/metabo13040563, doi:10.3390/metabo13040563. This article has 7 citations.</p>
+</li>
+<li>
+<p>(riverabarahona2018identificationof34 pages 1-5): Ana Rivera-Barahona, Rosa Navarrete, Raquel García-Rodríguez, Eva Richard, Magdalena Ugarte, Celia Pérez-Cerda, Belén Pérez, Alejandra Gámez, and Lourdes R. Desviat. Identification of 34 novel mutations in propionic acidemia: functional characterization of missense variants and phenotype associations. Molecular genetics and metabolism, 125 3:266-275, Nov 2018. URL: https://doi.org/10.1016/j.ymgme.2018.09.008, doi:10.1016/j.ymgme.2018.09.008. This article has 29 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2024structuralinsightsinto pages 6-7): Fayang Zhou, Yuanyuan Zhang, Yuyao Zhu, Qiang Zhou, Yigong Shi, and Qiuyu Hu. Structural insights into human propionyl-coa carboxylase (pcc) and 3-methylcrotonyl-coa carboxylase (mcc). bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.04.30.591959, doi:10.1101/2024.04.30.591959. This article has 10 citations.</p>
+</li>
+<li>
+<p>(jitrapakdee2003thebiotinenzyme pages 10-11): Sarawut Jitrapakdee and John Wallace. The biotin enzyme family: conserved structural motifs and domain rearrangements. Jun 2003. URL: https://doi.org/10.2174/1389203033487199, doi:10.2174/1389203033487199. This article has 142 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2024structuralinsightsinto pages 11-14): Fayang Zhou, Yuanyuan Zhang, Yuyao Zhu, Qiang Zhou, Yigong Shi, and Qiuyu Hu. Structural insights into human propionyl-coa carboxylase (pcc) and 3-methylcrotonyl-coa carboxylase (mcc). bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.04.30.591959, doi:10.1101/2024.04.30.591959. This article has 10 citations.</p>
+</li>
+<li>
+<p>(zhou2024structuralinsightsinto pages 9-11): Fayang Zhou, Yuanyuan Zhang, Yuyao Zhu, Qiang Zhou, Yigong Shi, and Qiuyu Hu. Structural insights into human propionyl-coa carboxylase (pcc) and 3-methylcrotonyl-coa carboxylase (mcc). bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.04.30.591959, doi:10.1101/2024.04.30.591959. This article has 10 citations.</p>
+</li>
+<li>
+<p>(lu2026lossofpropionylcoa pages 1-5): Fang Lu, Chorlada Paiboonrungruang, Wentao He, Zhaohui Xiong, Pingchuan Tang, Takhar Kasumov, Xiaoxin Chen, and Guo-Fang Zhang. Loss of propionyl-coa carboxylase reprograms hepatic metabolism by suppressing mitochondrial pyruvate carboxylation and fatty acid oxidation. bioRxiv, Apr 2026. URL: https://doi.org/10.64898/2026.04.13.718201, doi:10.64898/2026.04.13.718201. This article has 0 citations.</p>
+</li>
+<li>
+<p>(chen2025elevatedpropionateand pages 2-3): Xiaoxin Chen, Qing Cheng, and Guo-Fang Zhang. Elevated propionate and its association with neurological dysfunctions in propionic acidemia. Frontiers in Molecular Neuroscience, Mar 2025. URL: https://doi.org/10.3389/fnmol.2025.1499376, doi:10.3389/fnmol.2025.1499376. This article has 11 citations.</p>
+</li>
+<li>
+<p>(lu2026lossofpropionylcoa pages 5-8): Fang Lu, Chorlada Paiboonrungruang, Wentao He, Zhaohui Xiong, Pingchuan Tang, Takhar Kasumov, Xiaoxin Chen, and Guo-Fang Zhang. Loss of propionyl-coa carboxylase reprograms hepatic metabolism by suppressing mitochondrial pyruvate carboxylation and fatty acid oxidation. bioRxiv, Apr 2026. URL: https://doi.org/10.64898/2026.04.13.718201, doi:10.64898/2026.04.13.718201. This article has 0 citations.</p>
+</li>
+<li>
+<p>(lu2026lossofpropionylcoa pages 8-11): Fang Lu, Chorlada Paiboonrungruang, Wentao He, Zhaohui Xiong, Pingchuan Tang, Takhar Kasumov, Xiaoxin Chen, and Guo-Fang Zhang. Loss of propionyl-coa carboxylase reprograms hepatic metabolism by suppressing mitochondrial pyruvate carboxylation and fatty acid oxidation. bioRxiv, Apr 2026. URL: https://doi.org/10.64898/2026.04.13.718201, doi:10.64898/2026.04.13.718201. This article has 0 citations.</p>
+</li>
+<li>
+<p>(chen2025elevatedpropionateand pages 3-4): Xiaoxin Chen, Qing Cheng, and Guo-Fang Zhang. Elevated propionate and its association with neurological dysfunctions in propionic acidemia. Frontiers in Molecular Neuroscience, Mar 2025. URL: https://doi.org/10.3389/fnmol.2025.1499376, doi:10.3389/fnmol.2025.1499376. This article has 11 citations.</p>
+</li>
+<li>
+<p>(maines2023understandingthepathogenesis pages 4-5): Evelina Maines, Michele Moretti, Nicola Vitturi, Giorgia Gugelmo, Ilaria Fasan, Livia Lenzini, Giovanni Piccoli, Vincenza Gragnaniello, Arianna Maiorana, Massimo Soffiati, Alberto Burlina, and Roberto Franceschi. Understanding the pathogenesis of cardiac complications in patients with propionic acidemia and exploring therapeutic alternatives for those who are not eligible or are waiting for liver transplantation. Metabolites, 13(4):563, Apr 2023. URL: https://doi.org/10.3390/metabo13040563, doi:10.3390/metabo13040563. This article has 7 citations.</p>
+</li>
+<li>
+<p>(chen2025elevatedpropionateand pages 7-7): Xiaoxin Chen, Qing Cheng, and Guo-Fang Zhang. Elevated propionate and its association with neurological dysfunctions in propionic acidemia. Frontiers in Molecular Neuroscience, Mar 2025. URL: https://doi.org/10.3389/fnmol.2025.1499376, doi:10.3389/fnmol.2025.1499376. This article has 11 citations.</p>
+</li>
+<li>
+<p>(maines2023understandingthepathogenesis pages 11-13): Evelina Maines, Michele Moretti, Nicola Vitturi, Giorgia Gugelmo, Ilaria Fasan, Livia Lenzini, Giovanni Piccoli, Vincenza Gragnaniello, Arianna Maiorana, Massimo Soffiati, Alberto Burlina, and Roberto Franceschi. Understanding the pathogenesis of cardiac complications in patients with propionic acidemia and exploring therapeutic alternatives for those who are not eligible or are waiting for liver transplantation. Metabolites, 13(4):563, Apr 2023. URL: https://doi.org/10.3390/metabo13040563, doi:10.3390/metabo13040563. This article has 7 citations.</p>
+</li>
+<li>
+<p>(maines2023understandingthepathogenesis pages 13-14): Evelina Maines, Michele Moretti, Nicola Vitturi, Giorgia Gugelmo, Ilaria Fasan, Livia Lenzini, Giovanni Piccoli, Vincenza Gragnaniello, Arianna Maiorana, Massimo Soffiati, Alberto Burlina, and Roberto Franceschi. Understanding the pathogenesis of cardiac complications in patients with propionic acidemia and exploring therapeutic alternatives for those who are not eligible or are waiting for liver transplantation. Metabolites, 13(4):563, Apr 2023. URL: https://doi.org/10.3390/metabo13040563, doi:10.3390/metabo13040563. This article has 7 citations.</p>
+</li>
+<li>
+<p>(koeberl2024interimanalysesof pages 1-2): Dwight Koeberl, Andreas Schulze, Neal Sondheimer, Gerald S. Lipshutz, Tarekegn Geberhiwot, Lerong Li, Rajnish Saini, Junxiang Luo, Vanja Sikirica, Ling Jin, Min Liang, Mary Leuchars, and Stephanie Grunewald. Interim analyses of a first-in-human phase 1/2 mrna trial for propionic acidaemia. Nature, 628:872-877, Apr 2024. URL: https://doi.org/10.1038/s41586-024-07266-7, doi:10.1038/s41586-024-07266-7. This article has 136 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(koeberl2024interimanalysesof pages 2-3): Dwight Koeberl, Andreas Schulze, Neal Sondheimer, Gerald S. Lipshutz, Tarekegn Geberhiwot, Lerong Li, Rajnish Saini, Junxiang Luo, Vanja Sikirica, Ling Jin, Min Liang, Mary Leuchars, and Stephanie Grunewald. Interim analyses of a first-in-human phase 1/2 mrna trial for propionic acidaemia. Nature, 628:872-877, Apr 2024. URL: https://doi.org/10.1038/s41586-024-07266-7, doi:10.1038/s41586-024-07266-7. This article has 136 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(koeberl2024interimanalysesof pages 5-6): Dwight Koeberl, Andreas Schulze, Neal Sondheimer, Gerald S. Lipshutz, Tarekegn Geberhiwot, Lerong Li, Rajnish Saini, Junxiang Luo, Vanja Sikirica, Ling Jin, Min Liang, Mary Leuchars, and Stephanie Grunewald. Interim analyses of a first-in-human phase 1/2 mrna trial for propionic acidaemia. Nature, 628:872-877, Apr 2024. URL: https://doi.org/10.1038/s41586-024-07266-7, doi:10.1038/s41586-024-07266-7. This article has 136 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="PCCA-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="PCCA-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kelson1996chaperoninmediatedassemblyof pages 1-2</li>
+<li>zhou2024structuralinsightsinto pages 4-6</li>
+<li>zhou2024structuralinsightsinto pages 6-7</li>
+<li>jitrapakdee2003thebiotinenzyme pages 10-11</li>
+<li>kelson1996chaperoninmediatedassemblyof pages 2-3</li>
+<li>erdal2025aminoacidmetabolism pages 9-10</li>
+<li>lu2026lossofpropionylcoa pages 1-5</li>
+<li>chen2025elevatedpropionateand pages 2-3</li>
+<li>chen2025elevatedpropionateand pages 3-4</li>
+<li>maines2023understandingthepathogenesis pages 1-2</li>
+<li>chen2025elevatedpropionateand pages 7-7</li>
+<li>maines2023understandingthepathogenesis pages 11-13</li>
+<li>koeberl2024interimanalysesof pages 1-2</li>
+<li>koeberl2024interimanalysesof pages 2-3</li>
+<li>koeberl2024interimanalysesof pages 5-6</li>
+<li>jitrapakdee2003thebiotinenzyme pages 4-6</li>
+<li>zhou2024structuralinsightsinto pages 1-4</li>
+<li>erdal2025aminoacidmetabolism pages 6-9</li>
+<li>zhou2024structuralinsightsinto pages 11-14</li>
+<li>zhou2024structuralinsightsinto pages 9-11</li>
+<li>lu2026lossofpropionylcoa pages 5-8</li>
+<li>lu2026lossofpropionylcoa pages 8-11</li>
+<li>maines2023understandingthepathogenesis pages 4-5</li>
+<li>maines2023understandingthepathogenesis pages 13-14</li>
+<li>https://doi.org/10.1093/hmg/5.3.331,</li>
+<li>https://doi.org/10.3390/metabo15070446,</li>
+<li>https://doi.org/10.2174/1389203033487199,</li>
+<li>https://doi.org/10.1101/2024.04.30.591959,</li>
+<li>https://doi.org/10.3390/metabo13040563,</li>
+<li>https://doi.org/10.1016/j.ymgme.2018.09.008,</li>
+<li>https://doi.org/10.64898/2026.04.13.718201,</li>
+<li>https://doi.org/10.3389/fnmol.2025.1499376,</li>
+<li>https://doi.org/10.1038/s41586-024-07266-7,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PCCA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P05165" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pcca-p05165-review-notes">PCCA (P05165) review notes</h1>
+<h2 id="schema-shape-reminders-validated">Schema shape reminders (validated)</h2>
+<ul>
+<li>core_functions.directly_involved_in: multivalued list of Term ({id,label}).</li>
+<li>suggested_questions: list of {question: "...", experts: [...]}.</li>
+<li>suggested_experiments: list of {description: "...", hypothesis: "..."}.</li>
+</ul>
+<h2 id="deep-research-status">Deep research status</h2>
+<p><code>just deep-research-falcon human P05165</code> / <code>uv run scripts/deep_research_wrapper.py</code><br />
+did NOT produce a <code>PCCA-deep-research-falcon.md</code> (falcon wrapper: system python 3.9<br />
+chokes on <code>dict | None</code>; run via uv started but produced no output/log within the<br />
+poll window). Per instructions I did NOT fabricate a <code>-deep-research-*.md</code>. Grounded<br />
+this review in <code>PCCA-uniprot.txt</code>, the seeded GOA, <code>dismech/kb/disorders/Propionic_Acidemia.yaml</code>,<br />
+and the cached <code>publications/PMID_*.md</code>.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<p>PCCA = biotin-containing alpha subunit of mitochondrial propionyl-CoA carboxylase (PCC),<br />
+a biotin-dependent carboxylase. PCC catalyses the first committed, ATP-dependent step of<br />
+propionyl-CoA catabolism: propanoyl-CoA + HCO3- + ATP -&gt; (S)-methylmalonyl-CoA + ADP + Pi<br />
+(EC 6.4.1.3; RHEA:23720). Holoenzyme = alpha6beta6 dodecamer (~750 kDa) of PCCA (alpha) +<br />
+PCCB (beta) [PMID:20725044, PMID:29033250].</p>
+<ul>
+<li>alpha subunit (PCCA) carries the biotin carboxylase (BC) + biotin-carboxyl-carrier<br />
+  protein (BCCP) domains; biotin is covalently attached at Lys694 by HLCS; alpha<br />
+  catalyses the ATP-dependent carboxylation of biotin. beta subunit (PCCB) supplies the<br />
+  carboxyltransferase (CT) activity. UniProt: BC domain 62-509, ATP-grasp 181-378,<br />
+  biotinyl-binding 653-728; ACT_SITE 349; ATP/Mg2+/Mn2+ binding sites; biotin at 409/694.</li>
+<li>Substrate: propionyl-CoA (Km 0.29 mM); also butyryl-CoA (-&gt; ethylmalonyl-CoA) at much<br />
+  lower rate; minor acetyl-CoA [PMID:6765947, PMID:29033250, UniProt CATALYTIC ACTIVITY].</li>
+<li>Location: mitochondrial matrix (matrix enzyme; loosely bound to inner membrane-matrix<br />
+  fraction) [UniProt SUBCELLULAR LOCATION; PMID:10101253; PMID:16023992; PMID:29033250].<br />
+  Cleavable N-terminal transit peptide (1-52) <a href="https://pubmed.ncbi.nlm.nih.gov/16023992">PMID:16023992</a>.</li>
+<li>Pathway: propanoyl-CoA degradation; succinyl-CoA from propanoyl-CoA step 1/3<br />
+  (UniPathway UPA00945/UER00908; UniProt PATHWAY). Product methylmalonyl-CoA -&gt; succinyl-CoA,<br />
+  a TCA anaplerotic intermediate <a href="https://pubmed.ncbi.nlm.nih.gov/29033250">PMID:29033250</a>.</li>
+<li>Precursors of propionyl-CoA: cholesterol, valine, odd-chain FA, methionine, isoleucine,<br />
+  threonine ("c-VOMIT") <a href="https://pubmed.ncbi.nlm.nih.gov/29033250">PMID:29033250</a>.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Biallelic PCCA (or PCCB) loss-of-function -&gt; propionic acidemia (PA-1, MIM:606054;<br />
+MONDO:0011628) [UniProt DISEASE; PMID:10101253; disorder KB]. Autosomal recessive organic<br />
+acidemia; toxic organic acid accumulation, metabolic acidosis, hyperammonemia.</p>
+<h2 id="interactions">Interactions</h2>
+<ul>
+<li>PCCB (P05166): obligate partner in holoenzyme; multiple IntAct/interactome hits<br />
+  (PMID:20725044, PMID:33961781, PMID:40205054). These are the biological complex partner.</li>
+<li>MCC / MCCC1 (P23508): IntAct hit (PMID:32296183 HuRI). Cross-carboxylase / likely<br />
+  systematic Y2H; MCC is a paralogous biotin carboxylase.</li>
+<li>HLCS / holocarboxylase synthetase (P50747): biotinylates PCCA at K694; PCCA is HLCS<br />
+  substrate; enzyme binding (PMID:19157941 uses the PCCA-derived p67 substrate).</li>
+<li>SIRT3/4/5: deacylate/interact with acetylated biotin-dependent carboxylases including<br />
+  PCCA (UniProt SUBUNIT; PMID:23438705 - not in GOA).</li>
+</ul>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>MF: GO:0004658 propionyl-CoA carboxylase activity (IBA, IEA, IDA PMID:6765947,<br />
+  IMP PMID:8434582) -&gt; ACCEPT (core). biotin binding, ATP binding, metal ion binding -&gt; ACCEPT<br />
+  (cofactor/substrate, well supported by structure/UniProt features). ligase forming C-C<br />
+  bonds (GO:0016885, IEA) -&gt; ACCEPT parent (correct but general). enzyme binding IPI<br />
+  PMID:19157941 (HLCS) -&gt; KEEP_AS_NON_CORE (real, but a modification substrate relationship,<br />
+  not core enzymatic function).</li>
+<li>CC: mitochondrial matrix (multiple IDA/EXP/IEA/TAS) -&gt; ACCEPT. mitochondrion (IBA/IDA/HTP)<br />
+  -&gt; ACCEPT (broader but correct). cytosol (Reactome TAS) -&gt; KEEP_AS_NON_CORE (reflects<br />
+  cytosolic apo-precursor before import; not functional site). catalytic complex GO:1902494<br />
+  (IPI PMID:20725044) -&gt; MODIFY too general; propose propionyl-CoA carboxylase complex.</li>
+<li>BP: propionate metabolism / propionyl-CoA catabolism. short-chain fatty acid catabolic<br />
+  process (GO:0019626, IC) -&gt; MODIFY to propionyl-CoA catabolic process GO:1902859.<br />
+  succinyl-CoA biosynthetic process (GO:1901290, IDA PMID:8434582) -&gt; KEEP_AS_NON_CORE<br />
+  (downstream product; PCC makes methylmalonyl-CoA, not succinyl-CoA directly). fatty acid<br />
+  metabolic process (GO:0006631, NAS) -&gt; KEEP_AS_NON_CORE (broad). branched-chain amino acid<br />
+  metabolic process (GO:0009081, NAS) -&gt; KEEP_AS_NON_CORE (Ile/Val/Thr/Met feed in; real<br />
+  physiological role but not the direct reaction).</li>
+<li>protein binding (GO:0005515) IPIs: bare term; MARK_AS_OVER_ANNOTATED (per policy, not REMOVE).<br />
+  PMID:20725044/33961781/40205054 = PCCB (the genuine complex partner); PMID:32296183 = MCC/HuRI.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P05165
+gene_symbol: PCCA
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PCCA encodes the biotin-containing alpha subunit of mitochondrial propionyl-CoA
+  carboxylase (PCC; EC 6.4.1.3), a biotin-dependent carboxylase of the mitochondrial
+  matrix. PCC catalyses the first, committed, ATP-dependent step of propionyl-CoA
+  catabolism, converting propanoyl-CoA + bicarbonate + ATP into (S)-methylmalonyl-CoA
+  + ADP + phosphate; the methylmalonyl-CoA product is subsequently converted to
+  succinyl-CoA and enters the tricarboxylic acid cycle. Propionyl-CoA arises from the
+  catabolism of the amino acids isoleucine, valine, methionine and threonine, of
+  odd-chain fatty acids, and of cholesterol. The functional holoenzyme is a large
+  alpha6-beta6 dodecamer (~750 kDa) built from six PCCA (alpha) and six PCCB (beta)
+  subunits. The alpha subunit carries the biotin carboxylase (BC) domain and the
+  C-terminal biotin-carboxyl-carrier-protein (BCCP) domain to which biotin is
+  covalently attached (at Lys694, by holocarboxylase synthetase); it binds ATP and
+  bicarbonate and catalyses the Mg2+-dependent carboxylation of biotin, whereas the
+  beta subunit (PCCB) supplies the carboxyltransferase activity that transfers the
+  carboxyl group to propionyl-CoA. The alpha subunit is synthesized with a cleavable
+  N-terminal mitochondrial targeting presequence and matures in the matrix. Loss of
+  PCC activity through biallelic pathogenic variants in PCCA (or PCCB) causes propionic
+  acidemia, an autosomal recessive organic acidemia.
+alternative_products:
+- name: &#39;1&#39;
+  id: P05165-1
+- name: &#39;2&#39;
+  id: P05165-2
+  sequence_note: VSP_039857
+- name: &#39;3&#39;
+  id: P05165-3
+  sequence_note: VSP_044458
+existing_annotations:
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred propionyl-CoA carboxylase activity. This is the core,
+      defining molecular function of PCCA as the biotin-containing alpha subunit of the
+      PCC holoenzyme, directly supported by biochemistry and disease genetics.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported core function; the IBA is at the correct level of specificity and
+      concordant with experimental (IDA/IMP) annotations and the EC 6.4.1.3 assignment.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Propionyl-CoA carboxylase (PCC) is the enzyme which catalyzes the carboxylation
+        of propionyl-CoA to methylmalonyl-CoA and is encoded by the genes PCCA and PCCB
+        to form a hetero-dodecamer.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred mitochondrial localization/activity. Correct: PCC is a
+      mitochondrial matrix enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with experimental matrix localization (below); mitochondrion is a
+      correct, if less specific, compartment for where the enzyme is active.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        Propionyl-coenzyme A carboxylase (PCC), a mitochondrial biotin-dependent enzyme,
+        is essential for the catabolism of the amino acids Thr, Val, Ile and Met,
+        cholesterol and fatty acids with an odd number of carbon atoms.
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (RHEA:23720 / EC 6.4.1.3 mapping) assignment of propionyl-CoA
+      carboxylase activity. Redundant with, and confirmed by, the experimental IDA/IMP
+      annotations of the same term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function; the EC/RHEA mapping matches the demonstrated
+      catalytic activity.
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        We have purified propionyl-CoA carboxylase from normal, postmortem human liver
+        to homogeneity.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-based ATP binding. The alpha subunit contains an ATP-grasp domain and
+      catalyses the ATP-dependent carboxylation of biotin; ATP is a substrate of the BC
+      reaction (Km ~0.08 mM).
+    action: ACCEPT
+    reason: &gt;-
+      Supported by the catalytic mechanism, the ATP-grasp domain, and multiple ATP
+      binding-site features in UniProt; ATP binding is integral to the alpha-subunit
+      biotin carboxylase step.
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        The apparent Km values for ATP, propionyl-CoA, and bicarbonate
+        are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (UniProt subcellular location / ARBA) assignment of mitochondrial
+      matrix. Correct and concordant with experimental EXP/IDA matrix annotations.
+    action: ACCEPT
+    reason: &gt;-
+      PCC is a matrix enzyme; the electronic assignment matches the curated UniProt
+      subcellular location and experimental evidence.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with sonication.
+- term:
+    id: GO:0009374
+    label: biotin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA electronic assignment of biotin binding. Biotin is the obligate cofactor of
+      PCC and is covalently attached to the C-terminal biotinyl domain of the alpha
+      subunit; each holoenzyme carries biotin almost entirely on the alpha subunit.
+    action: ACCEPT
+    reason: &gt;-
+      Strongly supported: biotin is the defining cofactor of this biotin-dependent
+      carboxylase and is carried by PCCA.
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        Each mole of native enzyme
+        contains 4 mol of bound biotin, virtually all of which is found with the larger
+        (alpha) subunit.
+- term:
+    id: GO:0016885
+    label: ligase activity, forming carbon-carbon bonds
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ARBA electronic assignment of the parent ligase term. This is the correct broad
+      catalytic class (EC 6.4 ligases forming C-C bonds) for propionyl-CoA carboxylase,
+      but is less informative than the specific GO:0004658 already annotated.
+    action: ACCEPT
+    reason: &gt;-
+      Correct parent activity; not wrong, but subsumed by the more specific
+      propionyl-CoA carboxylase activity. Retained as a valid, if general, IEA.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Propionyl-CoA carboxylase (PCC) is the enzyme which catalyzes the carboxylation
+        of propionyl-CoA to methylmalonyl-CoA
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-based metal ion binding. The alpha-subunit biotin carboxylase/ATP-grasp
+      domain binds two divalent metal ions (Mg2+ or Mn2+) per subunit that are required
+      for the ATP-dependent carboxylation step.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by UniProt cofactor annotation (binds 2 Mg2+/Mn2+ per subunit) and
+      metal-binding site features; a general but correct molecular function.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        The active site of the BC domain is conserved with that of E. coli BC, and all
+        the residues that interact with the substrates of this reaction have essentially
+        the same conformation in both structures
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20725044
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated binary interaction with PCCB (P05166), the beta subunit. This is
+      the genuine, obligate holoenzyme partnership (alpha6-beta6), but the bare
+      &#34;protein binding&#34; term is uninformative about the actual molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation policy, bare protein binding IPIs are not removed. The interaction
+      itself (with PCCB) is real and biologically central, but &#34;protein binding&#34; adds no
+      functional specificity beyond what is captured by the propionyl-CoA carboxylase
+      complex membership; a more informative term (structural constituent of the PCC
+      holoenzyme) would be preferable.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        The holoenzyme of PCC
+        is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct/HuRI systematic binary interactome hit, here with MCC (MCCC1, P23508), a
+      paralogous biotin-dependent carboxylase. Bare &#34;protein binding&#34; from a
+      high-throughput all-by-all screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative term from a proteome-scale Y2H screen; not the core function.
+      Retained per policy (not removed) but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &gt;-
+        Here we present a human &#39;all-by-all&#39;
+        reference interactome map of human binary protein interactions, or &#39;HuRI&#39;.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with PCCB (P05166) from a proteome-scale interactome
+      study (BioPlex-type). Again the genuine beta-subunit partner, reported via the
+      uninformative &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Real interaction (PCCB, the holoenzyme partner) but bare protein binding is not
+      the core molecular function; retained per policy and flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling of the human
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction with PCCB (P05166) from a multimodal cell-map / genomics
+      study. The beta-subunit partner again, via bare &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Genuine PCCB partnership but uninformative term; retained per policy and flagged
+      as over-annotation rather than removed.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: Multimodal cell maps as a foundation for structural and functional genomics.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence (Human Protein Atlas) localization to mitochondrion. Correct,
+      if less specific than the matrix annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Direct localization evidence consistent with PCC being a mitochondrial matrix
+      enzyme.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with sonication.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: NAS
+  original_reference_id: PMID:29033250
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal (CPX-6169) NAS assignment of mitochondrial matrix, from the PCC
+      review. Correct compartment for the holoenzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental EXP/IDA matrix evidence and the curated UniProt
+      subcellular location.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with sonication.
+- term:
+    id: GO:0006631
+    label: fatty acid metabolic process
+  evidence_type: NAS
+  original_reference_id: PMID:29033250
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS: PCC participates in fatty acid metabolism, since propionyl-CoA
+      is the end product of beta-oxidation of odd-chain fatty acids and PCC channels it
+      into the TCA cycle. Broad process term.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real but non-core physiological context. PCC acts on the propionyl-CoA node of
+      odd-chain fatty acid catabolism; the direct reaction is more precisely
+      propionyl-CoA carboxylation/propionate catabolism than generic fatty acid
+      metabolism.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Disruption of PCC leads to accumulation of odd-chain fatty acids (FA), as
+        propionyl-CoA is the end product of beta oxidation of odd-numbered FA.
+- term:
+    id: GO:0009081
+    label: branched-chain amino acid metabolic process
+  evidence_type: NAS
+  original_reference_id: PMID:29033250
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS: PCC is downstream in the catabolism of branched-chain and other
+      amino acids (isoleucine, valine, methionine, threonine) that generate propionyl-CoA.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Valid physiological role (Ile and Val catabolism converge on propionyl-CoA), but
+      not the direct reaction PCCA catalyses; kept as a relevant non-core process.
+      Note GO:0009081 covers isoleucine/leucine/valine; PCC also serves Met/Thr, which
+      are not branched-chain, so this term is a partial view of PCC&#39;s amino-acid role.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain fatty
+        acids, methionine, isoleucine and threonine
+- term:
+    id: GO:1902494
+    label: catalytic complex
+  evidence_type: IPI
+  original_reference_id: PMID:20725044
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal IPI: PCCA is part of a catalytic complex, i.e. the alpha6-beta6 PCC
+      holoenzyme (ComplexPortal CPX-6169, Mitochondrial propionyl-CoA carboxylase complex).
+    action: ACCEPT
+    reason: &gt;-
+      Correct: PCCA is an obligate structural subunit of the catalytic PCC holoenzyme.
+      A dedicated &#34;propionyl-CoA carboxylase complex&#34; GO term does not currently exist
+      (only acetyl-CoA and methylcrotonoyl-CoA carboxylase complexes), so the general
+      &#34;catalytic complex&#34; is retained rather than modified to a nonexistent term.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        The holoenzyme of PCC
+        is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: EXP
+  original_reference_id: PMID:10101253
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental import/localization: in vitro-expressed PCCA precursor is imported
+      into mitochondria and processed to the mature matrix form. Supports mitochondrial
+      matrix localization.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence for mitochondrial import and maturation, consistent
+      with the matrix location of the enzyme.
+    supported_by:
+    - reference_id: PMID:10101253
+      supporting_text: &gt;-
+        Both wild-type and mutant proteins were imported into
+        mitochondria and processed into the mature form with similar efficiency
+- term:
+    id: GO:1901290
+    label: succinyl-CoA biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:8434582
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA (propionate-flux complementation) linking PCCA to production of succinyl-CoA.
+      PCC catalyses the first step (propionyl-CoA -&gt; methylmalonyl-CoA); succinyl-CoA is
+      the downstream product of the three-step propanoyl-CoA degradation pathway.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      PCC&#39;s direct product is (S)-methylmalonyl-CoA, not succinyl-CoA; succinyl-CoA
+      formation requires the downstream MCEE and MUT steps. The annotation reflects
+      PCCA&#39;s contribution to the pathway output rather than its direct catalytic
+      product, so it is kept as non-core.
+    supported_by:
+    - reference_id: PMID:8434582
+      supporting_text: &gt;-
+        Both
+        clones reconstitute propionate flux to normal levels in fibroblasts from
+        patients genetically deficient in PCCA (pccA).
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteomics assignment to mitochondrion. Concordant
+      with the established mitochondrial matrix localization.
+    action: ACCEPT
+    reason: &gt;-
+      High-confidence mitochondrial proteome evidence consistent with the curated
+      compartment; correct though less specific than matrix.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: Quantitative high-confidence human mitochondrial proteome and its dynamics
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:16023992
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct evidence: the mature PCCA amino-terminus and cleavable N-terminal targeting
+      presequence were defined, showing import into the mitochondrial matrix by the
+      classical presequence pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental determination of the mitochondrial targeting signal and mature matrix
+      peptide directly supports matrix localization.
+    supported_by:
+    - reference_id: PMID:16023992
+      supporting_text: &gt;-
+        the two subunits of the enzyme (MCCalpha; MCCbeta)
+        are imported into the mitochondrial matrix by the classical pathway involving
+        cleavable amino-terminal targeting presequences.
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IDA
+  original_reference_id: PMID:6765947
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct biochemical demonstration: PCC purified from human liver to homogeneity,
+      shown to be a biotin-containing alpha/beta enzyme carboxylating propionyl-CoA with
+      defined kinetic parameters. Core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Definitive experimental evidence for propionyl-CoA carboxylase activity; anchors
+      this as the core function of the enzyme.
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        The apparent Km values for ATP, propionyl-CoA, and bicarbonate
+        are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.
+- term:
+    id: GO:0019626
+    label: short-chain fatty acid catabolic process
+  evidence_type: IC
+  original_reference_id: PMID:6765947
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Curator inference (from GO:0004658) that PCC participates in short-chain fatty acid
+      catabolism. Propionate/propionyl-CoA is a short-chain acid, but a more precise
+      process term is available.
+    action: MODIFY
+    reason: &gt;-
+      The reaction PCC catalyses is specifically the committed step of propionyl-CoA
+      catabolism; &#34;short-chain fatty acid catabolic process&#34; is broader and less
+      accurate than the dedicated term. Propose replacement with propionyl-CoA catabolic
+      process.
+    proposed_replacement_terms:
+    - id: GO:1902859
+      label: propionyl-CoA catabolic process
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        PCC&#39;s
+        primary function is to catalyze the carboxylation of propionyl-CoA to produce
+        methylmalonyl-CoA
+- term:
+    id: GO:0019626
+    label: short-chain fatty acid catabolic process
+  evidence_type: IC
+  original_reference_id: PMID:8434582
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Second curator inference (from GO:0004658) of short-chain fatty acid catabolism,
+      based on the propionate-flux complementation study. Same over-broad term as above.
+    action: MODIFY
+    reason: &gt;-
+      As above, the direct process is propionyl-CoA / propionate catabolism; replace the
+      broad short-chain fatty acid term with the specific propionyl-CoA catabolic process.
+    proposed_replacement_terms:
+    - id: GO:1902859
+      label: propionyl-CoA catabolic process
+    supported_by:
+    - reference_id: PMID:8434582
+      supporting_text: &gt;-
+        Both
+        clones reconstitute propionate flux to normal levels in fibroblasts from
+        patients genetically deficient in PCCA (pccA).
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IMP
+  original_reference_id: PMID:8434582
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IMP: recombinant human PCCA rescues (complements) the propionate-flux defect in
+      PCCA-deficient (pccA) patient fibroblasts, demonstrating that PCCA is required for
+      propionyl-CoA carboxylase activity in cells. Core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Genetic complementation directly ties PCCA to the propionyl-CoA carboxylase
+      activity and propionate flux; strong support for the core function.
+    supported_by:
+    - reference_id: PMID:8434582
+      supporting_text: &gt;-
+        We describe cDNA clones expressing
+        human PCCA and complementation of the genetic defect in pccA fibroblasts by
+        DNA-mediated gene transfer.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2993447
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS placing PCCA in the cytosol, reflecting the pre-import apo-precursor
+      and the Reactome &#34;HLCS biotinylates 6x(PCCA:PCCB)&#34; / cytosolic-to-matrix
+      translocation events. PCC is not catalytically active in the cytosol.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The functional, biotinylated, active holoenzyme resides in the mitochondrial
+      matrix; the cytosolic assignment reflects the transient apo-precursor stage before
+      mitochondrial import (any cytosolic biotinylation is likely non-functional). Kept
+      as a non-core, transient localization rather than removed.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        The PCCA precursor does not contain biotin until imported into the mitochondrion
+        and cleaved
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3323111
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS (cytosolic carboxylases translocate to mitochondrial matrix) placing
+      the PCCA precursor in the cytosol prior to import.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      As above: transient pre-import cytosolic localization of the apo-precursor; the
+      active enzyme is a matrix enzyme. Non-core.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        The PCCA precursor does not contain biotin until imported into the mitochondrion
+        and cleaved
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9035990
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS (defective HLCS does not biotinylate 6x(PCCA:PCCB)) placing PCCA in
+      the cytosol as part of the biotinylation/multiple-carboxylase-deficiency pathway.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Same transient cytosolic apo-precursor context; not the functional compartment.
+      Kept as non-core.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        The PCCA precursor does not contain biotin until imported into the mitochondrion
+        and cleaved
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3065959
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS assignment of mitochondrial matrix (from the carboxylase degradation
+      reaction). Correct functional compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental matrix evidence; the mature active enzyme is in the
+      matrix.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with sonication.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3323111
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS assignment of mitochondrial matrix (post-translocation destination in
+      the cytosol-&gt;matrix translocation reaction). Correct functional compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Matches the established matrix localization of the mature enzyme.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with sonication.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71031
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS assignment of mitochondrial matrix, associated with the core PCC
+      reaction (propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + Pi). This is
+      the compartment where the catalytic reaction occurs.
+    action: ACCEPT
+    reason: &gt;-
+      Correct: the propionyl-CoA carboxylase reaction takes place in the mitochondrial
+      matrix.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with sonication.
+- term:
+    id: GO:0019899
+    label: enzyme binding
+  evidence_type: IPI
+  original_reference_id: PMID:19157941
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI interaction with holocarboxylase synthetase (HLCS, P50747), the enzyme that
+      covalently attaches biotin to PCCA. The study used the PCCA-derived C-terminal p67
+      polypeptide (biotinylation site K669/K694) as the HLCS substrate in Y2H and docking
+      assays, defining the PCCA-HLCS substrate-enzyme interaction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A real and biologically meaningful interaction (PCCA is the substrate of HLCS-
+      mediated biotinylation, essential for activity), but it describes a
+      post-translational modification relationship rather than PCCA&#39;s own core molecular
+      function. &#34;Enzyme binding&#34; is more informative than bare protein binding, so it is
+      retained as non-core.
+    supported_by:
+    - reference_id: PMID:19157941
+      supporting_text: &gt;-
+        The polypeptide p67 comprises the 67 C-terminal amino acids in human PCC (GenBank
+        accession #AAA60035), including the biotin-binding site K669
+- term:
+    id: GO:0009374
+    label: biotin binding
+  evidence_type: TAS
+  original_reference_id: PMID:3460076
+  qualifier: enables
+  review:
+    summary: &gt;-
+      TAS (ProtInc) biotin binding, from the cDNA-cloning paper that identified the
+      alpha chain via its conserved Ala-Met-Lys-Met biotin-binding-site motif. Biotin is
+      the obligate cofactor carried by PCCA.
+    action: ACCEPT
+    reason: &gt;-
+      Well-established core cofactor relationship; the alpha chain was in fact identified
+      through its biotin-binding-site sequence.
+    supported_by:
+    - reference_id: PMID:3460076
+      supporting_text: &gt;-
+        One class contained the anticipated Ala-Met-Lys-Met
+        sequence, corresponding to the biotin binding site found in several
+        biotin-dependent carboxylases, thus confirming the alpha-chain assignment of
+        these clones.
+core_functions:
+- description: &gt;-
+    Propionyl-CoA carboxylase alpha subunit: within the alpha6-beta6 PCC holoenzyme, the
+    alpha subunit binds ATP and bicarbonate and catalyses the Mg2+-dependent ATP-driven
+    carboxylation of its covalently bound biotin, contributing the biotin carboxylase
+    half-reaction of propionyl-CoA carboxylase activity (conversion of propanoyl-CoA to
+    (S)-methylmalonyl-CoA), the first committed step of propionyl-CoA / propionate
+    catabolism in the mitochondrial matrix.
+  molecular_function:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  directly_involved_in:
+  - id: GO:1902859
+    label: propionyl-CoA catabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:6765947
+    supporting_text: &gt;-
+      The apparent Km values for ATP, propionyl-CoA, and bicarbonate
+      are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.
+  - reference_id: PMID:29033250
+    supporting_text: &gt;-
+      PCC&#39;s
+      primary function is to catalyze the carboxylation of propionyl-CoA to produce
+      methylmalonyl-CoA
+- description: &gt;-
+    Biotin cofactor carrier: the alpha subunit carries the C-terminal biotinyl (BCCP)
+    domain and binds biotin, which is covalently attached (by holocarboxylase synthetase)
+    and is obligately required for catalytic activity of the biotin-dependent carboxylase.
+  molecular_function:
+    id: GO:0009374
+    label: biotin binding
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:6765947
+    supporting_text: &gt;-
+      Each mole of native enzyme
+      contains 4 mol of bound biotin, virtually all of which is found with the larger
+      (alpha) subunit.
+- description: &gt;-
+    ATP binding: the alpha subunit ATP-grasp/biotin carboxylase domain binds ATP (Km
+    ~0.08 mM) as a substrate of the ATP-dependent biotin carboxylation step.
+  molecular_function:
+    id: GO:0005524
+    label: ATP binding
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:6765947
+    supporting_text: &gt;-
+      The apparent Km values for ATP, propionyl-CoA, and bicarbonate
+      are 0.08 mM, 0.29 mM, and 3.0 mM, respectively.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Do the three PCCA splice isoforms (P05165-1/-2/-3) differ in enzymatic function,
+    holoenzyme incorporation, or tissue distribution? Their functional impact has not
+    been well characterized.
+- question: &gt;-
+    Does PCCA (or the PCC holoenzyme) have any moonlighting or regulatory role beyond
+    carboxylation, e.g. via its reported acetylation/succinylation and interactions with
+    SIRT3/4/5?
+suggested_experiments:
+- description: &gt;-
+    Isoform-resolved enzyme kinetics and holoenzyme-assembly assays for P05165-2 and
+    P05165-3 versus the canonical isoform, to determine whether alternative splicing
+    alters propionyl-CoA carboxylase activity.
+- description: &gt;-
+    Quantitative biotinylation/acylation site mapping of PCCA in matched control and
+    propionic-acidemia cells to test how post-translational modification state modulates
+    PCC activity.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10101253
+  title: Genetic heterogeneity in propionic acidemia patients with alpha-subunit defects.
+    Identification of five novel mutations, one of them causing instability of the
+    protein.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; provides experimental mitochondrial import/maturation and
+      PA-causing PCCA variant data. Supports the EXP mitochondrial-matrix annotation.
+- id: PMID:16023992
+  title: Mitochondrial targeting signals and mature peptides of 3-methylcrotonyl-CoA
+    carboxylase.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Focuses on MCC but the abstract explicitly reports the mitochondrial targeting
+      signal and mature N-terminus of propionyl-CoA carboxylase as a paralog; supports
+      the matrix-import IDA for PCCA.
+- id: PMID:19157941
+  title: N- and C-terminal domains in human holocarboxylase synthetase participate
+    in substrate recognition.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Uses the PCCA-derived C-terminal p67 (biotinylation site) as the HLCS substrate;
+      documents the PCCA-HLCS enzyme-substrate interaction underlying the enzyme-binding
+      annotation.
+- id: PMID:20725044
+  title: Crystal structure of the alpha(6)beta(6) holoenzyme of propionyl-coenzyme
+    A carboxylase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines the alpha6-beta6 holoenzyme architecture, BC/BCCP/BT domains of the alpha
+      subunit, and BC active site; the source of the PCCB-interaction and catalytic-complex
+      annotations.
+- id: PMID:29033250
+  title: Propionyl-CoA carboxylase - A review.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Authoritative review of PCC structure, function, mechanism, localization, and
+      disease; primary basis for the description and process/localization judgments.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI all-by-all binary interactome; source of a systematic PCCA-MCC(MCCC1) hit
+      reported as bare protein binding. Not informative about core function.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale interactome study; source of a PCCA-PCCB protein-binding hit. The
+      interaction (beta subunit) is genuine but the term is uninformative.
+- id: PMID:3460076
+  title: &#39;Isolation of cDNA clones coding for the alpha and beta chains of human propionyl-CoA
+    carboxylase: chromosomal assignments and DNA polymorphisms associated with PCCA
+    and PCCB genes.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Identified the PCCA (alpha) cDNA via the conserved biotin-binding-site motif;
+      supports the biotin-binding TAS annotation.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-confidence mitochondrial proteome; independent HTP evidence for mitochondrial
+      localization of PCCA.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Multimodal cell-map genomics resource; source of a PCCA-PCCB protein-binding hit.
+      Genuine partner, uninformative term.
+- id: PMID:6765947
+  title: Isolation and characterization of propionyl-CoA carboxylase from normal human
+    liver. Evidence for a protomeric tetramer of nonidentical subunits.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Definitive biochemical characterization of purified human PCC: biotin content on the
+      alpha subunit, kinetic parameters for ATP/propionyl-CoA/bicarbonate, substrate range.
+      Primary support for the catalytic-activity, cofactor and ATP-binding core functions.
+- id: PMID:8434582
+  title: Cloning of functional alpha propionyl CoA carboxylase and correction of enzyme
+    deficiency in pccA fibroblasts.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Functional cloning and complementation of PCCA-deficient fibroblasts restoring
+      propionate flux; support for the IMP propionyl-CoA carboxylase and pathway annotations.
+- id: Reactome:R-HSA-2993447
+  title: HLCS biotinylates 6x(PCCA:PCCB)
+  findings: []
+- id: Reactome:R-HSA-3065959
+  title: An unknown protease degrades hCBXs
+  findings: []
+- id: Reactome:R-HSA-3323111
+  title: Cytosolic carboxylases translocate to mitochondrial matrix
+  findings: []
+- id: Reactome:R-HSA-71031
+  title: propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + orthophosphate
+  findings: []
+- id: Reactome:R-HSA-9035990
+  title: Defective HLCS does not biotinylate 6x(PCCA:PCCB)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PCCB/PCCB-ai-review.html
+++ b/genes/human/PCCB/PCCB-ai-review.html
@@ -1,0 +1,4901 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PCCB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PCCB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P05166" target="_blank" class="term-link">
+                        P05166
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PCCB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P05166" data-a="DESCRIPTION: PCCB encodes the beta (carboxyltransferase) subuni..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PCCB encodes the beta (carboxyltransferase) subunit of mitochondrial propionyl-CoA carboxylase (PCC; EC 6.4.1.3), a biotin-dependent carboxylase of the mitochondrial matrix. The functional holoenzyme is an alpha6-beta6 dodecamer (~750 kDa) built around a central beta6 hexamer core decorated by six PCCA (alpha) subunits. Within PCC, the alpha subunit carboxylates biotin on its biotin-carboxyl-carrier (BCCP) domain in an ATP-dependent step, and the beta subunit then transfers the carboxyl group from carboxybiotin to propionyl-CoA, converting propanoyl-CoA + hydrogencarbonate + ATP to (S)-methylmalonyl-CoA + ADP + phosphate. This is the committed step of propionyl-CoA (propionate) catabolism: propionyl-CoA arises from degradation of the amino acids isoleucine, valine, methionine and threonine, of odd-chain fatty acids, and of the cholesterol side chain, and the methylmalonyl-CoA product is isomerized and converted to succinyl-CoA, an anaplerotic entry point into the tricarboxylic acid cycle. The enzyme is promiscuous, also carboxylating butyryl-CoA and acetyl-CoA at much lower rates. Biallelic loss-of-function variants in PCCB (or PCCA) cause propionic acidemia, an autosomal recessive organic acidemia characterized by metabolic acidosis, ketosis, hyperammonemia, and multi-organ complications; many PCCB missense variants act by impairing holoenzyme assembly and stability rather than by directly abolishing catalysis.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred mitochondrial localization of the PCC beta subunit. PCC is a well-established mitochondrial matrix enzyme, so mitochondrion is correct but less specific than the matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PCC is a mitochondrial biotin-dependent enzyme; the beta subunit is imported into the mitochondrial matrix. Mitochondrion is correct at a broader granularity than mitochondrial matrix (GO:0005759), which is the precise compartment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8188292" target="_blank" class="term-link">
+                                        PMID:8188292
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA carboxylase (PCC) is a mitochondrial, biotin-dependent enzyme, composed of an equal number of alpha and beta subunits</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0004658" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred propionyl-CoA carboxylase activity. This is the defining molecular function of the PCC beta (carboxyltransferase) subunit and is directly supported by biochemical characterization of the human enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function. The beta subunit supplies the carboxyltransferase activity that transfers the carboxyl group from carboxybiotin to propionyl-CoA; the holoenzyme carboxylates propionyl-CoA to (S)/D-methylmalonyl-CoA. Consistent with the IDA/EXP annotations from the purified human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the alpha-subunit contains the biotin carboxylase (BC) and biotin carboxyl carrier protein (BCCP) domains, whereas the beta-subunit supplies the carboxyltransferase (CT) activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0004658" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of propionyl-CoA carboxylase activity mapped from RHEA:23720 / EC 6.4.1.3. Concordant with the experimental molecular function and the UniProt catalytic activity statement.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the RHEA/EC mapping matches the experimentally characterized reaction (propanoyl-CoA + hydrogencarbonate + ATP = (S)-methylmalonyl-CoA + ADP + phosphate).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15890657" target="_blank" class="term-link">
+                                        PMID:15890657
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA carboxylase (PCC) is a biotin-dependent mitochondrial enzyme that catalyzes the conversion of propionyl-CoA to D-methylmalonyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to mitochondrial matrix from the UniProt subcellular location vocabulary mapping (SL-0170). Matches the experimental IDA/NAS/TAS matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization. The mature beta subunit resides in the mitochondrial matrix, where the PCC holoenzyme functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009062" target="_blank" class="term-link">
+                                    GO:0009062
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0009062" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation to fatty acid catabolic process. Odd-chain fatty acid beta-oxidation is one of the sources of the propionyl-CoA substrate, so PCC contributes to fatty acid catabolism, but this is a broad framing rather than PCC&#39;s direct committed reaction (propionate catabolism).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong: propionyl-CoA is the end product of beta-oxidation of odd-numbered fatty acids, and PCC clears it. However this is a downstream/broad biological-process framing; the precise, direct role is propionate catabolic process (proposed as a core BP). Keep as non-core contextual annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Disruption of PCC leads to accumulation of odd-chain fatty acids (FA), as propionyl-CoA is the end product of beta oxidation of odd-numbered FA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016874" target="_blank" class="term-link">
+                                    GO:0016874
+                                </a>
+                            </span>
+                            <span class="term-label">ligase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0016874" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to the generic parent term ligase activity, from the CoA carboxyltransferase C-terminal domain signature (IPR011763). The specific activity (propionyl-CoA carboxylase) is experimentally established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ligase activity is far too general for a protein whose specific molecular function is known. Propionyl-CoA carboxylase is formally an ATP-dependent ligase (EC 6.4.1.3), and the precise term GO:0004658 propionyl-CoA carboxylase activity is available and experimentally supported. Replace with the specific term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    propionyl-CoA carboxylase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20725044
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the alpha(6)beta(6) holoenzyme of propi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005515" data-r="PMID:20725044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein-binding annotation with PCCA (P05165), the obligate alpha partner subunit, from the PCC holoenzyme crystal-structure study. The interaction is biologically real (PCCB and PCCA form the alpha6-beta6 dodecamer) but the bare &#34;protein binding&#34; term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare protein binding (GO:0005515) conveys no specific molecular function. The meaningful biology (PCCB-PCCA holoenzyme assembly) is captured by the catalytic-complex annotation (GO:1902494) and the carboxylase MF, so this IPI is redundant/over-annotated as an MF. Not removed, per policy on IPI protein-binding annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein-binding annotation from the HuRI binary interactome (yeast two-hybrid) with ACTN3 (Q08043), a cytoskeletal alpha-actinin. There is no biological corroboration for a physical role of the mitochondrial matrix enzyme PCCB with a sarcomeric protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding (GO:0005515) is uninformative, and this high-throughput binary interactome hit (with a cytoskeletal protein not co-localized with the matrix enzyme) is most consistent with a screen artifact. Marked as over-annotated rather than removed, per policy on IPI protein-binding annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein-binding annotation from the BioPlex (AP-MS) interactome with PCCA (P05165), the obligate alpha partner subunit. Recapitulates the known PCCB-PCCA physical association but via the uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding (GO:0005515) is uninformative. The captured PCCB-PCCA association is already represented by the holoenzyme/complex (GO:1902494) and MF annotations. Marked as over-annotated rather than removed, per policy on IPI protein-binding annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PCCB requires PCCA for stability</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein-binding annotation from a multimodal cell-map / AP-MS study with PCCA (P05165), the obligate alpha partner subunit. Again reflects the known PCCB-PCCA association through the uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding (GO:0005515) is uninformative and redundant with the complex and MF annotations that already capture PCCB-PCCA holoenzyme assembly. Marked as over-annotated rather than removed, per policy on IPI protein-binding annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PCC is 750 kDa heterododecamer composed of 6 propionyl-CoA carboxylase, alpha (PCCA, OMIM 232000) and 6 propionyl-CoA carboxylase, beta subunits</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="PMID:29033250" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation to mitochondrial matrix, consistent with the established localization of the PCC holoenzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization. Multiple independent lines (IDA, IEA, TAS) place PCC in the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006631" target="_blank" class="term-link">
+                                    GO:0006631
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0006631" data-r="PMID:29033250" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation to the broad term fatty acid metabolic process. PCC participates in odd-chain fatty acid catabolism (a source of its propionyl-CoA substrate), but this is a high-level parent term, not the committed reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad and contextual. Odd-chain fatty acid metabolism generates the propionyl-CoA that PCC carboxylates, so involvement in fatty acid metabolism is defensible, but the direct role is propionate catabolic process. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain fatty acids, methionine, isoleucine and threonine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009081" target="_blank" class="term-link">
+                                    GO:0009081
+                                </a>
+                            </span>
+                            <span class="term-label">branched-chain amino acid metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0009081" data-r="PMID:29033250" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation reflecting that degradation of the branched-chain amino acids isoleucine and valine (and of methionine and threonine) feeds propionyl-CoA into the PCC reaction. This is an upstream metabolic-context role rather than PCC&#39;s direct catalytic step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in that Ile/Val (BCAA) catabolism produces propionyl-CoA, the PCC substrate; PCC clears this intermediate. But PCC&#39;s own reaction is propionate catabolism, not BCAA metabolism per se, so retain as a non-core contextual annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain fatty acids, methionine, isoleucine and threonine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902494" target="_blank" class="term-link">
+                                    GO:1902494
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20725044
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the alpha(6)beta(6) holoenzyme of propi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:1902494" data-r="PMID:20725044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal annotation (CPX-6169, mitochondrial propionyl-CoA carboxylase complex) that PCCB is part of a catalytic complex. PCCB is a constitutive subunit of the alpha6-beta6 PCC holoenzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and informative: PCCB is an obligate subunit of the PCC catalytic holoenzyme (the mitochondrial propionyl-CoA carboxylase complex). Captures the PCCB-PCCA assembly better than a bare protein-binding term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                        PMID:20725044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15890657" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15890657
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of four variant forms of human propionyl-Co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0004658" data-r="PMID:15890657" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation of propionyl-CoA carboxylase activity from recombinant human PCC (wild-type and PCCB variants) purified and assayed. Directly supports the defining molecular function of the beta subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, experimentally established. The study purified recombinant human PCC containing the beta subunit and measured propionyl-CoA carboxylase kinetics (kcat/Km), confirming the carboxylase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15890657" target="_blank" class="term-link">
+                                        PMID:15890657
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Propionyl-CoA carboxylase (PCC) is a biotin-dependent mitochondrial enzyme that catalyzes the conversion of propionyl-CoA to D-methylmalonyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics annotation placing PCCB in the mitochondrion, from a quantitative high-confidence human mitochondrial proteome study. Concordant with the established matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization at the organelle level (less specific than mitochondrial matrix). Consistent with all other localization evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16023992
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial targeting signals and mature peptides of 3-met...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="PMID:16023992" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to mitochondrial matrix based on direct determination of the PCC N-terminal targeting presequence and mature peptide, showing matrix import by the classical presequence pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, directly supported. The study identified the cleavage sites and mature amino-termini and demonstrated matrix import of PCC (studied alongside its paralog MCC) via cleavable presequences.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                                        PMID:16023992
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019626" target="_blank" class="term-link">
+                                    GO:0019626
+                                </a>
+                            </span>
+                            <span class="term-label">short-chain fatty acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6765947
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation and characterization of propionyl-CoA carboxylase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0019626" data-r="PMID:6765947" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator-inferred (IC, from GO:0004658) annotation to short-chain fatty acid catabolic process. Propionyl-CoA (a short-chain acyl-CoA) is catabolized via the PCC reaction, so this is defensible, but the precise process term is propionate catabolic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable framing (propionyl-CoA/propionate is a short-chain fatty acid derivative and PCC initiates its catabolism), but the direct, specific biological process is propionate catabolic process (GO:0019543), proposed as the core BP. Retain this broader term as non-core rather than removing it.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The enzyme also catalyzes the carboxylation of acetyl-CoA and butyryl-CoA to a limited degree, but not that of crotonyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                                    GO:0004658
+                                </a>
+                            </span>
+                            <span class="term-label">propionyl-CoA carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6765947
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation and characterization of propionyl-CoA carboxylase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0004658" data-r="PMID:6765947" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation of propionyl-CoA carboxylase activity from the enzyme purified to homogeneity from normal human liver, with measured kinetics for propionyl-CoA, ATP and bicarbonate. This is the strongest experimental support for the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, directly demonstrated on the human enzyme. The purified PCC (alpha/beta) carboxylates propionyl-CoA with defined Km values.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                        PMID:6765947
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3065959
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="Reactome:R-HSA-3065959" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to mitochondrial matrix (in the context of PCC degradation). Consistent with the established matrix localization of PCCB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, concordant with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3323111
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="Reactome:R-HSA-3323111" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to mitochondrial matrix (from the &#34;Cytosolic carboxylases translocate to mitochondrial matrix&#34; reaction). Represents the functional matrix compartment of PCC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization. This reaction models the endpoint of import into the matrix, where PCC functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                                        PMID:16023992
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71031
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="Reactome:R-HSA-71031" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to mitochondrial matrix from the PCC catalytic reaction (propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + orthophosphate). Places the enzymatic activity in the matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization; the PCC-catalyzed reaction occurs in the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the carboxylation of propionyl-CoA with bicarbonate producing methylmalonyl-CoA which is then converted to succinyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838081
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="Reactome:R-HSA-9838081" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to mitochondrial matrix (LONP1-mediated matrix protein degradation context). Consistent with PCCB being a matrix protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, concordant with all other evidence for matrix residence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838093
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005759" data-r="Reactome:R-HSA-9838093" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to mitochondrial matrix (LONP1 binds mitochondrial matrix proteins context). Consistent with the established matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, concordant with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is often described as a matrix enzyme because it can dissociate with sonication</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-2993447
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005829" data-r="Reactome:R-HSA-2993447" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to cytosol from the &#34;HLCS biotinylates 6x(PCCA:PCCB)&#34; reaction, which Reactome models in the cytosol prior to mitochondrial import. This reflects a transient biogenesis stage, not the mature functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functional PCC holoenzyme acts in the mitochondrial matrix. Reactome places biotinylation/assembly steps in the cytosol before import, so this cytosol annotation captures a transient itinerary compartment. Retain as non-core rather than treating it as a functional localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                                        PMID:16023992
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3323111
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005829" data-r="Reactome:R-HSA-3323111" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to cytosol from the &#34;Cytosolic carboxylases translocate to mitochondrial matrix&#34; reaction, representing the pre-import cytosolic stage of the carboxylase precursor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transient localization of the newly synthesized precursor before matrix import; not the functional compartment. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                                        PMID:16023992
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9035990
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005829" data-r="Reactome:R-HSA-9035990" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to cytosol from the &#34;Defective HLCS does not biotinylate 6x(PCCA:PCCB)&#34; reaction, again a cytosolic biogenesis step preceding matrix import.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects the pre-import cytosolic assembly/biotinylation stage, not the mature functional site. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                                        PMID:16023992
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8188292" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8188292
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Correction of the metabolic defect in propionic acidemia fib...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0005739" data-r="PMID:8188292" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation to mitochondrion. The microinjection/complementation study confirmed that beta subunits are transported into mitochondria and assemble with alpha subunits to form functional PCC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization at the organelle level (less specific than matrix). Directly supported by the demonstration that beta subunits are imported into mitochondria and form functional holoenzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8188292" target="_blank" class="term-link">
+                                        PMID:8188292
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the capacity for beta subunits derived from the microinjected cDNA or RNA to be transported into mitochondria and assembled with endogenously derived alpha subunits to form functional PCC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019543" target="_blank" class="term-link">
+                                    GO:0019543
+                                </a>
+                            </span>
+                            <span class="term-label">propionate catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29033250
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Propionyl-CoA carboxylase - A review.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P05166" data-a="GO:0019543" data-r="PMID:29033250" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed core biological-process annotation. PCC catalyzes the committed step of propionyl-CoA (propionate) catabolism, converting propionyl-CoA to methylmalonyl-CoA en route to succinyl-CoA; loss of PCC activity in propionic acidemia directly reflects a defect in propionate catabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GOA currently annotates PCCB only to broader/adjacent process terms (fatty acid catabolic/metabolic process, short-chain fatty acid catabolic process, branched-chain amino acid metabolic process). The precise, direct biological process is propionate catabolic process, which is the process decreased in propionic acidemia (per the disorder knowledge base). Inferred (IC) from the established propionyl-CoA carboxylase activity (GO:0004658).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                                        PMID:29033250
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the carboxylation of propionyl-CoA with bicarbonate producing methylmalonyl-CoA which is then converted to succinyl-CoA, an intermediate in the tricarboxylic acid cycle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Carboxyltransferase subunit of the mitochondrial propionyl-CoA carboxylase holoenzyme; transfers the carboxyl group from carboxybiotin to propionyl-CoA, carboxylating propionyl-CoA to (S)-methylmalonyl-CoA in the committed step of propionate catabolism.</h3>
+                <span class="vote-buttons" data-g="P05166" data-a="FUNCTION: Carboxyltransferase subunit of the mitochondrial p..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004658" target="_blank" class="term-link">
+                            propionyl-CoA carboxylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019543" target="_blank" class="term-link">
+                                propionate catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902494" target="_blank" class="term-link">
+                            catalytic complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                                PMID:20725044
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the alpha-subunit contains the biotin carboxylase (BC) and biotin carboxyl carrier protein (BCCP) domains, whereas the beta-subunit supplies the carboxyltransferase (CT) activity</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                                PMID:6765947
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15890657" target="_blank" class="term-link">
+                            PMID:15890657
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of four variant forms of human propionyl-CoA carboxylase expressed in Escherichia coli.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" target="_blank" class="term-link">
+                            PMID:16023992
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial targeting signals and mature peptides of 3-methylcrotonyl-CoA carboxylase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" target="_blank" class="term-link">
+                            PMID:20725044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of the alpha(6)beta(6) holoenzyme of propionyl-coenzyme A carboxylase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" target="_blank" class="term-link">
+                            PMID:29033250
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Propionyl-CoA carboxylase - A review.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/6765947" target="_blank" class="term-link">
+                            PMID:6765947
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Isolation and characterization of propionyl-CoA carboxylase from normal human liver. Evidence for a protomeric tetramer of nonidentical subunits.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8188292" target="_blank" class="term-link">
+                            PMID:8188292
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Correction of the metabolic defect in propionic acidemia fibroblasts by microinjection of a full-length cDNA or RNA transcript encoding the propionyl-CoA carboxylase beta subunit.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-2993447
+
+                    </span>
+                </div>
+
+                <div class="reference-title">HLCS biotinylates 6x(PCCA:PCCB)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3065959
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An unknown protease degrades hCBXs</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3323111
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cytosolic carboxylases translocate to mitochondrial matrix</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71031
+
+                    </span>
+                </div>
+
+                <div class="reference-title">propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + orthophosphate</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9035990
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective HLCS does not biotinylate 6x(PCCA:PCCB)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838081
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LONP1 degrades mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838093
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LONP1 binds mitochondrial matrix proteins</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are any of the reported minor substrate activities of PCC (butyryl-CoA, acetyl-CoA) physiologically relevant in humans, or purely in vitro promiscuity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P05166" data-a="Q: Are any of the reported minor substrate activities..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the proposed non-catalytic/moonlighting roles of the PCCB precursor in the cytosol (e.g., reported interactions with glucokinase or the mineralocorticoid receptor) have any physiological significance, or are they artifacts?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P05166" data-a="Q: Do the proposed non-catalytic/moonlighting roles o..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided kinetic characterization of additional PCCB carboxyltransferase active-site residues to distinguish variants that impair catalysis from those that impair holoenzyme assembly.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Some PCCB pathogenic variants abolish carboxyltransferase catalysis directly, whereas others reduce activity indirectly by destabilizing the alpha6-beta6 holoenzyme.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P05166" data-a="EXPERIMENT: Structure-guided kinetic characterization of addit..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative mitochondrial import and holoenzyme-assembly assays comparing PCCB isoform 1 and isoform 2 to determine whether the alternative splice product forms functional PCC.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PCCB isoform 2 (VSP_042568) differs in its capacity to assemble into a catalytically competent holoenzyme.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P05166" data-a="EXPERIMENT: Quantitative mitochondrial import and holoenzyme-a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PCCB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P05166" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pccb-human-gene-review-notes">PCCB (human) — gene review notes</h1>
+<p>UniProtKB:P05166 — Propionyl-CoA carboxylase beta chain, mitochondrial. HGNC:8654. 539 aa precursor.</p>
+<h2 id="core-biology-well-established">Core biology (well established)</h2>
+<p>PCCB is the <strong>beta (carboxyltransferase) subunit</strong> of the mitochondrial <strong>propionyl-CoA carboxylase (PCC)</strong> holoenzyme, a biotin-dependent carboxylase (EC 6.4.1.3). The holoenzyme is an <strong>alpha6-beta6 dodecamer</strong> (~750 kDa) built around a central beta6 hexamer core, with the six PCCA (alpha) subunits arranged as monomers decorating the ends.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" title="The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass of 750 kDa. The alpha-subunit contains the biotin carboxylase (BC) and biotin carboxyl carrier protein (BCCP) domains, whereas the beta-subunit supplies the carboxyltransferase (CT) activity.">PMID:20725044</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" title="PCC is 750 kDa heterododecamer composed of 6 propionyl-CoA carboxylase, alpha (PCCA...) and 6 propionyl-CoA carboxylase, beta subunits (PCCB...).">PMID:29033250</a></p>
+<p><strong>Catalysis / division of labor:</strong> The alpha subunit (PCCA) catalyzes the ATP-dependent carboxylation of biotin (on its BCCP domain); the <strong>beta subunit (PCCB) then transfers the carboxyl group from carboxybiotin to propionyl-CoA</strong>, producing (S)-/D-methylmalonyl-CoA. The CT active site is at the interface of a beta-subunit dimer.<br />
+- UniProt FUNCTION: "the alpha subunit catalyzes the ATP-dependent carboxylation of the biotin ... while the beta subunit then transfers the carboxyl group from carboxylated biotin to propionyl-CoA".<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/20725044" title="The active site of CT is located at the interface of its dimer">PMID:20725044</a> and "after which the carboxyl group is transferred from biotin to the alpha-carbon of propionyl-CoA" <a href="https://pubmed.ncbi.nlm.nih.gov/29033250">PMID:29033250</a>.</p>
+<p><strong>Reaction (RHEA:23720, EC 6.4.1.3):</strong> propanoyl-CoA + hydrogencarbonate + ATP = (S)-methylmalonyl-CoA + ADP + phosphate + H+. Km(propanoyl-CoA)=0.29 mM; Km(bicarbonate)=3.0 mM (PMID:6765947).</p>
+<p><strong>Enzyme purified from human liver; MF characterized biochemically:</strong><br />
+- [PMID:6765947 "The native enzyme has a molecular weight of approximately 540,000 and is composed of nonidentical subunits (alpha and beta)"; "The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM, 0.29 mM, and 3.0 mM, respectively."] — IDA propionyl-CoA carboxylase activity + subunit composition.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/15890657" title="Propionyl-CoA carboxylase (PCC) is a biotin-dependent mitochondrial enzyme that catalyzes the conversion of propionyl-CoA to D-methylmalonyl-CoA.">PMID:15890657</a> — EXP MF; also characterizes PCCB pathogenic variants (R165W, E168K, R410W) and A497V polymorphism.</p>
+<p><strong>Substrate promiscuity:</strong> minor activity on butyryl-CoA (-&gt; ethylmalonyl-CoA), acetyl-CoA (~1.5% rate), crotonoyl-CoA; greatest affinity for propionyl-CoA (PMID:6765947, PMID:29033250, UniProt CATALYTIC ACTIVITY RHEA:59520).</p>
+<h2 id="pathway-biological-process">Pathway / biological process</h2>
+<p>PCC catalyzes step 1 of propanoyl-CoA degradation to succinyl-CoA (UniPathway UPA00945/UER00908; "succinyl-CoA from propanoyl-CoA: step 1/3"). Propionyl-CoA is generated from catabolism of the branched-chain/other amino acids <strong>isoleucine, valine, methionine, threonine</strong>, odd-chain fatty acids, and cholesterol side chain ("c-VOMIT").<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" title="Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain fatty acids, methionine, isoleucine and threonine (c-VOMIT)">PMID:29033250</a>.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" title="catalyzes the carboxylation of propionyl-CoA with bicarbonate producing methylmalonyl-CoA which is then converted to succinyl-CoA, an intermediate in the tricarboxylic acid cycle (TCA)">PMID:29033250</a>.<br />
+- disorders KB (Propionic_Acidemia.yaml): biological process = <strong>GO:0019543 propionate catabolic process</strong> (DECREASED in PA); MF = GO:0004658; location = GO:0005739.</p>
+<p>Best-fit BP for the direct role: <strong>propionate catabolic process (GO:0019543)</strong>. The GOA "short-chain fatty acid catabolic process" (GO:0019626, IC) and "fatty acid catabolic process / metabolic process" IEA/NAS terms are broader parent-ish framings that capture the odd-chain-FA-derived and general FA-catabolism aspects. "branched-chain amino acid metabolic process" (GO:0009081, NAS) captures the Ile/Val degradation feed-in (upstream, not PCC's direct reaction).</p>
+<h2 id="localization">Localization</h2>
+<p>Mitochondrial <strong>matrix</strong>. PCC precursors carry cleavable N-terminal targeting presequences and are imported into the matrix; PCCB transit peptide = residues 1-28 (mature protein 29-539).<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/16023992" title="the two subunits of the enzyme (MCCalpha; MCCbeta) are imported into the mitochondrial matrix by the classical pathway involving cleavable amino-terminal targeting presequences. We identified the cleavage sites ... and the amino-termini of the mature polypeptides of MCC and propionyl-CoA carboxylase, a mitochondrial paralog.">PMID:16023992</a> — establishes PCC N-terminus / matrix import (IDA source for GO:0005759).<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/29033250" title="It is often described as a matrix enzyme because it can dissociate with sonication.">PMID:29033250</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/8188292" title="Propionyl-CoA carboxylase (PCC) is a mitochondrial, biotin-dependent enzyme">PMID:8188292</a> — TAS mitochondrion.<br />
+- UniProt SUBCELLULAR LOCATION: Mitochondrion matrix (ECO:0000305|PubMed:16023992).</p>
+<p>Reactome models a transient <strong>cytosolic</strong> stage before mitochondrial import ("Cytosolic carboxylases translocate to mitochondrial matrix", R-HSA-3323111; "HLCS biotinylates 6x(PCCA:PCCB)", R-HSA-2993447). These cytosol TAS annotations reflect the biosynthesis/import itinerary, not the functional compartment; keep as non-core.</p>
+<h2 id="protein-interactions-ipi-bare-protein-binding">Protein interactions (IPI, bare "protein binding")</h2>
+<ul>
+<li>PMID:20725044 with PCCA (P05165) — obligate partner subunit (holoenzyme). Meaningful but captured by MF/complex terms; bare "protein binding" is uninformative.</li>
+<li>PMID:33961781 (BioPlex) with PCCA (P05165).</li>
+<li>PMID:40205054 (multimodal cell maps) with PCCA (P05165).</li>
+<li>PMID:32296183 (HuRI binary interactome) with ACTN3 (Q08043) — likely high-throughput; not biologically corroborated for a matrix enzyme.<br />
+All four are bare GO:0005515 protein binding IPIs → per curation policy, MARK_AS_OVER_ANNOTATED (do not REMOVE; do not invent a specific MF). The complex membership is better captured by the ComplexPortal GO:1902494 catalytic complex (CPX-6169) annotation.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Biallelic PCCB (or PCCA) pathogenic variants cause <strong>propionic acidemia</strong> (PA / propionic acidemia type II, MIM:606054; MONDO:0011628) — autosomal recessive organic acidemia with metabolic acidosis, hyperammonemia, ketosis, and multi-organ complications. Many PCCB variants act by impairing holoenzyme assembly/stability rather than directly abolishing catalysis (PMID:15890657).</p>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>MF GO:0004658 propionyl-CoA carboxylase activity (IBA, IEA, EXP, IDA) → ACCEPT (core). This is the defining function.</li>
+<li>GO:0016874 ligase activity (IEA, InterPro) → MODIFY to GO:0004658 (too general; the specific carboxylase/ligase activity is known).</li>
+<li>GO:0005759 mitochondrial matrix (IDA, IEA, NAS, TAS) → ACCEPT (core location).</li>
+<li>GO:0005739 mitochondrion (IBA is_active_in, HTP, TAS) → ACCEPT / KEEP (correct but less specific than matrix).</li>
+<li>GO:0005829 cytosol (TAS Reactome) → KEEP_AS_NON_CORE (transient import intermediate, not functional site).</li>
+<li>GO:1902494 catalytic complex (IPI, ComplexPortal) → ACCEPT (PCC holoenzyme).</li>
+<li>GO:0019543 not currently in GOA as such; add as NEW core BP (propionate catabolic process) — the direct pathway role.</li>
+<li>GO:0019626 short-chain fatty acid catabolic process (IC) → KEEP_AS_NON_CORE (reasonable but propionate catabolic process is the precise term).</li>
+<li>GO:0009062 fatty acid catabolic process (IEA ARBA) / GO:0006631 fatty acid metabolic process (NAS) → KEEP_AS_NON_CORE (odd-chain FA are one propionyl-CoA source; broad).</li>
+<li>GO:0009081 branched-chain amino acid metabolic process (NAS) → KEEP_AS_NON_CORE (Ile/Val degradation feeds propionyl-CoA; upstream context).</li>
+<li>4x GO:0005515 protein binding (IPI) → MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>falcon deep-research file was polled for ~8 min and not present at review time; review grounded in UniProt (P05166), seeded GOA, cached publications (all 10 present), and dismech Propionic_Acidemia.yaml.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P05166
+gene_symbol: PCCB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PCCB encodes the beta (carboxyltransferase) subunit of mitochondrial
+  propionyl-CoA carboxylase (PCC; EC 6.4.1.3), a biotin-dependent carboxylase of
+  the mitochondrial matrix. The functional holoenzyme is an alpha6-beta6
+  dodecamer (~750 kDa) built around a central beta6 hexamer core decorated by six
+  PCCA (alpha) subunits. Within PCC, the alpha subunit carboxylates biotin on its
+  biotin-carboxyl-carrier (BCCP) domain in an ATP-dependent step, and the beta
+  subunit then transfers the carboxyl group from carboxybiotin to propionyl-CoA,
+  converting propanoyl-CoA + hydrogencarbonate + ATP to (S)-methylmalonyl-CoA +
+  ADP + phosphate. This is the committed step of propionyl-CoA (propionate)
+  catabolism: propionyl-CoA arises from degradation of the amino acids
+  isoleucine, valine, methionine and threonine, of odd-chain fatty acids, and of
+  the cholesterol side chain, and the methylmalonyl-CoA product is isomerized and
+  converted to succinyl-CoA, an anaplerotic entry point into the tricarboxylic
+  acid cycle. The enzyme is promiscuous, also carboxylating butyryl-CoA and
+  acetyl-CoA at much lower rates. Biallelic loss-of-function variants in PCCB
+  (or PCCA) cause propionic acidemia, an autosomal recessive organic acidemia
+  characterized by metabolic acidosis, ketosis, hyperammonemia, and multi-organ
+  complications; many PCCB missense variants act by impairing holoenzyme
+  assembly and stability rather than by directly abolishing catalysis.
+alternative_products:
+- name: &#39;1&#39;
+  id: P05166-1
+- name: &#39;2&#39;
+  id: P05166-2
+  sequence_note: VSP_042568
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred mitochondrial localization of the PCC beta
+      subunit. PCC is a well-established mitochondrial matrix enzyme, so
+      mitochondrion is correct but less specific than the matrix annotations.
+    action: ACCEPT
+    reason: &gt;-
+      PCC is a mitochondrial biotin-dependent enzyme; the beta subunit is imported
+      into the mitochondrial matrix. Mitochondrion is correct at a broader
+      granularity than mitochondrial matrix (GO:0005759), which is the precise
+      compartment.
+    supported_by:
+    - reference_id: PMID:8188292
+      supporting_text: &gt;-
+        Propionyl-CoA carboxylase (PCC) is a mitochondrial, biotin-dependent
+        enzyme, composed of an equal number of alpha and beta subunits
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred propionyl-CoA carboxylase activity. This is the
+      defining molecular function of the PCC beta (carboxyltransferase) subunit
+      and is directly supported by biochemical characterization of the human
+      enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function. The beta subunit supplies the carboxyltransferase
+      activity that transfers the carboxyl group from carboxybiotin to
+      propionyl-CoA; the holoenzyme carboxylates propionyl-CoA to
+      (S)/D-methylmalonyl-CoA. Consistent with the IDA/EXP annotations from the
+      purified human enzyme.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        the alpha-subunit contains the biotin carboxylase (BC) and biotin carboxyl
+        carrier protein (BCCP) domains, whereas the beta-subunit supplies the
+        carboxyltransferase (CT) activity
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic annotation of propionyl-CoA carboxylase activity mapped from
+      RHEA:23720 / EC 6.4.1.3. Concordant with the experimental molecular
+      function and the UniProt catalytic activity statement.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function; the RHEA/EC mapping matches the
+      experimentally characterized reaction (propanoyl-CoA + hydrogencarbonate +
+      ATP = (S)-methylmalonyl-CoA + ADP + phosphate).
+    supported_by:
+    - reference_id: PMID:15890657
+      supporting_text: &gt;-
+        Propionyl-CoA carboxylase (PCC) is a biotin-dependent mitochondrial enzyme
+        that catalyzes the conversion of propionyl-CoA to D-methylmalonyl-CoA
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to mitochondrial matrix from the UniProt subcellular
+      location vocabulary mapping (SL-0170). Matches the experimental IDA/NAS/TAS
+      matrix annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization. The mature beta subunit resides in the
+      mitochondrial matrix, where the PCC holoenzyme functions.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with
+        sonication
+- term:
+    id: GO:0009062
+    label: fatty acid catabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic annotation to fatty acid catabolic process. Odd-chain fatty
+      acid beta-oxidation is one of the sources of the propionyl-CoA substrate, so
+      PCC contributes to fatty acid catabolism, but this is a broad framing rather
+      than PCC&#39;s direct committed reaction (propionate catabolism).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Not wrong: propionyl-CoA is the end product of beta-oxidation of odd-numbered
+      fatty acids, and PCC clears it. However this is a downstream/broad
+      biological-process framing; the precise, direct role is propionate catabolic
+      process (proposed as a core BP). Keep as non-core contextual annotation.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Disruption of PCC leads to accumulation of odd-chain fatty acids (FA), as
+        propionyl-CoA is the end product of beta oxidation of odd-numbered FA
+- term:
+    id: GO:0016874
+    label: ligase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to the generic parent term ligase
+      activity, from the CoA carboxyltransferase C-terminal domain signature
+      (IPR011763). The specific activity (propionyl-CoA carboxylase) is
+      experimentally established.
+    action: MODIFY
+    reason: &gt;-
+      Ligase activity is far too general for a protein whose specific molecular
+      function is known. Propionyl-CoA carboxylase is formally an ATP-dependent
+      ligase (EC 6.4.1.3), and the precise term GO:0004658 propionyl-CoA carboxylase
+      activity is available and experimentally supported. Replace with the specific
+      term.
+    proposed_replacement_terms:
+    - id: GO:0004658
+      label: propionyl-CoA carboxylase activity
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM,
+        0.29 mM, and 3.0 mM, respectively
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20725044
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein-binding annotation with PCCA (P05165), the obligate alpha partner
+      subunit, from the PCC holoenzyme crystal-structure study. The interaction is
+      biologically real (PCCB and PCCA form the alpha6-beta6 dodecamer) but the
+      bare &#34;protein binding&#34; term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidelines, bare protein binding (GO:0005515) conveys no specific
+      molecular function. The meaningful biology (PCCB-PCCA holoenzyme assembly) is
+      captured by the catalytic-complex annotation (GO:1902494) and the carboxylase
+      MF, so this IPI is redundant/over-annotated as an MF. Not removed, per policy
+      on IPI protein-binding annotations.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass
+        of 750 kDa
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein-binding annotation from the HuRI binary interactome (yeast
+      two-hybrid) with ACTN3 (Q08043), a cytoskeletal alpha-actinin. There is no
+      biological corroboration for a physical role of the mitochondrial matrix
+      enzyme PCCB with a sarcomeric protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding (GO:0005515) is uninformative, and this high-throughput
+      binary interactome hit (with a cytoskeletal protein not co-localized with the
+      matrix enzyme) is most consistent with a screen artifact. Marked as
+      over-annotated rather than removed, per policy on IPI protein-binding
+      annotations.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: A reference map of the human binary protein interactome
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein-binding annotation from the BioPlex (AP-MS) interactome with
+      PCCA (P05165), the obligate alpha partner subunit. Recapitulates the known
+      PCCB-PCCA physical association but via the uninformative &#34;protein binding&#34;
+      term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding (GO:0005515) is uninformative. The captured
+      PCCB-PCCA association is already represented by the holoenzyme/complex
+      (GO:1902494) and MF annotations. Marked as over-annotated rather than removed,
+      per policy on IPI protein-binding annotations.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        PCCB requires PCCA for stability
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein-binding annotation from a multimodal cell-map / AP-MS study with
+      PCCA (P05165), the obligate alpha partner subunit. Again reflects the known
+      PCCB-PCCA association through the uninformative &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding (GO:0005515) is uninformative and redundant with the
+      complex and MF annotations that already capture PCCB-PCCA holoenzyme assembly.
+      Marked as over-annotated rather than removed, per policy on IPI
+      protein-binding annotations.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        PCC is 750 kDa heterododecamer composed of 6 propionyl-CoA carboxylase,
+        alpha (PCCA, OMIM 232000) and 6 propionyl-CoA carboxylase, beta subunits
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: NAS
+  original_reference_id: PMID:29033250
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation to mitochondrial matrix, consistent with the
+      established localization of the PCC holoenzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization. Multiple independent lines (IDA, IEA, TAS) place
+      PCC in the mitochondrial matrix.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with
+        sonication
+- term:
+    id: GO:0006631
+    label: fatty acid metabolic process
+  evidence_type: NAS
+  original_reference_id: PMID:29033250
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation to the broad term fatty acid metabolic process.
+      PCC participates in odd-chain fatty acid catabolism (a source of its
+      propionyl-CoA substrate), but this is a high-level parent term, not the
+      committed reaction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Broad and contextual. Odd-chain fatty acid metabolism generates the
+      propionyl-CoA that PCC carboxylates, so involvement in fatty acid metabolism
+      is defensible, but the direct role is propionate catabolic process. Retain as
+      non-core.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain
+        fatty acids, methionine, isoleucine and threonine
+- term:
+    id: GO:0009081
+    label: branched-chain amino acid metabolic process
+  evidence_type: NAS
+  original_reference_id: PMID:29033250
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation reflecting that degradation of the branched-chain
+      amino acids isoleucine and valine (and of methionine and threonine) feeds
+      propionyl-CoA into the PCC reaction. This is an upstream metabolic-context
+      role rather than PCC&#39;s direct catalytic step.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct in that Ile/Val (BCAA) catabolism produces propionyl-CoA, the PCC
+      substrate; PCC clears this intermediate. But PCC&#39;s own reaction is propionate
+      catabolism, not BCAA metabolism per se, so retain as a non-core contextual
+      annotation.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        Propionyl-CoA is produced by catabolism of cholesterol, valine, odd chain
+        fatty acids, methionine, isoleucine and threonine
+- term:
+    id: GO:1902494
+    label: catalytic complex
+  evidence_type: IPI
+  original_reference_id: PMID:20725044
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal annotation (CPX-6169, mitochondrial propionyl-CoA carboxylase
+      complex) that PCCB is part of a catalytic complex. PCCB is a constitutive
+      subunit of the alpha6-beta6 PCC holoenzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and informative: PCCB is an obligate subunit of the PCC catalytic
+      holoenzyme (the mitochondrial propionyl-CoA carboxylase complex). Captures the
+      PCCB-PCCA assembly better than a bare protein-binding term.
+    supported_by:
+    - reference_id: PMID:20725044
+      supporting_text: &gt;-
+        The holoenzyme of PCC is an alpha(6)beta(6) dodecamer, with a molecular mass
+        of 750 kDa
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: EXP
+  original_reference_id: PMID:15890657
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental annotation of propionyl-CoA carboxylase activity from
+      recombinant human PCC (wild-type and PCCB variants) purified and assayed.
+      Directly supports the defining molecular function of the beta subunit.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function, experimentally established. The study purified
+      recombinant human PCC containing the beta subunit and measured propionyl-CoA
+      carboxylase kinetics (kcat/Km), confirming the carboxylase activity.
+    supported_by:
+    - reference_id: PMID:15890657
+      supporting_text: &gt;-
+        Propionyl-CoA carboxylase (PCC) is a biotin-dependent mitochondrial enzyme
+        that catalyzes the conversion of propionyl-CoA to D-methylmalonyl-CoA
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomics annotation placing PCCB in the mitochondrion,
+      from a quantitative high-confidence human mitochondrial proteome study.
+      Concordant with the established matrix localization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization at the organelle level (less specific than mitochondrial
+      matrix). Consistent with all other localization evidence.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: &gt;-
+        Quantitative high-confidence human mitochondrial proteome and its dynamics
+        in cellular context
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:16023992
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA annotation to mitochondrial matrix based on direct determination of the
+      PCC N-terminal targeting presequence and mature peptide, showing matrix import
+      by the classical presequence pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Core localization, directly supported. The study identified the cleavage sites
+      and mature amino-termini and demonstrated matrix import of PCC (studied
+      alongside its paralog MCC) via cleavable presequences.
+    supported_by:
+    - reference_id: PMID:16023992
+      supporting_text: &gt;-
+        are imported into the mitochondrial matrix by the classical pathway
+        involving cleavable amino-terminal targeting presequences
+- term:
+    id: GO:0019626
+    label: short-chain fatty acid catabolic process
+  evidence_type: IC
+  original_reference_id: PMID:6765947
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Curator-inferred (IC, from GO:0004658) annotation to short-chain fatty acid
+      catabolic process. Propionyl-CoA (a short-chain acyl-CoA) is catabolized via
+      the PCC reaction, so this is defensible, but the precise process term is
+      propionate catabolic process.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reasonable framing (propionyl-CoA/propionate is a short-chain fatty acid
+      derivative and PCC initiates its catabolism), but the direct, specific
+      biological process is propionate catabolic process (GO:0019543), proposed as
+      the core BP. Retain this broader term as non-core rather than removing it.
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        The enzyme also catalyzes the carboxylation of acetyl-CoA and butyryl-CoA to
+        a limited degree, but not that of crotonyl-CoA
+- term:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  evidence_type: IDA
+  original_reference_id: PMID:6765947
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA annotation of propionyl-CoA carboxylase activity from the enzyme purified
+      to homogeneity from normal human liver, with measured kinetics for
+      propionyl-CoA, ATP and bicarbonate. This is the strongest experimental support
+      for the core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function, directly demonstrated on the human enzyme. The
+      purified PCC (alpha/beta) carboxylates propionyl-CoA with defined Km values.
+    supported_by:
+    - reference_id: PMID:6765947
+      supporting_text: &gt;-
+        The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM,
+        0.29 mM, and 3.0 mM, respectively
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3065959
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to mitochondrial matrix (in the context of PCC
+      degradation). Consistent with the established matrix localization of PCCB.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization, concordant with experimental evidence.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with
+        sonication
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3323111
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to mitochondrial matrix (from the &#34;Cytosolic
+      carboxylases translocate to mitochondrial matrix&#34; reaction). Represents the
+      functional matrix compartment of PCC.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization. This reaction models the endpoint of import into
+      the matrix, where PCC functions.
+    supported_by:
+    - reference_id: PMID:16023992
+      supporting_text: &gt;-
+        are imported into the mitochondrial matrix by the classical pathway
+        involving cleavable amino-terminal targeting presequences
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71031
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to mitochondrial matrix from the PCC catalytic
+      reaction (propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP +
+      orthophosphate). Places the enzymatic activity in the matrix.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization; the PCC-catalyzed reaction occurs in the
+      mitochondrial matrix.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        catalyzes the carboxylation of propionyl-CoA with bicarbonate producing
+        methylmalonyl-CoA which is then converted to succinyl-CoA
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838081
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to mitochondrial matrix (LONP1-mediated matrix protein
+      degradation context). Consistent with PCCB being a matrix protein.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization, concordant with all other evidence for matrix
+      residence.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with
+        sonication
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838093
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to mitochondrial matrix (LONP1 binds mitochondrial
+      matrix proteins context). Consistent with the established matrix localization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization, concordant with experimental evidence.
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        It is often described as a matrix enzyme because it can dissociate with
+        sonication
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2993447
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to cytosol from the &#34;HLCS biotinylates 6x(PCCA:PCCB)&#34;
+      reaction, which Reactome models in the cytosol prior to mitochondrial import.
+      This reflects a transient biogenesis stage, not the mature functional
+      compartment.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The functional PCC holoenzyme acts in the mitochondrial matrix. Reactome
+      places biotinylation/assembly steps in the cytosol before import, so this
+      cytosol annotation captures a transient itinerary compartment. Retain as
+      non-core rather than treating it as a functional localization.
+    supported_by:
+    - reference_id: PMID:16023992
+      supporting_text: &gt;-
+        are imported into the mitochondrial matrix by the classical pathway
+        involving cleavable amino-terminal targeting presequences
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3323111
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to cytosol from the &#34;Cytosolic carboxylases
+      translocate to mitochondrial matrix&#34; reaction, representing the pre-import
+      cytosolic stage of the carboxylase precursor.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Transient localization of the newly synthesized precursor before matrix
+      import; not the functional compartment. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:16023992
+      supporting_text: &gt;-
+        are imported into the mitochondrial matrix by the classical pathway
+        involving cleavable amino-terminal targeting presequences
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9035990
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to cytosol from the &#34;Defective HLCS does not
+      biotinylate 6x(PCCA:PCCB)&#34; reaction, again a cytosolic biogenesis step
+      preceding matrix import.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reflects the pre-import cytosolic assembly/biotinylation stage, not the mature
+      functional site. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:16023992
+      supporting_text: &gt;-
+        are imported into the mitochondrial matrix by the classical pathway
+        involving cleavable amino-terminal targeting presequences
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: TAS
+  original_reference_id: PMID:8188292
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAS annotation to mitochondrion. The microinjection/complementation study
+      confirmed that beta subunits are transported into mitochondria and assemble
+      with alpha subunits to form functional PCC.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization at the organelle level (less specific than matrix).
+      Directly supported by the demonstration that beta subunits are imported into
+      mitochondria and form functional holoenzyme.
+    supported_by:
+    - reference_id: PMID:8188292
+      supporting_text: &gt;-
+        the capacity for beta subunits derived from the microinjected cDNA or RNA to
+        be transported into mitochondria and assembled with endogenously derived
+        alpha subunits to form functional PCC
+- term:
+    id: GO:0019543
+    label: propionate catabolic process
+  evidence_type: IC
+  original_reference_id: PMID:29033250
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Proposed core biological-process annotation. PCC catalyzes the committed step
+      of propionyl-CoA (propionate) catabolism, converting propionyl-CoA to
+      methylmalonyl-CoA en route to succinyl-CoA; loss of PCC activity in propionic
+      acidemia directly reflects a defect in propionate catabolism.
+    action: NEW
+    reason: &gt;-
+      GOA currently annotates PCCB only to broader/adjacent process terms (fatty
+      acid catabolic/metabolic process, short-chain fatty acid catabolic process,
+      branched-chain amino acid metabolic process). The precise, direct biological
+      process is propionate catabolic process, which is the process decreased in
+      propionic acidemia (per the disorder knowledge base). Inferred (IC) from the
+      established propionyl-CoA carboxylase activity (GO:0004658).
+    supported_by:
+    - reference_id: PMID:29033250
+      supporting_text: &gt;-
+        catalyzes the carboxylation of propionyl-CoA with bicarbonate producing
+        methylmalonyl-CoA which is then converted to succinyl-CoA, an intermediate
+        in the tricarboxylic acid cycle
+core_functions:
+- description: &gt;-
+    Carboxyltransferase subunit of the mitochondrial propionyl-CoA carboxylase
+    holoenzyme; transfers the carboxyl group from carboxybiotin to propionyl-CoA,
+    carboxylating propionyl-CoA to (S)-methylmalonyl-CoA in the committed step of
+    propionate catabolism.
+  molecular_function:
+    id: GO:0004658
+    label: propionyl-CoA carboxylase activity
+  directly_involved_in:
+  - id: GO:0019543
+    label: propionate catabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:1902494
+    label: catalytic complex
+  supported_by:
+  - reference_id: PMID:20725044
+    supporting_text: &gt;-
+      the alpha-subunit contains the biotin carboxylase (BC) and biotin carboxyl
+      carrier protein (BCCP) domains, whereas the beta-subunit supplies the
+      carboxyltransferase (CT) activity
+  - reference_id: PMID:6765947
+    supporting_text: &gt;-
+      The apparent Km values for ATP, propionyl-CoA, and bicarbonate are 0.08 mM,
+      0.29 mM, and 3.0 mM, respectively
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Are any of the reported minor substrate activities of PCC (butyryl-CoA,
+    acetyl-CoA) physiologically relevant in humans, or purely in vitro
+    promiscuity?
+- question: &gt;-
+    Do the proposed non-catalytic/moonlighting roles of the PCCB precursor in the
+    cytosol (e.g., reported interactions with glucokinase or the mineralocorticoid
+    receptor) have any physiological significance, or are they artifacts?
+suggested_experiments:
+- description: &gt;-
+    Structure-guided kinetic characterization of additional PCCB
+    carboxyltransferase active-site residues to distinguish variants that impair
+    catalysis from those that impair holoenzyme assembly.
+  hypothesis: &gt;-
+    Some PCCB pathogenic variants abolish carboxyltransferase catalysis directly,
+    whereas others reduce activity indirectly by destabilizing the alpha6-beta6
+    holoenzyme.
+- description: &gt;-
+    Quantitative mitochondrial import and holoenzyme-assembly assays comparing
+    PCCB isoform 1 and isoform 2 to determine whether the alternative splice
+    product forms functional PCC.
+  hypothesis: &gt;-
+    PCCB isoform 2 (VSP_042568) differs in its capacity to assemble into a
+    catalytically competent holoenzyme.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15890657
+  title: Characterization of four variant forms of human propionyl-CoA carboxylase
+    expressed in Escherichia coli.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Verified against cached abstract; establishes PCC as a biotin-dependent
+      mitochondrial enzyme catalyzing propionyl-CoA to D-methylmalonyl-CoA and
+      characterizes PCCB pathogenic variants (assembly defects). Supports the EXP
+      propionyl-CoA carboxylase activity annotation.
+- id: PMID:16023992
+  title: Mitochondrial targeting signals and mature peptides of 3-methylcrotonyl-CoA
+    carboxylase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Title foregrounds MCC, but the study explicitly also defines the mitochondrial
+      targeting presequence and mature N-terminus of propionyl-CoA carboxylase and
+      demonstrates matrix import; correct source for the IDA mitochondrial matrix
+      annotation.
+- id: PMID:20725044
+  title: Crystal structure of the alpha(6)beta(6) holoenzyme of propionyl-coenzyme
+    A carboxylase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available; defines the alpha6-beta6 dodecamer architecture and that
+      the beta subunit supplies the carboxyltransferase activity. Supports subunit
+      composition, complex membership, and MF.
+- id: PMID:29033250
+  title: Propionyl-CoA carboxylase - A review.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Comprehensive review; verified full text supports the reaction, substrate
+      sources (c-VOMIT), matrix localization, holoenzyme composition, and disease
+      links used throughout this review.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      Large-scale yeast two-hybrid interactome; the PCCB-ACTN3 hit is not
+      biologically corroborated for a mitochondrial matrix enzyme and is most likely
+      a high-throughput artifact. Supports only a bare protein-binding IPI.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex AP-MS interactome; the reported PCCB-PCCA interaction is the genuine
+      obligate partner association but is captured more informatively by the complex
+      and MF annotations than by bare protein binding.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-confidence mitochondrial proteome study supporting mitochondrial
+      localization (HTP) of PCCB; concordant with matrix annotations.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Multimodal cell-map / AP-MS study; the reported PCCB-PCCA interaction is the
+      genuine partner-subunit association, redundant with the complex/MF
+      annotations. Supports only a bare protein-binding IPI.
+- id: PMID:6765947
+  title: Isolation and characterization of propionyl-CoA carboxylase from normal human
+    liver. Evidence for a protomeric tetramer of nonidentical subunits.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Purified the human enzyme to homogeneity, established alpha/beta subunit
+      composition and biotin content, and measured propionyl-CoA carboxylase
+      kinetics. Primary experimental support for the core MF (IDA) and substrate
+      properties.
+- id: PMID:8188292
+  title: Correction of the metabolic defect in propionic acidemia fibroblasts by microinjection
+    of a full-length cDNA or RNA transcript encoding the propionyl-CoA carboxylase
+    beta subunit.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cloned full-length human PCCB, demonstrated mitochondrial import and assembly
+      of beta subunits into functional PCC, and corrected the PA fibroblast defect.
+      Basis for the RecName evidence and the TAS mitochondrion annotation.
+- id: Reactome:R-HSA-2993447
+  title: HLCS biotinylates 6x(PCCA:PCCB)
+  findings: []
+- id: Reactome:R-HSA-3065959
+  title: An unknown protease degrades hCBXs
+  findings: []
+- id: Reactome:R-HSA-3323111
+  title: Cytosolic carboxylases translocate to mitochondrial matrix
+  findings: []
+- id: Reactome:R-HSA-71031
+  title: propionyl-CoA + CO2 + ATP &lt;=&gt; D-methylmalonyl-CoA + ADP + orthophosphate
+  findings: []
+- id: Reactome:R-HSA-9035990
+  title: Defective HLCS does not biotinylate 6x(PCCA:PCCB)
+  findings: []
+- id: Reactome:R-HSA-9838081
+  title: LONP1 degrades mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9838093
+  title: LONP1 binds mitochondrial matrix proteins
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>91</span> / 91 modules</div>
+        <div class="count"><span data-visible-count>92</span> / 92 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -2089,6 +2089,29 @@ Design intent for complexes (the central modelling question): each respiratory c
                         3
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/cellulose_biosynthesis.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Propionyl-CoA catabolism (propionate to succinyl-CoA via the methylmalonyl-CoA pathway)">
+                        <a class="module-name" href="propionyl_coa_catabolism.html">Propionyl-CoA catabolism (propionate to succinyl-CoA via the methylmalonyl-CoA pathway)</a><span class="module-id">MODULE:propionyl_coa_catabolism</span>                        <span class="module-desc">The mitochondrial pathway that converts propionyl-CoA to succinyl-CoA, the anaplerotic route by which propionate carbon enters the TCA cycle....</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">The mitochondrial pathway that converts propionyl-CoA to succinyl-CoA, the anaplerotic route by which propionate carbon enters the TCA cycle. Propionyl-CoA arises from the catabolism of the branched-chain amino acids isoleucine and valine, of methionine and threonine, of odd-chain fatty acids, and of the cholesterol side chain (and from gut-microbial propionate). Three enzymatic steps: (1) the biotin-dependent propionyl-CoA carboxylase (PCC), an alpha6-beta6 dodecamer of PCCA (biotin-carboxylase / biotin-carboxyl-carrier alpha subunit) and PCCB (carboxyltransferase beta subunit), carboxylates propionyl-CoA to (2S)-methylmalonyl-CoA (D-methylmalonyl-CoA) using bicarbonate and ATP; (2) methylmalonyl-CoA epimerase (MCEE) racemises this to (2R)-methylmalonyl-CoA (L-methylmalonyl-CoA); and (3) the adenosylcobalamin (AdoCbl / vitamin B12)- dependent methylmalonyl-CoA mutase (MMUT) performs the carbon-skeleton rearrangement of L-methylmalonyl-CoA to succinyl-CoA. The mutase step depends on a dedicated cobalamin cofactor-supply system: MMAB (cblB) is the ATP:cob(I)alamin adenosyltransferase that synthesises AdoCbl, and MMAA (cblA) is a mitochondrial G3E-family GTPase that gates AdoCbl loading onto MMUT and protects/reactivates the holo-mutase. Inherited defects map cleanly onto the steps: PCCA/PCCB → propionic acidemia; MCEE → (usually mild) methylmalonic aciduria; MMUT → methylmalonic aciduria (mut type); MMAB → cblB and MMAA → cblA methylmalonic aciduria (both often vitamin-B12-responsive because they act on cofactor supply).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">propionyl-CoA catabolic process</span>                        </div>                    </td>
+                    <td class="num">5</td>
+                    <td class="num">6</td>
+                    <td class="num">4</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">3</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/propionyl_coa_catabolism.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="RIG-I signaling pathway module">
                         <a class="module-name" href="rig_i_signaling.html">RIG-I signaling pathway module</a><span class="module-id">MODULE:rig_i_signaling</span>                        <span class="module-desc">RIG-I detects viral RNA and signals through MAVS to activate TBK1/IKK-family kinases and IRF transcription factors that induce type I interferon...</span>                        <details class="module-desc-more">

--- a/pages/modules/propionyl_coa_catabolism.html
+++ b/pages/modules/propionyl_coa_catabolism.html
@@ -1,0 +1,964 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Propionyl-CoA catabolism (propionate to succinyl-CoA via the methylmalonyl-CoA pathway) - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Propionyl-CoA catabolism (propionate to succinyl-CoA via the methylmalonyl-CoA pathway)
+    </nav>
+
+    <header class="header">
+        <h1>Propionyl-CoA catabolism (propionate to succinyl-CoA via the methylmalonyl-CoA pathway)</h1>            <p class="description">The mitochondrial pathway that converts propionyl-CoA to succinyl-CoA, the anaplerotic route by which propionate carbon enters the TCA cycle. Propionyl-CoA arises from the catabolism of the branched-chain amino acids isoleucine and valine, of methionine and threonine, of odd-chain fatty acids, and of the cholesterol side chain (and from gut-microbial propionate). Three enzymatic steps: (1) the biotin-dependent propionyl-CoA carboxylase (PCC), an alpha6-beta6 dodecamer of PCCA (biotin-carboxylase / biotin-carboxyl-carrier alpha subunit) and PCCB (carboxyltransferase beta subunit), carboxylates propionyl-CoA to (2S)-methylmalonyl-CoA (D-methylmalonyl-CoA) using bicarbonate and ATP; (2) methylmalonyl-CoA epimerase (MCEE) racemises this to (2R)-methylmalonyl-CoA (L-methylmalonyl-CoA); and (3) the adenosylcobalamin (AdoCbl / vitamin B12)- dependent methylmalonyl-CoA mutase (MMUT) performs the carbon-skeleton rearrangement of L-methylmalonyl-CoA to succinyl-CoA. The mutase step depends on a dedicated cobalamin cofactor-supply system: MMAB (cblB) is the ATP:cob(I)alamin adenosyltransferase that synthesises AdoCbl, and MMAA (cblA) is a mitochondrial G3E-family GTPase that gates AdoCbl loading onto MMUT and protects/reactivates the holo-mutase. Inherited defects map cleanly onto the steps: PCCA/PCCB → propionic acidemia; MCEE → (usually mild) methylmalonic aciduria; MMUT → methylmalonic aciduria (mut type); MMAB → cblB and MMAA → cblA methylmalonic aciduria (both often vitamin-B12-responsive because they act on cofactor supply).</p>        <div class="meta-row"><span class="pill">MODULE:propionyl_coa_catabolism</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/propionyl_coa_catabolism.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>propionyl-CoA catabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:1902859" target="_blank" rel="noopener">GO:1902859</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:1902859" target="_blank" rel="noopener">GO:1902859</a><div><strong>propionyl-CoA catabolic process</strong></div><div>The module is grounded in the GO propionyl-CoA catabolic process (GO:1902859) leading to succinyl-CoA.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-71032</span><div><strong>Propionyl-CoA catabolism</strong></div><div>Step order and reaction stoichiometries follow the human Reactome &#34;Propionyl-CoA catabolism&#34; pathway (R-HSA-71032): R-HSA-71031 (PCC), R-HSA-71020 (MCEE), R-HSA-71010 (MMUT), with AdoCbl supply by MMAB (R-HSA-3159253) and MMAA-gated loading (R-HSA-3159259).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PCCA/PCCA-ai-review.yaml</span><div><strong>PCCA gene review (human)</strong></div><div>The PCC alpha-subunit grounding (UniProtKB:P05165, GO:0004658 propionyl-CoA carboxylase activity) matches the completed human PCCA review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PCCB/PCCB-ai-review.yaml</span><div><strong>PCCB gene review (human)</strong></div><div>The PCC beta-subunit grounding (UniProtKB:P05166, GO:0004658) matches the completed human PCCB review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/MCEE/MCEE-ai-review.yaml</span><div><strong>MCEE gene review (human)</strong></div><div>The epimerase step grounding (UniProtKB:Q96PE7, GO:0004493 methylmalonyl-CoA epimerase activity) matches the completed human MCEE review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/MMUT/MMUT-ai-review.yaml</span><div><strong>MMUT gene review (human)</strong></div><div>The mutase step grounding (UniProtKB:P22033, GO:0004494 methylmalonyl-CoA mutase activity, GO:0031419 cobalamin binding) matches the completed human MMUT review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/MMAB/MMAB-ai-review.yaml</span><div><strong>MMAB gene review (human)</strong></div><div>The AdoCbl-synthesis step (UniProtKB:Q96EY8, GO:0008817 cob(I)alamin adenosyltransferase activity) matches the completed human MMAB review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/MMAA/MMAA-ai-review.yaml</span><div><strong>MMAA gene review (human)</strong></div><div>The cofactor-loading GTPase chaperone (UniProtKB:Q8IVH4, GO:0003924 GTPase activity) matches the completed human MMAA review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:propionyl_coa_catabolism</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        5 complete review(s) &middot;
+                        1 with deep research &middot;
+                        0 missing review &middot;
+                        5 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>MCEE
+                                        <span class="muted term-id">Q96PE7</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>MMAA
+                                        <span class="muted term-id">Q8IVH4</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>MMAB
+                                        <span class="muted term-id">Q96EY8</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>MMUT
+                                        <span class="muted term-id">P22033</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">53/54</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PCCA
+                                        <span class="muted term-id">P05165</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>PCCB
+                                        <span class="muted term-id">P05166</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-propionyl_coa_catabolism">Propionyl-CoA catabolism (methylmalonyl-CoA pathway)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">propionyl_coa_catabolism</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. biotin-dependent carboxylation (committed step)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pcc_step">propionyl-CoA + HCO3- + ATP to (S)-methylmalonyl-CoA + ADP + Pi</a><span class="pill type">Protein Complex</span><span class="tree-id">pcc_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pcca_activity">PCCA: propionyl-CoA carboxylase alpha (biotin carboxylase)</a>
+                                <span class="tree-id">Family: Biotin-dependent carboxylase alpha/biotin-carboxylase family (PCCA)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pccb_activity">PCCB: propionyl-CoA carboxylase beta (carboxyltransferase)</a>
+                                <span class="tree-id">Family: Propionyl-CoA carboxylase beta / carboxyltransferase family (PCCB)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. epimerization to the mutase substrate</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mcee_step">(S)-methylmalonyl-CoA to (R)-methylmalonyl-CoA</a><span class="pill type">Reaction</span><span class="tree-id">mcee_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mcee_activity">MCEE: methylmalonyl-CoA epimerase</a>
+                                <span class="tree-id">Family: Methylmalonyl-CoA epimerase / VOC (glyoxalase) superfamily (MCEE)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. AdoCbl-dependent isomerization to succinyl-CoA (terminal step)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mmut_step">(R)-methylmalonyl-CoA to succinyl-CoA</a><span class="pill type">Reaction</span><span class="tree-id">mmut_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mmut_activity">MMUT: methylmalonyl-CoA mutase (AdoCbl-dependent)</a>
+                                <span class="tree-id">Family: Methylmalonyl-CoA mutase family (MMUT)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. adenosylcobalamin cofactor supply and loading (supports the mutase step)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-adocbl_supply">AdoCbl synthesis (MMAB) and MMAA-gated loading onto the mutase</a><span class="pill type">Regulatory Step</span><span class="tree-id">adocbl_supply</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mmab_activity">MMAB/cblB: ATP:cob(I)alamin adenosyltransferase</a>
+                                <span class="tree-id">Family: Corrinoid adenosyltransferase family (MMAB)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mmaa_activity">MMAA/cblA: G3E GTPase chaperone for the mutase</a>
+                                <span class="tree-id">Family: G3E-family (MeaB/ArgK) GTPase metallochaperone (MMAA)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-propionyl_coa_catabolism">
+        <div class="node-heading">
+            <span class="node-title">Propionyl-CoA catabolism (methylmalonyl-CoA pathway)</span><span class="pill type">Metabolic Pathway</span><span class="pill">propionyl_coa_catabolism</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>propionyl-CoA catabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:1902859" target="_blank" rel="noopener">GO:1902859</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>
+
+            </div>
+        <p class="muted small">Three-enzyme mitochondrial propionyl-CoA catabolism plus its adenosylcobalamin cofactor-supply system, grounded to the human enzymes PCCA (UniProtKB:P05165) and PCCB (P05166) of propionyl-CoA carboxylase (GO:0004658, EC 6.4.1.3), MCEE (Q96PE7, GO:0004493, EC 5.1.99.1) and MMUT (P22033, GO:0004494, EC 5.4.99.2), with cofactor supply by MMAB (Q96EY8, GO:0008817, EC 2.5.1.17) and the GTPase chaperone MMAA (Q8IVH4, GO:0003924). GO molecular-function terms were taken from the human GOA records; Reactome reaction ids and titles were verified against the local reactome cache. Each step uses a PANTHER family selector (generic over paralogs and orthologs) plus a concrete human representative member. Upstream, propionyl-CoA derives from Ile/Val/Met/Thr, odd-chain fatty acids and the cholesterol side chain (see the BCAA catabolism module for the Ile/Val source); downstream, succinyl-CoA is anaplerotic for the TCA cycle. MMAA is deliberately represented as a cofactor chaperone (GTPase), not as a methylmalonyl-CoA-metabolizing enzyme.</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pcc_step">pcc_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-mcee_step">mcee_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">(S)-methylmalonyl-CoA from PCC is epimerised by MCEE.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-mcee_step">mcee_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-mmut_step">mmut_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">(R)-methylmalonyl-CoA from MCEE is the substrate of MMUT.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-adocbl_supply">adocbl_supply</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-mmut_step">mmut_step</a>                            <span class="pill">Positively Regulates</span></div>                        <div class="muted">MMAB synthesises AdoCbl and MMAA gates its loading/maintenance on MMUT; without this cofactor supply the mutase step cannot proceed (cblA/cblB methylmalonic aciduria phenocopy mut-type deficiency).</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: biotin-dependent carboxylation (committed step)</div>
+                <section class="node-detail depth-1" id="node-pcc_step">
+        <div class="node-heading">
+            <span class="node-title">propionyl-CoA + HCO3- + ATP to (S)-methylmalonyl-CoA + ADP + Pi</span><span class="pill type">Protein Complex</span><span class="pill">pcc_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pcca_activity">
+        <div class="annoton-title">PCCA: propionyl-CoA carboxylase alpha (biotin carboxylase)</div>
+        <div class="small muted">pcca_activity</div>            <div class="small"><strong>Participant:</strong> Family: Biotin-dependent carboxylase alpha/biotin-carboxylase family (PCCA)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Biotin-dependent carboxylase alpha/biotin-carboxylase family (PCCA)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR18866" target="_blank" rel="noopener">PANTHER:PTHR18866</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PCCA (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P05165/entry" target="_blank" rel="noopener">UniProtKB:P05165</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>propionyl-CoA carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004658" target="_blank" rel="noopener">GO:0004658</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>propionyl-CoA</span></span>                            <span class="descriptor">
+            <span>hydrogencarbonate</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                            <span class="descriptor">
+            <span>biotin (covalent cofactor)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>(S)-methylmalonyl-CoA</span></span>                            <span class="descriptor">
+            <span>ADP</span></span>                            <span class="descriptor">
+            <span>phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Biotin-carrying alpha subunit: ATP-dependently carboxylates its covalently-bound biotin using bicarbonate, then the carboxyl group is transferred (by PCCB) to propionyl-CoA. PCCA + PCCB assemble as an alpha6-beta6 dodecamer. Loss of function causes propionic acidemia.</p></article>                    <article class="annoton-card" id="annoton-pccb_activity">
+        <div class="annoton-title">PCCB: propionyl-CoA carboxylase beta (carboxyltransferase)</div>
+        <div class="small muted">pccb_activity</div>            <div class="small"><strong>Participant:</strong> Family: Propionyl-CoA carboxylase beta / carboxyltransferase family (PCCB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Propionyl-CoA carboxylase beta / carboxyltransferase family (PCCB)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43842" target="_blank" rel="noopener">PANTHER:PTHR43842</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PCCB (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P05166/entry" target="_blank" rel="noopener">UniProtKB:P05166</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>propionyl-CoA carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004658" target="_blank" rel="noopener">GO:0004658</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>propionyl-CoA</span></span>                            <span class="descriptor">
+            <span>carboxybiotin (from PCCA)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>(S)-methylmalonyl-CoA</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Carboxyltransferase beta subunit: binds propionyl-CoA and transfers the carboxyl group from carboxybiotin to it, producing (S)-methylmalonyl-CoA. Loss of function causes propionic acidemia.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: epimerization to the mutase substrate</div>
+                <section class="node-detail depth-1" id="node-mcee_step">
+        <div class="node-heading">
+            <span class="node-title">(S)-methylmalonyl-CoA to (R)-methylmalonyl-CoA</span><span class="pill type">Reaction</span><span class="pill">mcee_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mcee_activity">
+        <div class="annoton-title">MCEE: methylmalonyl-CoA epimerase</div>
+        <div class="small muted">mcee_activity</div>            <div class="small"><strong>Participant:</strong> Family: Methylmalonyl-CoA epimerase / VOC (glyoxalase) superfamily (MCEE)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Methylmalonyl-CoA epimerase / VOC (glyoxalase) superfamily (MCEE)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43048" target="_blank" rel="noopener">PANTHER:PTHR43048</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>MCEE (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q96PE7/entry" target="_blank" rel="noopener">UniProtKB:Q96PE7</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methylmalonyl-CoA epimerase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004493" target="_blank" rel="noopener">GO:0004493</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>(S)-methylmalonyl-CoA</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>(R)-methylmalonyl-CoA</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Racemises the PCC product to the (2R)/L-isomer that methylmalonyl-CoA mutase requires. Member of the vicinal-oxygen-chelate (glyoxalase) superfamily; deficiency causes a usually mild methylmalonic aciduria.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: AdoCbl-dependent isomerization to succinyl-CoA (terminal step)</div>
+                <section class="node-detail depth-1" id="node-mmut_step">
+        <div class="node-heading">
+            <span class="node-title">(R)-methylmalonyl-CoA to succinyl-CoA</span><span class="pill type">Reaction</span><span class="pill">mmut_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mmut_activity">
+        <div class="annoton-title">MMUT: methylmalonyl-CoA mutase (AdoCbl-dependent)</div>
+        <div class="small muted">mmut_activity</div>            <div class="small"><strong>Participant:</strong> Family: Methylmalonyl-CoA mutase family (MMUT)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Methylmalonyl-CoA mutase family (MMUT)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR48101" target="_blank" rel="noopener">PANTHER:PTHR48101</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>MMUT (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P22033/entry" target="_blank" rel="noopener">UniProtKB:P22033</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methylmalonyl-CoA mutase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004494" target="_blank" rel="noopener">GO:0004494</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>(R)-methylmalonyl-CoA</span></span>                            <span class="descriptor">
+            <span>adenosylcobalamin (AdoCbl cofactor)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>succinyl-CoA</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Radical (adenosylcobalamin-dependent) carbon-skeleton mutase that rearranges L-methylmalonyl-CoA to succinyl-CoA, feeding propionate carbon into the TCA cycle. Homodimer; requires AdoCbl supplied and maintained by MMAB and MMAA. Deficiency causes mut-type methylmalonic aciduria.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: adenosylcobalamin cofactor supply and loading (supports the mutase step)</div>
+                <section class="node-detail depth-1" id="node-adocbl_supply">
+        <div class="node-heading">
+            <span class="node-title">AdoCbl synthesis (MMAB) and MMAA-gated loading onto the mutase</span><span class="pill type">Regulatory Step</span><span class="pill">adocbl_supply</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mmab_activity">
+        <div class="annoton-title">MMAB/cblB: ATP:cob(I)alamin adenosyltransferase</div>
+        <div class="small muted">mmab_activity</div>            <div class="small"><strong>Participant:</strong> Family: Corrinoid adenosyltransferase family (MMAB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Corrinoid adenosyltransferase family (MMAB)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12213" target="_blank" rel="noopener">PANTHER:PTHR12213</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>MMAB (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q96EY8/entry" target="_blank" rel="noopener">UniProtKB:Q96EY8</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cob(I)alamin adenosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008817" target="_blank" rel="noopener">GO:0008817</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cob(I)alamin</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>adenosylcobalamin (AdoCbl)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Homotrimeric adenosyltransferase that makes the AdoCbl cofactor required by MMUT; deficiency causes cblB methylmalonic aciduria.</p></article>                    <article class="annoton-card" id="annoton-mmaa_activity">
+        <div class="annoton-title">MMAA/cblA: G3E GTPase chaperone for the mutase</div>
+        <div class="small muted">mmaa_activity</div>            <div class="small"><strong>Participant:</strong> Family: G3E-family (MeaB/ArgK) GTPase metallochaperone (MMAA)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>G3E-family (MeaB/ArgK) GTPase metallochaperone (MMAA)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR23408" target="_blank" rel="noopener">PANTHER:PTHR23408</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>MMAA (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8IVH4/entry" target="_blank" rel="noopener">UniProtKB:Q8IVH4</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>GTPase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003924" target="_blank" rel="noopener">GO:0003924</a></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Not a methylmalonyl-CoA-metabolizing enzyme: a GTP-dependent metallochaperone that gates transfer of AdoCbl onto MMUT and protects/reactivates the holo-mutase. Deficiency causes cblA methylmalonic aciduria (often B12-responsive).</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3044 |
| Gene review HTML pages | 3044 |
| Project pages | 1108 |
| Module pages | 93 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
